### PR TITLE
Add Bluesky provider to FOSSE admin UI

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -131,6 +131,7 @@ add_action(
  */
 if ( class_exists( \Automattic\Fosse\Provider_Loader::class ) ) {
 	\Automattic\Fosse\Admin\AP_Provider::init();
+	\Automattic\Fosse\Admin\Bluesky_Provider::init();
 
 	\Automattic\Fosse\Provider_Loader::boot();
 }

--- a/sdd/onboarding-setup-ux/plan.md
+++ b/sdd/onboarding-setup-ux/plan.md
@@ -18,7 +18,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 ## Tasks
 
 ### Task 1: Create Connection_Provider interface + Registry
-- **Status**: ✅ Done
+- **Status**: ✅ Done (#27)
 - **Files**: `src/Admin/Connection_Provider.php`, `src/Admin/Connection_Provider_Registry.php`
 - **Do**:
   1. Create `Connection_Provider` interface with methods: `get_slug()`, `get_name()`, `is_available()`, `get_status()`, `render_setup_section()`, `render_status_card()`, `register_hooks()`.
@@ -30,7 +30,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: none
 
 ### Task 2: Create Menu.php + wire up in fosse.php
-- **Status**: ✅ Done
+- **Status**: ✅ Done (#27)
 - **Files**: `src/Admin/Menu.php`, `fosse.php`
 - **Do**:
   1. Create `Menu` class with `register()` static method that fires `fosse_register_providers`, calls `register_hooks()` on available providers, hooks `admin_menu` at priority 9 (register menu) and 99 (hide bundled menus), and hooks `admin_enqueue_scripts` for CSS.
@@ -50,7 +50,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 1
 
 ### Task 3: Create AP_Provider + Setup_Page shell
-- **Status**: ✅ Done
+- **Status**: ✅ Done (#27)
 - **Files**: `src/Admin/AP_Provider.php`, `src/Admin/Setup_Page.php`, `src/Admin/templates/setup-page.php`
 - **Do**:
   1. Create `AP_Provider` implementing `Connection_Provider`. Self-registers on `fosse_register_providers` with `class_exists('\Activitypub\Activitypub')` guard.
@@ -66,7 +66,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 2
 
 ### Task 4: Open upstream Atmosphere PRs
-- **Status**: ✅ Done
+- **Status**: ✅ Done (Automattic/wordpress-atmosphere#33)
 
 - **Do**:
   1. Open PR against wordpress-atmosphere for (a) a filter on `Client::redirect_uri()` so consumers can set their own callback URL.
@@ -77,7 +77,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: none
 
 ### Task 5: Create Bluesky_Provider
-- **Status**: In progress
+- **Status**: ✅ Done (#34)
 - **Files**: `src/Admin/Bluesky_Provider.php`
 - **Do**:
   1. Create `Bluesky_Provider` implementing `Connection_Provider`. Self-registers on `fosse_register_providers` with `class_exists('\Atmosphere\Atmosphere')` guard.
@@ -92,7 +92,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 2, Task 4
 
 ### Task 6: Create Status_Page with provider status cards
-- **Status**: ✅ Done
+- **Status**: ✅ Done (#27)
 - **Files**: `src/Admin/Status_Page.php`, `src/Admin/templates/status-page.php`
 - **Do**:
   1. Create `Status_Page` that iterates providers, counts total/connected, and includes template.
@@ -103,7 +103,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 3, Task 5
 
 ### Task 7: Add admin CSS
-- **Status**: ✅ Done
+- **Status**: ✅ Done (#27)
 - **Files**: `src/Admin/assets/css/admin.css`
 - **Do**:
   1. Status indicator dots (green/red).
@@ -116,7 +116,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 6
 
 ### Task 8: Write tests
-- **Status**: In progress
+- **Status**: ✅ Done (#27, #34)
 - **Files**: `tests/php/Admin/Connection_Provider_RegistryTest.php`, `tests/php/Admin/AP_ProviderTest.php`, `tests/php/Admin/Bluesky_ProviderTest.php`
 - **Do**:
   1. Registry tests: register/retrieve, get_providers returns all, duplicate slug ignored, unknown slug returns null, reset clears.
@@ -129,7 +129,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 3, Task 5
 
 ### Task 9: Exclude `src/` from WordPress.Files.FileName PHPCS sniff
-- **Status**: ✅ Done
+- **Status**: ✅ Done (#27)
 - **Files**: `.phpcs.xml.dist`
 - **Do**:
   1. Add `<exclude-pattern>src/</exclude-pattern>` to the `WordPress.Files.FileName` rule block (alongside the existing `tests/php/` exclusion).

--- a/sdd/onboarding-setup-ux/plan.md
+++ b/sdd/onboarding-setup-ux/plan.md
@@ -2,9 +2,23 @@
 
 Based on: sdd/onboarding-setup-ux/spec.md
 
+## Progress
+
+- [x] Task 1: Create Connection_Provider interface + Registry
+- [x] Task 2: Create Menu.php + wire up in fosse.php
+- [x] Task 3: Create AP_Provider + Setup_Page shell
+- [x] Task 4: Open upstream Atmosphere PRs
+- [x] Task 5: Create Bluesky_Provider
+- [x] Task 6: Create Status_Page with provider status cards
+- [x] Task 7: Add admin CSS
+- [x] Task 8: Write tests
+- [x] Task 9: Exclude `src/` from WordPress.Files.FileName PHPCS sniff
+- [ ] Task 10: Update SDD documentation
+
 ## Tasks
 
 ### Task 1: Create Connection_Provider interface + Registry
+- **Status**: ✅ Done
 - **Files**: `src/Admin/Connection_Provider.php`, `src/Admin/Connection_Provider_Registry.php`
 - **Do**:
   1. Create `Connection_Provider` interface with methods: `get_slug()`, `get_name()`, `is_available()`, `get_status()`, `render_setup_section()`, `render_status_card()`, `register_hooks()`.
@@ -16,6 +30,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: none
 
 ### Task 2: Create Menu.php + wire up in fosse.php
+- **Status**: ✅ Done
 - **Files**: `src/Admin/Menu.php`, `fosse.php`
 - **Do**:
   1. Create `Menu` class with `register()` static method that fires `fosse_register_providers`, calls `register_hooks()` on available providers, hooks `admin_menu` at priority 9 (register menu) and 99 (hide bundled menus), and hooks `admin_enqueue_scripts` for CSS.
@@ -35,6 +50,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 1
 
 ### Task 3: Create AP_Provider + Setup_Page shell
+- **Status**: ✅ Done
 - **Files**: `src/Admin/AP_Provider.php`, `src/Admin/Setup_Page.php`, `src/Admin/templates/setup-page.php`
 - **Do**:
   1. Create `AP_Provider` implementing `Connection_Provider`. Self-registers on `fosse_register_providers` with `class_exists('\Activitypub\Activitypub')` guard.
@@ -50,6 +66,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 2
 
 ### Task 4: Open upstream Atmosphere PRs
+- **Status**: ✅ Done
 
 - **Do**:
   1. Open PR against wordpress-atmosphere for (a) a filter on `Client::redirect_uri()` so consumers can set their own callback URL.
@@ -60,6 +77,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: none
 
 ### Task 5: Create Bluesky_Provider
+- **Status**: In progress
 - **Files**: `src/Admin/Bluesky_Provider.php`
 - **Do**:
   1. Create `Bluesky_Provider` implementing `Connection_Provider`. Self-registers on `fosse_register_providers` with `class_exists('\Atmosphere\Atmosphere')` guard.
@@ -74,6 +92,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 2, Task 4
 
 ### Task 6: Create Status_Page with provider status cards
+- **Status**: ✅ Done
 - **Files**: `src/Admin/Status_Page.php`, `src/Admin/templates/status-page.php`
 - **Do**:
   1. Create `Status_Page` that iterates providers, counts total/connected, and includes template.
@@ -84,6 +103,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 3, Task 5
 
 ### Task 7: Add admin CSS
+- **Status**: ✅ Done
 - **Files**: `src/Admin/assets/css/admin.css`
 - **Do**:
   1. Status indicator dots (green/red).
@@ -96,6 +116,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 6
 
 ### Task 8: Write tests
+- **Status**: In progress
 - **Files**: `tests/php/Admin/Connection_Provider_RegistryTest.php`, `tests/php/Admin/AP_ProviderTest.php`, `tests/php/Admin/Bluesky_ProviderTest.php`
 - **Do**:
   1. Registry tests: register/retrieve, get_providers returns all, duplicate slug ignored, unknown slug returns null, reset clears.
@@ -108,6 +129,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 3, Task 5
 
 ### Task 9: Exclude `src/` from WordPress.Files.FileName PHPCS sniff
+- **Status**: ✅ Done
 - **Files**: `.phpcs.xml.dist`
 - **Do**:
   1. Add `<exclude-pattern>src/</exclude-pattern>` to the `WordPress.Files.FileName` rule block (alongside the existing `tests/php/` exclusion).
@@ -117,6 +139,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: none
 
 ### Task 10: Update SDD documentation
+- **Status**: In progress
 - **Files**: `sdd/onboarding-setup-ux/requirements.md`, `spec.md`, `plan.md`, `planned-decisions.md`
 - **Do**:
   1. Update all four SDD documents to reflect the as-built implementation — verify deviations, decisions, and limitations are accurate.

--- a/sdd/onboarding-setup-ux/plan.md
+++ b/sdd/onboarding-setup-ux/plan.md
@@ -121,8 +121,9 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Do**:
   1. Registry tests: register/retrieve, get_providers returns all, duplicate slug ignored, unknown slug returns null, reset clears.
   2. AP_Provider tests: status shape, direct `update_option()` writes to `activitypub_actor_mode` / `activitypub_support_post_types`, post type defaults and overrides, slug and name.
-  3. Bluesky_Provider tests: redirect URI filter integration, persisted-notice read, status disconnected/connected/expired-token.
+  3. Bluesky_Provider tests: redirect URI filter integration, persisted-notice read, status disconnected/connected/expired-token, unauthorized user rejection, bad nonce rejection, handle `@` normalization.
   4. Run `composer run-script lint-php` and `composer run-script test-php`.
+- **Known gap**: `handle_oauth_callback()` success/warning/error branches are not unit-tested because `Client::handle_callback()` requires real PKCE state. These branches rely on manual verification (connect flow, `sync_publication` failure).
 - **Verify**:
   - All tests pass.
   - Lint clean.

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -1,0 +1,350 @@
+<?php
+/**
+ * Bluesky connection provider.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Admin;
+
+/**
+ * Integrates the bundled Atmosphere plugin into FOSSE's admin UI.
+ *
+ * Uses Atmosphere's public APIs for OAuth, connection storage, and
+ * publication setup. FOSSE owns only the wrapper admin flow.
+ */
+class Bluesky_Provider implements Connection_Provider {
+
+	/**
+	 * Hook into fosse_register_providers to self-register.
+	 *
+	 * @return void
+	 */
+	public static function init(): void {
+		add_action( 'fosse_register_providers', array( static::class, 'register_provider' ) );
+	}
+
+	/**
+	 * Register this provider if Atmosphere is available.
+	 *
+	 * @return void
+	 */
+	public static function register_provider(): void {
+		$provider = new self();
+		if ( $provider->is_available() ) {
+			Connection_Provider_Registry::register( $provider );
+		}
+	}
+
+	/**
+	 * Get the provider slug.
+	 *
+	 * @return string
+	 */
+	public function get_slug(): string {
+		return 'bluesky';
+	}
+
+	/**
+	 * Get the provider display name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'Bluesky';
+	}
+
+	/**
+	 * Check if Atmosphere is loaded.
+	 *
+	 * @return bool
+	 */
+	public function is_available(): bool {
+		return class_exists( '\Atmosphere\Atmosphere' );
+	}
+
+	/**
+	 * Get current Bluesky connection status from Atmosphere.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_status(): array {
+		$connection   = function_exists( '\Atmosphere\get_connection' ) ? \Atmosphere\get_connection() : array();
+		$connected    = function_exists( '\Atmosphere\is_connected' ) ? \Atmosphere\is_connected() : false;
+		$auto_publish = '1' === get_option( 'atmosphere_auto_publish', '1' );
+		$token_error  = null;
+
+		if ( $connected && method_exists( '\Atmosphere\OAuth\Client', 'access_token' ) ) {
+			$token = \Atmosphere\OAuth\Client::access_token();
+			if ( is_wp_error( $token ) ) {
+				$token_error = $token->get_error_message();
+			}
+		}
+
+		return array(
+			'connected'    => $connected,
+			'handle'       => $connection['handle'] ?? '',
+			'did'          => $connection['did'] ?? '',
+			'pds_endpoint' => $connection['pds_endpoint'] ?? '',
+			'auto_publish' => $auto_publish,
+			'token_error'  => $token_error,
+		);
+	}
+
+	/**
+	 * Render the Bluesky setup section on the FOSSE Setup page.
+	 *
+	 * @return void
+	 */
+	public function render_setup_section(): void {
+		$status = $this->get_status();
+
+		?>
+		<div class="fosse-provider-section">
+			<h2><?php esc_html_e( 'Bluesky', 'fosse' ); ?></h2>
+
+			<?php settings_errors( 'atmosphere' ); ?>
+
+			<?php if ( ! $status['connected'] ) : ?>
+				<p><?php esc_html_e( 'Connect your Bluesky account to let FOSSE publish through Atmosphere.', 'fosse' ); ?></p>
+
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="fosse_connect_bluesky" />
+					<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_connect_bluesky' ) ); ?>" />
+
+					<table class="form-table">
+						<tr>
+							<th scope="row">
+								<label for="fosse_bluesky_handle"><?php esc_html_e( 'Handle', 'fosse' ); ?></label>
+							</th>
+							<td>
+								<input
+									type="text"
+									class="regular-text"
+									name="bluesky_handle"
+									id="fosse_bluesky_handle"
+									placeholder="alice.bsky.social"
+								/>
+								<p class="description"><?php esc_html_e( 'Your AT Protocol handle, e.g. alice.bsky.social or your own domain.', 'fosse' ); ?></p>
+							</td>
+						</tr>
+					</table>
+
+					<?php submit_button( __( 'Connect Bluesky', 'fosse' ) ); ?>
+				</form>
+			<?php else : ?>
+				<table class="form-table">
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Handle', 'fosse' ); ?></th>
+						<td><strong><?php echo esc_html( $status['handle'] ); ?></strong></td>
+					</tr>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'DID', 'fosse' ); ?></th>
+						<td><code><?php echo esc_html( $status['did'] ); ?></code></td>
+					</tr>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'PDS', 'fosse' ); ?></th>
+						<td><code><?php echo esc_html( $status['pds_endpoint'] ); ?></code></td>
+					</tr>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Auto Publish', 'fosse' ); ?></th>
+						<td><?php echo esc_html( $status['auto_publish'] ? __( 'Enabled', 'fosse' ) : __( 'Disabled', 'fosse' ) ); ?></td>
+					</tr>
+					<?php if ( $status['token_error'] ) : ?>
+						<tr>
+							<th scope="row"><?php esc_html_e( 'Token Health', 'fosse' ); ?></th>
+							<td><?php echo esc_html( $status['token_error'] ); ?></td>
+						</tr>
+					<?php endif; ?>
+				</table>
+
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="fosse_disconnect_bluesky" />
+					<input type="hidden" name="atmosphere_nonce" value="<?php echo esc_attr( wp_create_nonce( 'atmosphere_disconnect' ) ); ?>" />
+					<?php submit_button( __( 'Disconnect Bluesky', 'fosse' ), 'secondary' ); ?>
+				</form>
+			<?php endif; ?>
+
+			<p>
+				<a href="<?php echo esc_url( admin_url( 'options-general.php?page=atmosphere' ) ); ?>">
+					<?php esc_html_e( 'Show advanced Atmosphere settings', 'fosse' ); ?>
+				</a>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the Bluesky status card on the FOSSE Status page.
+	 *
+	 * @return void
+	 */
+	public function render_status_card(): void {
+		$status = $this->get_status();
+		?>
+		<div class="fosse-status-card">
+			<h3>
+				<span class="fosse-status-indicator <?php echo $status['connected'] ? 'connected' : 'disconnected'; ?>"></span>
+				<?php esc_html_e( 'Bluesky', 'fosse' ); ?>
+			</h3>
+
+			<table class="widefat striped">
+				<tbody>
+					<tr>
+						<td><?php esc_html_e( 'Connection', 'fosse' ); ?></td>
+						<td><?php echo esc_html( $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' ) ); ?></td>
+					</tr>
+					<?php if ( $status['handle'] ) : ?>
+						<tr>
+							<td><?php esc_html_e( 'Handle', 'fosse' ); ?></td>
+							<td><strong><?php echo esc_html( $status['handle'] ); ?></strong></td>
+						</tr>
+					<?php endif; ?>
+					<?php if ( $status['did'] ) : ?>
+						<tr>
+							<td><?php esc_html_e( 'DID', 'fosse' ); ?></td>
+							<td><code><?php echo esc_html( $status['did'] ); ?></code></td>
+						</tr>
+					<?php endif; ?>
+					<?php if ( $status['pds_endpoint'] ) : ?>
+						<tr>
+							<td><?php esc_html_e( 'PDS', 'fosse' ); ?></td>
+							<td><code><?php echo esc_html( $status['pds_endpoint'] ); ?></code></td>
+						</tr>
+					<?php endif; ?>
+					<tr>
+						<td><?php esc_html_e( 'Auto Publish', 'fosse' ); ?></td>
+						<td><?php echo esc_html( $status['auto_publish'] ? __( 'Enabled', 'fosse' ) : __( 'Disabled', 'fosse' ) ); ?></td>
+					</tr>
+					<tr>
+						<td><?php esc_html_e( 'Token Health', 'fosse' ); ?></td>
+						<td><?php echo esc_html( $status['token_error'] ? $status['token_error'] : __( 'OK', 'fosse' ) ); ?></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Register hooks for this provider.
+	 *
+	 * @return void
+	 */
+	public function register_hooks(): void {
+		add_action( 'admin_post_fosse_connect_bluesky', array( $this, 'handle_connect' ) );
+		add_action( 'admin_post_fosse_disconnect_bluesky', array( $this, 'handle_disconnect' ) );
+		add_action( 'admin_init', array( $this, 'handle_oauth_callback' ) );
+	}
+
+	/**
+	 * Handle the FOSSE Bluesky connect action.
+	 *
+	 * @return void
+	 */
+	public function handle_connect(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'fosse' ) );
+		}
+
+		check_admin_referer( 'fosse_connect_bluesky' );
+
+		$handle = sanitize_text_field( wp_unslash( $_POST['bluesky_handle'] ?? '' ) );
+
+		if ( empty( $handle ) ) {
+			$this->redirect_with_notice( __( 'Enter a Bluesky handle to continue.', 'fosse' ), 'error' );
+		}
+
+		add_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
+		$auth_url = \Atmosphere\OAuth\Client::authorize( $handle );
+		remove_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
+
+		if ( is_wp_error( $auth_url ) ) {
+			$this->redirect_with_notice( $auth_url->get_error_message(), 'error' );
+		}
+
+		wp_redirect( $auth_url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+		exit;
+	}
+
+	/**
+	 * Handle the FOSSE Bluesky disconnect action.
+	 *
+	 * @return void
+	 */
+	public function handle_disconnect(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'fosse' ) );
+		}
+
+		check_admin_referer( 'atmosphere_disconnect', 'atmosphere_nonce' );
+
+		\Atmosphere\OAuth\Client::disconnect();
+
+		$this->redirect_with_notice( __( 'Disconnected from Bluesky.', 'fosse' ), 'info' );
+	}
+
+	/**
+	 * Handle the OAuth callback when Atmosphere returns to the FOSSE page.
+	 *
+	 * @return void
+	 */
+	public function handle_oauth_callback(): void {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- OAuth callback query args are validated via state in Atmosphere\OAuth\Client::handle_callback().
+		$page = sanitize_text_field( wp_unslash( $_GET['page'] ?? '' ) );
+		if ( 'fosse' !== $page ) {
+			return;
+		}
+
+		$code  = sanitize_text_field( wp_unslash( $_GET['code'] ?? '' ) );
+		$state = sanitize_text_field( wp_unslash( $_GET['state'] ?? '' ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( empty( $code ) || empty( $state ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$result = \Atmosphere\OAuth\Client::handle_callback( $code, $state );
+
+		if ( is_wp_error( $result ) ) {
+			$this->redirect_with_notice( $result->get_error_message(), 'error' );
+		}
+
+		if ( method_exists( '\Atmosphere\Publisher', 'sync_publication' ) ) {
+			\Atmosphere\Publisher::sync_publication();
+		}
+
+		$this->redirect_with_notice( __( 'Successfully connected to Bluesky.', 'fosse' ), 'success' );
+	}
+
+	/**
+	 * Override Atmosphere's OAuth callback URI for FOSSE-initiated auth.
+	 *
+	 * @param string $uri Default Atmosphere URI.
+	 * @return string
+	 */
+	public function filter_oauth_redirect_uri( string $uri ): string {
+		unset( $uri );
+
+		return admin_url( 'admin.php?page=fosse' );
+	}
+
+	/**
+	 * Persist an admin notice and redirect back to the FOSSE setup page.
+	 *
+	 * @param string $message Notice message.
+	 * @param string $type    Notice type.
+	 * @return void
+	 */
+	private function redirect_with_notice( string $message, string $type ): void {
+		add_settings_error( 'atmosphere', 'fosse_bluesky_notice', $message, $type );
+		set_transient( 'settings_errors', get_settings_errors(), 30 );
+
+		wp_safe_redirect( admin_url( 'admin.php?page=fosse' ) );
+		exit;
+	}
+}

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -160,7 +160,7 @@ class Bluesky_Provider implements Connection_Provider {
 
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 					<input type="hidden" name="action" value="fosse_disconnect_bluesky" />
-					<input type="hidden" name="atmosphere_nonce" value="<?php echo esc_attr( wp_create_nonce( 'atmosphere_disconnect' ) ); ?>" />
+					<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_disconnect_bluesky' ) ); ?>" />
 					<?php submit_button( __( 'Disconnect Bluesky', 'fosse' ), 'secondary' ); ?>
 				</form>
 			<?php endif; ?>
@@ -253,6 +253,7 @@ class Bluesky_Provider implements Connection_Provider {
 
 		if ( empty( $handle ) ) {
 			$this->redirect_with_notice( __( 'Enter a Bluesky handle to continue.', 'fosse' ), 'error' );
+			return; // redirect_with_notice exits, but guard against future changes.
 		}
 
 		add_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
@@ -277,7 +278,7 @@ class Bluesky_Provider implements Connection_Provider {
 			wp_die( esc_html__( 'You do not have permission to do this.', 'fosse' ) );
 		}
 
-		check_admin_referer( 'atmosphere_disconnect', 'atmosphere_nonce' );
+		check_admin_referer( 'fosse_disconnect_bluesky' );
 
 		\Atmosphere\OAuth\Client::disconnect();
 
@@ -308,10 +309,13 @@ class Bluesky_Provider implements Connection_Provider {
 			return;
 		}
 
+		add_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
 		$result = \Atmosphere\OAuth\Client::handle_callback( $code, $state );
+		remove_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
 
 		if ( is_wp_error( $result ) ) {
 			$this->redirect_with_notice( $result->get_error_message(), 'error' );
+			return; // redirect_with_notice exits, but guard against future changes.
 		}
 
 		if ( method_exists( '\Atmosphere\Publisher', 'sync_publication' ) ) {
@@ -327,9 +331,7 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @param string $uri Default Atmosphere URI.
 	 * @return string
 	 */
-	public function filter_oauth_redirect_uri( string $uri ): string {
-		unset( $uri );
-
+	public function filter_oauth_redirect_uri( string $uri ): string { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter callback signature.
 		return admin_url( 'admin.php?page=fosse' );
 	}
 

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -150,12 +150,10 @@ class Bluesky_Provider implements Connection_Provider {
 						<th scope="row"><?php esc_html_e( 'Auto Publish', 'fosse' ); ?></th>
 						<td><?php echo esc_html( $status['auto_publish'] ? __( 'Enabled', 'fosse' ) : __( 'Disabled', 'fosse' ) ); ?></td>
 					</tr>
-					<?php if ( $status['token_error'] ) : ?>
-						<tr>
-							<th scope="row"><?php esc_html_e( 'Token Health', 'fosse' ); ?></th>
-							<td><?php echo esc_html( $status['token_error'] ); ?></td>
-						</tr>
-					<?php endif; ?>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Token Health', 'fosse' ); ?></th>
+						<td><?php echo esc_html( $status['token_error'] ? $status['token_error'] : __( 'OK', 'fosse' ) ); ?></td>
+					</tr>
 				</table>
 
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
@@ -235,6 +233,13 @@ class Bluesky_Provider implements Connection_Provider {
 		add_action( 'admin_post_fosse_connect_bluesky', array( $this, 'handle_connect' ) );
 		add_action( 'admin_post_fosse_disconnect_bluesky', array( $this, 'handle_disconnect' ) );
 		add_action( 'admin_init', array( $this, 'handle_oauth_callback' ) );
+
+		// Override Atmosphere's OAuth redirect URI so the auth server callback
+		// and the client-metadata REST endpoint both advertise FOSSE's page.
+		// Registered unconditionally (not just during handle_connect) because
+		// the auth server fetches client metadata in a separate public request
+		// and validates redirect_uri against it.
+		add_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
 	}
 
 	/**
@@ -250,15 +255,14 @@ class Bluesky_Provider implements Connection_Provider {
 		check_admin_referer( 'fosse_connect_bluesky' );
 
 		$handle = sanitize_text_field( wp_unslash( $_POST['bluesky_handle'] ?? '' ) );
+		$handle = ltrim( $handle, '@' );
 
 		if ( empty( $handle ) ) {
 			$this->redirect_with_notice( __( 'Enter a Bluesky handle to continue.', 'fosse' ), 'error' );
 			return; // redirect_with_notice exits, but guard against future changes.
 		}
 
-		add_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
 		$auth_url = \Atmosphere\OAuth\Client::authorize( $handle );
-		remove_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
 
 		if ( is_wp_error( $auth_url ) ) {
 			$this->redirect_with_notice( $auth_url->get_error_message(), 'error' );
@@ -309,9 +313,7 @@ class Bluesky_Provider implements Connection_Provider {
 			return;
 		}
 
-		add_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
 		$result = \Atmosphere\OAuth\Client::handle_callback( $code, $state );
-		remove_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
 
 		if ( is_wp_error( $result ) ) {
 			$this->redirect_with_notice( $result->get_error_message(), 'error' );
@@ -346,7 +348,7 @@ class Bluesky_Provider implements Connection_Provider {
 		add_settings_error( 'atmosphere', 'fosse_bluesky_notice', $message, $type );
 		set_transient( 'settings_errors', get_settings_errors(), 30 );
 
-		wp_safe_redirect( admin_url( 'admin.php?page=fosse' ) );
+		wp_safe_redirect( admin_url( 'admin.php?page=fosse&settings-updated=true' ) );
 		exit;
 	}
 }

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -12,6 +12,12 @@ namespace Automattic\Fosse\Admin;
  *
  * Uses Atmosphere's public APIs for OAuth, connection storage, and
  * publication setup. FOSSE owns only the wrapper admin flow.
+ *
+ * When this provider is active, it takes ownership of the Bluesky
+ * OAuth flow by unconditionally filtering atmosphere_oauth_redirect_uri.
+ * This means OAuth flows initiated from Atmosphere's own settings page
+ * will also redirect to FOSSE. This is intentional: FOSSE hides the
+ * bundled plugin menus and presents itself as the single admin surface.
  */
 class Bluesky_Provider implements Connection_Provider {
 
@@ -163,11 +169,6 @@ class Bluesky_Provider implements Connection_Provider {
 				</form>
 			<?php endif; ?>
 
-			<p>
-				<a href="<?php echo esc_url( admin_url( 'options-general.php?page=atmosphere' ) ); ?>">
-					<?php esc_html_e( 'Show advanced Atmosphere settings', 'fosse' ); ?>
-				</a>
-			</p>
 		</div>
 		<?php
 	}
@@ -266,6 +267,7 @@ class Bluesky_Provider implements Connection_Provider {
 
 		if ( is_wp_error( $auth_url ) ) {
 			$this->redirect_with_notice( $auth_url->get_error_message(), 'error' );
+			return; // redirect_with_notice exits, but guard against future changes.
 		}
 
 		wp_redirect( $auth_url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
@@ -310,7 +312,7 @@ class Bluesky_Provider implements Connection_Provider {
 		}
 
 		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
+			wp_die( esc_html__( 'You do not have permission to complete the Bluesky connection.', 'fosse' ) );
 		}
 
 		$result = \Atmosphere\OAuth\Client::handle_callback( $code, $state );
@@ -320,8 +322,20 @@ class Bluesky_Provider implements Connection_Provider {
 			return; // redirect_with_notice exits, but guard against future changes.
 		}
 
-		if ( method_exists( '\Atmosphere\Publisher', 'sync_publication' ) ) {
-			\Atmosphere\Publisher::sync_publication();
+		$sync_result = method_exists( '\Atmosphere\Publisher', 'sync_publication' )
+			? \Atmosphere\Publisher::sync_publication()
+			: null;
+
+		if ( is_wp_error( $sync_result ) ) {
+			$this->redirect_with_notice(
+				sprintf(
+					/* translators: %s: error message from Atmosphere publication setup. */
+					__( 'Connected to Bluesky, but publication setup failed: %s', 'fosse' ),
+					$sync_result->get_error_message()
+				),
+				'warning'
+			);
+			return;
 		}
 
 		$this->redirect_with_notice( __( 'Successfully connected to Bluesky.', 'fosse' ), 'success' );

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const setBlueskyState = async (
+	page: Page,
+	body: Record< string, unknown >
+) => {
+	const result = await page.evaluate( async ( payload ) => {
+		const res = await fetch( '/wp-json/fosse-e2e/v1/bluesky-state', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+			},
+			body: JSON.stringify( payload ),
+		} );
+
+		return { status: res.status, text: await res.text() };
+	}, body );
+
+	expect(
+		result.status,
+		`fosse-e2e/v1/bluesky-state returned: ${ result.text.slice( 0, 300 ) }`
+	).toBe( 200 );
+};
+
+test.describe( 'Bluesky provider UI', () => {
+	test.beforeEach( async ( { page } ) => {
+		await page.goto( '/wp-admin/post-new.php' );
+		await page.waitForFunction(
+			() => !! ( window as any ).wpApiSettings?.nonce
+		);
+	} );
+
+	test( 'setup and status pages show Bluesky disconnected by default', async ( {
+		page,
+	} ) => {
+		await setBlueskyState( page, {
+			connected: false,
+			auto_publish: true,
+		} );
+
+		await page.goto( '/wp-admin/admin.php?page=fosse' );
+
+		const blueskySection = page
+			.locator( '.fosse-provider-section' )
+			.filter( { hasText: 'Bluesky' } );
+
+		await expect(
+			page.getByRole( 'heading', { name: 'Bluesky' } )
+		).toBeVisible();
+		await expect(
+			blueskySection.locator( '#fosse_bluesky_handle' )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: 'Connect Bluesky' } )
+		).toBeVisible();
+
+		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
+
+		const blueskyCard = page
+			.locator( '.fosse-status-card' )
+			.filter( { hasText: 'Bluesky' } );
+		await expect( blueskyCard ).toContainText( 'Disconnected' );
+		await expect( blueskyCard ).toContainText( 'Enabled' );
+	} );
+
+	test( 'setup and status pages show mocked connected Bluesky details', async ( {
+		page,
+	} ) => {
+		await setBlueskyState( page, {
+			connected: true,
+			handle: 'alice.bsky.social',
+			did: 'did:plc:alice123',
+			pds_endpoint: 'https://bsky.social',
+			auto_publish: false,
+		} );
+
+		await page.goto( '/wp-admin/admin.php?page=fosse' );
+
+		const blueskySection = page
+			.locator( '.fosse-provider-section' )
+			.filter( { hasText: 'Bluesky' } );
+
+		await expect(
+			page.getByRole( 'button', { name: 'Disconnect Bluesky' } )
+		).toBeVisible();
+		await expect( blueskySection ).toContainText( 'alice.bsky.social' );
+		await expect( blueskySection ).toContainText( 'did:plc:alice123' );
+		await expect( blueskySection ).toContainText( 'Disabled' );
+
+		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
+
+		const blueskyCard = page
+			.locator( '.fosse-status-card' )
+			.filter( { hasText: 'Bluesky' } );
+		await expect( blueskyCard ).toContainText( 'Connected' );
+		await expect( blueskyCard ).toContainText( 'alice.bsky.social' );
+		await expect( blueskyCard ).toContainText( 'did:plc:alice123' );
+		await expect( blueskyCard ).toContainText( 'Disabled' );
+		await expect( blueskyCard ).toContainText( 'OK' );
+	} );
+} );

--- a/tests/e2e/mu-plugins/fosse-bsky-capture.php
+++ b/tests/e2e/mu-plugins/fosse-bsky-capture.php
@@ -115,5 +115,80 @@ add_action(
 				},
 			)
 		);
+
+		\register_rest_route(
+			'fosse-e2e/v1',
+			'/bluesky-state',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => static function (): bool {
+					return \current_user_can( 'manage_options' );
+				},
+				'args'                => array(
+					'connected'    => array(
+						'type'     => 'boolean',
+						'required' => false,
+					),
+					'handle'       => array(
+						'type'     => 'string',
+						'required' => false,
+					),
+					'did'          => array(
+						'type'     => 'string',
+						'required' => false,
+					),
+					'pds_endpoint' => array(
+						'type'     => 'string',
+						'required' => false,
+					),
+					'auto_publish' => array(
+						'type'     => 'boolean',
+						'required' => false,
+					),
+				),
+				'callback'            => static function ( $request ) {
+					try {
+						$connected = (bool) $request->get_param( 'connected' );
+						$auto_publish = $request->get_param( 'auto_publish' );
+
+						if ( $connected ) {
+							\update_option(
+								'atmosphere_connection',
+								array(
+									'did'          => (string) ( $request->get_param( 'did' ) ?: 'did:plc:fossee2e123' ),
+									'handle'       => (string) ( $request->get_param( 'handle' ) ?: 'alice.bsky.social' ),
+									'pds_endpoint' => (string) ( $request->get_param( 'pds_endpoint' ) ?: 'https://bsky.social' ),
+									'access_token' => \Atmosphere\OAuth\Encryption::encrypt( 'fosse-e2e-token' ),
+								)
+							);
+						} else {
+							\delete_option( 'atmosphere_connection' );
+						}
+
+						if ( null !== $auto_publish ) {
+							\update_option( 'atmosphere_auto_publish', $auto_publish ? '1' : '0' );
+						}
+
+						return \rest_ensure_response(
+							array(
+								'ok'             => true,
+								'connected'      => $connected,
+								'connection'     => \get_option( 'atmosphere_connection', array() ),
+								'auto_publish'   => \get_option( 'atmosphere_auto_publish', '1' ),
+							)
+						);
+					} catch ( \Throwable $e ) {
+						\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+							'[fosse-e2e/bluesky-state] ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine()
+						);
+						return new \WP_Error(
+							'fosse_e2e_error',
+							$e->getMessage(),
+							array( 'status' => 500 )
+						);
+					}
+				},
+			)
+		);
 	}
 );

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -1,0 +1,315 @@
+<?php
+/**
+ * Tests for Bluesky_Provider.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests\Admin;
+
+use Atmosphere\OAuth\Encryption;
+use Automattic\Fosse\Admin\Bluesky_Provider;
+use Automattic\Fosse\Admin\Connection_Provider_Registry;
+use Automattic\Fosse\Provider_Loader;
+use PHPUnit\Framework\Attributes\Before;
+use WorDBless\BaseTestCase;
+
+/**
+ * Verifies Bluesky_Provider metadata, registration, status, and handlers.
+ */
+class Bluesky_ProviderTest extends BaseTestCase {
+
+	/**
+	 * Provider instance under test.
+	 *
+	 * @var Bluesky_Provider
+	 */
+	private Bluesky_Provider $provider;
+
+	/**
+	 * Clean state before each test.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function set_up_provider(): void {
+		if ( ! defined( 'AUTH_KEY' ) ) {
+			define( 'AUTH_KEY', 'fosse-test-auth-key' );
+		}
+
+		if ( ! defined( 'AUTH_SALT' ) ) {
+			define( 'AUTH_SALT', 'fosse-test-auth-salt' );
+		}
+
+		$this->provider = new Bluesky_Provider();
+
+		Connection_Provider_Registry::reset();
+		delete_option( 'atmosphere_connection' );
+		delete_option( 'atmosphere_auto_publish' );
+
+		remove_all_filters( 'fosse_register_providers' );
+		remove_all_filters( 'atmosphere_oauth_redirect_uri' );
+		remove_all_filters( 'wp_redirect' );
+		remove_all_filters( 'admin_post_fosse_connect_bluesky' );
+		remove_all_filters( 'admin_post_fosse_disconnect_bluesky' );
+		remove_all_filters( 'admin_init' );
+
+		global $wp_settings_errors;
+		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- reset core settings-error storage for test isolation.
+	}
+
+	/**
+	 * Slug is 'bluesky'.
+	 */
+	public function test_slug() {
+		$this->assertSame( 'bluesky', $this->provider->get_slug() );
+	}
+
+	/**
+	 * Display name is 'Bluesky'.
+	 */
+	public function test_name() {
+		$this->assertSame( 'Bluesky', $this->provider->get_name() );
+	}
+
+	/**
+	 * Atmosphere is available in the bundled test environment.
+	 */
+	public function test_is_available() {
+		$this->assertTrue( $this->provider->is_available() );
+	}
+
+	/**
+	 * Provider self-registers through the loader.
+	 */
+	public function test_registers_through_provider_loader() {
+		Bluesky_Provider::init();
+		Provider_Loader::boot();
+
+		$this->assertNotNull( Connection_Provider_Registry::get_provider( 'bluesky' ) );
+	}
+
+	/**
+	 * Default status is disconnected with auto-publish enabled.
+	 */
+	public function test_status_disconnected_by_default() {
+		$status = $this->provider->get_status();
+
+		$this->assertFalse( $status['connected'] );
+		$this->assertSame( '', $status['handle'] );
+		$this->assertSame( '', $status['did'] );
+		$this->assertSame( '', $status['pds_endpoint'] );
+		$this->assertTrue( $status['auto_publish'] );
+		$this->assertNull( $status['token_error'] );
+	}
+
+	/**
+	 * Connected status reflects the Atmosphere connection option.
+	 */
+	public function test_status_connected_reflects_connection() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+		update_option( 'atmosphere_auto_publish', '0' );
+
+		$status = $this->provider->get_status();
+
+		$this->assertTrue( $status['connected'] );
+		$this->assertSame( 'alice.bsky.social', $status['handle'] );
+		$this->assertSame( 'did:plc:test123', $status['did'] );
+		$this->assertSame( 'https://bsky.social', $status['pds_endpoint'] );
+		$this->assertFalse( $status['auto_publish'] );
+		$this->assertNull( $status['token_error'] );
+	}
+
+	/**
+	 * Corrupt tokens surface as token health errors without dropping connection state.
+	 */
+	public function test_status_reports_token_error() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => 'garbage',
+			)
+		);
+
+		$status = $this->provider->get_status();
+
+		$this->assertTrue( $status['connected'] );
+		$this->assertNotNull( $status['token_error'] );
+	}
+
+	/**
+	 * Disconnected setup UI renders the connect action.
+	 */
+	public function test_render_setup_section_disconnected_contains_connect_form() {
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'fosse_connect_bluesky', $output );
+		$this->assertStringContainsString( 'bluesky_handle', $output );
+	}
+
+	/**
+	 * Connected setup UI renders the disconnect action.
+	 */
+	public function test_render_setup_section_connected_contains_disconnect_form() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'fosse_disconnect_bluesky', $output );
+		$this->assertStringContainsString( 'alice.bsky.social', $output );
+	}
+
+	/**
+	 * FOSSE-initiated OAuth should return to the FOSSE setup page.
+	 */
+	public function test_filter_oauth_redirect_uri_returns_fosse_page() {
+		$this->assertSame(
+			admin_url( 'admin.php?page=fosse' ),
+			$this->provider->filter_oauth_redirect_uri( admin_url( 'options-general.php?page=atmosphere' ) )
+		);
+	}
+
+	/**
+	 * Disconnect clears the Atmosphere connection and redirects back to FOSSE.
+	 */
+	public function test_handle_disconnect_clears_connection_and_redirects() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'atmosphere_nonce' => wp_create_nonce( 'atmosphere_disconnect' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_disconnect();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( array(), get_option( 'atmosphere_connection', array() ) );
+		$this->assertNotEmpty( get_settings_errors( 'atmosphere' ) );
+	}
+
+	/**
+	 * Empty-handle connect requests fail early and redirect with an error.
+	 */
+	public function test_handle_connect_rejects_empty_handle() {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'       => wp_create_nonce( 'fosse_connect_bluesky' ),
+			'bluesky_handle' => '',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_connect();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors   = get_settings_errors( 'atmosphere' );
+		$messages = array_column( $errors, 'message' );
+
+		$this->assertNotEmpty( $messages );
+		$this->assertStringContainsString( 'handle', strtolower( implode( ' ', $messages ) ) );
+	}
+
+	/**
+	 * Callback handling is a no-op when the request is not for the FOSSE page.
+	 */
+	public function test_handle_oauth_callback_ignores_non_fosse_page() {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array(
+			'page'  => 'atmosphere',
+			'code'  => 'abc',
+			'state' => 'def',
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		$this->provider->handle_oauth_callback();
+
+		$this->assertEmpty( get_settings_errors( 'atmosphere' ) );
+	}
+
+	/**
+	 * Provider registers the expected hooks.
+	 */
+	public function test_register_hooks_adds_actions() {
+		$this->provider->register_hooks();
+
+		$this->assertNotFalse( has_action( 'admin_post_fosse_connect_bluesky', array( $this->provider, 'handle_connect' ) ) );
+		$this->assertNotFalse( has_action( 'admin_post_fosse_disconnect_bluesky', array( $this->provider, 'handle_disconnect' ) ) );
+		$this->assertNotFalse( has_action( 'admin_init', array( $this->provider, 'handle_oauth_callback' ) ) );
+	}
+
+	/**
+	 * Create and authenticate an administrator for handler tests.
+	 *
+	 * @return void
+	 */
+	private function become_admin(): void {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'fosse_admin_' . uniqid( '', true ),
+				'user_pass'  => 'test',
+				'role'       => 'administrator',
+			)
+		);
+
+		wp_set_current_user( $user_id );
+	}
+}

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -11,6 +11,7 @@ use Atmosphere\OAuth\Encryption;
 use Automattic\Fosse\Admin\Bluesky_Provider;
 use Automattic\Fosse\Admin\Connection_Provider_Registry;
 use Automattic\Fosse\Provider_Loader;
+use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 use WorDBless\BaseTestCase;
 
@@ -56,6 +57,21 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		global $wp_settings_errors;
 		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- reset core settings-error storage for test isolation.
+	}
+
+	/**
+	 * Clean up globals after each test.
+	 *
+	 * @after
+	 */
+	#[After]
+	public function tear_down_globals(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- test cleanup.
+		$_POST    = array();
+		$_REQUEST = array();
+		$_GET     = array();
+
+		remove_all_filters( 'wp_redirect' );
 	}
 
 	/**
@@ -210,7 +226,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
 		$_POST    = array(
-			'atmosphere_nonce' => wp_create_nonce( 'atmosphere_disconnect' ),
+			'_wpnonce' => wp_create_nonce( 'fosse_disconnect_bluesky' ),
 		);
 		$_REQUEST = $_POST;
 		// phpcs:enable WordPress.Security.NonceVerification.Missing

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -72,6 +72,23 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$_GET     = array();
 
 		remove_all_filters( 'wp_redirect' );
+		remove_all_filters( 'wp_die_handler' );
+	}
+
+	/**
+	 * Install a wp_die handler that throws an exception instead of exiting.
+	 *
+	 * @return void
+	 */
+	private function install_wp_die_handler(): void {
+		add_filter(
+			'wp_die_handler',
+			static function () {
+				return static function ( $message ) {
+					throw new \RuntimeException( wp_kses( $message, array() ) );
+				};
+			}
+		);
 	}
 
 	/**
@@ -301,6 +318,159 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertEmpty( get_settings_errors( 'atmosphere' ) );
 	}
 
+	// --- unauthorized user tests ---
+
+	/**
+	 * Connect rejects non-admin users.
+	 */
+	public function test_handle_connect_rejects_subscriber() {
+		$this->become_subscriber();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'       => wp_create_nonce( 'fosse_connect_bluesky' ),
+			'bluesky_handle' => 'alice.bsky.social',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$this->install_wp_die_handler();
+		$this->expectException( \RuntimeException::class );
+		$this->provider->handle_connect();
+	}
+
+	/**
+	 * Disconnect rejects non-admin users.
+	 */
+	public function test_handle_disconnect_rejects_subscriber() {
+		$this->become_subscriber();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => wp_create_nonce( 'fosse_disconnect_bluesky' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$this->install_wp_die_handler();
+		$this->expectException( \RuntimeException::class );
+		$this->provider->handle_disconnect();
+	}
+
+	/**
+	 * OAuth callback rejects non-admin users with wp_die.
+	 */
+	public function test_handle_oauth_callback_rejects_subscriber() {
+		$this->become_subscriber();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array(
+			'page'  => 'fosse',
+			'code'  => 'abc',
+			'state' => 'def',
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		$this->install_wp_die_handler();
+		$this->expectException( \RuntimeException::class );
+		$this->provider->handle_oauth_callback();
+	}
+
+	// --- nonce tests ---
+
+	/**
+	 * Connect rejects requests with missing or invalid nonce.
+	 */
+	public function test_handle_connect_rejects_bad_nonce() {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'       => 'invalid_nonce_value',
+			'bluesky_handle' => 'alice.bsky.social',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$this->install_wp_die_handler();
+		$this->expectException( \RuntimeException::class );
+		$this->provider->handle_connect();
+	}
+
+	/**
+	 * Disconnect rejects requests with missing or invalid nonce.
+	 */
+	public function test_handle_disconnect_rejects_bad_nonce() {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => 'invalid_nonce_value',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$this->install_wp_die_handler();
+		$this->expectException( \RuntimeException::class );
+		$this->provider->handle_disconnect();
+	}
+
+	// --- handle normalization ---
+
+	/**
+	 * Leading @ is stripped from the submitted handle before authorize.
+	 */
+	public function test_handle_connect_strips_leading_at() {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'       => wp_create_nonce( 'fosse_connect_bluesky' ),
+			'bluesky_handle' => '@alice.bsky.social',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		// Intercept the HTTP request that Client::authorize() makes to
+		// the handle's auth server, and capture the handle it resolved.
+		$captured_handle = null;
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$captured_handle ) {
+				// The first HTTP call from authorize() is handle resolution.
+				// Capture the URL to verify no leading @ was passed.
+				$captured_handle = $url;
+				// Return an error to short-circuit the flow.
+				return new \WP_Error( 'fosse_test_intercept', 'intercepted' );
+			},
+			10,
+			3
+		);
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_connect();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		// The captured URL should not contain '@alice' — it should be 'alice'.
+		if ( null !== $captured_handle ) {
+			$this->assertStringNotContainsString( '@alice', $captured_handle );
+		}
+
+		// At minimum, verify the handle didn't pass through with the @.
+		// The error redirect confirms the flow reached Client::authorize().
+		$errors = get_settings_errors( 'atmosphere' );
+		$this->assertNotEmpty( $errors );
+	}
+
 	/**
 	 * Provider registers the expected hooks.
 	 */
@@ -324,6 +494,23 @@ class Bluesky_ProviderTest extends BaseTestCase {
 				'user_login' => 'fosse_admin_' . uniqid( '', true ),
 				'user_pass'  => 'test',
 				'role'       => 'administrator',
+			)
+		);
+
+		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Create and authenticate a subscriber (non-admin) for rejection tests.
+	 *
+	 * @return void
+	 */
+	private function become_subscriber(): void {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'fosse_sub_' . uniqid( '', true ),
+				'user_pass'  => 'test',
+				'role'       => 'subscriber',
 			)
 		);
 

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -310,6 +310,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertNotFalse( has_action( 'admin_post_fosse_connect_bluesky', array( $this->provider, 'handle_connect' ) ) );
 		$this->assertNotFalse( has_action( 'admin_post_fosse_disconnect_bluesky', array( $this->provider, 'handle_disconnect' ) ) );
 		$this->assertNotFalse( has_action( 'admin_init', array( $this->provider, 'handle_oauth_callback' ) ) );
+		$this->assertNotFalse( has_filter( 'atmosphere_oauth_redirect_uri', array( $this->provider, 'filter_oauth_redirect_uri' ) ) );
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -460,15 +460,12 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			unset( $e );
 		}
 
-		// The captured URL should not contain '@alice' — it should be 'alice'.
-		if ( null !== $captured_handle ) {
-			$this->assertStringNotContainsString( '@alice', $captured_handle );
-		}
-
-		// At minimum, verify the handle didn't pass through with the @.
-		// The error redirect confirms the flow reached Client::authorize().
-		$errors = get_settings_errors( 'atmosphere' );
-		$this->assertNotEmpty( $errors );
+		// Verify pre_http_request fired (authorize() made an HTTP call).
+		$this->assertNotNull(
+			$captured_handle,
+			'Expected pre_http_request to fire from Client::authorize() — handle normalization could not be verified.'
+		);
+		$this->assertStringNotContainsString( '@alice', $captured_handle );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds the FOSSE-side `Bluesky_Provider` that plugs Bluesky connection management into the existing provider-based Setup and Status pages introduced in #27.

- **FOSSE-owned Bluesky provider** — registers through the existing `Connection_Provider` architecture and renders its own Setup section + Status card
- **Setup page connect/disconnect flow** — disconnected state shows a handle form and Connect action; connected state shows handle, DID, PDS, auto-publish, token health, and Disconnect action
- **FOSSE-owned OAuth wrapper flow** — `admin_post` handlers for connect/disconnect plus callback handling on the FOSSE Setup page
- **OAuth redirect takeover** — uses Atmosphere's `atmosphere_oauth_redirect_uri` filter unconditionally so both the authorize flow and the client-metadata REST endpoint advertise FOSSE's callback URL. FOSSE takes ownership of all Bluesky OAuth when loaded; the advanced Atmosphere settings link is removed to avoid advertising a broken path.
- **FOSSE-owned disconnect nonce** — disconnect is now fully namespaced to the FOSSE action rather than depending on Atmosphere's admin nonce name
- **SDD plan status update** — adds `## Progress` and per-task status markers to `sdd/onboarding-setup-ux/plan.md`

### Test coverage

- **PHPUnit (54 tests)** — covers provider registration, status derivation, connected/disconnected rendering, connect/disconnect handler behavior, callback no-op and unauthorized rejection, redirect URI handling, handle `@` normalization, unauthorized user rejection on all three handlers, and bad nonce rejection on connect/disconnect
- **Playwright** — covers disconnected and mocked-connected Bluesky UI states in Playground
- **Test helper** — adds a test-only REST helper to seed `atmosphere_connection` in Playground so E2E can exercise the connected state deterministically

### Known test gaps

- **OAuth callback success/warning/error branches** — `handle_oauth_callback()` has three redirect outcomes after `Client::handle_callback()` succeeds, returns `WP_Error`, or `sync_publication()` fails. These are not covered by PHPUnit because `Client::handle_callback()` requires real PKCE state that can't be seeded without mocking the full OAuth handshake. These branches rely on manual verification via the test plan below.

### What's not in this PR

- **Real OAuth E2E coverage** — the Playwright test does not perform a live Bluesky OAuth round-trip; it seeds connection state via a test-only helper
- **Wizard integration** — the onboarding wizard remains in #33
- **Full SDD doc sync** — this updates `plan.md` status tracking only, not the rest of the onboarding SDD docs

## Test plan

- [ ] `composer run-script test-php` passes (54 tests, 90 assertions)
- [ ] `composer run-script lint-php` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run lint` passes
- [ ] `pnpm exec playwright test tests/e2e/bluesky-provider.spec.ts` passes
- [ ] Manual: open `wp-admin/admin.php?page=fosse` with no Atmosphere connection and confirm Bluesky shows the disconnected state
- [ ] Manual: complete a real Bluesky connect flow and confirm the callback returns to `admin.php?page=fosse` with a success notice
- [ ] Manual: after connect, confirm handle / DID / PDS / auto-publish / token health render correctly on Setup and Status pages
- [ ] Manual: disconnect Bluesky and confirm the connection is cleared and the success notice renders on the FOSSE Setup page
- [ ] Manual: verify that a failed `sync_publication()` after connect shows a warning notice (not a success notice)

Refs: DOTCOM-16801