### PR TITLE
Add Bluesky connect flow to onboarding wizard

### DIFF
--- a/sdd/onboarding-setup-ux/plan.md
+++ b/sdd/onboarding-setup-ux/plan.md
@@ -10,6 +10,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - [x] Task 4: Open upstream Atmosphere PRs
 - [x] Task 5: Create Bluesky_Provider
 - [x] Task 5.5: Create first-run onboarding wizard
+- [ ] Task 5.6: Replace Bluesky wizard placeholder with live connect form
 - [x] Task 6: Create Status_Page with provider status cards
 - [x] Task 7: Add admin CSS
 - [x] Task 8: Write tests
@@ -95,15 +96,15 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Status**: ✅ Done (#33)
 - **Files**: `src/Admin/class-onboarding-wizard.php`, `src/Admin/class-menu.php`, `src/Admin/assets/css/admin.css`, `fosse.php`
 - **Do**:
-  1. Create `Onboarding_Wizard` class with step-based rendering: Welcome, Appearance (actor mode), Content (post types), Bluesky (placeholder), Complete.
+  1. Create `Onboarding_Wizard` class with step-based rendering: Welcome, Appearance (actor mode), Content (post types), Bluesky, Complete.
   2. Register the wizard as a hidden submenu in `Menu::add_menu()` by passing an empty parent slug to `add_submenu_page()`. The page has a real admin URL (`?page=fosse-wizard`) and inherits capability checks, but never appears in the menu sidebar.
   3. Add `register_activation_hook` in `fosse.php` that writes a one-shot `fosse_activation_redirect` option (autoload `false`).
   4. Add `admin_init` handler in `Menu` that checks the option, deletes it, and redirects to `?page=fosse-wizard` on first activation.
   5. Each step with form data POSTs to `admin_post.php?action=fosse_wizard_save`. Handler validates nonce + capability, saves step settings directly to AP's `activitypub_actor_mode` / `activitypub_support_post_types` options (matching AP_Provider's direct-write pattern), redirects to next step.
   6. "Skip setup" and the completion step both set `fosse_onboarding_completed` option to `1`.
   7. Actor mode selection uses card-style UI with hidden radio inputs inside `<label>` elements (works without JS). Post type selection uses checkboxes.
-  8. Bluesky step renders a placeholder/coming-soon state since `Bluesky_Provider` is not yet built.
-  9. Completion step shows summary of configured values with links to Status Dashboard and Setup page.
+  8. Bluesky step renders a placeholder for future Bluesky setup work.
+  9. Completion step shows summary of configured values, with links to Status Dashboard and Setup page.
   10. Add wizard CSS to `admin.css` under `.fosse-wizard` prefix. Styles use WP design tokens (colors, spacing, radii) and lean on native WP admin classes where possible.
 - **Verify**:
   - `composer run-script lint-php` passes.
@@ -113,6 +114,26 @@ Based on: sdd/onboarding-setup-ux/spec.md
   - Playground: after completion, visiting FOSSE menu goes to Setup page (not wizard).
   - Wizard page is not visible in the admin menu sidebar.
 - **Depends on**: Task 3
+
+### Task 5.6: Replace Bluesky wizard placeholder with live connect form
+- **Status**: In progress
+- **Files**: `src/Admin/class-onboarding-wizard.php`, `src/Admin/class-bluesky-provider.php`, `src/Admin/assets/css/admin.css`, `tests/php/Admin/Onboarding_WizardTest.php`, `tests/php/Admin/Bluesky_ProviderTest.php`, `tests/e2e/onboarding-wizard.spec.ts`, `sdd/onboarding-setup-ux/spec.md`, `sdd/onboarding-setup-ux/planned-decisions.md`
+- **Do**:
+  1. Have the wizard Bluesky step read Bluesky provider status through the provider registry, with a direct provider fallback for tests and early admin boot.
+  2. When disconnected, render the live OAuth handle form that posts to `admin-post.php?action=fosse_connect_bluesky`.
+  3. Include a hidden wizard return context so successful wizard-origin OAuth flows return to `?page=fosse-wizard&step=bluesky`.
+  4. When connected, render the connected handle/DID/auto-publish summary and make the primary action finish setup.
+  5. When unavailable, render a skip-only notice instead of a connect form.
+  6. Include Bluesky connection status in the completion summary.
+  7. Clear stale wizard return context when a later setup-page connect attempt starts without the wizard return marker.
+  8. Update wizard CSS, PHP tests, e2e coverage, and SDD docs for the live Bluesky step.
+- **Verify**:
+  - `composer run-script lint-php` passes.
+  - `composer run-script test-php` passes.
+  - `pnpm run format:check` passes.
+  - `pnpm run lint` passes.
+  - `pnpm exec playwright test tests/e2e/onboarding-wizard.spec.ts` passes.
+- **Depends on**: Task 5, Task 5.5
 
 ### Task 6: Create Status_Page with provider status cards
 - **Status**: ✅ Done (#27)

--- a/sdd/onboarding-setup-ux/planned-decisions.md
+++ b/sdd/onboarding-setup-ux/planned-decisions.md
@@ -24,10 +24,22 @@ These implementation notes capture the planned implementation decisions, constra
 - **Decision**: `Menu::register()` fires `fosse_register_providers`, then iterates registered providers and calls `register_hooks()` on each. Provider hooks (like `admin_post_*` handlers) are only registered in admin context.
 - **Reason**: Avoids registering admin-post handlers on front-end requests. The `is_admin()` guard in `fosse.php` already limits this to admin context, but having `Menu::register()` control the lifecycle is cleaner.
 
+### Wizard Bluesky step uses provider state
+- **Decision**: The first-run wizard's Bluesky step reads the registered Bluesky provider status instead of keeping wizard-specific Bluesky state. Disconnected sites render the same OAuth handle form used by the Setup page; connected sites render the connected handle/DID/auto-publish summary; unavailable sites render a skip-only notice.
+- **Reason**: Bluesky connection state belongs to Atmosphere and is already surfaced through `Bluesky_Provider::get_status()`. Reusing that provider keeps the wizard, Setup page, and Status page consistent while avoiding a parallel wizard-only option.
+
+### Wizard-origin Bluesky OAuth preserves return context
+- **Decision**: The wizard connect form includes a `fosse_bluesky_return=wizard` hidden field. `Bluesky_Provider::handle_connect()` stores that context in a per-user transient only after `Atmosphere\OAuth\Client::authorize()` returns an auth URL. The external OAuth callback still lands on the FOSSE Setup page, then `handle_oauth_callback()` consumes the transient and redirects back to the wizard's Bluesky step with `settings-updated=true`.
+- **Reason**: Atmosphere's client metadata endpoint can advertise only a stable callback URI for the OAuth client, and FOSSE already owns that URI as `admin.php?page=fosse`. A FOSSE-side return-context transient lets the wizard preserve its flow without changing the registered OAuth callback or introducing wizard-owned Bluesky connection state.
+
+### Wizard step order remains unchanged for the Bluesky-connect PR
+- **Decision**: This PR keeps the existing wizard order: Welcome → Appearance → Content → Bluesky → Complete.
+- **Reason**: The PR scope is limited to replacing the Bluesky placeholder with the real provider-backed connect state. After this ships, revisit the onboarding sequence so Bluesky no longer feels like an afterthought relative to the ActivityPub content settings.
+
 ## Known Limitations (Expected)
 
 ### Users must configure their domain handle on bsky.app separately
-The OAuth flow authorizes an existing Bluesky account but does not configure the user's domain as their Bluesky handle. Users who want `@theirdomain.com` as their handle still need to set up DNS TXT or `/.well-known/atproto-did` and use Bluesky's "Change Handle" UI. The Setup page will include a help link explaining this prerequisite. Guiding users through this process within FOSSE is a future feature.
+The OAuth flow authorizes an existing Bluesky account but does not configure the user's domain as their Bluesky handle. Users who want `@theirdomain.com` as their handle still need to set up DNS TXT or `/.well-known/atproto-did` and use Bluesky's "Change Handle" UI. The Setup page and wizard include help links explaining this prerequisite. Guiding users through this process within FOSSE is a separate Bluesky handle setup epic.
 
 ### Status dashboard will not auto-refresh
 The status dashboard will be a static PHP page. Token expiry, connection health, and follower counts are current as of page load only. No AJAX polling or auto-refresh planned for MVP.
@@ -52,7 +64,7 @@ This epic does not define what happens to FOSSE's menu state when FOSSE is deact
 
 ### Wizard completion tracked by a single option
 - **Decision**: `fosse_onboarding_completed` option (value `1`) tracks whether the wizard has run. Both "Skip setup" and the final completion step set this.
-- **Reason**: A single boolean is the simplest state to check. The Setup page can show a "Run setup wizard" link when this option is absent, giving users a way back in without making the wizard re-trigger on every visit. The option is deliberately not tied to a version number: if we want to re-trigger the wizard for a future major feature (e.g., Bluesky going live), we can add a versioned check later.
+- **Reason**: A single boolean is the simplest state to check. The Setup page can show a "Run setup wizard" link when this option is absent, giving users a way back in without making the wizard re-trigger on every visit. The option is deliberately not tied to a version number: if we want to re-trigger the wizard for a future major feature, we can add a versioned check later.
 
 ### Setup page shows notice, not auto-redirect, when wizard is incomplete
 - **Decision**: When `fosse_onboarding_completed` is absent, the Setup page renders normally but shows an admin notice linking to the wizard. It does not auto-redirect.

--- a/sdd/onboarding-setup-ux/spec.md
+++ b/sdd/onboarding-setup-ux/spec.md
@@ -77,6 +77,19 @@ Setup_Page and Status_Page iterate `Connection_Provider_Registry::get_providers(
 
 Disconnect uses `admin_post_fosse_disconnect_bluesky`, calls `\Atmosphere\OAuth\Client::disconnect()` (public static), redirects back to FOSSE.
 
+### First-run Wizard Bluesky Step
+
+The wizard's Bluesky step is optional and backed by the same provider state as the Setup page:
+
+- Disconnected: render a handle input form that POSTs to `admin_post.php?action=fosse_connect_bluesky`.
+- Connected: render the connected handle/DID/auto-publish summary and a "Finish setup" action.
+- Unavailable: render a skip-only notice instead of a connect form.
+- Complete: include the current Bluesky status in the final summary row.
+
+The wizard does not own a separate Bluesky option. It reads `Bluesky_Provider::get_status()` through the provider registry so the Setup page, Status page, and wizard remain consistent.
+
+OAuth client metadata still advertises the FOSSE Setup page as the callback URI (`admin.php?page=fosse`), because the ATProto auth server validates the callback against Atmosphere's client metadata endpoint. When the connect form starts from the wizard, FOSSE stores a per-user return-context transient before redirecting to the auth server. After Atmosphere completes the callback on the Setup page, `Bluesky_Provider` consumes that transient and redirects back to `admin.php?page=fosse-wizard&step=bluesky&settings-updated=true`.
+
 ### AP Settings Integration (AP_Provider)
 
 Minimum viable configuration on the Setup page. Start with the two settings that gate whether federation works:

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -437,14 +437,12 @@
 	flex: 1;
 }
 
-/* Bluesky placeholder */
-.fosse-bluesky-placeholder {
-	opacity: 0.5;
-	pointer-events: none;
+/* Bluesky wizard */
+.fosse-bluesky-form {
 	margin-top: 16px;
 }
 
-.fosse-bluesky-placeholder__label {
+.fosse-bluesky-form__label {
 	display: block;
 	font-size: 11px;
 	font-weight: 500;
@@ -453,12 +451,12 @@
 	margin-bottom: 8px;
 }
 
-.fosse-bluesky-connect {
+.fosse-bluesky-form__controls {
 	display: flex;
 	gap: 8px;
 }
 
-.fosse-bluesky-connect .regular-text {
+.fosse-bluesky-form__controls .regular-text {
 	flex: 1;
 }
 

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -22,6 +22,27 @@ namespace Automattic\Fosse\Admin;
 class Bluesky_Provider implements Connection_Provider {
 
 	/**
+	 * Hidden form field used to identify wizard-origin connect flows.
+	 *
+	 * @var string
+	 */
+	private const RETURN_CONTEXT_FIELD = 'fosse_bluesky_return';
+
+	/**
+	 * Return context value for the first-run wizard.
+	 *
+	 * @var string
+	 */
+	private const RETURN_CONTEXT_WIZARD = 'wizard';
+
+	/**
+	 * Per-user transient prefix for pending OAuth return context.
+	 *
+	 * @var string
+	 */
+	private const OAUTH_RETURN_TRANSIENT_PREFIX = 'fosse_bluesky_oauth_return_';
+
+	/**
 	 * Hook into fosse_register_providers to self-register.
 	 *
 	 * @return void
@@ -259,20 +280,27 @@ class Bluesky_Provider implements Connection_Provider {
 
 		check_admin_referer( 'fosse_connect_bluesky' );
 
+		$return_context = $this->get_connect_return_context();
+		if ( self::RETURN_CONTEXT_WIZARD !== $return_context ) {
+			$this->forget_oauth_return_context();
+		}
+
 		$handle = sanitize_text_field( wp_unslash( $_POST['bluesky_handle'] ?? '' ) );
 		$handle = ltrim( $handle, '@' );
 
 		if ( empty( $handle ) ) {
-			$this->redirect_with_notice( __( 'Enter a Bluesky handle to continue.', 'fosse' ), 'error' );
+			$this->redirect_with_notice( __( 'Enter a Bluesky handle to continue.', 'fosse' ), 'error', $return_context );
 			return; // redirect_with_notice exits, but guard against future changes.
 		}
 
 		$auth_url = \Atmosphere\OAuth\Client::authorize( $handle );
 
 		if ( is_wp_error( $auth_url ) ) {
-			$this->redirect_with_notice( $auth_url->get_error_message(), 'error' );
+			$this->redirect_with_notice( $auth_url->get_error_message(), 'error', $return_context );
 			return; // redirect_with_notice exits, but guard against future changes.
 		}
+
+		$this->remember_oauth_return_context( $return_context );
 
 		wp_redirect( $auth_url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		exit;
@@ -319,10 +347,11 @@ class Bluesky_Provider implements Connection_Provider {
 			wp_die( esc_html__( 'You do not have permission to complete the Bluesky connection.', 'fosse' ) );
 		}
 
-		$result = \Atmosphere\OAuth\Client::handle_callback( $code, $state );
+		$result         = \Atmosphere\OAuth\Client::handle_callback( $code, $state );
+		$return_context = $this->consume_oauth_return_context();
 
 		if ( is_wp_error( $result ) ) {
-			$this->redirect_with_notice( $result->get_error_message(), 'error' );
+			$this->redirect_with_notice( $result->get_error_message(), 'error', $return_context );
 			return; // redirect_with_notice exits, but guard against future changes.
 		}
 
@@ -337,12 +366,13 @@ class Bluesky_Provider implements Connection_Provider {
 					__( 'Connected to Bluesky, but publication setup failed: %s', 'fosse' ),
 					$sync_result->get_error_message()
 				),
-				'warning'
+				'warning',
+				$return_context
 			);
 			return;
 		}
 
-		$this->redirect_with_notice( __( 'Successfully connected to Bluesky.', 'fosse' ), 'success' );
+		$this->redirect_with_notice( __( 'Successfully connected to Bluesky.', 'fosse' ), 'success', $return_context );
 	}
 
 	/**
@@ -356,17 +386,103 @@ class Bluesky_Provider implements Connection_Provider {
 	}
 
 	/**
-	 * Persist an admin notice and redirect back to the FOSSE setup page.
+	 * Persist an admin notice and redirect back to the originating FOSSE screen.
 	 *
-	 * @param string $message Notice message.
-	 * @param string $type    Notice type.
+	 * @param string $message        Notice message.
+	 * @param string $type           Notice type.
+	 * @param string $return_context Optional return context.
 	 * @return void
 	 */
-	private function redirect_with_notice( string $message, string $type ): void {
+	private function redirect_with_notice( string $message, string $type, string $return_context = '' ): void {
 		add_settings_error( 'atmosphere', 'fosse_bluesky_notice', $message, $type );
 		set_transient( 'settings_errors', get_settings_errors(), 30 );
 
-		wp_safe_redirect( admin_url( 'admin.php?page=fosse&settings-updated=true' ) );
+		wp_safe_redirect( $this->get_redirect_url( $return_context ) );
 		exit;
+	}
+
+	/**
+	 * Read the requested return context from a connect form submission.
+	 *
+	 * @return string
+	 */
+	private function get_connect_return_context(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce is checked in handle_connect() before this helper is called.
+		$return_context = isset( $_POST[ self::RETURN_CONTEXT_FIELD ] ) ? sanitize_key( wp_unslash( $_POST[ self::RETURN_CONTEXT_FIELD ] ) ) : '';
+
+		return self::RETURN_CONTEXT_WIZARD === $return_context ? self::RETURN_CONTEXT_WIZARD : '';
+	}
+
+	/**
+	 * Remember where a successful OAuth start should return after callback.
+	 *
+	 * @param string $return_context Return context.
+	 * @return void
+	 */
+	private function remember_oauth_return_context( string $return_context ): void {
+		$this->forget_oauth_return_context();
+
+		if ( self::RETURN_CONTEXT_WIZARD !== $return_context ) {
+			return;
+		}
+
+		set_transient(
+			$this->get_oauth_return_transient_key(),
+			self::RETURN_CONTEXT_WIZARD,
+			HOUR_IN_SECONDS
+		);
+	}
+
+	/**
+	 * Clear any remembered OAuth return context for the current user.
+	 *
+	 * @return void
+	 */
+	private function forget_oauth_return_context(): void {
+		delete_transient( $this->get_oauth_return_transient_key() );
+	}
+
+	/**
+	 * Consume any remembered OAuth return context for the current user.
+	 *
+	 * @return string
+	 */
+	private function consume_oauth_return_context(): string {
+		$key            = $this->get_oauth_return_transient_key();
+		$return_context = get_transient( $key );
+
+		delete_transient( $key );
+
+		return self::RETURN_CONTEXT_WIZARD === $return_context ? self::RETURN_CONTEXT_WIZARD : '';
+	}
+
+	/**
+	 * Build the per-user OAuth return transient key.
+	 *
+	 * @return string
+	 */
+	private function get_oauth_return_transient_key(): string {
+		return self::OAUTH_RETURN_TRANSIENT_PREFIX . get_current_user_id();
+	}
+
+	/**
+	 * Build the admin URL for a return context.
+	 *
+	 * @param string $return_context Return context.
+	 * @return string
+	 */
+	private function get_redirect_url( string $return_context ): string {
+		if ( self::RETURN_CONTEXT_WIZARD === $return_context ) {
+			return add_query_arg(
+				array(
+					'page'             => 'fosse-wizard',
+					'step'             => 'bluesky',
+					'settings-updated' => 'true',
+				),
+				admin_url( 'admin.php' )
+			);
+		}
+
+		return admin_url( 'admin.php?page=fosse&settings-updated=true' );
 	}
 }

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -347,17 +347,41 @@ class Bluesky_Provider implements Connection_Provider {
 			wp_die( esc_html__( 'You do not have permission to complete the Bluesky connection.', 'fosse' ) );
 		}
 
-		$result         = \Atmosphere\OAuth\Client::handle_callback( $code, $state );
-		$return_context = $this->consume_oauth_return_context();
+		// Resolve the return context against the inbound state before we hand
+		// off to Atmosphere so a stale or replayed callback can't strip the
+		// wizard marker away from a legitimate callback that arrives later.
+		$return_context = $this->consume_oauth_return_context( $state );
+
+		$result = \Atmosphere\OAuth\Client::handle_callback( $code, $state );
 
 		if ( is_wp_error( $result ) ) {
 			$this->redirect_with_notice( $result->get_error_message(), 'error', $return_context );
-			return; // redirect_with_notice exits, but guard against future changes.
+			return;
 		}
 
-		$sync_result = method_exists( '\Atmosphere\Publisher', 'sync_publication' )
-			? \Atmosphere\Publisher::sync_publication()
-			: null;
+		// Atmosphere reports success on token exchange but writes the
+		// connection option separately. If that write was lost (DB error,
+		// hostile filter), `is_connected()` flips back to false — surface
+		// that instead of falsely telling the user they're connected.
+		if ( ! \Atmosphere\is_connected() ) {
+			$this->redirect_with_notice(
+				__( 'Bluesky responded successfully, but the connection was not saved. Please try connecting again.', 'fosse' ),
+				'error',
+				$return_context
+			);
+			return;
+		}
+
+		if ( ! method_exists( '\Atmosphere\Publisher', 'sync_publication' ) ) {
+			$this->redirect_with_notice(
+				__( 'Connected to Bluesky, but publication setup is unavailable in the current Atmosphere version. Posts will not sync until this is resolved.', 'fosse' ),
+				'warning',
+				$return_context
+			);
+			return;
+		}
+
+		$sync_result = \Atmosphere\Publisher::sync_publication();
 
 		if ( is_wp_error( $sync_result ) ) {
 			$this->redirect_with_notice(
@@ -416,6 +440,11 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Remember where a successful OAuth start should return after callback.
 	 *
+	 * Binds the return context to Atmosphere's freshly-minted OAuth state so a
+	 * stale or replayed callback can't consume it before the legitimate one
+	 * arrives. `Client::authorize()` always writes `atmosphere_oauth_state`
+	 * before returning the auth URL, so reading it here is safe.
+	 *
 	 * @param string $return_context Return context.
 	 * @return void
 	 */
@@ -426,9 +455,17 @@ class Bluesky_Provider implements Connection_Provider {
 			return;
 		}
 
+		$oauth_state = get_transient( 'atmosphere_oauth_state' );
+		if ( ! is_string( $oauth_state ) || '' === $oauth_state ) {
+			return;
+		}
+
 		set_transient(
 			$this->get_oauth_return_transient_key(),
-			self::RETURN_CONTEXT_WIZARD,
+			array(
+				'context' => self::RETURN_CONTEXT_WIZARD,
+				'state'   => $oauth_state,
+			),
 			HOUR_IN_SECONDS
 		);
 	}
@@ -445,15 +482,31 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Consume any remembered OAuth return context for the current user.
 	 *
+	 * Only deletes and returns the context when the inbound callback state
+	 * matches the OAuth state the marker was bound to. A non-matching state
+	 * leaves the marker intact so the legitimate callback can still find it.
+	 *
+	 * @param string $callback_state Inbound OAuth `state` query arg.
 	 * @return string
 	 */
-	private function consume_oauth_return_context(): string {
-		$key            = $this->get_oauth_return_transient_key();
-		$return_context = get_transient( $key );
+	private function consume_oauth_return_context( string $callback_state ): string {
+		$key    = $this->get_oauth_return_transient_key();
+		$stored = get_transient( $key );
+
+		if ( ! is_array( $stored ) ) {
+			return '';
+		}
+
+		$stored_state   = isset( $stored['state'] ) && is_string( $stored['state'] ) ? $stored['state'] : '';
+		$stored_context = isset( $stored['context'] ) && is_string( $stored['context'] ) ? $stored['context'] : '';
+
+		if ( '' === $stored_state || '' === $callback_state || ! hash_equals( $stored_state, $callback_state ) ) {
+			return '';
+		}
 
 		delete_transient( $key );
 
-		return self::RETURN_CONTEXT_WIZARD === $return_context ? self::RETURN_CONTEXT_WIZARD : '';
+		return self::RETURN_CONTEXT_WIZARD === $stored_context ? self::RETURN_CONTEXT_WIZARD : '';
 	}
 
 	/**

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -320,6 +320,21 @@ class Bluesky_Provider implements Connection_Provider {
 
 		\Atmosphere\OAuth\Client::disconnect();
 
+		// Disconnect orphans any in-flight wizard return marker; clear it so
+		// a subsequent connect attempt starts from a clean slate.
+		$this->forget_oauth_return_context();
+
+		// Atmosphere's `disconnect()` returns void and just deletes the
+		// connection option. Verify the option actually went away so a DB
+		// or filter failure surfaces instead of falsely showing "Disconnected".
+		if ( \Atmosphere\is_connected() ) {
+			$this->redirect_with_notice(
+				__( 'Could not disconnect from Bluesky. Please try again.', 'fosse' ),
+				'error'
+			);
+			return;
+		}
+
 		$this->redirect_with_notice( __( 'Disconnected from Bluesky.', 'fosse' ), 'info' );
 	}
 

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -84,10 +84,17 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Check if Atmosphere is loaded.
 	 *
+	 * Requires the main class plus the procedural helpers `get_status()`
+	 * relies on. Half-loaded Atmosphere (class present but functions
+	 * missing) reports unavailable so the wizard / Setup page render the
+	 * unavailable notice instead of a connect form that can't be backed.
+	 *
 	 * @return bool
 	 */
 	public function is_available(): bool {
-		return class_exists( '\Atmosphere\Atmosphere' );
+		return class_exists( '\Atmosphere\Atmosphere' )
+			&& function_exists( '\Atmosphere\get_connection' )
+			&& function_exists( '\Atmosphere\is_connected' );
 	}
 
 	/**
@@ -96,8 +103,8 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return array<string, mixed>
 	 */
 	public function get_status(): array {
-		$connection   = function_exists( '\Atmosphere\get_connection' ) ? \Atmosphere\get_connection() : array();
-		$connected    = function_exists( '\Atmosphere\is_connected' ) ? \Atmosphere\is_connected() : false;
+		$connection   = \Atmosphere\get_connection();
+		$connected    = \Atmosphere\is_connected();
 		$auto_publish = '1' === get_option( 'atmosphere_auto_publish', '1' );
 		$token_error  = null;
 
@@ -286,11 +293,24 @@ class Bluesky_Provider implements Connection_Provider {
 		}
 
 		$handle = sanitize_text_field( wp_unslash( $_POST['bluesky_handle'] ?? '' ) );
-		$handle = ltrim( $handle, '@' );
+		$handle = strtolower( trim( ltrim( trim( $handle ), '@' ) ) );
 
 		if ( empty( $handle ) ) {
 			$this->redirect_with_notice( __( 'Enter a Bluesky handle to continue.', 'fosse' ), 'error', $return_context );
-			return; // redirect_with_notice exits, but guard against future changes.
+			return;
+		}
+
+		// AT Protocol handles are domain names: at least one dot, only ASCII
+		// alphanumerics and hyphens per label, no leading/trailing hyphens.
+		// Pre-validate so users get an actionable hint instead of a raw
+		// upstream error like "PDS lookup failed: dns_get_record returned false".
+		if ( ! preg_match( '/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/', $handle ) ) {
+			$this->redirect_with_notice(
+				__( 'That doesn\'t look like a Bluesky handle. Try something like alice.bsky.social.', 'fosse' ),
+				'error',
+				$return_context
+			);
+			return;
 		}
 
 		$auth_url = \Atmosphere\OAuth\Client::authorize( $handle );
@@ -354,12 +374,24 @@ class Bluesky_Provider implements Connection_Provider {
 		$state = sanitize_text_field( wp_unslash( $_GET['state'] ?? '' ) );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-		if ( empty( $code ) || empty( $state ) ) {
+		// No code and no state → ordinary page hit, not an OAuth callback.
+		if ( '' === $code && '' === $state ) {
 			return;
 		}
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'You do not have permission to complete the Bluesky connection.', 'fosse' ) );
+		}
+
+		// Exactly one of code/state present means the auth server redirected
+		// back but something stripped the other parameter mid-flight. Treat
+		// it as a real error instead of silently rendering an empty page.
+		if ( '' === $code || '' === $state ) {
+			$this->redirect_with_notice(
+				__( 'Bluesky returned an incomplete response. Please try connecting again.', 'fosse' ),
+				'error'
+			);
+			return;
 		}
 
 		// Resolve the return context against the inbound state before we hand

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -24,21 +24,21 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Hidden form field used to identify wizard-origin connect flows.
 	 *
-	 * @var string
+	 * Exposed so callers (e.g. the onboarding wizard template) can render a
+	 * hidden input that round-trips through admin-post and is read back by
+	 * `get_connect_return_context()` without duplicating the literal string.
 	 */
-	private const RETURN_CONTEXT_FIELD = 'fosse_bluesky_return';
+	public const RETURN_CONTEXT_FIELD = 'fosse_bluesky_return';
 
 	/**
 	 * Return context value for the first-run wizard.
 	 *
-	 * @var string
+	 * Public for the same reason as {@see self::RETURN_CONTEXT_FIELD}.
 	 */
-	private const RETURN_CONTEXT_WIZARD = 'wizard';
+	public const RETURN_CONTEXT_WIZARD = 'wizard';
 
 	/**
 	 * Per-user transient prefix for pending OAuth return context.
-	 *
-	 * @var string
 	 */
 	private const OAUTH_RETURN_TRANSIENT_PREFIX = 'fosse_bluesky_oauth_return_';
 
@@ -317,7 +317,7 @@ class Bluesky_Provider implements Connection_Provider {
 
 		if ( is_wp_error( $auth_url ) ) {
 			$this->redirect_with_notice( $auth_url->get_error_message(), 'error', $return_context );
-			return; // redirect_with_notice exits, but guard against future changes.
+			return;
 		}
 
 		$this->remember_oauth_return_context( $return_context );
@@ -475,13 +475,30 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Read the requested return context from a connect form submission.
 	 *
+	 * Caller MUST verify the form nonce before invoking — the PHPCS nonce
+	 * check is suppressed on that assumption.
+	 *
 	 * @return string
 	 */
 	private function get_connect_return_context(): string {
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce is checked in handle_connect() before this helper is called.
-		$return_context = isset( $_POST[ self::RETURN_CONTEXT_FIELD ] ) ? sanitize_key( wp_unslash( $_POST[ self::RETURN_CONTEXT_FIELD ] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- caller (handle_connect) verifies the nonce before this helper runs.
+		$raw = isset( $_POST[ self::RETURN_CONTEXT_FIELD ] ) ? sanitize_key( wp_unslash( $_POST[ self::RETURN_CONTEXT_FIELD ] ) ) : '';
 
-		return self::RETURN_CONTEXT_WIZARD === $return_context ? self::RETURN_CONTEXT_WIZARD : '';
+		return self::normalize_return_context( $raw );
+	}
+
+	/**
+	 * Coerce an arbitrary value to a known return-context slug.
+	 *
+	 * Single chokepoint for return-context normalization: every read,
+	 * write, and comparison routes through here so adding a new context
+	 * value is a one-line change.
+	 *
+	 * @param mixed $raw Raw value to normalize.
+	 * @return string Normalized context slug, or `''` for unknown input.
+	 */
+	private static function normalize_return_context( $raw ): string {
+		return is_string( $raw ) && self::RETURN_CONTEXT_WIZARD === $raw ? self::RETURN_CONTEXT_WIZARD : '';
 	}
 
 	/**
@@ -496,9 +513,15 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return void
 	 */
 	private function remember_oauth_return_context( string $return_context ): void {
-		$this->forget_oauth_return_context();
+		$key = $this->get_oauth_return_transient_key();
+		if ( '' === $key ) {
+			return;
+		}
 
-		if ( self::RETURN_CONTEXT_WIZARD !== $return_context ) {
+		delete_transient( $key );
+
+		$context = self::normalize_return_context( $return_context );
+		if ( '' === $context ) {
 			return;
 		}
 
@@ -508,9 +531,9 @@ class Bluesky_Provider implements Connection_Provider {
 		}
 
 		set_transient(
-			$this->get_oauth_return_transient_key(),
+			$key,
 			array(
-				'context' => self::RETURN_CONTEXT_WIZARD,
+				'context' => $context,
 				'state'   => $oauth_state,
 			),
 			HOUR_IN_SECONDS
@@ -523,7 +546,12 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return void
 	 */
 	private function forget_oauth_return_context(): void {
-		delete_transient( $this->get_oauth_return_transient_key() );
+		$key = $this->get_oauth_return_transient_key();
+		if ( '' === $key ) {
+			return;
+		}
+
+		delete_transient( $key );
 	}
 
 	/**
@@ -537,7 +565,11 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return string
 	 */
 	private function consume_oauth_return_context( string $callback_state ): string {
-		$key    = $this->get_oauth_return_transient_key();
+		$key = $this->get_oauth_return_transient_key();
+		if ( '' === $key ) {
+			return '';
+		}
+
 		$stored = get_transient( $key );
 
 		if ( ! is_array( $stored ) ) {
@@ -553,16 +585,25 @@ class Bluesky_Provider implements Connection_Provider {
 
 		delete_transient( $key );
 
-		return self::RETURN_CONTEXT_WIZARD === $stored_context ? self::RETURN_CONTEXT_WIZARD : '';
+		return self::normalize_return_context( $stored_context );
 	}
 
 	/**
 	 * Build the per-user OAuth return transient key.
 	 *
+	 * Returns `''` for an unauthenticated context (`get_current_user_id() === 0`)
+	 * so the per-user namespace can't collapse into a shared key for all
+	 * anonymous requests. Callers MUST treat an empty key as "skip".
+	 *
 	 * @return string
 	 */
 	private function get_oauth_return_transient_key(): string {
-		return self::OAUTH_RETURN_TRANSIENT_PREFIX . get_current_user_id();
+		$user_id = get_current_user_id();
+		if ( 0 === $user_id ) {
+			return '';
+		}
+
+		return self::OAUTH_RETURN_TRANSIENT_PREFIX . $user_id;
 	}
 
 	/**
@@ -572,7 +613,7 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return string
 	 */
 	private function get_redirect_url( string $return_context ): string {
-		if ( self::RETURN_CONTEXT_WIZARD === $return_context ) {
+		if ( self::RETURN_CONTEXT_WIZARD === self::normalize_return_context( $return_context ) ) {
 			return add_query_arg(
 				array(
 					'page'             => 'fosse-wizard',

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -802,6 +802,11 @@ class Onboarding_Wizard {
 	/**
 	 * Render Step 4: Bluesky.
 	 *
+	 * Three states drive the rendered markup:
+	 *  - Unavailable (provider not registered or not is_available): info notice.
+	 *  - Connected: account summary table.
+	 *  - Disconnected: OAuth-start form posting to admin-post.php.
+	 *
 	 * @return void
 	 */
 	private static function render_step_bluesky(): void {
@@ -853,7 +858,7 @@ class Onboarding_Wizard {
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 					<input type="hidden" name="action" value="fosse_connect_bluesky" />
 					<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_connect_bluesky' ) ); ?>" />
-					<input type="hidden" name="fosse_bluesky_return" value="wizard" />
+					<input type="hidden" name="<?php echo esc_attr( Bluesky_Provider::RETURN_CONTEXT_FIELD ); ?>" value="<?php echo esc_attr( Bluesky_Provider::RETURN_CONTEXT_WIZARD ); ?>" />
 
 					<div class="fosse-bluesky-form">
 						<label for="fosse-bsky-handle" class="fosse-bluesky-form__label">

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -476,15 +476,16 @@ class Onboarding_Wizard {
 	/**
 	 * Read Bluesky connection status from the registered provider.
 	 *
+	 * Reads strictly through the registry. If the provider isn't registered
+	 * (registration hook never fired, third-party removed it, etc.) the
+	 * wizard renders the unavailable notice rather than instantiating a
+	 * provider whose connect form would post to an unhooked admin-post
+	 * action and silently 404.
+	 *
 	 * @return array<string, mixed>
 	 */
 	private static function get_bluesky_status(): array {
 		$provider = Connection_Provider_Registry::get_provider( 'bluesky' );
-
-		if ( null === $provider ) {
-			$fallback_provider = new Bluesky_Provider();
-			$provider          = $fallback_provider->is_available() ? $fallback_provider : null;
-		}
 
 		$defaults = array(
 			'available'    => false,

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -14,7 +14,7 @@ namespace Automattic\Fosse\Admin;
  *  1. Welcome - value prop overview
  *  2. Appearance - actor mode selection (blog / actor / actor_blog)
  *  3. Content - post type selection
- *  4. Bluesky - placeholder until Bluesky_Provider ships
+ *  4. Bluesky - optional OAuth connection
  *  5. Complete - summary and handoff to Setup/Status pages
  */
 class Onboarding_Wizard {
@@ -474,6 +474,40 @@ class Onboarding_Wizard {
 	}
 
 	/**
+	 * Read Bluesky connection status from the registered provider.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function get_bluesky_status(): array {
+		$provider = Connection_Provider_Registry::get_provider( 'bluesky' );
+
+		if ( null === $provider ) {
+			$fallback_provider = new Bluesky_Provider();
+			$provider          = $fallback_provider->is_available() ? $fallback_provider : null;
+		}
+
+		$defaults = array(
+			'available'    => false,
+			'connected'    => false,
+			'handle'       => '',
+			'did'          => '',
+			'pds_endpoint' => '',
+			'auto_publish' => false,
+			'token_error'  => null,
+		);
+
+		if ( null === $provider || ! $provider->is_available() ) {
+			return $defaults;
+		}
+
+		return array_merge(
+			$defaults,
+			$provider->get_status(),
+			array( 'available' => true )
+		);
+	}
+
+	/**
 	 * Render the progress indicator.
 	 *
 	 * @param string $current_step Current step slug.
@@ -765,58 +799,93 @@ class Onboarding_Wizard {
 	}
 
 	/**
-	 * Render Step 4: Bluesky (placeholder).
+	 * Render Step 4: Bluesky.
 	 *
 	 * @return void
 	 */
 	private static function render_step_bluesky(): void {
 		self::render_progress( 'bluesky' );
+		$status = self::get_bluesky_status();
 		?>
 		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Connect to Bluesky', 'fosse' ); ?></h1>
 		<p class="fosse-wizard__description">
 			<?php esc_html_e( 'Link your Bluesky account so your posts also appear on Bluesky. This step is optional. You can always connect later from the FOSSE Setup page.', 'fosse' ); ?>
 		</p>
 
+		<?php settings_errors( 'atmosphere' ); ?>
+
 		<div class="fosse-wizard__card">
-			<div class="notice notice-warning inline fosse-wizard__notice">
-				<p>
-					<strong><?php esc_html_e( 'Coming Soon', 'fosse' ); ?></strong>
-					<?php esc_html_e( 'Bluesky connection is being finalized. Skip this step for now and connect once it\'s ready.', 'fosse' ); ?>
-				</p>
-			</div>
-
-			<div class="fosse-bluesky-placeholder">
-				<label for="fosse-bsky-handle" class="fosse-bluesky-placeholder__label">
-					<?php esc_html_e( 'Bluesky Handle', 'fosse' ); ?>
-				</label>
-				<div class="fosse-bluesky-connect">
-					<input
-						type="text"
-						id="fosse-bsky-handle"
-						class="regular-text"
-						placeholder="<?php esc_attr_e( 'yourname.bsky.social', 'fosse' ); ?>"
-						disabled
-					/>
-					<button type="button" class="button" disabled>
-						<?php esc_html_e( 'Connect', 'fosse' ); ?>
-					</button>
+			<?php if ( ! $status['available'] ) : ?>
+				<div class="notice notice-info inline fosse-wizard__notice">
+					<p>
+						<strong><?php esc_html_e( 'Bluesky setup is unavailable.', 'fosse' ); ?></strong>
+						<?php esc_html_e( 'Skip this step for now and connect from the FOSSE Setup page once Bluesky support is available.', 'fosse' ); ?>
+					</p>
 				</div>
-			</div>
+			<?php elseif ( $status['connected'] ) : ?>
+				<div class="notice notice-success inline fosse-wizard__notice">
+					<p>
+						<strong><?php esc_html_e( 'Bluesky is connected.', 'fosse' ); ?></strong>
+						<?php esc_html_e( 'FOSSE can publish eligible posts to this account.', 'fosse' ); ?>
+					</p>
+				</div>
 
-			<div class="fosse-wizard__hint">
-				<p>
-					<?php
-					echo wp_kses_post(
-						sprintf(
-							/* translators: 1: opening anchor tag, 2: closing anchor tag */
-							__( 'You\'ll need an existing Bluesky account. If you want to use your domain as your Bluesky handle, %1$slearn how to set that up%2$s.', 'fosse' ),
-							'<a href="' . esc_url( 'https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial' ) . '" target="_blank" rel="noopener noreferrer">',
-							'</a>'
-						)
-					);
-					?>
-				</p>
-			</div>
+				<table class="fosse-summary">
+					<?php if ( $status['handle'] ) : ?>
+						<tr>
+							<td class="fosse-summary__label"><?php esc_html_e( 'Handle', 'fosse' ); ?></td>
+							<td class="fosse-summary__value"><?php echo esc_html( $status['handle'] ); ?></td>
+						</tr>
+					<?php endif; ?>
+					<?php if ( $status['did'] ) : ?>
+						<tr>
+							<td class="fosse-summary__label"><?php esc_html_e( 'DID', 'fosse' ); ?></td>
+							<td class="fosse-summary__value"><code><?php echo esc_html( $status['did'] ); ?></code></td>
+						</tr>
+					<?php endif; ?>
+					<tr>
+						<td class="fosse-summary__label"><?php esc_html_e( 'Auto Publish', 'fosse' ); ?></td>
+						<td class="fosse-summary__value"><?php echo esc_html( $status['auto_publish'] ? __( 'Enabled', 'fosse' ) : __( 'Disabled', 'fosse' ) ); ?></td>
+					</tr>
+				</table>
+			<?php else : ?>
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="fosse_connect_bluesky" />
+					<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_connect_bluesky' ) ); ?>" />
+					<input type="hidden" name="fosse_bluesky_return" value="wizard" />
+
+					<div class="fosse-bluesky-form">
+						<label for="fosse-bsky-handle" class="fosse-bluesky-form__label">
+							<?php esc_html_e( 'Bluesky Handle', 'fosse' ); ?>
+						</label>
+						<div class="fosse-bluesky-form__controls">
+							<input
+								type="text"
+								id="fosse-bsky-handle"
+								name="bluesky_handle"
+								class="regular-text"
+								placeholder="<?php esc_attr_e( 'yourname.bsky.social', 'fosse' ); ?>"
+							/>
+							<?php submit_button( __( 'Connect Bluesky', 'fosse' ), 'primary', 'submit', false ); ?>
+						</div>
+					</div>
+				</form>
+
+				<div class="fosse-wizard__hint">
+					<p>
+						<?php
+						echo wp_kses_post(
+							sprintf(
+								/* translators: 1: opening anchor tag, 2: closing anchor tag */
+								__( 'Want your domain as your handle? %1$sLearn how%2$s.', 'fosse' ),
+								'<a href="' . esc_url( 'https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial' ) . '" target="_blank" rel="noopener noreferrer">',
+								'</a>'
+							)
+						);
+						?>
+					</p>
+				</div>
+			<?php endif; ?>
 		</div>
 
 		<div class="fosse-wizard__actions">
@@ -825,7 +894,7 @@ class Onboarding_Wizard {
 			</a>
 			<div class="fosse-wizard__actions-primary">
 				<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=fosse_wizard_complete' ), 'fosse_wizard_complete' ) ); ?>" class="button button-primary">
-					<?php esc_html_e( 'Skip for now', 'fosse' ); ?>
+					<?php echo esc_html( $status['connected'] ? __( 'Finish setup', 'fosse' ) : __( 'Skip for now', 'fosse' ) ); ?>
 				</a>
 			</div>
 		</div>
@@ -849,6 +918,7 @@ class Onboarding_Wizard {
 		$post_types = get_option( 'activitypub_support_post_types', array( 'post' ) );
 		$site_host  = wp_parse_url( home_url(), PHP_URL_HOST );
 		$site_url   = $site_host ? $site_host : 'yoursite.com';
+		$bluesky    = self::get_bluesky_status();
 
 		$mode_labels = array(
 			'actor'      => __( 'As you (author profiles)', 'fosse' ),
@@ -867,6 +937,17 @@ class Onboarding_Wizard {
 			},
 			$post_types
 		);
+
+		$bluesky_summary = $bluesky['available'] ? __( 'Not connected', 'fosse' ) : __( 'Unavailable', 'fosse' );
+		if ( $bluesky['connected'] ) {
+			$bluesky_summary = $bluesky['handle']
+				? sprintf(
+					/* translators: %s: Bluesky handle. */
+					__( 'Connected as %s', 'fosse' ),
+					$bluesky['handle']
+				)
+				: __( 'Connected', 'fosse' );
+		}
 
 		?>
 		<div class="fosse-wizard__complete-header">
@@ -891,7 +972,7 @@ class Onboarding_Wizard {
 				</tr>
 				<tr>
 					<td class="fosse-summary__label"><?php esc_html_e( 'Bluesky', 'fosse' ); ?></td>
-					<td class="fosse-summary__value fosse-summary__value--muted"><?php esc_html_e( 'Not connected', 'fosse' ); ?></td>
+					<td class="fosse-summary__value<?php echo $bluesky['connected'] ? '' : ' fosse-summary__value--muted'; ?>"><?php echo esc_html( $bluesky_summary ); ?></td>
 				</tr>
 			</table>
 

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -81,7 +81,7 @@ test( 'Content step saves post types and advances to Bluesky', async ( {
 	await expect( page ).toHaveURL( /step=bluesky/ );
 } );
 
-test( 'Bluesky step shows coming soon notice', async ( { page } ) => {
+test( 'Bluesky step shows connect form', async ( { page } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
 
 	await expect(
@@ -89,7 +89,11 @@ test( 'Bluesky step shows coming soon notice', async ( { page } ) => {
 			hasText: 'Connect to Bluesky',
 		} )
 	).toBeVisible();
-	await expect( page.locator( 'text=Coming Soon' ) ).toBeVisible();
+	await expect( page.locator( '#fosse-bsky-handle' ) ).toBeVisible();
+	await expect(
+		page.getByRole( 'button', { name: 'Connect Bluesky' } )
+	).toBeVisible();
+	await expect( page.locator( 'text=Coming Soon' ) ).toHaveCount( 0 );
 } );
 
 test( 'Skip for now on Bluesky step goes to completion', async ( { page } ) => {

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -508,6 +508,125 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Callback URLs missing exactly one of code/state surface an error notice
+	 * instead of silently rendering an empty page that the user can't act on.
+	 */
+	public function test_handle_oauth_callback_partial_params_show_error() {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array(
+			'page' => 'fosse',
+			'code' => 'auth-code-only',
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_oauth_callback();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = array_column( $errors, 'type' );
+
+		$this->assertContains( 'error', $types );
+	}
+
+	/**
+	 * Callback URLs with neither code nor state are normal admin page hits
+	 * and must remain a no-op (no redirect, no notice).
+	 */
+	public function test_handle_oauth_callback_no_params_is_silent() {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array( 'page' => 'fosse' );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		$this->provider->handle_oauth_callback();
+
+		$this->assertEmpty( get_settings_errors( 'atmosphere' ) );
+	}
+
+	// --- handle validation ---
+
+	/**
+	 * Malformed handles are rejected with an actionable error notice
+	 * before any HTTP call to Atmosphere\OAuth\Client::authorize().
+	 *
+	 * @dataProvider invalid_handle_provider
+	 *
+	 * @param string $raw_handle Raw user input.
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider( 'invalid_handle_provider' )]
+	public function test_handle_connect_rejects_malformed_handle( string $raw_handle ) {
+		$this->become_admin();
+
+		$network_called = false;
+		add_filter(
+			'pre_http_request',
+			static function () use ( &$network_called ) {
+				$network_called = true;
+				return new \WP_Error( 'fosse_test', 'should not be called' );
+			}
+		);
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'       => wp_create_nonce( 'fosse_connect_bluesky' ),
+			'bluesky_handle' => $raw_handle,
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_connect();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( $network_called, 'Authorize() must not run for malformed handles.' );
+
+		$errors   = get_settings_errors( 'atmosphere' );
+		$messages = array_column( $errors, 'message' );
+
+		$this->assertNotEmpty( $messages );
+		$this->assertStringContainsString( 'handle', strtolower( implode( ' ', $messages ) ) );
+	}
+
+	/**
+	 * Data provider for malformed handles.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function invalid_handle_provider(): array {
+		return array(
+			'no dot, single label' => array( 'alice' ),
+			'leading dot'          => array( '.bsky.social' ),
+			'trailing dot'         => array( 'alice.bsky.social.' ),
+			'space inside'         => array( 'alice bsky.social' ),
+			'underscore'           => array( 'al_ice.bsky.social' ),
+			'mastodon style'       => array( '@alice@host.example' ),
+			'leading hyphen label' => array( '-alice.bsky.social' ),
+		);
+	}
+
+	/**
 	 * Empty-handle connect requests fail early and redirect with an error.
 	 */
 	public function test_handle_connect_rejects_empty_handle() {

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -13,6 +13,7 @@ use Automattic\Fosse\Admin\Connection_Provider_Registry;
 use Automattic\Fosse\Provider_Loader;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 
 /**
@@ -255,13 +256,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		add_filter(
 			'wp_redirect',
 			static function () {
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_disconnect();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -298,13 +299,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		add_filter(
 			'wp_redirect',
 			static function () {
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_disconnect();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -341,13 +342,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		add_filter(
 			'wp_redirect',
 			static function () {
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_disconnect();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -397,13 +398,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			'wp_redirect',
 			static function ( $location ) use ( &$captured ) {
 				$captured = (string) $location;
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_oauth_callback();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -446,13 +447,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		add_filter(
 			'wp_redirect',
 			static function () {
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_oauth_callback();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -490,13 +491,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		add_filter(
 			'wp_redirect',
 			static function () {
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_oauth_callback();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -524,13 +525,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		add_filter(
 			'wp_redirect',
 			static function () {
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_oauth_callback();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -566,7 +567,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	 *
 	 * @param string $raw_handle Raw user input.
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider( 'invalid_handle_provider' )]
+	#[DataProvider( 'invalid_handle_provider' )]
 	public function test_handle_connect_rejects_malformed_handle( string $raw_handle ) {
 		$this->become_admin();
 
@@ -590,13 +591,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		add_filter(
 			'wp_redirect',
 			static function () {
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_connect();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -643,13 +644,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		add_filter(
 			'wp_redirect',
 			static function () {
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_connect();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -683,13 +684,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			'wp_redirect',
 			static function ( $location ) use ( &$captured ) {
 				$captured = (string) $location;
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_connect();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -720,13 +721,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			'wp_redirect',
 			static function ( $location ) use ( &$captured ) {
 				$captured = (string) $location;
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_connect();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -785,13 +786,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			'wp_redirect',
 			static function ( $location ) use ( &$captured ) {
 				$captured = (string) $location;
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_oauth_callback();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -834,13 +835,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			'wp_redirect',
 			static function ( $location ) use ( &$captured ) {
 				$captured = (string) $location;
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_oauth_callback();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -879,13 +880,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			'wp_redirect',
 			static function ( $location ) use ( &$captured ) {
 				$captured = (string) $location;
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_oauth_callback();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 
@@ -1025,13 +1026,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		add_filter(
 			'wp_redirect',
 			static function () {
-				throw new \Exception( 'redirect' );
+				throw new RedirectFired( 'redirect' );
 			}
 		);
 
 		try {
 			$this->provider->handle_connect();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
 

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -395,12 +395,20 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * OAuth callbacks from wizard-origin flows redirect back to the Bluesky step.
+	 * OAuth callbacks from wizard-origin flows redirect back to the Bluesky step
+	 * when the inbound state matches the state the wizard marker was bound to.
 	 */
 	public function test_handle_oauth_callback_returns_to_wizard_when_context_was_remembered() {
 		$this->become_admin();
 
-		set_transient( 'fosse_bluesky_oauth_return_' . get_current_user_id(), 'wizard', HOUR_IN_SECONDS );
+		set_transient(
+			'fosse_bluesky_oauth_return_' . get_current_user_id(),
+			array(
+				'context' => 'wizard',
+				'state'   => 'def',
+			),
+			HOUR_IN_SECONDS
+		);
 
 		$captured = null;
 
@@ -431,6 +439,97 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'step=bluesky', $captured );
 		$this->assertStringContainsString( 'settings-updated=true', $captured );
 		$this->assertFalse( get_transient( 'fosse_bluesky_oauth_return_' . get_current_user_id() ) );
+	}
+
+	/**
+	 * A callback whose state does not match the wizard marker leaves the
+	 * marker in place and falls back to the default (Setup-page) redirect,
+	 * so a legitimate callback that arrives later can still recover it.
+	 */
+	public function test_handle_oauth_callback_with_mismatched_state_preserves_wizard_marker() {
+		$this->become_admin();
+
+		$transient_key = 'fosse_bluesky_oauth_return_' . get_current_user_id();
+		set_transient(
+			$transient_key,
+			array(
+				'context' => 'wizard',
+				'state'   => 'real-state',
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$captured = null;
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array(
+			'page'  => 'fosse',
+			'code'  => 'abc',
+			'state' => 'stale-state',
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_oauth_callback();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull( $captured );
+		$this->assertStringContainsString( 'page=fosse', $captured );
+		$this->assertStringNotContainsString( 'page=fosse-wizard', $captured );
+
+		$stored = get_transient( $transient_key );
+		$this->assertIsArray( $stored );
+		$this->assertSame( 'wizard', $stored['context'] );
+		$this->assertSame( 'real-state', $stored['state'] );
+	}
+
+	/**
+	 * Legacy single-string transients (pre state-binding) are not honored —
+	 * an upgraded site with a stale legacy marker falls back to the default
+	 * redirect rather than mistaking a string for a valid bound context.
+	 */
+	public function test_handle_oauth_callback_ignores_legacy_string_transient() {
+		$this->become_admin();
+
+		// Pre-state-binding transients stored just the literal context string.
+		set_transient( 'fosse_bluesky_oauth_return_' . get_current_user_id(), 'wizard', HOUR_IN_SECONDS );
+
+		$captured = null;
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array(
+			'page'  => 'fosse',
+			'code'  => 'abc',
+			'state' => 'def',
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_oauth_callback();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull( $captured );
+		$this->assertStringNotContainsString( 'page=fosse-wizard', $captured );
 	}
 
 	// --- unauthorized user tests ---

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -54,6 +54,8 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		remove_all_filters( 'admin_post_fosse_connect_bluesky' );
 		remove_all_filters( 'admin_post_fosse_disconnect_bluesky' );
 		remove_all_filters( 'admin_init' );
+		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'pre_option_atmosphere_connection' );
 
 		global $wp_settings_errors;
 		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- reset core settings-error storage for test isolation.
@@ -73,6 +75,8 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		remove_all_filters( 'wp_redirect' );
 		remove_all_filters( 'wp_die_handler' );
+		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'pre_option_atmosphere_connection' );
 	}
 
 	/**
@@ -263,6 +267,244 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		$this->assertSame( array(), get_option( 'atmosphere_connection', array() ) );
 		$this->assertNotEmpty( get_settings_errors( 'atmosphere' ) );
+	}
+
+	/**
+	 * Disconnect clears any orphan wizard return-context transient so a
+	 * subsequent connect attempt starts from a clean slate.
+	 */
+	public function test_handle_disconnect_clears_wizard_return_context() {
+		$this->seed_connected_atmosphere_connection();
+
+		$this->become_admin();
+
+		$transient_key = 'fosse_bluesky_oauth_return_' . get_current_user_id();
+		set_transient(
+			$transient_key,
+			array(
+				'context' => 'wizard',
+				'state'   => 'pending-state',
+			),
+			HOUR_IN_SECONDS
+		);
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => wp_create_nonce( 'fosse_disconnect_bluesky' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_disconnect();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( get_transient( $transient_key ) );
+	}
+
+	/**
+	 * Disconnect surfaces an error notice when the connection option fails
+	 * to clear (e.g. a hostile filter pins it). The success notice would
+	 * otherwise mislead the user into thinking the disconnect worked.
+	 */
+	public function test_handle_disconnect_reports_error_when_connection_persists() {
+		$this->seed_connected_atmosphere_connection();
+
+		// Pin the connection in place so Atmosphere's delete_option call
+		// can't make is_connected() flip to false.
+		$pinned = get_option( 'atmosphere_connection' );
+		add_filter(
+			'pre_option_atmosphere_connection',
+			static function () use ( $pinned ) {
+				return $pinned;
+			}
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => wp_create_nonce( 'fosse_disconnect_bluesky' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_disconnect();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = array_column( $errors, 'type' );
+
+		$this->assertNotEmpty( $errors );
+		$this->assertContains( 'error', $types );
+		$this->assertNotContains( 'info', $types );
+	}
+
+	// --- handle_oauth_callback: success branches ---
+
+	/**
+	 * A fully successful OAuth round-trip (token exchange OK, connection
+	 * persisted, sync_publication OK) emits the success notice and
+	 * redirects back to the originating screen.
+	 */
+	public function test_handle_oauth_callback_success_emits_success_notice() {
+		$this->become_admin();
+
+		$state = 'state-success';
+		$this->fake_atmosphere_oauth_environment( $state );
+		$this->intercept_token_endpoint_success();
+		$this->intercept_pds_create_record_success();
+
+		set_transient(
+			'fosse_bluesky_oauth_return_' . get_current_user_id(),
+			array(
+				'context' => 'wizard',
+				'state'   => $state,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$captured = null;
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array(
+			'page'  => 'fosse',
+			'code'  => 'auth-code',
+			'state' => $state,
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_oauth_callback();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull( $captured );
+		$this->assertStringContainsString( 'page=fosse-wizard', $captured );
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = array_column( $errors, 'type' );
+		$this->assertContains( 'success', $types );
+		$this->assertNotContains( 'error', $types );
+		$this->assertNotContains( 'warning', $types );
+
+		$this->assertTrue( \Atmosphere\is_connected() );
+	}
+
+	/**
+	 * Token exchange succeeds but the connection option does not persist
+	 * (e.g. DB write fails or a filter blocks it). The user must see an
+	 * error notice rather than a misleading success banner.
+	 */
+	public function test_handle_oauth_callback_warns_when_connection_not_persisted() {
+		$this->become_admin();
+
+		$state = 'state-not-saved';
+		$this->fake_atmosphere_oauth_environment( $state );
+		$this->intercept_token_endpoint_success();
+
+		// Force is_connected() to return false even though Atmosphere
+		// reports success — simulate a lost option write.
+		add_filter( 'pre_option_atmosphere_connection', static fn() => array() );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array(
+			'page'  => 'fosse',
+			'code'  => 'auth-code',
+			'state' => $state,
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_oauth_callback();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors   = get_settings_errors( 'atmosphere' );
+		$types    = array_column( $errors, 'type' );
+		$messages = array_column( $errors, 'message' );
+
+		$this->assertContains( 'error', $types );
+		$this->assertNotContains( 'success', $types );
+		$this->assertStringContainsString( 'not saved', strtolower( implode( ' ', $messages ) ) );
+	}
+
+	/**
+	 * Token exchange succeeds and the connection persists, but the PDS
+	 * publication record write fails. The user should see a `warning`
+	 * notice (connected, but publication setup failed) rather than a
+	 * green success banner.
+	 */
+	public function test_handle_oauth_callback_warns_when_sync_publication_fails() {
+		$this->become_admin();
+
+		$state = 'state-sync-error';
+		$this->fake_atmosphere_oauth_environment( $state );
+		$this->intercept_token_endpoint_success();
+		$this->intercept_pds_create_record_failure();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array(
+			'page'  => 'fosse',
+			'code'  => 'auth-code',
+			'state' => $state,
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_oauth_callback();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = array_column( $errors, 'type' );
+
+		$this->assertContains( 'warning', $types );
+		$this->assertNotContains( 'success', $types );
 	}
 
 	/**
@@ -692,6 +934,141 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertNotFalse( has_action( 'admin_post_fosse_disconnect_bluesky', array( $this->provider, 'handle_disconnect' ) ) );
 		$this->assertNotFalse( has_action( 'admin_init', array( $this->provider, 'handle_oauth_callback' ) ) );
 		$this->assertNotFalse( has_filter( 'atmosphere_oauth_redirect_uri', array( $this->provider, 'filter_oauth_redirect_uri' ) ) );
+	}
+
+	/**
+	 * Seed a connected Atmosphere connection (handle, did, encrypted token).
+	 *
+	 * @return void
+	 */
+	private function seed_connected_atmosphere_connection(): void {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+	}
+
+	/**
+	 * Seed the OAuth transients Atmosphere\OAuth\Client::handle_callback()
+	 * expects to find when validating an inbound callback.
+	 *
+	 * @param string $state          Stored OAuth state value.
+	 * @param string $token_endpoint Token endpoint URL the test will intercept.
+	 * @return void
+	 */
+	private function fake_atmosphere_oauth_environment(
+		string $state,
+		string $token_endpoint = 'https://example.test/oauth/token'
+	): void {
+		set_transient( 'atmosphere_oauth_state', $state, HOUR_IN_SECONDS );
+		set_transient( 'atmosphere_oauth_verifier', 'test-verifier-' . uniqid( '', true ), HOUR_IN_SECONDS );
+		set_transient( 'atmosphere_oauth_dpop_jwk', \Atmosphere\OAuth\DPoP::generate_key(), HOUR_IN_SECONDS );
+		set_transient(
+			'atmosphere_oauth_resolved',
+			array(
+				'did'          => 'did:plc:test123',
+				'pds_endpoint' => 'https://bsky.social',
+				'auth_server'  => array(
+					'token_endpoint' => $token_endpoint,
+					'issuer_url'     => 'https://example.test',
+				),
+				'handle'       => 'alice.bsky.social',
+			),
+			HOUR_IN_SECONDS
+		);
+	}
+
+	/**
+	 * Intercept the OAuth token endpoint and return a 200 with valid token data.
+	 *
+	 * @param string $token_endpoint Token endpoint URL to match.
+	 * @return void
+	 */
+	private function intercept_token_endpoint_success( string $token_endpoint = 'https://example.test/oauth/token' ): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $token_endpoint ) {
+				if ( $url !== $token_endpoint ) {
+					return $preempt;
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode( // phpcs:ignore Jetpack.Functions.JsonEncodeFlags.Missing -- test fixture, no escaping concerns.
+						array(
+							'access_token'  => 'access-tk',
+							'refresh_token' => 'refresh-tk',
+							'expires_in'    => 3600,
+						)
+					),
+					'headers'  => array(),
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Intercept PDS createRecord/putRecord requests with a successful response,
+	 * so Publisher::sync_publication() returns array (not WP_Error).
+	 *
+	 * @return void
+	 */
+	private function intercept_pds_create_record_success(): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) {
+				if ( false === strpos( $url, '/xrpc/com.atproto.repo.' ) ) {
+					return $preempt;
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode( // phpcs:ignore Jetpack.Functions.JsonEncodeFlags.Missing -- test fixture, no escaping concerns.
+						array(
+							'uri' => 'at://did:plc:test123/site.standard.publication/self',
+							'cid' => 'bafyrei-test-cid',
+						)
+					),
+					'headers'  => array(),
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Intercept PDS createRecord/putRecord requests with a 500 response,
+	 * so Publisher::sync_publication() returns WP_Error.
+	 *
+	 * @return void
+	 */
+	private function intercept_pds_create_record_failure(): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) {
+				if ( false === strpos( $url, '/xrpc/com.atproto.repo.' ) ) {
+					return $preempt;
+				}
+				return array(
+					'response' => array( 'code' => 500 ),
+					'body'     => wp_json_encode( // phpcs:ignore Jetpack.Functions.JsonEncodeFlags.Missing -- test fixture, no escaping concerns.
+						array(
+							'error'   => 'InternalServerError',
+							'message' => 'PDS unavailable',
+						)
+					),
+					'headers'  => array(),
+				);
+			},
+			10,
+			3
+		);
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -300,6 +300,82 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Setup-origin connect requests clear stale wizard OAuth return context.
+	 */
+	public function test_handle_connect_from_setup_clears_stale_wizard_return_context() {
+		$this->become_admin();
+
+		$return_key = 'fosse_bluesky_oauth_return_' . get_current_user_id();
+		set_transient( $return_key, 'wizard', HOUR_IN_SECONDS );
+
+		$captured = null;
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'       => wp_create_nonce( 'fosse_connect_bluesky' ),
+			'bluesky_handle' => '',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_connect();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull( $captured );
+		$this->assertStringContainsString( 'page=fosse', $captured );
+		$this->assertStringNotContainsString( 'page=fosse-wizard', $captured );
+		$this->assertFalse( get_transient( $return_key ) );
+	}
+
+	/**
+	 * Empty-handle connect requests from the wizard redirect back to the Bluesky step.
+	 */
+	public function test_handle_connect_rejects_empty_handle_from_wizard() {
+		$this->become_admin();
+
+		$captured = null;
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'             => wp_create_nonce( 'fosse_connect_bluesky' ),
+			'bluesky_handle'       => '',
+			'fosse_bluesky_return' => 'wizard',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_connect();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull( $captured );
+		$this->assertStringContainsString( 'page=fosse-wizard', $captured );
+		$this->assertStringContainsString( 'step=bluesky', $captured );
+		$this->assertStringContainsString( 'settings-updated=true', $captured );
+	}
+
+	/**
 	 * Callback handling is a no-op when the request is not for the FOSSE page.
 	 */
 	public function test_handle_oauth_callback_ignores_non_fosse_page() {
@@ -316,6 +392,45 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->handle_oauth_callback();
 
 		$this->assertEmpty( get_settings_errors( 'atmosphere' ) );
+	}
+
+	/**
+	 * OAuth callbacks from wizard-origin flows redirect back to the Bluesky step.
+	 */
+	public function test_handle_oauth_callback_returns_to_wizard_when_context_was_remembered() {
+		$this->become_admin();
+
+		set_transient( 'fosse_bluesky_oauth_return_' . get_current_user_id(), 'wizard', HOUR_IN_SECONDS );
+
+		$captured = null;
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array(
+			'page'  => 'fosse',
+			'code'  => 'abc',
+			'state' => 'def',
+		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new \Exception( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_oauth_callback();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull( $captured );
+		$this->assertStringContainsString( 'page=fosse-wizard', $captured );
+		$this->assertStringContainsString( 'step=bluesky', $captured );
+		$this->assertStringContainsString( 'settings-updated=true', $captured );
+		$this->assertFalse( get_transient( 'fosse_bluesky_oauth_return_' . get_current_user_id() ) );
 	}
 
 	// --- unauthorized user tests ---

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -364,6 +364,47 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
+	 * The wizard's connect form embeds a `_wpnonce` that validates against
+	 * the `fosse_connect_bluesky` action — so a typo'd action name in the
+	 * form template would surface as a test failure rather than a 403 in
+	 * production.
+	 */
+	public function test_render_bluesky_step_emits_valid_connect_nonce(): void {
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertMatchesRegularExpression(
+			'/<input[^>]*\bname="_wpnonce"[^>]*\bvalue="([^"]+)"/i',
+			$output,
+			'Expected a _wpnonce hidden input in the rendered form.'
+		);
+
+		preg_match( '/<input[^>]*\bname="_wpnonce"[^>]*\bvalue="([^"]+)"/i', $output, $matches );
+		$nonce = $matches[1] ?? '';
+
+		$this->assertNotEmpty( $nonce );
+		$this->assertNotFalse(
+			wp_verify_nonce( $nonce, 'fosse_connect_bluesky' ),
+			'Embedded form nonce must validate against fosse_connect_bluesky.'
+		);
+	}
+
+	/**
+	 * When the Bluesky provider is not registered at all, the wizard renders
+	 * the unavailable notice rather than a connect form whose admin-post
+	 * handler isn't attached.
+	 */
+	public function test_render_bluesky_step_unregistered_provider_shows_unavailable(): void {
+		Connection_Provider_Registry::reset();
+		AP_Provider::register_provider();
+		// Deliberately do NOT register Bluesky_Provider.
+
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertStringContainsString( 'Bluesky setup is unavailable', $output );
+		$this->assertStringNotContainsString( 'fosse_connect_bluesky', $output );
+	}
+
+	/**
 	 * The Bluesky wizard step does not render a dead connect form when unavailable.
 	 */
 	public function test_render_bluesky_step_unavailable_omits_connect_form(): void {

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -7,7 +7,10 @@
 
 namespace Automattic\Fosse\Tests\Admin;
 
+use Atmosphere\OAuth\Encryption;
 use Automattic\Fosse\Admin\AP_Provider;
+use Automattic\Fosse\Admin\Bluesky_Provider;
+use Automattic\Fosse\Admin\Connection_Provider;
 use Automattic\Fosse\Admin\Connection_Provider_Registry;
 use Automattic\Fosse\Admin\Onboarding_Wizard;
 use PHPUnit\Framework\Attributes\After;
@@ -28,9 +31,19 @@ class Onboarding_WizardTest extends BaseTestCase {
 	 */
 	#[Before]
 	public function set_up_state(): void {
+		if ( ! defined( 'AUTH_KEY' ) ) {
+			define( 'AUTH_KEY', 'fosse-test-auth-key' );
+		}
+
+		if ( ! defined( 'AUTH_SALT' ) ) {
+			define( 'AUTH_SALT', 'fosse-test-auth-salt' );
+		}
+
 		delete_option( Onboarding_Wizard::COMPLETED_OPTION );
 		delete_option( 'activitypub_actor_mode' );
 		delete_option( 'activitypub_support_post_types' );
+		delete_option( 'atmosphere_connection' );
+		delete_option( 'atmosphere_auto_publish' );
 		delete_option( Onboarding_Wizard::REDIRECT_OPTION );
 		delete_transient( Onboarding_Wizard::REDIRECT_TRANSIENT );
 
@@ -39,6 +52,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		// explicitly; the @after restores the provider for the next test.
 		Connection_Provider_Registry::reset();
 		AP_Provider::register_provider();
+		Bluesky_Provider::register_provider();
 	}
 
 	/**
@@ -59,6 +73,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		Connection_Provider_Registry::reset();
 		AP_Provider::register_provider();
+		Bluesky_Provider::register_provider();
 	}
 
 	// --- is_complete / mark_complete ---
@@ -327,6 +342,131 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'ActivityPub', $output );
 	}
 
+	// --- Bluesky step render ---
+
+	/**
+	 * The Bluesky wizard step renders the live OAuth connect form when disconnected.
+	 */
+	public function test_render_bluesky_step_disconnected_shows_connect_form(): void {
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertStringContainsString( 'fosse_connect_bluesky', $output );
+		$this->assertStringContainsString( 'bluesky_handle', $output );
+		$this->assertStringContainsString( 'fosse_bluesky_return', $output );
+		$this->assertStringContainsString( 'value="wizard"', $output );
+		$this->assertStringContainsString( 'Connect Bluesky', $output );
+		$this->assertStringContainsString( 'Skip for now', $output );
+		$this->assertStringContainsString( 'fosse-bluesky-form', $output );
+		$this->assertStringNotContainsString( 'fosse-bluesky-placeholder', $output );
+		$this->assertStringNotContainsString( 'Coming Soon', $output );
+		$this->assertMatchesRegularExpression( '/<input\b(?=[^>]*\bid="fosse-bsky-handle")(?=[^>]*\bname="bluesky_handle")[^>]*>/i', $output );
+		$this->assertDoesNotMatchRegularExpression( '/<input\b(?=[^>]*\bid="fosse-bsky-handle")[^>]*\bdisabled\b/i', $output );
+	}
+
+	/**
+	 * The Bluesky wizard step does not render a dead connect form when unavailable.
+	 */
+	public function test_render_bluesky_step_unavailable_omits_connect_form(): void {
+		Connection_Provider_Registry::reset();
+		AP_Provider::register_provider();
+		Connection_Provider_Registry::register(
+			new class() implements Connection_Provider {
+				/**
+				 * Get the provider slug.
+				 *
+				 * @return string
+				 */
+				public function get_slug(): string {
+					return 'bluesky';
+				}
+
+				/**
+				 * Get the provider display name.
+				 *
+				 * @return string
+				 */
+				public function get_name(): string {
+					return 'Bluesky';
+				}
+
+				/**
+				 * Whether the provider is available.
+				 *
+				 * @return bool
+				 */
+				public function is_available(): bool {
+					return false;
+				}
+
+				/**
+				 * Get current provider status.
+				 *
+				 * @return array<string, mixed>
+				 */
+				public function get_status(): array {
+					return array( 'connected' => false );
+				}
+
+				/**
+				 * Render setup UI.
+				 *
+				 * @return void
+				 */
+				public function render_setup_section(): void {}
+
+				/**
+				 * Render status UI.
+				 *
+				 * @return void
+				 */
+				public function render_status_card(): void {}
+
+				/**
+				 * Register hooks.
+				 *
+				 * @return void
+				 */
+				public function register_hooks(): void {}
+			}
+		);
+
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertStringContainsString( 'Bluesky setup is unavailable', $output );
+		$this->assertStringContainsString( 'Skip for now', $output );
+		$this->assertStringNotContainsString( 'fosse_connect_bluesky', $output );
+		$this->assertStringNotContainsString( 'fosse-bsky-handle', $output );
+	}
+
+	/**
+	 * The Bluesky wizard step renders connected account details instead of the form.
+	 */
+	public function test_render_bluesky_step_connected_shows_connection_details(): void {
+		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
+
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertStringContainsString( 'Bluesky is connected', $output );
+		$this->assertStringContainsString( 'alice.bsky.social', $output );
+		$this->assertStringContainsString( 'did:plc:alice123', $output );
+		$this->assertStringContainsString( 'Finish setup', $output );
+		$this->assertStringNotContainsString( 'fosse_connect_bluesky', $output );
+	}
+
+	/**
+	 * The completion summary reflects an already-connected Bluesky account.
+	 */
+	public function test_complete_summary_shows_connected_bluesky_account(): void {
+		Onboarding_Wizard::mark_complete();
+		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'Bluesky', $output );
+		$this->assertStringContainsString( 'Connected as alice.bsky.social', $output );
+		$this->assertStringNotContainsString( 'Not connected', $output );
+	}
+
 	// --- audit hook: handler cap/nonce failures (parameterized) ---
 
 	/**
@@ -553,6 +693,50 @@ class Onboarding_WizardTest extends BaseTestCase {
 	private function call_normalize( string $handle ): string {
 		$method = new ReflectionMethod( Onboarding_Wizard::class, 'normalize_handle_preview' );
 		return (string) $method->invoke( null, $handle );
+	}
+
+	/**
+	 * Render the wizard at a specific step and return the captured markup.
+	 *
+	 * @param string $step Step slug.
+	 * @return string
+	 */
+	private function render_wizard_step( string $step ): string {
+		$this->become_admin();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array(
+			'page' => 'fosse-wizard',
+			'step' => $step,
+		);
+
+		ob_start();
+		try {
+			Onboarding_Wizard::render();
+		} finally {
+			$output = ob_get_clean();
+		}
+
+		return (string) $output;
+	}
+
+	/**
+	 * Seed Atmosphere's connected account option.
+	 *
+	 * @param string $handle Connected Bluesky handle.
+	 * @param string $did    Connected Bluesky DID.
+	 * @return void
+	 */
+	private function seed_bluesky_connection( string $handle, string $did ): void {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => $did,
+				'handle'       => $handle,
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
 	}
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -49,7 +49,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		// Most tests assume an ActivityPub provider is registered. Tests
 		// that need the unavailable path call Connection_Provider_Registry::reset()
-		// explicitly; the @after restores the provider for the next test.
+		// explicitly; the #[After] hook re-registers AP and Bluesky for the
+		// next test.
 		Connection_Provider_Registry::reset();
 		AP_Provider::register_provider();
 		Bluesky_Provider::register_provider();


### PR DESCRIPTION
## Summary
- Replace the Bluesky onboarding placeholder with provider-backed live connect, connected, and unavailable states.
- Preserve wizard-origin OAuth return context so callbacks return to the Bluesky wizard step.
- Keep this PR scoped to the current wizard order; reordering the wizard can be handled in a follow-up after this lands.

## Testing
- `composer run-script lint-php`
- `composer run-script test-php`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm exec playwright test tests/e2e/onboarding-wizard.spec.ts`