### PR TITLE
Build: drive build-zip from .gitattributes export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,21 +2,31 @@
 # `composer build-zip`. Anything tracked and NOT listed here ships in
 # the plugin zip, so prefer adding new dev-only paths here over rewriting
 # build-zip.sh.
+#
+# Directories get two entries: the bare path (prunes the dir from
+# archives) and `path/**` (so `git check-attr` on files under it also
+# reports the attribute — matters for any tool that queries attrs per
+# file rather than walking the tree like git-archive does).
 
-/.github          export-ignore
-/.gitattributes   export-ignore
-/.gitignore       export-ignore
-/.phpcs.xml.dist  export-ignore
-/.prettierignore  export-ignore
-/AGENTS.md        export-ignore
-/CLAUDE.md        export-ignore
-/bin              export-ignore
-/eslint.config.mjs export-ignore
-/jest.config.js   export-ignore
-/package.json     export-ignore
-/phpunit.xml.dist export-ignore
-/playwright.config.ts export-ignore
-/pnpm-lock.yaml   export-ignore
-/sdd              export-ignore
-/tests            export-ignore
-/tools            export-ignore
+/.github               export-ignore
+/.github/**            export-ignore
+/.gitattributes        export-ignore
+/.gitignore            export-ignore
+/.phpcs.xml.dist       export-ignore
+/.prettierignore       export-ignore
+/AGENTS.md             export-ignore
+/CLAUDE.md             export-ignore
+/bin                   export-ignore
+/bin/**                export-ignore
+/eslint.config.mjs     export-ignore
+/jest.config.js        export-ignore
+/package.json          export-ignore
+/phpunit.xml.dist      export-ignore
+/playwright.config.ts  export-ignore
+/pnpm-lock.yaml        export-ignore
+/sdd                   export-ignore
+/sdd/**                export-ignore
+/tests                 export-ignore
+/tests/**              export-ignore
+/tools                 export-ignore
+/tools/**              export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Files and directories excluded from `git archive`, which backs
+# `composer build-zip`. Anything tracked and NOT listed here ships in
+# the plugin zip, so prefer adding new dev-only paths here over rewriting
+# build-zip.sh.
+
+/.github          export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.phpcs.xml.dist  export-ignore
+/.prettierignore  export-ignore
+/AGENTS.md        export-ignore
+/CLAUDE.md        export-ignore
+/bin              export-ignore
+/eslint.config.mjs export-ignore
+/jest.config.js   export-ignore
+/package.json     export-ignore
+/phpunit.xml.dist export-ignore
+/playwright.config.ts export-ignore
+/pnpm-lock.yaml   export-ignore
+/sdd              export-ignore
+/tests            export-ignore
+/tools            export-ignore

--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -2,9 +2,10 @@
 #
 # Build a distributable zip of the FOSSE plugin at build/fosse.zip.
 #
-# The zip unpacks to a single fosse/ directory containing fosse.php, src/,
-# and a production vendor/ (no dev dependencies, no composer.json/lock),
-# ready to drop into wp-content/plugins/.
+# The zip unpacks to a single fosse/ directory containing every tracked
+# file not marked `export-ignore` in .gitattributes, plus a production
+# vendor/ (no dev dependencies, no composer.json/lock), ready to drop
+# into wp-content/plugins/.
 #
 # Environment:
 #   FOSSE_VERSION  If set, overrides the `Version:` header in the staged
@@ -27,12 +28,11 @@ ZIP_PATH="$BUILD_DIR/fosse.zip"
 rm -rf "$BUILD_DIR"
 mkdir -p "$STAGE_DIR"
 
-cp "$ROOT/fosse.php" "$STAGE_DIR/"
-cp -R "$ROOT/src" "$STAGE_DIR/"
-cp "$ROOT/composer.json" "$STAGE_DIR/"
-if [ -f "$ROOT/composer.lock" ]; then
-	cp "$ROOT/composer.lock" "$STAGE_DIR/"
-fi
+# Stage via `git archive`: the tree at HEAD, minus anything marked
+# `export-ignore` in .gitattributes. --worktree-attributes lets local
+# edits to .gitattributes take effect without a commit, which matches
+# how everything else in this script reads from the worktree.
+git -C "$ROOT" archive --format=tar --worktree-attributes HEAD | tar -x -C "$STAGE_DIR"
 
 if [ -n "${FOSSE_VERSION:-}" ]; then
 	# sed -i with a backup suffix is portable across GNU and BSD sed.


### PR DESCRIPTION
## Summary

- Replace the hand-maintained allowlist (`cp fosse.php; cp -R src; ...`) in `bin/build-zip.sh` with a single `git archive --worktree-attributes HEAD`.
- Add `.gitattributes` listing the dev/CI paths to exclude: `tests/`, `tools/`, `.github/`, `AGENTS.md`, `CLAUDE.md`, lint/formatter configs, `pnpm-lock.yaml`, `sdd/`, `bin/`, and `.gitattributes` itself.
- New top-level directories that belong in the plugin now ship automatically; the inverse class of bug — forgetting to copy a new dir and silently shipping a gutted zip — is what motivated this. (It's how `bundled/` was left out of the first release build.)

## Test plan

- [x] Ran `composer build-zip` locally on this branch. The resulting `fosse.zip` contains only `fosse/fosse.php`, `fosse/src/`, and a production `fosse/vendor/`. No `tests/`, `tools/`, `.github/`, `AGENTS.md`, `CLAUDE.md`, configs, or `bin/` leak.
- [ ] CI `build-zip` workflow green on this PR.
- [ ] After merge, the `latest-trunk` prerelease zip is still correctly shaped.

## Notes for sdd/bundled-backends

Once this merges to `trunk`, the `sdd/bundled-backends` branch (which adds `bundled/`) can merge `trunk` down, drop the `cp -R bundled` hunk from its local `build-zip.sh` change, and let `.gitattributes` do the work. `bundled/` is intentionally NOT export-ignored, so it'll ship automatically. The sanity-check block in `build-zip.sh` can still be extended there to require `bundled/activitypub/activitypub.php` and `bundled/atmosphere/atmosphere.php`.