### PR TITLE
docs: long-form strategy worked example in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,3 +210,10 @@ Worked example from the Bluesky-native-publishing epic:
 -   **FOSSE** — the `Automattic\Fosse\Object_Type` projector that reads the `fosse_object_type` option and drives both upstream filters in lockstep. This only makes sense inside FOSSE's "publish once, reach everywhere" model where AP and atproto must agree on the shape of a given post.
 
 See PR #18 (DOTCOM-16812) for the full decision record.
+
+Worked example from the long-form Bluesky strategy ([DOTCOM-16810](https://linear.app/a8c/issue/DOTCOM-16810)):
+
+-   **Upstream** — Atmosphere's `atmosphere_long_form_composition` filter, the `build_long_form_records()` / `build_teaser_thread()` / `build_truncate_link_text()` composition methods on `Transformer\Post`, the `META_THREAD_RECORDS` post-meta constant, and the thread-aware redesign of `Publisher::publish/update/delete` (sequential writes with rollback + partial-meta writes). Every piece describes a universal "how does Atmosphere compose and persist long posts" concern that's valuable to any consumer of `wordpress-atmosphere`.
+-   **FOSSE** — the `Automattic\Fosse\Long_Form_Strategy` projector that reads `fosse_long_form_strategy` and drives the single `atmosphere_long_form_composition` filter. It encodes FOSSE's opinion (default `'teaser-thread'`, coerce unknown/empty → default) and nothing more.
+
+See the `sdd/long-form-bluesky-strategy/` SDD for the full decision record, including why FOSSE's default diverges from upstream's (upstream stays on `'link-card'`).


### PR DESCRIPTION
Extends the upstream-contribution policy in [AGENTS.md](https://github.com/Automattic/fosse/blob/trunk/AGENTS.md) with a second worked example — the long-form Bluesky strategy ([DOTCOM-16810](https://linear.app/a8c/issue/DOTCOM-16810)).

The design it documents is still in flight:

- Upstream [wordpress-atmosphere#34](https://github.com/Automattic/wordpress-atmosphere/pull/34) (draft) adds the \`atmosphere_long_form_composition\` filter, the composition methods, the \`META_THREAD_RECORDS\` constant, and the thread-aware Publisher redesign.
- FOSSE-side \`Long_Form_Strategy\` projector will ship in a follow-up PR once upstream merges (Task 3 of the [SDD plan](https://github.com/Automattic/fosse/tree/trunk/sdd/long-form-bluesky-strategy/plan.md)).

The worked example references both. Both are fair game to describe even pre-merge — the SDD has locked the shape.

### Notes

- No \`readme.txt\` entry in this PR. FOSSE has no \`readme.txt\` today and nothing in the build / CI references one. The SDD plan mentioned one, but creating it would be a separate decision from this docs tweak.
- Staying as a draft until the upstream + follow-on FOSSE PRs are further along.

Fixes DOTCOM-16890
See DOTCOM-16810 (parent epic)
