### PR TITLE
Add Bluesky handle setup SDD and well-known route

### DIFF
--- a/sdd/bluesky-handle-setup/implementation-notes.md
+++ b/sdd/bluesky-handle-setup/implementation-notes.md
@@ -1,5 +1,9 @@
 # Implementation Notes — Bluesky Handle Setup
 
+## Status Snapshot
+
+Task 1 is implemented on this branch: `/.well-known/atproto-did` is served from `Bluesky_Provider`, the FOSSE opt-out filter is honored, and the bundled Atmosphere fallback is suppressed when FOSSE opts out. The resolver, UI, DNS fallback, admin-post handlers, and tests remain planned work.
+
 ## Design Decisions
 
 ### Verification via Bluesky's resolveHandle API, not local DNS
@@ -10,6 +14,10 @@
 - **Decision**: When Bluesky is connected, FOSSE serves `/.well-known/atproto-did` automatically. A `fosse_serve_atproto_did_well_known` filter (default `true`) lets users disable it.
 - **Reason**: The whole point of this feature is to make the verification step disappear for the common case. Most WordPress sites don't have anything else competing for `.well-known/atproto-did`. The filter exists for the edge cases (managed hosts that intercept `.well-known`, sites running multiple ATProto identities, etc.) so users have an out without us needing a settings toggle.
 
+### FOSSE re-serves a route Atmosphere also serves
+- **Decision**: FOSSE serves the well-known response itself and suppresses Atmosphere's handler when `fosse_serve_atproto_did_well_known` returns false.
+- **Reason**: FOSSE owns the unified setup experience and its opt-out filter must mean "FOSSE will not serve this route, and the bundled fallback will not silently serve it either." This behavior is FOSSE-shaped, so it stays out of `bundled/`. A generic upstream Atmosphere opt-out hook can replace the suppression shim later if it becomes useful outside FOSSE.
+
 ### Domain handle UI lives inside Bluesky_Provider, not a new admin page
 - **Decision**: The setup, verification, and status UI all live as a subsection inside `Bluesky_Provider::render_setup_section()`.
 - **Reason**: This is an extension of "your Bluesky connection," not a separate concept. Adding a top-level FOSSE > Domain Handle page would split related state across two admin surfaces and make the connection ↔ handle relationship less obvious. The subsection only renders when Bluesky is connected, so it follows the user's mental model (Bluesky first, then domain handle).
@@ -19,8 +27,12 @@
 - **Reason**: The verification result itself is the source of truth for "is this working?" — we don't want a separate "is verified" boolean that can drift. The boolean is just for UI state ("show the CTA vs. show the verification panel"). Once the user starts, the panel stays even if verification fails, so they have somewhere to retry.
 
 ### Verification cached for 5 minutes
-- **Decision**: Results from `check_handle_verification()` are cached in a transient keyed by hash of `domain + expected DID` for 5 minutes. The "Check verification" button busts the transient. The DID is part of the key so reconnecting a different Bluesky account within the cache window doesn't reuse a stale `verified` result.
+- **Decision**: Results from `check_handle_verification()` are cached in a transient keyed by `md5( $domain . '|' . $expected_did )` for 5 minutes. The "Check verification" button busts the transient. The DID is part of the key so reconnecting a different Bluesky account within the cache window doesn't reuse a stale `verified` result.
 - **Reason**: Page loads in the WordPress admin can hit this multiple times (status card, setup section). 5 minutes is short enough that user intent ("I just changed my DNS, check again") still works via the explicit button, but long enough that incidental page loads don't hammer Bluesky.
+
+### Path-bound installs are ineligible
+- **Decision**: The UI checks `'' === trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' )` before offering domain-handle setup.
+- **Reason**: ATProto handles are DNS names. A WordPress site at `example.com/blog` cannot use `example.com/blog` as a handle, and offering `example.com` would be misleading because FOSSE does not control that host root. Subdomain multisite remains eligible because each subsite still lives at a host root.
 
 ## Known Limitations (Expected)
 

--- a/sdd/bluesky-handle-setup/implementation-notes.md
+++ b/sdd/bluesky-handle-setup/implementation-notes.md
@@ -2,7 +2,7 @@
 
 ## Status Snapshot
 
-Task 1 is implemented on this branch: `/.well-known/atproto-did` is served from `Bluesky_Provider`, the FOSSE opt-out filter is honored, and the bundled Atmosphere fallback is suppressed when FOSSE opts out. The resolver, UI, DNS fallback, admin-post handlers, and tests remain planned work.
+Task 1 is implemented on this branch: `/.well-known/atproto-did` is served from `Bluesky_Provider` only when Atmosphere reports a connected account, the FOSSE opt-out filter is honored, and the bundled Atmosphere fallback is suppressed when FOSSE opts out. The resolver, UI, DNS fallback, admin-post handlers, and broader feature tests remain planned work.
 
 ## Design Decisions
 

--- a/sdd/bluesky-handle-setup/plan.md
+++ b/sdd/bluesky-handle-setup/plan.md
@@ -25,6 +25,7 @@ Based on: sdd/bluesky-handle-setup/spec.md
   3. Apply `fosse_serve_atproto_did_well_known` filter (default `true`). If false, return.
   4. Read `atmosphere_connection['did']`. If empty, send 404 and exit.
   5. Set `Content-Type: text/plain` header. Echo DID with no trailing newline. Exit.
+  6. Add a paired `maybe_suppress_atmosphere_well_known()` method hooked to `template_redirect` priority 1. Clears Atmosphere's `atmosphere_wellknown` query var when the FOSSE filter is false, so Atmosphere's own handler doesn't take over after FOSSE opts out.
 - **Verify**:
   - `composer run-script lint-php` passes.
   - Curl `/.well-known/atproto-did` on a connected site returns plain-text DID.

--- a/sdd/bluesky-handle-setup/plan.md
+++ b/sdd/bluesky-handle-setup/plan.md
@@ -17,7 +17,7 @@ Based on: sdd/bluesky-handle-setup/spec.md
 ## Tasks
 
 ### Task 1: Add `/.well-known/atproto-did` route handler
-- **Status**: Not started
+- **Status**: In progress
 - **Files**: `src/Admin/class-bluesky-provider.php`
 - **Do**:
   1. Add `serve_atproto_did_well_known()` method. Hook to `init` priority 1 inside `register_hooks()`.

--- a/sdd/bluesky-handle-setup/plan.md
+++ b/sdd/bluesky-handle-setup/plan.md
@@ -4,7 +4,7 @@ Based on: sdd/bluesky-handle-setup/spec.md
 
 ## Progress
 
-- [ ] Task 1: Add `/.well-known/atproto-did` route handler
+- [x] Task 1: Add `/.well-known/atproto-did` route handler
 - [ ] Task 2: Add verification check method
 - [ ] Task 2.5: Add `fetch_current_handle($did)` helper
 - [ ] Task 3: Add domain-handle UI to Bluesky_Provider setup section
@@ -17,15 +17,15 @@ Based on: sdd/bluesky-handle-setup/spec.md
 ## Tasks
 
 ### Task 1: Add `/.well-known/atproto-did` route handler
-- **Status**: In progress
+- **Status**: ✅ Done (396985f, 138404f, bc43461)
 - **Files**: `src/Admin/class-bluesky-provider.php`
 - **Do**:
   1. Add `serve_atproto_did_well_known()` method. Hook to `init` priority 1 inside `register_hooks()`.
-  2. Match `$_SERVER['REQUEST_URI']` against `/^\/\.well-known\/atproto-did(\?|$)/`. If no match, return early.
+  2. Parse `$_SERVER['REQUEST_URI']` with `wp_parse_url( ..., PHP_URL_PATH )` and match strict equality against `/.well-known/atproto-did`. If no match, return early.
   3. Apply `fosse_serve_atproto_did_well_known` filter (default `true`). If false, return.
   4. Read `atmosphere_connection['did']`. If empty, send 404 and exit.
   5. Set `Content-Type: text/plain` header. Echo DID with no trailing newline. Exit.
-  6. Add a paired `maybe_suppress_atmosphere_well_known()` method hooked to `template_redirect` priority 1. Clears Atmosphere's `atmosphere_wellknown` query var when the FOSSE filter is false, so Atmosphere's own handler doesn't take over after FOSSE opts out.
+  6. Add a paired `maybe_suppress_atmosphere_well_known()` method hooked to `template_redirect` priority 1. Clears Atmosphere's `atmosphere_wellknown` query var and marks the request 404 when the FOSSE filter is false, so Atmosphere's own handler doesn't take over after FOSSE opts out.
 - **Verify**:
   - `composer run-script lint-php` passes.
   - Curl `/.well-known/atproto-did` on a connected site returns plain-text DID.
@@ -61,20 +61,21 @@ Based on: sdd/bluesky-handle-setup/spec.md
 - **Files**: `src/Admin/class-bluesky-provider.php`
 - **Do**:
   1. Extract a `render_domain_handle_subsection()` method called from the existing `render_setup_section()` when connected.
-  2. Implement five UI states from spec.md (hidden / CTA / pending / verified / active).
-  3. Use `wp_parse_url( home_url(), PHP_URL_HOST )` to extract the host as the suggested handle. This avoids producing invalid handles like `example.com/blog` on subdirectory installs.
-  4. Status pulls from `check_handle_verification($host)`, `fetch_current_handle($did)` (see Task 2.5), and the `fosse_bluesky_handle_setup_started` option. The "active" state is only reached when `fetch_current_handle($did) === $host`, since `atmosphere_connection['handle']` is captured at OAuth time and goes stale after a handle change.
+  2. Implement six UI states from spec.md (hidden / ineligible / CTA / pending / verified / active).
+  3. Derive the candidate handle from `wp_parse_url( home_url(), PHP_URL_HOST )`; normalize to lowercase, strip any trailing dot, reject hosts with ports, and convert IDNs to ASCII with `idn_to_ascii()` when available.
+  4. Check root-domain eligibility before showing setup controls: `'' === trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' )`. Subdirectory installs and subdirectory-multisite subsites are ineligible because ATProto handles cannot contain paths. Subdomain-multisite subsites and subdirectory-multisite main sites remain eligible when `home_url()` is host-root.
+  5. Status pulls from `check_handle_verification($host)`, `fetch_current_handle($did)` (see Task 2.5), and the `fosse_bluesky_handle_setup_started` option. The "active" state is only reached when `fetch_current_handle($did) === $host`, since `atmosphere_connection['handle']` is captured at OAuth time and goes stale after a handle change.
 - **Verify**:
   - `composer run-script lint-php` passes.
-  - Playground: each UI state renders for a manually-set option combination.
+  - Playground: each UI state renders for a manually-set option combination, including the ineligible subdirectory-install state.
 - **Depends on**: Task 1, Task 2, Task 2.5
 
 ### Task 4: Add admin-post handlers
 - **Status**: Not started
 - **Files**: `src/Admin/class-bluesky-provider.php`
 - **Do**:
-  1. Add `admin_post_fosse_bluesky_start_handle_setup` handler. Verify nonce + capability. Set `fosse_bluesky_handle_setup_started` to `1`. Redirect back to FOSSE Setup with `settings-updated=true`.
-  2. Add `admin_post_fosse_bluesky_check_handle` handler. Verify nonce + capability. Bust both the verification transient (`fosse_handle_check_<md5(domain.did)>`) AND the current-handle transient (`fosse_handle_current_<md5(did)>`) so the UI reflects the post-handoff state immediately. Redirect back to FOSSE Setup with `settings-updated=true`.
+  1. Add `admin_post_fosse_bluesky_start_handle_setup` handler. Verify nonce + capability. Set `fosse_bluesky_handle_setup_started` to `1` with autoload disabled (`add_option( ..., '', false )` on first write; `update_option()` afterward). Redirect back to FOSSE Setup with `settings-updated=true`.
+  2. Add `admin_post_fosse_bluesky_check_handle` handler. Verify nonce + capability. Bust both the verification transient (`fosse_handle_check_<md5(domain . '|' . did)>`) AND the current-handle transient (`fosse_handle_current_<md5(did)>`) so the UI reflects the post-handoff state immediately. Redirect back to FOSSE Setup with `settings-updated=true`.
   3. Register both in `register_hooks()`.
 - **Verify**:
   - `composer run-script lint-php` passes.
@@ -99,7 +100,9 @@ Based on: sdd/bluesky-handle-setup/spec.md
 - **Do**:
   1. Test `serve_atproto_did_well_known`: matches path, ignores other paths, respects filter, returns 404 when not connected.
   2. Test `check_handle_verification`: each status branch via `pre_http_request` intercept. Caching honored.
-  3. Test admin-post handlers: nonce required, capability required, option toggled, transient busted, redirect target correct.
+  3. Test `fetch_current_handle`: happy path returns handle, malformed response returns `null`, HTTP/WP_Error responses return `null`, and caching is honored.
+  4. Test domain normalization/eligibility: lowercase host, strip trailing dot, reject path-bound installs, convert IDNs when supported.
+  5. Test admin-post handlers: nonce required, capability required, option toggled with autoload disabled, transient busted, redirect target correct.
 - **Verify**:
   - `composer run-script test-php` all green.
   - `composer run-script lint-php` clean.
@@ -119,7 +122,7 @@ Based on: sdd/bluesky-handle-setup/spec.md
 
 ### Task 7: Update SDD documentation
 - **Status**: Not started
-- **Files**: `sdd/bluesky-handle-setup/requirements.md`, `spec.md`, `plan.md`, `planned-decisions.md`
+- **Files**: `sdd/bluesky-handle-setup/requirements.md`, `spec.md`, `plan.md`, `implementation-notes.md`
 - **Do**:
   1. Update all four SDD documents to reflect as-built implementation. Add Done markers with PR ref.
 - **Verify**:

--- a/sdd/bluesky-handle-setup/plan.md
+++ b/sdd/bluesky-handle-setup/plan.md
@@ -23,7 +23,7 @@ Based on: sdd/bluesky-handle-setup/spec.md
   1. Add `serve_atproto_did_well_known()` method. Hook to `init` priority 1 inside `register_hooks()`.
   2. Parse `$_SERVER['REQUEST_URI']` with `wp_parse_url( ..., PHP_URL_PATH )` and match strict equality against `/.well-known/atproto-did`. If no match, return early.
   3. Apply `fosse_serve_atproto_did_well_known` filter (default `true`). If false, return.
-  4. Read `atmosphere_connection['did']`. If empty, send 404 and exit.
+  4. Require Atmosphere to report connected (`did` and access token present), then read `atmosphere_connection['did']`. If not connected or the DID is empty, send 404 and exit.
   5. Set `Content-Type: text/plain` header. Echo DID with no trailing newline. Exit.
   6. Add a paired `maybe_suppress_atmosphere_well_known()` method hooked to `template_redirect` priority 1. Clears Atmosphere's `atmosphere_wellknown` query var and marks the request 404 when the FOSSE filter is false, so Atmosphere's own handler doesn't take over after FOSSE opts out.
 - **Verify**:
@@ -61,7 +61,7 @@ Based on: sdd/bluesky-handle-setup/spec.md
 - **Files**: `src/Admin/class-bluesky-provider.php`
 - **Do**:
   1. Extract a `render_domain_handle_subsection()` method called from the existing `render_setup_section()` when connected.
-  2. Implement six UI states from spec.md (hidden / ineligible / CTA / pending / verified / active).
+  2. Implement the UI states from spec.md (hidden / ineligible / CTA / pending-not-found / mismatch / error / verified / active).
   3. Derive the candidate handle from `wp_parse_url( home_url(), PHP_URL_HOST )`; normalize to lowercase, strip any trailing dot, reject hosts with ports, and convert IDNs to ASCII with `idn_to_ascii()` when available.
   4. Check root-domain eligibility before showing setup controls: `'' === trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' )`. Subdirectory installs and subdirectory-multisite subsites are ineligible because ATProto handles cannot contain paths. Subdomain-multisite subsites and subdirectory-multisite main sites remain eligible when `home_url()` is host-root.
   5. Status pulls from `check_handle_verification($host)`, `fetch_current_handle($did)` (see Task 2.5), and the `fosse_bluesky_handle_setup_started` option. The "active" state is only reached when `fetch_current_handle($did) === $host`, since `atmosphere_connection['handle']` is captured at OAuth time and goes stale after a handle change.
@@ -112,7 +112,7 @@ Based on: sdd/bluesky-handle-setup/spec.md
 - **Status**: Not started
 - **Files**: `tests/e2e/bluesky-handle.spec.ts`
 - **Do**:
-  1. New spec that activates a fixture mu-plugin which seeds a fake `atmosphere_connection` (with a known DID) so the well-known route has data to serve.
+  1. New spec that activates a fixture mu-plugin which seeds a fake connected `atmosphere_connection` (with a known DID and access token) so the well-known route has data to serve.
   2. Test 1: `GET /.well-known/atproto-did` returns 200, content-type `text/plain`, body equals the seeded DID with no trailing newline.
   3. Test 2: When the fixture mu-plugin clears the connection option, the same request returns 404.
   4. Test 3: When the `fosse_serve_atproto_did_well_known` filter returns `false`, the request returns 404 (verifies the disable filter works).

--- a/sdd/bluesky-handle-setup/plan.md
+++ b/sdd/bluesky-handle-setup/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Bluesky Handle Setup
+
+Based on: sdd/bluesky-handle-setup/spec.md
+
+## Progress
+
+- [ ] Task 1: Add `/.well-known/atproto-did` route handler
+- [ ] Task 2: Add verification check method
+- [ ] Task 2.5: Add `fetch_current_handle($did)` helper
+- [ ] Task 3: Add domain-handle UI to Bluesky_Provider setup section
+- [ ] Task 4: Add admin-post handlers
+- [ ] Task 5: Add DNS TXT fallback display
+- [ ] Task 6: Unit tests
+- [ ] Task 6.5: Add Playwright E2E test for well-known route
+- [ ] Task 7: Update SDD documentation
+
+## Tasks
+
+### Task 1: Add `/.well-known/atproto-did` route handler
+- **Status**: Not started
+- **Files**: `src/Admin/class-bluesky-provider.php`
+- **Do**:
+  1. Add `serve_atproto_did_well_known()` method. Hook to `init` priority 1 inside `register_hooks()`.
+  2. Match `$_SERVER['REQUEST_URI']` against `/^\/\.well-known\/atproto-did(\?|$)/`. If no match, return early.
+  3. Apply `fosse_serve_atproto_did_well_known` filter (default `true`). If false, return.
+  4. Read `atmosphere_connection['did']`. If empty, send 404 and exit.
+  5. Set `Content-Type: text/plain` header. Echo DID with no trailing newline. Exit.
+- **Verify**:
+  - `composer run-script lint-php` passes.
+  - Curl `/.well-known/atproto-did` on a connected site returns plain-text DID.
+- **Depends on**: none
+
+### Task 2: Add verification check method
+- **Status**: Not started
+- **Files**: `src/Admin/class-bluesky-provider.php`
+- **Do**:
+  1. Add `check_handle_verification(string $domain): array` returning `['status', 'resolved_did', 'error']`.
+  2. Build `wp_remote_get` to `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=<domain>`.
+  3. Parse JSON. If `did` matches stored DID, status `verified`. If response has `did` but mismatched, status `mismatch`. If the resolver returns `HandleNotFound` (the common "domain not configured yet" case), status `not_found`. Other errors → `error`.
+  4. Cache result in transient `fosse_handle_check_<md5(domain . '|' . expected_did)>` for 5 minutes. Include the expected DID in the key so reconnecting a different account within the cache window doesn't reuse a stale `verified` result for the new DID.
+- **Verify**:
+  - `composer run-script lint-php` passes.
+  - Unit test verified/mismatch/not-found/error branches via `pre_http_request` intercept.
+- **Depends on**: none
+
+### Task 2.5: Add `fetch_current_handle($did)` helper
+- **Status**: Not started
+- **Files**: `src/Admin/class-bluesky-provider.php`
+- **Do**:
+  1. Add `fetch_current_handle(string $did): ?string` returning the actor's current handle, or `null` on error.
+  2. Call `https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=<did>` via `wp_remote_get`.
+  3. Cache result in transient `fosse_handle_current_<md5(did)>` for 5 minutes (paired with the verification cache, busted by the same "Check verification" button).
+- **Verify**:
+  - `composer run-script lint-php` passes.
+  - Unit test happy/missing/error branches via `pre_http_request` intercept.
+- **Depends on**: none
+
+### Task 3: Add domain-handle UI to Bluesky_Provider setup section
+- **Status**: Not started
+- **Files**: `src/Admin/class-bluesky-provider.php`
+- **Do**:
+  1. Extract a `render_domain_handle_subsection()` method called from the existing `render_setup_section()` when connected.
+  2. Implement five UI states from spec.md (hidden / CTA / pending / verified / active).
+  3. Use `wp_parse_url( home_url(), PHP_URL_HOST )` to extract the host as the suggested handle. This avoids producing invalid handles like `example.com/blog` on subdirectory installs.
+  4. Status pulls from `check_handle_verification($host)`, `fetch_current_handle($did)` (see Task 2.5), and the `fosse_bluesky_handle_setup_started` option. The "active" state is only reached when `fetch_current_handle($did) === $host`, since `atmosphere_connection['handle']` is captured at OAuth time and goes stale after a handle change.
+- **Verify**:
+  - `composer run-script lint-php` passes.
+  - Playground: each UI state renders for a manually-set option combination.
+- **Depends on**: Task 1, Task 2, Task 2.5
+
+### Task 4: Add admin-post handlers
+- **Status**: Not started
+- **Files**: `src/Admin/class-bluesky-provider.php`
+- **Do**:
+  1. Add `admin_post_fosse_bluesky_start_handle_setup` handler. Verify nonce + capability. Set `fosse_bluesky_handle_setup_started` to `1`. Redirect back to FOSSE Setup with `settings-updated=true`.
+  2. Add `admin_post_fosse_bluesky_check_handle` handler. Verify nonce + capability. Bust both the verification transient (`fosse_handle_check_<md5(domain.did)>`) AND the current-handle transient (`fosse_handle_current_<md5(did)>`) so the UI reflects the post-handoff state immediately. Redirect back to FOSSE Setup with `settings-updated=true`.
+  3. Register both in `register_hooks()`.
+- **Verify**:
+  - `composer run-script lint-php` passes.
+  - Playground: clicking "Set up" and "Check verification" each redirect cleanly with notices.
+- **Depends on**: Task 3
+
+### Task 5: Add DNS TXT fallback display
+- **Status**: Not started
+- **Files**: `src/Admin/class-bluesky-provider.php`, `src/Admin/assets/css/admin.css`
+- **Do**:
+  1. Add a `<details>` element inside the pending-state UI labeled "Show DNS fallback."
+  2. Render a code block with `_atproto.<domain>` (left) and `did=<did>` (right). Add a copy-to-clipboard button.
+  3. Style the code block with monospace font and light background per FOSSE admin conventions.
+- **Verify**:
+  - `composer run-script lint-php` passes.
+  - Playground: details element expands to show TXT record content. Copy button works.
+- **Depends on**: Task 3
+
+### Task 6: Unit tests
+- **Status**: Not started
+- **Files**: `tests/php/Admin/Bluesky_Handle_SetupTest.php`
+- **Do**:
+  1. Test `serve_atproto_did_well_known`: matches path, ignores other paths, respects filter, returns 404 when not connected.
+  2. Test `check_handle_verification`: each status branch via `pre_http_request` intercept. Caching honored.
+  3. Test admin-post handlers: nonce required, capability required, option toggled, transient busted, redirect target correct.
+- **Verify**:
+  - `composer run-script test-php` all green.
+  - `composer run-script lint-php` clean.
+- **Depends on**: Task 5
+
+### Task 6.5: Add Playwright E2E test for well-known route
+- **Status**: Not started
+- **Files**: `tests/e2e/bluesky-handle.spec.ts`
+- **Do**:
+  1. New spec that activates a fixture mu-plugin which seeds a fake `atmosphere_connection` (with a known DID) so the well-known route has data to serve.
+  2. Test 1: `GET /.well-known/atproto-did` returns 200, content-type `text/plain`, body equals the seeded DID with no trailing newline.
+  3. Test 2: When the fixture mu-plugin clears the connection option, the same request returns 404.
+  4. Test 3: When the `fosse_serve_atproto_did_well_known` filter returns `false`, the request returns 404 (verifies the disable filter works).
+- **Verify**:
+  - `pnpm exec playwright test tests/e2e/bluesky-handle.spec.ts` all green locally.
+- **Depends on**: Task 1
+
+### Task 7: Update SDD documentation
+- **Status**: Not started
+- **Files**: `sdd/bluesky-handle-setup/requirements.md`, `spec.md`, `plan.md`, `planned-decisions.md`
+- **Do**:
+  1. Update all four SDD documents to reflect as-built implementation. Add Done markers with PR ref.
+- **Verify**:
+  - Four files exist. Content matches code.
+- **Depends on**: Task 6, Task 6.5

--- a/sdd/bluesky-handle-setup/planned-decisions.md
+++ b/sdd/bluesky-handle-setup/planned-decisions.md
@@ -1,0 +1,37 @@
+# Implementation Notes — Bluesky Handle Setup
+
+## Design Decisions
+
+### Verification via Bluesky's resolveHandle API, not local DNS
+- **Decision**: `check_handle_verification()` calls `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=<domain>` rather than doing a local `dns_get_record` lookup.
+- **Reason**: The user's actual question is "does Bluesky see my domain as my handle?" — only Bluesky's resolver can answer that authoritatively. Local DNS could resolve correctly while Bluesky's cache is still warm with the old answer, producing a green status that turns out wrong. Plus, PHP DNS extensions aren't guaranteed on managed hosts.
+
+### Well-known route is default-on with an opt-out filter
+- **Decision**: When Bluesky is connected, FOSSE serves `/.well-known/atproto-did` automatically. A `fosse_serve_atproto_did_well_known` filter (default `true`) lets users disable it.
+- **Reason**: The whole point of this feature is to make the verification step disappear for the common case. Most WordPress sites don't have anything else competing for `.well-known/atproto-did`. The filter exists for the edge cases (managed hosts that intercept `.well-known`, sites running multiple ATProto identities, etc.) so users have an out without us needing a settings toggle.
+
+### Domain handle UI lives inside Bluesky_Provider, not a new admin page
+- **Decision**: The setup, verification, and status UI all live as a subsection inside `Bluesky_Provider::render_setup_section()`.
+- **Reason**: This is an extension of "your Bluesky connection," not a separate concept. Adding a top-level FOSSE > Domain Handle page would split related state across two admin surfaces and make the connection ↔ handle relationship less obvious. The subsection only renders when Bluesky is connected, so it follows the user's mental model (Bluesky first, then domain handle).
+
+### Single boolean tracks setup intent
+- **Decision**: `fosse_bluesky_handle_setup_started` (autoload-false option) flips to `1` when the user clicks "Set up domain handle" and never flips back.
+- **Reason**: The verification result itself is the source of truth for "is this working?" — we don't want a separate "is verified" boolean that can drift. The boolean is just for UI state ("show the CTA vs. show the verification panel"). Once the user starts, the panel stays even if verification fails, so they have somewhere to retry.
+
+### Verification cached for 5 minutes
+- **Decision**: Results from `check_handle_verification()` are cached in a transient keyed by hash of `domain + expected DID` for 5 minutes. The "Check verification" button busts the transient. The DID is part of the key so reconnecting a different Bluesky account within the cache window doesn't reuse a stale `verified` result.
+- **Reason**: Page loads in the WordPress admin can hit this multiple times (status card, setup section). 5 minutes is short enough that user intent ("I just changed my DNS, check again") still works via the explicit button, but long enough that incidental page loads don't hammer Bluesky.
+
+## Known Limitations (Expected)
+
+### No automatic DNS configuration
+FOSSE displays the TXT record content with a copy button but does not attempt to configure DNS at the user's registrar. Most users will need to log into their DNS provider (Cloudflare, Namecheap, etc.) and add the record manually. Future work could integrate with WordPress.com's DNS API for wpcom-hosted sites, but is out of scope for the radical-month MVP.
+
+### No automatic handle change on Bluesky
+Bluesky doesn't expose a public API for third-party handle changes (security boundary — the user must consent on their own session). FOSSE displays the deep link to `https://bsky.app/settings/account/handle` and shows the exact handle to paste, but the user has to complete the change in Bluesky's app.
+
+### Verification status is point-in-time
+The verification check runs when the page loads (or when the user clicks "Check verification"). It does not poll continuously. If Bluesky's resolver state changes after page load, the user sees stale status until the next refresh.
+
+### Domain change requires re-running verification
+If the user's WordPress moves to a new domain (e.g., custom domain change, host migration), the well-known route serves the same DID but now from a different host. Bluesky's verification will fail for the new domain until the user re-runs setup. This is expected ATProto behavior, not a FOSSE bug, but worth noting in user-facing copy.

--- a/sdd/bluesky-handle-setup/requirements.md
+++ b/sdd/bluesky-handle-setup/requirements.md
@@ -18,12 +18,14 @@ Kraft, 2026-04-20: *"I can switch over to use my domain as my handle but looks l
 3. **Verification status UI.** Tell the user whether their domain currently resolves to their DID. Surface clear next-steps if it doesn't.
 4. **Handoff guidance to bsky.app.** Once verification is in place, link the user to Bluesky's "Change Handle" flow with their domain pre-prepared, so they can complete the swap on Bluesky's side.
 5. **Bluesky_Provider extension, not a new component.** This work extends the existing provider rather than introducing a new top-level admin surface.
+6. **Root-domain eligibility only.** The site must live at the host root for its domain to be usable as an ATProto handle. Subdirectory installs and subdirectory-multisite subsites are ineligible because handles cannot contain URL paths.
 
 ## Constraints
 
 - Self-hosted WordPress plugin first.
 - PHP 8.2+, WP 6.9+.
 - Bundled plugins (`bundled/atmosphere/`) must NOT be modified. If an upstream change is needed, open a PR there.
+- The suggested handle is derived from `home_url()`'s host, normalized as a DNS name, and rejected when `home_url()` contains a non-empty path.
 - Must pass the existing CI matrix.
 
 ## Out of Scope
@@ -31,3 +33,4 @@ Kraft, 2026-04-20: *"I can switch over to use my domain as my handle but looks l
 - Helping the user set up DNS records programmatically (we display, they configure their DNS provider).
 - Automating the bsky.app "Change Handle" step itself (Bluesky's API doesn't allow third-party handle changes).
 - Multi-user / per-user handles. Single-site-owner flow only.
+- Path-based domain handles such as `example.com/blog`; ATProto handles are DNS names only.

--- a/sdd/bluesky-handle-setup/requirements.md
+++ b/sdd/bluesky-handle-setup/requirements.md
@@ -1,0 +1,33 @@
+# Bluesky Handle Setup — Requirements
+
+## Goal
+
+Let users claim their domain (e.g., `@ryancowl.es`) as their Bluesky handle without leaving WordPress. Today, even after FOSSE connects a Bluesky account via OAuth, the user still has to manually set up DNS TXT or a `/.well-known/atproto-did` file, then go to bsky.app's "Change Handle" UI to complete verification. FOSSE knows the domain (it's running on it) and already knows the DID (stored after OAuth), so most of this can be automated.
+
+Kraft, 2026-04-20: *"I can switch over to use my domain as my handle but looks like I need to do it from the bsky end. I don't see anything locally offering/suggesting."*
+
+## Linear Issues
+
+- **DOTCOM-16801** — Bluesky handle/DID setup done inside WordPress (this epic)
+- **DOTCOM-16793** — parent epic (Onboarding & Setup UX)
+
+## Requirements
+
+1. **Serve `/.well-known/atproto-did`** automatically for sites where FOSSE is active and a Bluesky account is connected. Returns plain text containing only the connected account's DID.
+2. **DNS TXT fallback display.** For sites that can't serve the well-known route (managed hosts, edge caches, etc.), show the user the exact TXT record content (`_atproto.<domain>` → `did=<did>`) with copy buttons.
+3. **Verification status UI.** Tell the user whether their domain currently resolves to their DID. Surface clear next-steps if it doesn't.
+4. **Handoff guidance to bsky.app.** Once verification is in place, link the user to Bluesky's "Change Handle" flow with their domain pre-prepared, so they can complete the swap on Bluesky's side.
+5. **Bluesky_Provider extension, not a new component.** This work extends the existing provider rather than introducing a new top-level admin surface.
+
+## Constraints
+
+- Self-hosted WordPress plugin first.
+- PHP 8.2+, WP 6.9+.
+- Bundled plugins (`bundled/atmosphere/`) must NOT be modified. If an upstream change is needed, open a PR there.
+- Must pass the existing CI matrix.
+
+## Out of Scope
+
+- Helping the user set up DNS records programmatically (we display, they configure their DNS provider).
+- Automating the bsky.app "Change Handle" step itself (Bluesky's API doesn't allow third-party handle changes).
+- Multi-user / per-user handles. Single-site-owner flow only.

--- a/sdd/bluesky-handle-setup/spec.md
+++ b/sdd/bluesky-handle-setup/spec.md
@@ -1,0 +1,76 @@
+# Spec: Bluesky Handle Setup
+
+## Goal
+
+Let users claim their domain as their Bluesky handle from inside FOSSE. Today the user has to leave WordPress to set up DNS or `/.well-known/atproto-did`, then go to bsky.app to apply the handle change. FOSSE can serve the well-known route automatically (since it controls the WordPress install at that domain) and show the user the verification status and next steps without leaving the admin.
+
+## Requirements Summary
+
+- Auto-serve `/.well-known/atproto-did` when Bluesky is connected.
+- Show DNS TXT fallback for hosts where the well-known route can't be served.
+- Surface verification status (does the domain currently resolve to the connected DID?).
+- Hand the user off to bsky.app with their domain pre-prepared once verification passes.
+- Live inside the existing `Bluesky_Provider`, not a new top-level admin surface.
+
+## Chosen Approach
+
+**Bluesky_Provider extension with a lightweight well-known handler.**
+
+### Verification path
+
+Two methods are valid for ATProto handle ownership:
+
+1. **`/.well-known/atproto-did`** — plain-text HTTPS response containing only the DID. FOSSE controls the WordPress install at the domain, so we serve this automatically.
+2. **DNS TXT record at `_atproto.<domain>`** — content `did=<did>`. Requires the user to configure DNS at their registrar. Used as a fallback for managed hosts that intercept `.well-known`.
+
+We default to method 1 and surface method 2 only when the user clicks "Show DNS fallback."
+
+### Verification check
+
+Use Bluesky's public `com.atproto.identity.resolveHandle` API to ask, "what DID does Bluesky see for this handle?" If it matches the stored DID, verified. If not, surface the mismatch.
+
+This avoids relying on PHP DNS extensions (not always available on managed hosts) and gives the user an authoritative answer from Bluesky itself.
+
+### Alternatives Considered
+
+- **A — Local DNS lookup via PHP `dns_get_record`.** Cheaper (no outbound HTTP) but requires PHP DNS extensions which aren't guaranteed on shared hosts. Also doesn't catch the case where DNS resolves but Bluesky hasn't yet picked it up.
+- **B — Skip verification, just trust the user.** Simplest, but loses the "did it actually work?" signal that's the whole point of this feature.
+- **C — Custom UI on a dedicated FOSSE > Domain Handle page.** Cleaner page hierarchy but adds menu surface for what's really just an extension of the Bluesky connection. Rejected for scope.
+
+## Technical Details
+
+### Well-known route
+
+Hook on `init` priority 1. If `$_SERVER['REQUEST_URI']` matches `/.well-known/atproto-did` (with any query string stripped), check that Bluesky is connected, set `Content-Type: text/plain`, print the DID, exit. No trailing newline. No HTML.
+
+Filter `fosse_serve_atproto_did_well_known` (default `true`) lets users disable the route if their host serves it differently.
+
+### Verification check
+
+`Bluesky_Provider::check_handle_verification($domain): array` calls `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=<domain>` with `wp_remote_get`. Returns `['status' => 'verified'|'mismatch'|'not_found'|'error', 'resolved_did' => string|null, 'error' => string|null]`. The `not_found` status corresponds to the resolver's `HandleNotFound` error (the common "domain not configured yet" case while the user is still setting up DNS or the well-known route).
+
+Cache results in a transient for 5 minutes keyed by hash of `domain + expected DID`, so reconnecting a different Bluesky account within the cache window doesn't reuse a stale `verified` result for the new DID.
+
+### UI states (inside Bluesky_Provider's setup section)
+
+| Bluesky state | Domain handle subsection shows |
+|---|---|
+| Not connected | Nothing (subsection hidden). |
+| Connected, using default `*.bsky.social` handle | CTA: "Use your domain as your Bluesky handle" with current site URL pre-populated and a "Set up" button. |
+| Setup started, not yet verified | Verification panel with two methods (well-known active by default; DNS TXT shown on click). "Check verification" button calls the resolver. Status: "Pending — Bluesky doesn't see your domain yet." |
+| Verified, handle not yet changed on Bluesky | "Verified! Now finish the change on bsky.app" with deep link to Bluesky's handle settings. |
+| Domain handle active on Bluesky | "Your Bluesky handle is `@yourdomain.com`. Keep this site up so the handle keeps resolving." |
+
+### Data
+
+No new options required. We read `did` from the existing `atmosphere_connection` option that `Bluesky_Provider` already uses. The stored `handle` in that option is captured at OAuth time and goes stale once the user changes their handle on bsky.app, so it cannot be used to drive the "active" state.
+
+A single new option `fosse_bluesky_handle_setup_started` (boolean) tracks whether the user has clicked "Set up domain handle" so the CTA disappears once they're in the flow.
+
+### Distinguishing "Verified" from "Active"
+
+After verification passes, we need to know whether the user has actually completed the handle change on bsky.app. We query `app.bsky.actor.getProfile?actor=<did>` (cached in the same 5-minute transient as the resolver lookup) to get the actor's *current* handle. If `current_handle === <domain>`, we're in the active state. Otherwise, we stay in the "Verified! Now finish the change on bsky.app" state. This avoids reading the stale `atmosphere_connection['handle']`.
+
+### bsky.app handoff
+
+Bluesky's settings deep link: `https://bsky.app/settings/account/handle`. We can't pre-fill the field via URL params (no public API for that), but we can show the user the exact handle to paste, with a copy button.

--- a/sdd/bluesky-handle-setup/spec.md
+++ b/sdd/bluesky-handle-setup/spec.md
@@ -11,10 +11,13 @@ Let users claim their domain as their Bluesky handle from inside FOSSE. Today th
 - Surface verification status (does the domain currently resolve to the connected DID?).
 - Hand the user off to bsky.app with their domain pre-prepared once verification passes.
 - Live inside the existing `Bluesky_Provider`, not a new top-level admin surface.
+- Offer the flow only when the WordPress site lives at the host root; path-bound installs get an ineligible state.
 
 ## Chosen Approach
 
 **Bluesky_Provider extension with a lightweight well-known handler.**
+
+The bundled Atmosphere plugin already serves `/.well-known/atproto-did`, but FOSSE re-serves it deliberately. FOSSE owns the unified setup UX and the `fosse_serve_atproto_did_well_known` opt-out contract; bundled-plugin policy also keeps FOSSE-specific behavior out of `bundled/`. Upstreaming a general Atmosphere opt-out hook was considered, but the immediate need is FOSSE-shaped: disable both FOSSE's route and the bundled fallback from FOSSE's setup flow. If Atmosphere later grows a generic opt-out filter, FOSSE can consume it and drop the local suppression shim.
 
 ### Verification path
 
@@ -41,7 +44,7 @@ This avoids relying on PHP DNS extensions (not always available on managed hosts
 
 ### Well-known route
 
-Hook on `init` priority 1. If `$_SERVER['REQUEST_URI']` matches `/.well-known/atproto-did` (with any query string stripped), check that Bluesky is connected, set `Content-Type: text/plain`, print the DID, exit. No trailing newline. No HTML.
+Hook on `init` priority 1. Parse `$_SERVER['REQUEST_URI']` with `wp_parse_url( ..., PHP_URL_PATH )` and require strict equality with `/.well-known/atproto-did`. Query strings are ignored by parsing the path; other paths return early. If Bluesky is connected, set `Content-Type: text/plain`, print the DID, exit. No trailing newline. No HTML.
 
 Filter `fosse_serve_atproto_did_well_known` (default `true`) lets users disable the route if their host serves it differently.
 
@@ -51,28 +54,52 @@ The bundled Atmosphere plugin registers its own `template_redirect` handler for 
 
 `Bluesky_Provider::check_handle_verification($domain): array` calls `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=<domain>` with `wp_remote_get`. Returns `['status' => 'verified'|'mismatch'|'not_found'|'error', 'resolved_did' => string|null, 'error' => string|null]`. The `not_found` status corresponds to the resolver's `HandleNotFound` error (the common "domain not configured yet" case while the user is still setting up DNS or the well-known route).
 
-Cache results in a transient for 5 minutes keyed by hash of `domain + expected DID`, so reconnecting a different Bluesky account within the cache window doesn't reuse a stale `verified` result for the new DID.
+Cache results in a transient for 5 minutes keyed by `md5( $domain . '|' . $expected_did )`, so reconnecting a different Bluesky account within the cache window doesn't reuse a stale `verified` result for the new DID. The delimiter is part of the contract; concatenating the two strings directly can produce ambiguous cache inputs.
+
+### Domain eligibility and normalization
+
+The suggested handle comes from `home_url()`, but ATProto handles are DNS names, not URLs. FOSSE must use only the host portion and must not offer the flow when the WordPress home URL is path-bound.
+
+Eligibility check:
+
+```php
+'' === trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' )
+```
+
+This allows single-site root installs, subdomain-multisite subsites, and subdirectory-multisite main sites when they live at host-root. It excludes subdirectory installs and subdirectory-multisite subsites because handles cannot include `/blog` or any other path segment.
+
+Domain normalization before resolver calls:
+
+- Lowercase the host.
+- Strip a trailing dot.
+- Reject hosts with an explicit port.
+- Convert IDNs to ASCII with `idn_to_ascii()` when available; if conversion is needed but unavailable or fails, surface an error state instead of sending a Unicode label to the resolver.
 
 ### UI states (inside Bluesky_Provider's setup section)
 
 | Bluesky state | Domain handle subsection shows |
 |---|---|
 | Not connected | Nothing (subsection hidden). |
+| Connected, but site URL is path-bound | Ineligible state explaining that Bluesky handles can only use the bare domain, not a URL path. Do not show setup buttons. |
 | Connected, using default `*.bsky.social` handle | CTA: "Use your domain as your Bluesky handle" with current site URL pre-populated and a "Set up" button. |
-| Setup started, not yet verified | Verification panel with two methods (well-known active by default; DNS TXT shown on click). "Check verification" button calls the resolver. Status: "Pending — Bluesky doesn't see your domain yet." |
+| Setup started, resolver returns `not_found` | Verification panel with two methods (well-known active by default; DNS TXT shown on click). "Check verification" button calls the resolver. Status: "Pending — Bluesky doesn't see your domain yet." |
+| Setup started, resolver returns `mismatch` | Warning state showing the connected DID and the DID Bluesky currently resolves for the domain. Keep the verification methods visible so the user can correct DNS or reconnect the right account. |
+| Setup started, resolver returns `error` | Error state with the resolver/API error message and a retry button. Keep DNS fallback visible; do not claim verification state. |
 | Verified, handle not yet changed on Bluesky | "Verified! Now finish the change on bsky.app" with deep link to Bluesky's handle settings. |
 | Domain handle active on Bluesky | "Your Bluesky handle is `@yourdomain.com`. Keep this site up so the handle keeps resolving." |
 
 ### Data
 
-No new options required. We read `did` from the existing `atmosphere_connection` option that `Bluesky_Provider` already uses. The stored `handle` in that option is captured at OAuth time and goes stale once the user changes their handle on bsky.app, so it cannot be used to drive the "active" state.
+No new persistent identity options are required. We read `did` from the existing `atmosphere_connection` option that `Bluesky_Provider` already uses. The stored `handle` in that option is captured at OAuth time and goes stale once the user changes their handle on bsky.app, so it cannot be used to drive the "active" state.
 
-A single new option `fosse_bluesky_handle_setup_started` (boolean) tracks whether the user has clicked "Set up domain handle" so the CTA disappears once they're in the flow.
+A single new option `fosse_bluesky_handle_setup_started` (boolean, autoload disabled) tracks whether the user has clicked "Set up domain handle" so the CTA disappears once they're in the flow.
 
 ### Distinguishing "Verified" from "Active"
 
-After verification passes, we need to know whether the user has actually completed the handle change on bsky.app. We query `app.bsky.actor.getProfile?actor=<did>` (cached in the same 5-minute transient as the resolver lookup) to get the actor's *current* handle. If `current_handle === <domain>`, we're in the active state. Otherwise, we stay in the "Verified! Now finish the change on bsky.app" state. This avoids reading the stale `atmosphere_connection['handle']`.
+After verification passes, we need to know whether the user has actually completed the handle change on bsky.app. We query `app.bsky.actor.getProfile?actor=<did>` (cached for 5 minutes in `fosse_handle_current_<md5(did)>`) to get the actor's *current* handle. If `current_handle === <domain>`, we're in the active state. Otherwise, we stay in the "Verified! Now finish the change on bsky.app" state. This avoids reading the stale `atmosphere_connection['handle']`.
 
 ### bsky.app handoff
 
 Bluesky's settings deep link: `https://bsky.app/settings/account/handle`. We can't pre-fill the field via URL params (no public API for that), but we can show the user the exact handle to paste, with a copy button.
+
+This is a single-site-owner flow. It does not try to assign per-user domain handles or coordinate multiple Bluesky accounts on one WordPress install.

--- a/sdd/bluesky-handle-setup/spec.md
+++ b/sdd/bluesky-handle-setup/spec.md
@@ -45,6 +45,8 @@ Hook on `init` priority 1. If `$_SERVER['REQUEST_URI']` matches `/.well-known/at
 
 Filter `fosse_serve_atproto_did_well_known` (default `true`) lets users disable the route if their host serves it differently.
 
+The bundled Atmosphere plugin registers its own `template_redirect` handler for the same path. When the FOSSE filter returns false, FOSSE also clears Atmosphere's `atmosphere_wellknown` query var via a paired `template_redirect` priority 1 hook so neither plugin serves the route (otherwise Atmosphere would silently take over and the opt-out wouldn't actually opt out).
+
 ### Verification check
 
 `Bluesky_Provider::check_handle_verification($domain): array` calls `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=<domain>` with `wp_remote_get`. Returns `['status' => 'verified'|'mismatch'|'not_found'|'error', 'resolved_did' => string|null, 'error' => string|null]`. The `not_found` status corresponds to the resolver's `HandleNotFound` error (the common "domain not configured yet" case while the user is still setting up DNS or the well-known route).

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -275,7 +275,7 @@ class Bluesky_Provider implements Connection_Provider {
 
 		header( 'Content-Type: text/plain; charset=utf-8' );
 		nocache_headers();
-		echo esc_html( $response['did'] );
+		echo $response['did']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- text/plain response; DID syntax validated in get_atproto_did_well_known_response().
 		exit;
 	}
 
@@ -320,7 +320,11 @@ class Bluesky_Provider implements Connection_Provider {
 		$connection = \Atmosphere\get_connection();
 		$did        = isset( $connection['did'] ) ? (string) $connection['did'] : '';
 
-		if ( '' === $did ) {
+		// Validate the DID against AT Proto syntax before promising to serve it.
+		// The response is plain text and a malformed value (newlines, control chars,
+		// HTML bytes) would corrupt the body or worse. Valid AT Proto DIDs are
+		// "did:" + method + ":" + ASCII alphanumerics with a small punctuation set.
+		if ( ! preg_match( '/^did:[a-z]+:[A-Za-z0-9._:%\-]+$/', $did ) ) {
 			return array(
 				'status' => 404,
 				'did'    => '',

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -246,15 +246,21 @@ class Bluesky_Provider implements Connection_Provider {
 	}
 
 	/**
-	 * Serve /.well-known/atproto-did with the connected account's DID.
+	 * Serve /.well-known/atproto-did when FOSSE owns the route.
 	 *
-	 * Lets a Bluesky user prove their domain ownership for the
-	 * "Change Handle" flow on bsky.app without leaving WordPress.
+	 * Returns silently for unrelated paths, when the
+	 * `fosse_serve_atproto_did_well_known` filter opts out, and when
+	 * Atmosphere isn't loaded. Sends a 404 and exits when Atmosphere is
+	 * loaded but no DID is available; otherwise sends a `text/plain` body
+	 * containing the connected DID and exits.
 	 *
 	 * @return void
 	 */
 	public function serve_atproto_did_well_known(): void {
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		// Path-match below uses strict equality; sanitize_text_field can normalize
+		// encoded characters in surprising ways, so read raw.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? (string) wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
 		$response    = $this->get_atproto_did_well_known_response( $request_uri );
 
 		if ( null === $response ) {
@@ -269,7 +275,7 @@ class Bluesky_Provider implements Connection_Provider {
 
 		header( 'Content-Type: text/plain; charset=utf-8' );
 		nocache_headers();
-		echo $response['did']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- text/plain response with controlled DID value.
+		echo esc_html( $response['did'] );
 		exit;
 	}
 
@@ -277,7 +283,7 @@ class Bluesky_Provider implements Connection_Provider {
 	 * Resolve the response data for FOSSE's /.well-known/atproto-did handler.
 	 *
 	 * @param string $request_uri Request URI.
-	 * @return array{status:int,did:string}|null Null when FOSSE should not handle the request.
+	 * @return array{status:200|404,did:string}|null Null when FOSSE should not handle the request; otherwise a status code and the DID (empty for 404).
 	 */
 	private function get_atproto_did_well_known_response( string $request_uri ): ?array {
 		$path = wp_parse_url( $request_uri, PHP_URL_PATH );
@@ -291,20 +297,27 @@ class Bluesky_Provider implements Connection_Provider {
 		 *
 		 * Disable to let another component (CDN, custom rewrite, etc.) own the path.
 		 *
-		 * @param bool $serve Default true when Bluesky is connected.
+		 * @param bool $serve Default true.
 		 */
 		if ( ! apply_filters( 'fosse_serve_atproto_did_well_known', true ) ) {
 			return null;
 		}
 
-		if ( ! function_exists( '\Atmosphere\is_connected' ) || ! \Atmosphere\is_connected() ) {
+		if ( ! function_exists( '\Atmosphere\is_connected' ) ) {
+			// Atmosphere isn't loaded. That's a structural error, not a
+			// user-facing "no connection" state. Decline to handle so a
+			// normal 404 happens via WordPress's main request flow.
+			return null;
+		}
+
+		if ( ! \Atmosphere\is_connected() ) {
 			return array(
 				'status' => 404,
 				'did'    => '',
 			);
 		}
 
-		$connection = function_exists( '\Atmosphere\get_connection' ) ? \Atmosphere\get_connection() : array();
+		$connection = \Atmosphere\get_connection();
 		$did        = isset( $connection['did'] ) ? (string) $connection['did'] : '';
 
 		if ( '' === $did ) {
@@ -326,7 +339,8 @@ class Bluesky_Provider implements Connection_Provider {
 	 * The fosse_serve_atproto_did_well_known filter only controls FOSSE's own handler.
 	 * Atmosphere registers an independent template_redirect handler that would otherwise
 	 * still serve the route, defeating the opt-out. Clearing Atmosphere's query var
-	 * makes its handler return early so neither plugin serves the route.
+	 * makes its handler return early so neither plugin serves the route. Also flags the
+	 * request 404 so WordPress doesn't render the front page for the well-known URL.
 	 *
 	 * @return void
 	 */
@@ -341,8 +355,9 @@ class Bluesky_Provider implements Connection_Provider {
 
 		// Clear Atmosphere's query var so its handler at priority 10 returns,
 		// then mark the request 404 so the rewrite rule doesn't render the
-		// front page for the well-known URL. Third-party handlers can still
-		// take over by calling status_header(200) and exit.
+		// front page for the well-known URL. Third-party handlers attached at
+		// template_redirect priority > 1 can still take over by calling
+		// status_header( 200 ), $wp_query->set_404( false ), and exit().
 		set_query_var( 'atmosphere_wellknown', '' );
 
 		global $wp_query;

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -255,10 +255,35 @@ class Bluesky_Provider implements Connection_Provider {
 	 */
 	public function serve_atproto_did_well_known(): void {
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-		$path        = wp_parse_url( $request_uri, PHP_URL_PATH );
+		$response    = $this->get_atproto_did_well_known_response( $request_uri );
+
+		if ( null === $response ) {
+			return;
+		}
+
+		if ( 404 === $response['status'] ) {
+			status_header( 404 );
+			nocache_headers();
+			exit;
+		}
+
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		nocache_headers();
+		echo $response['did']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- text/plain response with controlled DID value.
+		exit;
+	}
+
+	/**
+	 * Resolve the response data for FOSSE's /.well-known/atproto-did handler.
+	 *
+	 * @param string $request_uri Request URI.
+	 * @return array{status:int,did:string}|null Null when FOSSE should not handle the request.
+	 */
+	private function get_atproto_did_well_known_response( string $request_uri ): ?array {
+		$path = wp_parse_url( $request_uri, PHP_URL_PATH );
 
 		if ( '/.well-known/atproto-did' !== $path ) {
-			return;
+			return null;
 		}
 
 		/**
@@ -269,22 +294,30 @@ class Bluesky_Provider implements Connection_Provider {
 		 * @param bool $serve Default true when Bluesky is connected.
 		 */
 		if ( ! apply_filters( 'fosse_serve_atproto_did_well_known', true ) ) {
-			return;
+			return null;
 		}
 
-		$connection = get_option( 'atmosphere_connection' );
-		$did        = is_array( $connection ) && isset( $connection['did'] ) ? (string) $connection['did'] : '';
+		if ( ! function_exists( '\Atmosphere\is_connected' ) || ! \Atmosphere\is_connected() ) {
+			return array(
+				'status' => 404,
+				'did'    => '',
+			);
+		}
+
+		$connection = function_exists( '\Atmosphere\get_connection' ) ? \Atmosphere\get_connection() : array();
+		$did        = isset( $connection['did'] ) ? (string) $connection['did'] : '';
 
 		if ( '' === $did ) {
-			status_header( 404 );
-			nocache_headers();
-			exit;
+			return array(
+				'status' => 404,
+				'did'    => '',
+			);
 		}
 
-		header( 'Content-Type: text/plain; charset=utf-8' );
-		nocache_headers();
-		echo $did; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- text/plain response with controlled DID value.
-		exit;
+		return array(
+			'status' => 200,
+			'did'    => $did,
+		);
 	}
 
 	/**

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -234,6 +234,7 @@ class Bluesky_Provider implements Connection_Provider {
 		add_action( 'admin_post_fosse_connect_bluesky', array( $this, 'handle_connect' ) );
 		add_action( 'admin_post_fosse_disconnect_bluesky', array( $this, 'handle_disconnect' ) );
 		add_action( 'admin_init', array( $this, 'handle_oauth_callback' ) );
+		add_action( 'init', array( $this, 'serve_atproto_did_well_known' ), 1 );
 
 		// Override Atmosphere's OAuth redirect URI so the auth server callback
 		// and the client-metadata REST endpoint both advertise FOSSE's page.
@@ -241,6 +242,48 @@ class Bluesky_Provider implements Connection_Provider {
 		// the auth server fetches client metadata in a separate public request
 		// and validates redirect_uri against it.
 		add_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
+	}
+
+	/**
+	 * Serve /.well-known/atproto-did with the connected account's DID.
+	 *
+	 * Lets a Bluesky user prove their domain ownership for the
+	 * "Change Handle" flow on bsky.app without leaving WordPress.
+	 *
+	 * @return void
+	 */
+	public function serve_atproto_did_well_known(): void {
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$path        = wp_parse_url( $request_uri, PHP_URL_PATH );
+
+		if ( '/.well-known/atproto-did' !== $path ) {
+			return;
+		}
+
+		/**
+		 * Filter whether FOSSE serves the /.well-known/atproto-did route.
+		 *
+		 * Disable to let another component (CDN, custom rewrite, etc.) own the path.
+		 *
+		 * @param bool $serve Default true when Bluesky is connected.
+		 */
+		if ( ! apply_filters( 'fosse_serve_atproto_did_well_known', true ) ) {
+			return;
+		}
+
+		$connection = get_option( 'atmosphere_connection' );
+		$did        = is_array( $connection ) && isset( $connection['did'] ) ? (string) $connection['did'] : '';
+
+		if ( '' === $did ) {
+			status_header( 404 );
+			nocache_headers();
+			exit;
+		}
+
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		nocache_headers();
+		echo $did; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- text/plain response with controlled DID value.
+		exit;
 	}
 
 	/**

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -306,7 +306,18 @@ class Bluesky_Provider implements Connection_Provider {
 			return;
 		}
 
+		// Clear Atmosphere's query var so its handler at priority 10 returns,
+		// then mark the request 404 so the rewrite rule doesn't render the
+		// front page for the well-known URL. Third-party handlers can still
+		// take over by calling status_header(200) and exit.
 		set_query_var( 'atmosphere_wellknown', '' );
+
+		global $wp_query;
+		if ( $wp_query instanceof \WP_Query ) {
+			$wp_query->set_404();
+		}
+		status_header( 404 );
+		nocache_headers();
 	}
 
 	/**

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -235,6 +235,7 @@ class Bluesky_Provider implements Connection_Provider {
 		add_action( 'admin_post_fosse_disconnect_bluesky', array( $this, 'handle_disconnect' ) );
 		add_action( 'admin_init', array( $this, 'handle_oauth_callback' ) );
 		add_action( 'init', array( $this, 'serve_atproto_did_well_known' ), 1 );
+		add_action( 'template_redirect', array( $this, 'maybe_suppress_atmosphere_well_known' ), 1 );
 
 		// Override Atmosphere's OAuth redirect URI so the auth server callback
 		// and the client-metadata REST endpoint both advertise FOSSE's page.
@@ -284,6 +285,28 @@ class Bluesky_Provider implements Connection_Provider {
 		nocache_headers();
 		echo $did; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- text/plain response with controlled DID value.
 		exit;
+	}
+
+	/**
+	 * Suppress bundled Atmosphere's /.well-known/atproto-did handler when FOSSE opts out.
+	 *
+	 * The fosse_serve_atproto_did_well_known filter only controls FOSSE's own handler.
+	 * Atmosphere registers an independent template_redirect handler that would otherwise
+	 * still serve the route, defeating the opt-out. Clearing Atmosphere's query var
+	 * makes its handler return early so neither plugin serves the route.
+	 *
+	 * @return void
+	 */
+	public function maybe_suppress_atmosphere_well_known(): void {
+		if ( 'atproto-did' !== get_query_var( 'atmosphere_wellknown' ) ) {
+			return;
+		}
+
+		if ( apply_filters( 'fosse_serve_atproto_did_well_known', true ) ) {
+			return;
+		}
+
+		set_query_var( 'atmosphere_wellknown', '' );
 	}
 
 	/**

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -324,7 +324,9 @@ class Bluesky_Provider implements Connection_Provider {
 		// The response is plain text and a malformed value (newlines, control chars,
 		// HTML bytes) would corrupt the body or worse. Valid AT Proto DIDs are
 		// "did:" + method + ":" + ASCII alphanumerics with a small punctuation set.
-		if ( ! preg_match( '/^did:[a-z]+:[A-Za-z0-9._:%\-]+$/', $did ) ) {
+		// \A and \z anchor strictly so a stored DID with a trailing newline (which
+		// PHP's $ anchor permits) doesn't slip a stray byte into the response.
+		if ( ! preg_match( '/\Adid:[a-z]+:[A-Za-z0-9._:%\-]*[A-Za-z0-9._\-]\z/', $did ) ) {
 			return array(
 				'status' => 404,
 				'did'    => '',

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -298,6 +298,50 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * The suppression hook is a no-op for unrelated atmosphere_wellknown query vars.
+	 */
+	public function test_maybe_suppress_atmosphere_well_known_no_op_for_other_query_vars() {
+		global $wp_query;
+		$wp_query = new \WP_Query(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- isolating $wp_query state for the suppression hook.
+		set_query_var( 'atmosphere_wellknown', 'publication' );
+		add_filter( 'fosse_serve_atproto_did_well_known', '__return_false' );
+
+		$this->provider->maybe_suppress_atmosphere_well_known();
+
+		$this->assertSame( 'publication', get_query_var( 'atmosphere_wellknown' ) );
+		$this->assertFalse( $wp_query->is_404() );
+	}
+
+	/**
+	 * The suppression hook is a no-op when FOSSE will serve the route itself.
+	 */
+	public function test_maybe_suppress_atmosphere_well_known_no_op_when_filter_true() {
+		global $wp_query;
+		$wp_query = new \WP_Query(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- isolating $wp_query state for the suppression hook.
+		set_query_var( 'atmosphere_wellknown', 'atproto-did' );
+
+		$this->provider->maybe_suppress_atmosphere_well_known();
+
+		$this->assertSame( 'atproto-did', get_query_var( 'atmosphere_wellknown' ) );
+		$this->assertFalse( $wp_query->is_404() );
+	}
+
+	/**
+	 * Opting out via filter clears Atmosphere's query var and forces a 404.
+	 */
+	public function test_maybe_suppress_atmosphere_well_known_clears_query_var_and_404s_when_opted_out() {
+		global $wp_query;
+		$wp_query = new \WP_Query(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- isolating $wp_query state for the suppression hook.
+		set_query_var( 'atmosphere_wellknown', 'atproto-did' );
+		add_filter( 'fosse_serve_atproto_did_well_known', '__return_false' );
+
+		$this->provider->maybe_suppress_atmosphere_well_known();
+
+		$this->assertSame( '', get_query_var( 'atmosphere_wellknown' ) );
+		$this->assertTrue( $wp_query->is_404() );
+	}
+
+	/**
 	 * Disconnect clears the Atmosphere connection and redirects back to FOSSE.
 	 */
 	public function test_handle_disconnect_clears_connection_and_redirects() {
@@ -549,8 +593,8 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertNotFalse( has_action( 'admin_post_fosse_connect_bluesky', array( $this->provider, 'handle_connect' ) ) );
 		$this->assertNotFalse( has_action( 'admin_post_fosse_disconnect_bluesky', array( $this->provider, 'handle_disconnect' ) ) );
 		$this->assertNotFalse( has_action( 'admin_init', array( $this->provider, 'handle_oauth_callback' ) ) );
-		$this->assertNotFalse( has_action( 'init', array( $this->provider, 'serve_atproto_did_well_known' ) ) );
-		$this->assertNotFalse( has_action( 'template_redirect', array( $this->provider, 'maybe_suppress_atmosphere_well_known' ) ) );
+		$this->assertSame( 1, has_action( 'init', array( $this->provider, 'serve_atproto_did_well_known' ) ) );
+		$this->assertSame( 1, has_action( 'template_redirect', array( $this->provider, 'maybe_suppress_atmosphere_well_known' ) ) );
 		$this->assertNotFalse( has_filter( 'atmosphere_oauth_redirect_uri', array( $this->provider, 'filter_oauth_redirect_uri' ) ) );
 	}
 

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -322,6 +322,29 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * A stored DID with a single trailing newline is rejected (PHP's $ would have allowed it).
+	 */
+	public function test_atproto_did_well_known_response_rejects_did_with_trailing_newline() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => "did:plc:test123\n",
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'status' => 404,
+				'did'    => '',
+			),
+			$this->get_atproto_did_well_known_response( '/.well-known/atproto-did' )
+		);
+	}
+
+	/**
 	 * The suppression hook is a no-op for unrelated atmosphere_wellknown query vars.
 	 */
 	public function test_maybe_suppress_atmosphere_well_known_no_op_for_other_query_vars() {

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -13,6 +13,7 @@ use Automattic\Fosse\Admin\Connection_Provider_Registry;
 use Automattic\Fosse\Provider_Loader;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
+use ReflectionMethod;
 use WorDBless\BaseTestCase;
 
 /**
@@ -54,6 +55,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		remove_all_filters( 'admin_post_fosse_connect_bluesky' );
 		remove_all_filters( 'admin_post_fosse_disconnect_bluesky' );
 		remove_all_filters( 'admin_init' );
+		remove_all_filters( 'fosse_serve_atproto_did_well_known' );
 
 		global $wp_settings_errors;
 		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- reset core settings-error storage for test isolation.
@@ -223,6 +225,76 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			admin_url( 'admin.php?page=fosse' ),
 			$this->provider->filter_oauth_redirect_uri( admin_url( 'options-general.php?page=atmosphere' ) )
 		);
+	}
+
+	/**
+	 * The well-known route helper ignores unrelated request paths.
+	 */
+	public function test_atproto_did_well_known_response_ignores_other_paths() {
+		$this->assertNull( $this->get_atproto_did_well_known_response( '/about' ) );
+	}
+
+	/**
+	 * The well-known route helper returns the connected DID as plain response data.
+	 */
+	public function test_atproto_did_well_known_response_returns_connected_did() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'status' => 200,
+				'did'    => 'did:plc:test123',
+			),
+			$this->get_atproto_did_well_known_response( '/.well-known/atproto-did?ignored=1' )
+		);
+	}
+
+	/**
+	 * A stored DID is not enough to serve the well-known route without a connection.
+	 */
+	public function test_atproto_did_well_known_response_requires_connected_atmosphere() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'    => 'did:plc:test123',
+				'handle' => 'alice.bsky.social',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'status' => 404,
+				'did'    => '',
+			),
+			$this->get_atproto_did_well_known_response( '/.well-known/atproto-did' )
+		);
+	}
+
+	/**
+	 * The FOSSE opt-out filter prevents FOSSE from serving the well-known route.
+	 */
+	public function test_atproto_did_well_known_response_respects_opt_out_filter() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		add_filter( 'fosse_serve_atproto_did_well_known', '__return_false' );
+
+		$this->assertNull( $this->get_atproto_did_well_known_response( '/.well-known/atproto-did' ) );
 	}
 
 	/**
@@ -477,7 +549,20 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertNotFalse( has_action( 'admin_post_fosse_connect_bluesky', array( $this->provider, 'handle_connect' ) ) );
 		$this->assertNotFalse( has_action( 'admin_post_fosse_disconnect_bluesky', array( $this->provider, 'handle_disconnect' ) ) );
 		$this->assertNotFalse( has_action( 'admin_init', array( $this->provider, 'handle_oauth_callback' ) ) );
+		$this->assertNotFalse( has_action( 'init', array( $this->provider, 'serve_atproto_did_well_known' ) ) );
+		$this->assertNotFalse( has_action( 'template_redirect', array( $this->provider, 'maybe_suppress_atmosphere_well_known' ) ) );
 		$this->assertNotFalse( has_filter( 'atmosphere_oauth_redirect_uri', array( $this->provider, 'filter_oauth_redirect_uri' ) ) );
+	}
+
+	/**
+	 * Invoke the private well-known response helper via reflection.
+	 *
+	 * @param string $request_uri Request URI.
+	 * @return array{status:int,did:string}|null
+	 */
+	private function get_atproto_did_well_known_response( string $request_uri ): ?array {
+		$method = new ReflectionMethod( Bluesky_Provider::class, 'get_atproto_did_well_known_response' );
+		return $method->invoke( $this->provider, $request_uri );
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -56,6 +56,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		remove_all_filters( 'admin_post_fosse_disconnect_bluesky' );
 		remove_all_filters( 'admin_init' );
 		remove_all_filters( 'fosse_serve_atproto_did_well_known' );
+		remove_all_filters( 'status_header' );
 
 		global $wp_settings_errors;
 		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- reset core settings-error storage for test isolation.
@@ -298,6 +299,29 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * A stored DID that doesn't match AT Proto syntax is rejected with a 404.
+	 */
+	public function test_atproto_did_well_known_response_rejects_malformed_did() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => "did:plc:abc\n<script>alert(1)</script>",
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'status' => 404,
+				'did'    => '',
+			),
+			$this->get_atproto_did_well_known_response( '/.well-known/atproto-did' )
+		);
+	}
+
+	/**
 	 * The suppression hook is a no-op for unrelated atmosphere_wellknown query vars.
 	 */
 	public function test_maybe_suppress_atmosphere_well_known_no_op_for_other_query_vars() {
@@ -306,10 +330,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		set_query_var( 'atmosphere_wellknown', 'publication' );
 		add_filter( 'fosse_serve_atproto_did_well_known', '__return_false' );
 
+		$status_header_called = $this->capture_status_header();
+
 		$this->provider->maybe_suppress_atmosphere_well_known();
 
 		$this->assertSame( 'publication', get_query_var( 'atmosphere_wellknown' ) );
 		$this->assertFalse( $wp_query->is_404() );
+		$this->assertNull( $status_header_called->code, 'status_header should not be called for unrelated query vars.' );
 	}
 
 	/**
@@ -320,10 +347,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$wp_query = new \WP_Query(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- isolating $wp_query state for the suppression hook.
 		set_query_var( 'atmosphere_wellknown', 'atproto-did' );
 
+		$status_header_called = $this->capture_status_header();
+
 		$this->provider->maybe_suppress_atmosphere_well_known();
 
 		$this->assertSame( 'atproto-did', get_query_var( 'atmosphere_wellknown' ) );
 		$this->assertFalse( $wp_query->is_404() );
+		$this->assertNull( $status_header_called->code, 'status_header should not be called when FOSSE will serve the route.' );
 	}
 
 	/**
@@ -335,10 +365,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		set_query_var( 'atmosphere_wellknown', 'atproto-did' );
 		add_filter( 'fosse_serve_atproto_did_well_known', '__return_false' );
 
+		$status_header_called = $this->capture_status_header();
+
 		$this->provider->maybe_suppress_atmosphere_well_known();
 
 		$this->assertSame( '', get_query_var( 'atmosphere_wellknown' ) );
 		$this->assertTrue( $wp_query->is_404() );
+		$this->assertSame( 404, $status_header_called->code, 'status_header( 404 ) should be sent on opt-out.' );
 	}
 
 	/**
@@ -607,6 +640,26 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	private function get_atproto_did_well_known_response( string $request_uri ): ?array {
 		$method = new ReflectionMethod( Bluesky_Provider::class, 'get_atproto_did_well_known_response' );
 		return $method->invoke( $this->provider, $request_uri );
+	}
+
+	/**
+	 * Capture the next status_header call into a returned object's `code` property.
+	 *
+	 * @return object Object with a nullable int `code` property; null until status_header fires.
+	 */
+	private function capture_status_header(): object {
+		$capture       = new \stdClass();
+		$capture->code = null;
+		add_filter(
+			'status_header',
+			static function ( $header, $code ) use ( $capture ) {
+				$capture->code = (int) $code;
+				return $header;
+			},
+			10,
+			2
+		);
+		return $capture;
 	}
 
 	/**


### PR DESCRIPTION
Tracks DOTCOM-16801.

## Summary

This PR now contains the Bluesky handle setup SDD plus the first implemented slice:

- Adds the `sdd/bluesky-handle-setup/` requirements, spec, plan, and implementation notes.
- Serves `/.well-known/atproto-did` from `Bluesky_Provider` when Atmosphere reports a connected Bluesky account.
- Adds `fosse_serve_atproto_did_well_known` as the FOSSE opt-out filter and suppresses Atmosphere's bundled fallback when the filter opts out.
- Returns 404 when Bluesky is not connected, including stale/partial `atmosphere_connection` data that has a DID but no access token.
- Adds PHPUnit coverage for route matching, connected response data, disconnected/partial 404 behavior, opt-out behavior, and hook registration.

## Still Planned

The rest of the SDD remains planned follow-up work on this branch/feature:

- Resolver-backed verification UI.
- DNS TXT fallback display.
- bsky.app handoff guidance.
- Current-handle lookup to distinguish verified vs. active.
- Full UI/admin-post handlers for starting and rechecking domain handle setup.

## Verification

- [x] `git diff --check`
- [x] `composer run-script lint-php`
- [x] `composer run-script test-php` (`114 tests, 233 assertions`)
- [x] `pnpm run format:check`
- [x] `pnpm run lint` (passes with existing React-detect warning)
- [x] `pnpm test`
- [x] Manual local Playground check: mocked connected state serves `/.well-known/atproto-did`; cleared connection returns 404.

## Local E2E Caveat

`pnpm run test:e2e` currently fails locally with 18 passing and 2 failing specs:

- `tests/e2e/bluesky-provider.spec.ts`
- `tests/e2e/long-form-link-card.spec.ts`

Both failures time out waiting for `window.wpApiSettings?.nonce` after loading `/wp-admin/post-new.php`. This nonce-bootstrap pattern predates this PR (introduced in #21 and reused in #34) and appears to be a local Playground / WordPress latest admin bootstrap issue, not a failure in this branch's well-known route behavior.
