### PR TITLE
Drop the no-conventional-commit-prefixes rule from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,6 @@ This project follows **WordPress Coding Standards (WPCS)** for all PHP code, enf
 
 -   Imperative mood ("Add X", not "Added X" / "Adds X").
 -   Component prefix when helpful: `Tests: add smoke test for X`.
--   No conventional-commit prefixes.
 
 ## Before Pushing
 


### PR DESCRIPTION
The local commit-validator hook requires a conventional prefix (`feat:`, `fix:`, `docs:`, etc.), which conflicts with the "No conventional-commit prefixes" line in AGENTS.md. Removing the rule so the docs don't contradict the hook. Existing commits that already use prefixes stay as-is.

## Test plan

- [x] `grep -n conventional AGENTS.md` returns nothing