### PR TITLE
docs: link bundled-backends SDD to DOTCOM-16799

### DIFF
--- a/sdd/bundled-backends/requirements.md
+++ b/sdd/bundled-backends/requirements.md
@@ -1,5 +1,7 @@
 # Bundled Backends — Requirements
 
+Tracked under: [DOTCOM-16799](https://linear.app/a8c/issue/DOTCOM-16799) "7. Distribution, infrastructure, and external partnerships".
+
 ## Goal
 
 Bundle the release-build versions of `wordpress-activitypub` and `wordpress-atmosphere` into FOSSE so the plugin ships with Mastodon (ActivityPub) and Bluesky (AT Protocol) federation working out of the box. When the standalone plugin is already active on the site, skip loading FOSSE's bundled copy to avoid collisions. This is an intentionally short-term bootstrap — a "rough starting point" for the Week 1 milestone — that FOSSE will iterate on (crisp, unified UI replacing the bundled plugins' admin screens is a later SDD item).


### PR DESCRIPTION
## Summary

Adds a one-line `Tracked under` reference to `sdd/bundled-backends/requirements.md` pointing at [DOTCOM-16799](https://linear.app/a8c/issue/DOTCOM-16799) "7. Distribution, infrastructure, and external partnerships".

The bundled-backends SDD predates the DOTCOM-tracking convention used by later FOSSE SDDs and was the only feature folder without a Linear cross-reference. DOTCOM-16799's description explicitly cites PR 11's bundling as the short-term bootstrap, making it the natural parent epic.

## Test plan

- [ ] Visual review of `sdd/bundled-backends/requirements.md` — the new `Tracked under:` line appears between the title and the `## Goal` heading.

See DOTCOM-16799