### PR TITLE
Use Janitorial label for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,7 @@ updates:
           interval: weekly
       open-pull-requests-limit: 5
       labels:
-          - dependencies
-          - php
+          - Janitorial
 
     - package-ecosystem: composer
       directory: '/tools'
@@ -15,8 +14,7 @@ updates:
           interval: weekly
       open-pull-requests-limit: 5
       labels:
-          - dependencies
-          - php
+          - Janitorial
 
     - package-ecosystem: npm
       directory: '/'
@@ -24,13 +22,11 @@ updates:
           interval: weekly
       open-pull-requests-limit: 5
       labels:
-          - dependencies
-          - javascript
+          - Janitorial
 
     - package-ecosystem: github-actions
       directory: '/'
       schedule:
           interval: monthly
       labels:
-          - dependencies
-          - github-actions
+          - Janitorial


### PR DESCRIPTION
## Summary
- Replace the missing `dependencies` / `php` / `javascript` / `github-actions` labels in `.github/dependabot.yml` with a single `Janitorial` label.
- The `Janitorial` label is already created on the repo (color `c5def5`, description: "Routine maintenance: dependency bumps, CI tweaks, non-feature upkeep.").

Dependabot has been reporting: *"The following labels could not be found: dependencies, github-actions. Please create them before Dependabot can add them to a pull request."* The four missing labels were never created; this swaps them for one that exists.

## Test plan
- [ ] Wait for the next Dependabot run (or trigger one) and confirm new PRs come through with the `Janitorial` label and no label-not-found warnings.