### PR TITLE
Clarify ActivityPub profile mode settings

### DIFF
--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -116,13 +116,14 @@ class AP_Provider implements Connection_Provider {
 						<th scope="row"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></th>
 						<td>
 							<fieldset aria-describedby="fosse-activitypub-actor-mode-note">
+								<legend class="screen-reader-text"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></legend>
 								<label>
 									<input
 										type="radio"
 										id="fosse-activitypub-actor-mode-actor"
 										name="activitypub_actor_mode"
 										value="actor"
-										aria-describedby="fosse-activitypub-actor-mode-actor-desc"
+										aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"
 										<?php checked( 'actor', $actor_mode ); ?>
 									/>
 									<?php esc_html_e( 'Author profiles', 'fosse' ); ?>
@@ -136,7 +137,7 @@ class AP_Provider implements Connection_Provider {
 										id="fosse-activitypub-actor-mode-blog"
 										name="activitypub_actor_mode"
 										value="blog"
-										aria-describedby="fosse-activitypub-actor-mode-blog-desc"
+										aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"
 										<?php checked( 'blog', $actor_mode ); ?>
 									/>
 									<?php esc_html_e( 'Blog profile', 'fosse' ); ?>
@@ -150,7 +151,7 @@ class AP_Provider implements Connection_Provider {
 										id="fosse-activitypub-actor-mode-actor-blog"
 										name="activitypub_actor_mode"
 										value="actor_blog"
-										aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc"
+										aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"
 										<?php checked( 'actor_blog', $actor_mode ); ?>
 									/>
 									<?php esc_html_e( 'Both', 'fosse' ); ?>
@@ -158,8 +159,8 @@ class AP_Provider implements Connection_Provider {
 								<p id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
 									<?php esc_html_e( 'Authors keep individual profiles, and the site also has its own blog profile. People can follow either.', 'fosse' ); ?>
 								</p>
-								<div id="fosse-activitypub-actor-mode-note" class="fosse-activitypub-actor-mode-note">
-									<p class="description">
+								<div class="fosse-activitypub-actor-mode-note">
+									<p id="fosse-activitypub-actor-mode-note" class="description">
 										<?php esc_html_e( 'Changing modes does not move followers between profiles. Future posts publish from the profiles enabled by the selected mode.', 'fosse' ); ?>
 									</p>
 									<p class="description">

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -115,7 +115,7 @@ class AP_Provider implements Connection_Provider {
 					<tr>
 						<th scope="row"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></th>
 						<td>
-							<fieldset aria-describedby="fosse-activitypub-actor-mode-note">
+							<fieldset>
 								<legend class="screen-reader-text"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></legend>
 								<label>
 									<input
@@ -167,7 +167,7 @@ class AP_Provider implements Connection_Provider {
 										<?php
 										echo wp_kses(
 											sprintf(
-												/* translators: %s: link to ActivityPub blog profile settings. */
+												/* translators: %s: anchor link reading "Blog profile settings" pointing to the ActivityPub blog profile tab. */
 												__( 'Configure the site-wide blog profile name, image, and description in %s.', 'fosse' ),
 												'<a href="' . esc_url( admin_url( 'options-general.php?page=activitypub&tab=blog-profile' ) ) . '">' . esc_html__( 'Blog profile settings', 'fosse' ) . '</a>'
 											),

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -115,19 +115,70 @@ class AP_Provider implements Connection_Provider {
 					<tr>
 						<th scope="row"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></th>
 						<td>
-							<fieldset>
+							<fieldset aria-describedby="fosse-activitypub-actor-mode-note">
 								<label>
-									<input type="radio" name="activitypub_actor_mode" value="actor" <?php checked( 'actor', $actor_mode ); ?> />
+									<input
+										type="radio"
+										id="fosse-activitypub-actor-mode-actor"
+										name="activitypub_actor_mode"
+										value="actor"
+										aria-describedby="fosse-activitypub-actor-mode-actor-desc"
+										<?php checked( 'actor', $actor_mode ); ?>
+									/>
 									<?php esc_html_e( 'Author profiles', 'fosse' ); ?>
-								</label><br />
+								</label>
+								<p id="fosse-activitypub-actor-mode-actor-desc" class="description">
+									<?php esc_html_e( 'Each WordPress author publishes from their own fediverse profile. People follow individual authors, and posts appear under each author\'s name.', 'fosse' ); ?>
+								</p>
 								<label>
-									<input type="radio" name="activitypub_actor_mode" value="blog" <?php checked( 'blog', $actor_mode ); ?> />
+									<input
+										type="radio"
+										id="fosse-activitypub-actor-mode-blog"
+										name="activitypub_actor_mode"
+										value="blog"
+										aria-describedby="fosse-activitypub-actor-mode-blog-desc"
+										<?php checked( 'blog', $actor_mode ); ?>
+									/>
 									<?php esc_html_e( 'Blog profile', 'fosse' ); ?>
-								</label><br />
+								</label>
+								<p id="fosse-activitypub-actor-mode-blog-desc" class="description">
+									<?php esc_html_e( 'One site-wide profile publishes every post, regardless of author. Use this when people should follow the site as one account.', 'fosse' ); ?>
+								</p>
 								<label>
-									<input type="radio" name="activitypub_actor_mode" value="actor_blog" <?php checked( 'actor_blog', $actor_mode ); ?> />
+									<input
+										type="radio"
+										id="fosse-activitypub-actor-mode-actor-blog"
+										name="activitypub_actor_mode"
+										value="actor_blog"
+										aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc"
+										<?php checked( 'actor_blog', $actor_mode ); ?>
+									/>
 									<?php esc_html_e( 'Both', 'fosse' ); ?>
 								</label>
+								<p id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
+									<?php esc_html_e( 'Authors keep individual profiles, and the site also has its own blog profile. People can follow either.', 'fosse' ); ?>
+								</p>
+								<div id="fosse-activitypub-actor-mode-note" class="fosse-activitypub-actor-mode-note">
+									<p class="description">
+										<?php esc_html_e( 'Changing modes does not move followers between profiles. Future posts publish from the profiles enabled by the selected mode.', 'fosse' ); ?>
+									</p>
+									<p class="description">
+										<?php
+										echo wp_kses(
+											sprintf(
+												/* translators: %s: link to ActivityPub blog profile settings. */
+												__( 'Configure the site-wide blog profile name, image, and description in %s.', 'fosse' ),
+												'<a href="' . esc_url( admin_url( 'options-general.php?page=activitypub&tab=blog-profile' ) ) . '">' . esc_html__( 'Blog profile settings', 'fosse' ) . '</a>'
+											),
+											array(
+												'a' => array(
+													'href' => array(),
+												),
+											)
+										);
+										?>
+									</p>
+								</div>
 							</fieldset>
 						</td>
 					</tr>

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -147,22 +147,24 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Changing modes does not move followers between profiles.', $output );
 		$this->assertStringContainsString( 'Configure the site-wide blog profile name, image, and description', $output );
 		$this->assertStringContainsString( '<fieldset aria-describedby="fosse-activitypub-actor-mode-note">', $output );
+		$this->assertStringContainsString( '<legend class="screen-reader-text">Actor Mode</legend>', $output );
 		$this->assertMatchesRegularExpression(
-			'~<input[^>]+id="fosse-activitypub-actor-mode-actor"[^>]+aria-describedby="fosse-activitypub-actor-mode-actor-desc"[^>]+/>~',
+			'~<input[^>]+id="fosse-activitypub-actor-mode-actor"[^>]+aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"[^>]+/>~',
 			$output
 		);
 		$this->assertMatchesRegularExpression(
-			'~<input[^>]+id="fosse-activitypub-actor-mode-blog"[^>]+aria-describedby="fosse-activitypub-actor-mode-blog-desc"[^>]+/>~',
+			'~<input[^>]+id="fosse-activitypub-actor-mode-blog"[^>]+aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"[^>]+/>~',
 			$output
 		);
 		$this->assertMatchesRegularExpression(
-			'~<input[^>]+id="fosse-activitypub-actor-mode-actor-blog"[^>]+aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc"[^>]+/>~',
+			'~<input[^>]+id="fosse-activitypub-actor-mode-actor-blog"[^>]+aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"[^>]+/>~',
 			$output
 		);
 		$this->assertStringContainsString( 'id="fosse-activitypub-actor-mode-actor-desc"', $output );
 		$this->assertStringContainsString( 'id="fosse-activitypub-actor-mode-blog-desc"', $output );
 		$this->assertStringContainsString( 'id="fosse-activitypub-actor-mode-actor-blog-desc"', $output );
-		$this->assertStringContainsString( '<div id="fosse-activitypub-actor-mode-note" class="fosse-activitypub-actor-mode-note">', $output );
+		$this->assertStringContainsString( '<p id="fosse-activitypub-actor-mode-note" class="description">', $output );
+		$this->assertStringContainsString( '<div class="fosse-activitypub-actor-mode-note">', $output );
 		$this->assertMatchesRegularExpression(
 			'~<a href="[^"]*options-general\.php\?page=activitypub(?:&#038;|&amp;|&)tab=blog-profile">Blog profile settings</a>~',
 			$output

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -146,7 +146,7 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Authors keep individual profiles, and the site also has its own blog profile.', $output );
 		$this->assertStringContainsString( 'Changing modes does not move followers between profiles.', $output );
 		$this->assertStringContainsString( 'Configure the site-wide blog profile name, image, and description', $output );
-		$this->assertStringContainsString( '<fieldset aria-describedby="fosse-activitypub-actor-mode-note">', $output );
+		$this->assertStringNotContainsString( '<fieldset aria-describedby="fosse-activitypub-actor-mode-note">', $output );
 		$this->assertStringContainsString( '<legend class="screen-reader-text">Actor Mode</legend>', $output );
 		$this->assertMatchesRegularExpression(
 			'~<input[^>]+id="fosse-activitypub-actor-mode-actor"[^>]+aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"[^>]+/>~',
@@ -160,15 +160,55 @@ class AP_ProviderTest extends BaseTestCase {
 			'~<input[^>]+id="fosse-activitypub-actor-mode-actor-blog"[^>]+aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"[^>]+/>~',
 			$output
 		);
-		$this->assertStringContainsString( 'id="fosse-activitypub-actor-mode-actor-desc"', $output );
-		$this->assertStringContainsString( 'id="fosse-activitypub-actor-mode-blog-desc"', $output );
-		$this->assertStringContainsString( 'id="fosse-activitypub-actor-mode-actor-blog-desc"', $output );
 		$this->assertStringContainsString( '<p id="fosse-activitypub-actor-mode-note" class="description">', $output );
-		$this->assertStringContainsString( '<div class="fosse-activitypub-actor-mode-note">', $output );
 		$this->assertMatchesRegularExpression(
-			'~<a href="[^"]*options-general\.php\?page=activitypub(?:&#038;|&amp;|&)tab=blog-profile">Blog profile settings</a>~',
+			'~<a href="[^"]*options-general\.php\?page=activitypub(?:&#038;|&amp;)tab=blog-profile">Blog profile settings</a>~',
 			$output
 		);
+	}
+
+	/**
+	 * Setup UI selects the stored actor mode.
+	 */
+	public function test_render_setup_section_checks_selected_actor_mode() {
+		$modes = array( 'actor', 'blog', 'actor_blog' );
+
+		foreach ( $modes as $selected_mode ) {
+			update_option( 'activitypub_actor_mode', $selected_mode );
+
+			ob_start();
+			$this->provider->render_setup_section();
+			$output = ob_get_clean();
+
+			foreach ( $modes as $mode ) {
+				$input = $this->get_actor_mode_input_markup( $output, $mode );
+
+				if ( $selected_mode === $mode ) {
+					$this->assertStringContainsString( "checked='checked'", $input );
+				} else {
+					$this->assertStringNotContainsString( "checked='checked'", $input );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get the rendered radio input for an ActivityPub actor mode.
+	 *
+	 * @param string $output Rendered setup section markup.
+	 * @param string $mode   Actor mode value.
+	 * @return string
+	 */
+	private function get_actor_mode_input_markup( string $output, string $mode ): string {
+		preg_match(
+			'~<input\b(?=[^>]*\bname="activitypub_actor_mode")(?=[^>]*\bvalue="' . preg_quote( $mode, '~' ) . '")[^>]*>~s',
+			$output,
+			$matches
+		);
+
+		$this->assertNotEmpty( $matches, 'Expected actor mode input to be present.' );
+
+		return $matches[0];
 	}
 
 	// --- handle_save tests ---------------------------------------------------

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -133,6 +133,42 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( '#fosse-provider-activitypub', $output );
 	}
 
+	/**
+	 * Setup UI explains the available actor modes and links to blog profile settings.
+	 */
+	public function test_render_setup_section_explains_actor_modes() {
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Each WordPress author publishes from their own fediverse profile.', $output );
+		$this->assertStringContainsString( 'One site-wide profile publishes every post, regardless of author.', $output );
+		$this->assertStringContainsString( 'Authors keep individual profiles, and the site also has its own blog profile.', $output );
+		$this->assertStringContainsString( 'Changing modes does not move followers between profiles.', $output );
+		$this->assertStringContainsString( 'Configure the site-wide blog profile name, image, and description', $output );
+		$this->assertStringContainsString( '<fieldset aria-describedby="fosse-activitypub-actor-mode-note">', $output );
+		$this->assertMatchesRegularExpression(
+			'~<input[^>]+id="fosse-activitypub-actor-mode-actor"[^>]+aria-describedby="fosse-activitypub-actor-mode-actor-desc"[^>]+/>~',
+			$output
+		);
+		$this->assertMatchesRegularExpression(
+			'~<input[^>]+id="fosse-activitypub-actor-mode-blog"[^>]+aria-describedby="fosse-activitypub-actor-mode-blog-desc"[^>]+/>~',
+			$output
+		);
+		$this->assertMatchesRegularExpression(
+			'~<input[^>]+id="fosse-activitypub-actor-mode-actor-blog"[^>]+aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc"[^>]+/>~',
+			$output
+		);
+		$this->assertStringContainsString( 'id="fosse-activitypub-actor-mode-actor-desc"', $output );
+		$this->assertStringContainsString( 'id="fosse-activitypub-actor-mode-blog-desc"', $output );
+		$this->assertStringContainsString( 'id="fosse-activitypub-actor-mode-actor-blog-desc"', $output );
+		$this->assertStringContainsString( '<div id="fosse-activitypub-actor-mode-note" class="fosse-activitypub-actor-mode-note">', $output );
+		$this->assertMatchesRegularExpression(
+			'~<a href="[^"]*options-general\.php\?page=activitypub(?:&#038;|&amp;|&)tab=blog-profile">Blog profile settings</a>~',
+			$output
+		);
+	}
+
 	// --- handle_save tests ---------------------------------------------------
 
 	/**


### PR DESCRIPTION
## Summary
- Adds inline help text for ActivityPub actor/profile modes on the FOSSE Settings page.
- Links directly to ActivityPub Blog Profile settings.
- Adds a fieldset-wide note that changing modes does not move followers between profiles.
- Adds render coverage for the new help text and accessible descriptions.

## Testing
- composer run-script test-php
- composer run-script lint-php
- pnpm test
- pnpm run format:check
- pnpm run lint
- git diff --check

Fixes #37.