### PR TITLE
Docs: note WPCS as the project coding standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,8 @@ The script runs `composer install --no-dev --optimize-autoloader` inside the Atm
 
 ## Code Conventions
 
+This project follows **WordPress Coding Standards (WPCS)** for all PHP code, enforced via the Jetpack PHPCS ruleset.
+
 ### PHP
 
 -   **Jetpack ruleset** (WordPress-Extra + VariableAnalysis + PHPCompatibilityWP + selected MediaWiki sniffs).


### PR DESCRIPTION
## Summary
- Adds an explicit note to AGENTS.md that the project follows WordPress Coding Standards (WPCS), enforced via the Jetpack PHPCS ruleset.

## Test plan
- [x] Verify AGENTS.md renders correctly on GitHub