### PR TITLE
Stop Copilot PR review from reading bundled/ upstream code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,11 +32,17 @@
 /tools/**              export-ignore
 
 # Mark vendored upstream plugins so GitHub Linguist drops them from
-# language stats, PR diffs auto-collapse, and Copilot code review skips
-# them — fixes belong in the upstream repos, not here (refresh via
-# tools/sync-bundled.sh). Built JS/CSS and Atmosphere's vendor/ are
-# additionally marked `linguist-generated` so GitHub treats them as
-# fully machine-produced output.
-bundled/**             linguist-vendored
+# language stats, PR diffs auto-collapse, AND the Copilot PR review bot
+# skips the whole tree — fixes belong in the upstream repos, not here
+# (refresh via tools/sync-bundled.sh).
+#
+# `linguist-vendored` alone only collapses diffs and strips language
+# stats; it does NOT stop Copilot's code review from reading the files
+# (PR #15 had Copilot comment on bundled/atmosphere/includes/…). Adding
+# `linguist-generated` to the whole tree is a small semantic stretch
+# (vendored ≠ generated) but it is the attribute Copilot actually
+# honors for skipping review. Built JS/CSS and Atmosphere's vendor/
+# keep their own more specific `linguist-generated` lines for clarity.
+bundled/**             linguist-vendored linguist-generated
 bundled/*/build/**     linguist-generated
 bundled/*/vendor/**    linguist-generated

--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -1,0 +1,22 @@
+---
+applyTo: "bundled/**"
+---
+
+# Copilot code review: skip bundled upstream plugins
+
+Files under `bundled/activitypub/` and `bundled/atmosphere/` are vendored
+verbatim from the upstream `Automattic/wordpress-activitypub` and
+`Automattic/wordpress-atmosphere` repositories. They are refreshed by
+`tools/sync-bundled.sh` — **never edited by hand in this repo.**
+
+When reviewing a FOSSE PR:
+
+- Do not flag issues in files under `bundled/`. Any real problem belongs
+  in the upstream repo and will flow back here on the next sync.
+- Typos, style nits, portability concerns, and refactor suggestions for
+  `bundled/` are out of scope for FOSSE PRs.
+- FOSSE's own code lives at the repo root (`fosse.php`) and under
+  `src/`. Focus review there.
+
+`.gitattributes` also marks this tree as `linguist-generated` to reinforce
+the skip. See `AGENTS.md` Common Pitfalls for the longer version.

--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "bundled/**"
+applyTo: 'bundled/**'
 ---
 
 # Copilot code review: skip bundled upstream plugins
@@ -11,12 +11,12 @@ verbatim from the upstream `Automattic/wordpress-activitypub` and
 
 When reviewing a FOSSE PR:
 
-- Do not flag issues in files under `bundled/`. Any real problem belongs
-  in the upstream repo and will flow back here on the next sync.
-- Typos, style nits, portability concerns, and refactor suggestions for
-  `bundled/` are out of scope for FOSSE PRs.
-- FOSSE's own code lives at the repo root (`fosse.php`) and under
-  `src/`. Focus review there.
+-   Do not flag issues in files under `bundled/`. Any real problem belongs
+    in the upstream repo and will flow back here on the next sync.
+-   Typos, style nits, portability concerns, and refactor suggestions for
+    `bundled/` are out of scope for FOSSE PRs.
+-   FOSSE's own code lives at the repo root (`fosse.php`) and under
+    `src/`. Focus review there.
 
 `.gitattributes` also marks this tree as `linguist-generated` to reinforce
 the skip. See `AGENTS.md` Common Pitfalls for the longer version.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,18 @@ The script runs `composer install --no-dev --optimize-autoloader` inside the Atm
 -   Component prefix when helpful: `Tests: add smoke test for X`.
 -   No conventional-commit prefixes.
 
+## Before Pushing
+
+Run the lint suite at minimum before pushing any branch or opening a PR:
+
+```bash
+composer run-script lint-php       # PHPCS (Jetpack ruleset)
+pnpm run format:check              # Prettier
+pnpm run lint                      # ESLint
+```
+
+The full CI matrix runs on push, but catching formatting and style failures locally saves a round trip through GitHub Actions — and avoids re-triggering the Copilot PR review bot (and its review-points budget) on every retry push. PHPUnit and E2E can wait for CI; the linters are cheap and should be clean before the first push.
+
 ## CI Matrix
 
 -   `.github/workflows/tests.yml` runs PHPUnit across PHP 8.2/8.3/8.4/8.5 × WP 6.9/trunk. Trunk rows are `continue-on-error`. WP 7.0 covers via the `trunk` row until 7.0 releases, then it gets added as its own column.


### PR DESCRIPTION
## Summary

Two small belt-and-suspenders fixes so the Copilot PR review bot stops leaving comments on vendored upstream code under `bundled/`.

## Why

PR [#11](https://github.com/Automattic/fosse/pull/11) added:

- `bundled/** linguist-vendored` — drops bundled/ from language stats and auto-collapses diffs in the UI.
- `bundled/*/build/**` + `bundled/*/vendor/**` as `linguist-generated` — fully skipped by Copilot review.
- `.github/copilot-instructions.md` — prose telling reviewers to ignore `bundled/`.

PR [#15](https://github.com/Automattic/fosse/pull/15) showed the guard was incomplete. Copilot's own summary: *"reviewed 73 out of 78 changed files"* — the 5 it skipped were the `linguist-generated` ones. It still read everything under `bundled/*/includes/` and left an inline comment on `bundled/atmosphere/includes/class-reaction-sync.php`, which is exactly the tree we do not want it in.

## What changes

1. **`.gitattributes`:** extend `bundled/**` to also be `linguist-generated`. `linguist-vendored` alone doesn't stop the Copilot review bot from reading files; `linguist-generated` does. Semantically "generated" is a small stretch for vendored code, but the practical effect is the skip we want.

2. **`.github/instructions/copilot-review.instructions.md`:** add a scoped review-instructions file (`applyTo: "bundled/**"`). This is the location Copilot itself suggested on PR #11 (separate from `.github/copilot-instructions.md`, which targets in-editor Copilot Chat / code completion). If Copilot honors it, we win; if it only respects Linguist attrs, (1) already covers us.

## Test plan

- [ ] Confirm `git check-attr linguist-generated bundled/atmosphere/includes/class-reaction-sync.php` reports `set` (done locally).
- [ ] Confirm Copilot skips `bundled/` on the next bundled-refresh PR.