### PR TITLE
Status page UX: token errors, manage links, empty state

### DIFF
--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -104,7 +104,7 @@ class AP_Provider implements Connection_Provider {
 		$address        = $this->get_fediverse_address();
 		$nonce          = wp_create_nonce( 'fosse_save_ap_settings' );
 		?>
-		<div class="fosse-provider-section">
+		<div class="fosse-provider-section" id="fosse-provider-activitypub">
 			<h2><?php esc_html_e( 'ActivityPub', 'fosse' ); ?></h2>
 
 			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
@@ -212,6 +212,12 @@ class AP_Provider implements Connection_Provider {
 					<?php $this->render_follower_count_row(); ?>
 				</tbody>
 			</table>
+
+			<p class="fosse-status-card__manage">
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-provider-activitypub' ) ); ?>">
+					<?php esc_html_e( 'Manage ActivityPub settings', 'fosse' ); ?>
+				</a>
+			</p>
 		</div>
 		<?php
 	}

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -106,7 +106,7 @@ class Bluesky_Provider implements Connection_Provider {
 		$status = $this->get_status();
 
 		?>
-		<div class="fosse-provider-section">
+		<div class="fosse-provider-section" id="fosse-provider-bluesky">
 			<h2><?php esc_html_e( 'Bluesky', 'fosse' ); ?></h2>
 
 			<?php settings_errors( 'atmosphere' ); ?>
@@ -217,10 +217,29 @@ class Bluesky_Provider implements Connection_Provider {
 					</tr>
 					<tr>
 						<td><?php esc_html_e( 'Token Health', 'fosse' ); ?></td>
-						<td><?php echo esc_html( $status['token_error'] ? $status['token_error'] : __( 'OK', 'fosse' ) ); ?></td>
+						<td>
+							<?php if ( $status['token_error'] ) : ?>
+								<strong><?php esc_html_e( 'Reconnect required.', 'fosse' ); ?></strong>
+								<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-provider-bluesky' ) ); ?>">
+									<?php esc_html_e( 'Open Bluesky setup', 'fosse' ); ?>
+								</a>
+								<details class="fosse-status-card__error">
+									<summary><?php esc_html_e( 'Error details', 'fosse' ); ?></summary>
+									<code><?php echo esc_html( $status['token_error'] ); ?></code>
+								</details>
+							<?php else : ?>
+								<?php esc_html_e( 'OK', 'fosse' ); ?>
+							<?php endif; ?>
+						</td>
 					</tr>
 				</tbody>
 			</table>
+
+			<p class="fosse-status-card__manage">
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-provider-bluesky' ) ); ?>">
+					<?php esc_html_e( 'Manage Bluesky settings', 'fosse' ); ?>
+				</a>
+			</p>
 		</div>
 		<?php
 	}

--- a/src/Admin/templates/status-page.php
+++ b/src/Admin/templates/status-page.php
@@ -34,6 +34,13 @@ $connected = array_filter(
 				);
 				?>
 			</p>
+			<?php if ( empty( $connected ) ) : ?>
+				<p>
+					<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=fosse' ) ); ?>">
+						<?php esc_html_e( 'Set up FOSSE', 'fosse' ); ?>
+					</a>
+				</p>
+			<?php endif; ?>
 		</div>
 
 		<div class="fosse-status-cards">

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -107,6 +107,32 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertSame( array( 'page' ), $this->provider->get_status()['post_types'] );
 	}
 
+	/**
+	 * Setup section carries the fragment target id used by the Status-page
+	 * "Manage ActivityPub settings" deep link. Renaming the id without
+	 * updating the link would silently break navigation.
+	 */
+	public function test_render_setup_section_has_anchor_id() {
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="fosse-provider-activitypub"', $output );
+	}
+
+	/**
+	 * Status card deep-links back to the ActivityPub setup section. The
+	 * fragment must match the id rendered by render_setup_section().
+	 */
+	public function test_render_status_card_has_manage_settings_link() {
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Manage ActivityPub settings', $output );
+		$this->assertStringContainsString( '#fosse-provider-activitypub', $output );
+	}
+
 	// --- handle_save tests ---------------------------------------------------
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -216,6 +216,80 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Setup section carries the fragment target id used by the Status-page
+	 * "Manage Bluesky settings" deep link. Renaming the id without updating
+	 * the link would silently break navigation.
+	 */
+	public function test_render_setup_section_has_anchor_id() {
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="fosse-provider-bluesky"', $output );
+	}
+
+	/**
+	 * Status card surfaces the reconnect UI and a details element with the
+	 * raw error when the stored access token can't be decrypted.
+	 */
+	public function test_render_status_card_token_error_shows_reconnect_ui() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => 'garbage',
+			)
+		);
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Reconnect required', $output );
+		$this->assertStringContainsString( '#fosse-provider-bluesky', $output );
+		$this->assertStringContainsString( '<details', $output );
+	}
+
+	/**
+	 * Status card reports OK token health and omits the reconnect UI when
+	 * the connection is healthy.
+	 */
+	public function test_render_status_card_ok_state_omits_reconnect_ui() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/<td>\s*OK\s*<\/td>/', $output );
+		$this->assertStringNotContainsString( 'Reconnect required', $output );
+		$this->assertStringNotContainsString( '<details', $output );
+	}
+
+	/**
+	 * Status card deep-links back to the Bluesky setup section. The fragment
+	 * must match the id rendered by render_setup_section().
+	 */
+	public function test_render_status_card_has_manage_settings_link() {
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Manage Bluesky settings', $output );
+		$this->assertStringContainsString( '#fosse-provider-bluesky', $output );
+	}
+
+	/**
 	 * FOSSE-initiated OAuth should return to the FOSSE setup page.
 	 */
 	public function test_filter_oauth_redirect_uri_returns_fosse_page() {


### PR DESCRIPTION
## Summary

Three follow-up findings from the /design-review pass on PR #45. Splitting them out because each adds real UX rather than CSS polish.

**Token error UX** (`class-bluesky-provider.php` `render_status_card`)
The "Token Health" row used to dump Atmosphere's raw OAuth error string ("invalid_grant: token expired") with no path to action. Now: when a token error is set, the row shows "Reconnect required" + "Open Bluesky setup" link, with the raw error tucked into a `<details>` for debugging.

**Manage settings links** (both providers)
Each status card now has a "Manage Bluesky settings" / "Manage ActivityPub settings" link below the table, deep-linking via fragment to the provider's section on the Setup page. Setup-page provider sections grew matching `id` attributes (`fosse-provider-bluesky`, `fosse-provider-activitypub`) so the fragment lands you in the right spot.

**Empty-state CTA** (`templates/status-page.php`)
When zero providers are connected, the summary bar now includes a "Set up FOSSE" primary button. Previously a fresh install with no connections showed "0 of N connections active" + N empty-feeling cards with no obvious next step.

## Notes

- No CSS changes — relies on default WordPress admin link styling and `<button button-primary>`.
- Translation strings: 6 new (`'Reconnect required.'`, `'Open Bluesky setup'`, `'Error details'`, `'Manage Bluesky settings'`, `'Manage ActivityPub settings'`, `'Set up FOSSE'`).

## Test plan

- [ ] Force a Bluesky token error (e.g. revoke at the PDS); confirm row shows "Reconnect required" + link, not raw error
- [ ] Click "Manage Bluesky settings" — lands on Setup page scrolled to the Bluesky section
- [ ] Click "Manage ActivityPub settings" — lands on Setup page scrolled to the AP section
- [ ] Fresh install with neither connected: summary bar shows "Set up FOSSE" button
- [ ] Connect one, disconnect the other: button disappears