### PR TITLE
Polish FOSSE Status page

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -37,6 +37,13 @@
 	margin-top: 0;
 }
 
+/* Allow long opaque values (Bluesky DIDs, PDS URLs, fediverse handles) to
+   wrap inside the card. Without this, the cell's min-content width is the
+   full identifier and the table pushes past its container. */
+.fosse-status-card td {
+	overflow-wrap: anywhere;
+}
+
 /* Status indicator dots */
 .fosse-status-indicator {
 	display: inline-block;

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -11,6 +11,7 @@
 	border: 1px solid #c3c4c7;
 	border-left-width: 4px;
 	border-left-color: #00a32a;
+	border-radius: 4px;
 	padding: 12px 16px;
 	margin: 16px 0;
 }
@@ -30,10 +31,11 @@
 .fosse-status-card {
 	background: #fff;
 	border: 1px solid #c3c4c7;
+	border-radius: 4px;
 	padding: 16px;
 }
 
-.fosse-status-card h3 {
+.fosse-status-card h2 {
 	margin-top: 0;
 }
 
@@ -66,6 +68,7 @@
 .fosse-provider-section {
 	background: #fff;
 	border: 1px solid #c3c4c7;
+	border-radius: 4px;
 	padding: 16px 24px;
 	margin: 16px 0;
 }

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -188,10 +188,14 @@ class AP_Provider implements Connection_Provider {
 		);
 		?>
 		<div class="fosse-status-card">
-			<h3>
-				<span class="fosse-status-indicator <?php echo $status['connected'] ? 'connected' : 'disconnected'; ?>"></span>
+			<h2>
+				<span
+					class="fosse-status-indicator <?php echo $status['connected'] ? 'connected' : 'disconnected'; ?>"
+					role="img"
+					aria-label="<?php echo esc_attr( $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' ) ); ?>"
+				></span>
 				<?php esc_html_e( 'ActivityPub', 'fosse' ); ?>
-			</h3>
+			</h2>
 
 			<table class="widefat striped">
 				<tbody>

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -182,10 +182,14 @@ class Bluesky_Provider implements Connection_Provider {
 		$status = $this->get_status();
 		?>
 		<div class="fosse-status-card">
-			<h3>
-				<span class="fosse-status-indicator <?php echo $status['connected'] ? 'connected' : 'disconnected'; ?>"></span>
+			<h2>
+				<span
+					class="fosse-status-indicator <?php echo $status['connected'] ? 'connected' : 'disconnected'; ?>"
+					role="img"
+					aria-label="<?php echo esc_attr( $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' ) ); ?>"
+				></span>
 				<?php esc_html_e( 'Bluesky', 'fosse' ); ?>
-			</h3>
+			</h2>
 
 			<table class="widefat striped">
 				<tbody>

--- a/src/Admin/templates/status-page.php
+++ b/src/Admin/templates/status-page.php
@@ -27,8 +27,8 @@ $connected = array_filter(
 			<p>
 				<?php
 				printf(
-					/* translators: 1: number of connected protocols, 2: total available protocols */
-					esc_html__( '%1$d of %2$d protocols active', 'fosse' ),
+					/* translators: 1: number of active connections, 2: total available connections */
+					esc_html__( '%1$d of %2$d connections active', 'fosse' ),
 					count( $connected ),
 					count( $available )
 				);


### PR DESCRIPTION
## Summary

Status-page design polish from a /design-review pass, plus the original DID overflow fix.

**Bug fix**
- Long opaque identifiers (Bluesky DIDs, PDS URLs, fediverse handles) had no break opportunities, so the table cell's `min-content` width was the full string and the table pushed past `.fosse-status-card`. `overflow-wrap: anywhere` on `.fosse-status-card td` lets the browser break at any character and reduces the cell's `min-content` width.

**Design review polish**
- A11y: status indicator dot now has `role="img"` + localized `aria-label` so screen readers announce Connected/Disconnected at the heading level (was color-only encoding).
- Copy: summary bar reads "X of Y connections active" instead of "protocols active" — matches the "Connection: Connected" row label and the rest of the admin UI.
- Hierarchy: provider names in status cards bumped from `<h3>` to `<h2>`. Removes the h1 → h3 skip and matches the `.fosse-provider-section h2` used on Setup.
- Polish: 4px border-radius on `.fosse-status-card`, `.fosse-status-summary`, `.fosse-provider-section` for consistency with the wizard card and modern wp-admin surfaces.

Fixes #39

## Follow-ups (separate PR)

Three findings from the same design pass deserve their own scrutiny rather than being smuggled in here: token-error reconnect UX, per-card "Manage settings" link, empty-state CTA when zero providers connected.

## Test plan

- [ ] Visit FOSSE Status with a connected Bluesky account — confirm DID wraps, table is contained
- [ ] Disconnect Bluesky — screen reader announces "Disconnected, Bluesky" on the heading
- [ ] Confirm summary bar reads "N of M connections active"
- [ ] Visual: cards have subtle rounded corners; provider name styled as h2
- [ ] ActivityPub setup form-table on the Setup page is unchanged