### PR TITLE
Isolate Bluesky provider e2e state from onboarding wizard tests

### DIFF
--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -24,6 +24,35 @@ const setBlueskyState = async (
 };
 
 test.describe( 'Bluesky provider UI', () => {
+	// FOSSE's first-run activation redirect intercepts the first hit to
+	// /wp-admin/post-new.php and bounces the browser to the onboarding
+	// wizard, which doesn't expose wpApiSettings.nonce. Visit the wizard
+	// once up front so the one-shot redirect option is consumed before
+	// the per-test setup runs.
+	test.beforeAll( async ( { browser } ) => {
+		const page = await browser.newPage();
+		await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+		await page.close();
+	} );
+
+	// The connected-state test below leaves atmosphere_connection set,
+	// which flips the onboarding wizard's Bluesky step (rendered by
+	// later specs) to its connected-summary branch and hides the
+	// connect form. Reset to disconnected so spec ordering can't bleed
+	// state into onboarding-wizard.spec.ts.
+	test.afterAll( async ( { browser } ) => {
+		const page = await browser.newPage();
+		await page.goto( '/wp-admin/post-new.php' );
+		await page.waitForFunction(
+			() => !! ( window as any ).wpApiSettings?.nonce
+		);
+		await setBlueskyState( page, {
+			connected: false,
+			auto_publish: true,
+		} );
+		await page.close();
+	} );
+
 	test.beforeEach( async ( { page } ) => {
 		await page.goto( '/wp-admin/post-new.php' );
 		await page.waitForFunction(


### PR DESCRIPTION
## Summary

PR #47 made the onboarding wizard's Bluesky step render conditionally on the live `atmosphere_connection` option — connect-form when disconnected, summary table when connected — and flipped the bottom CTA from "Skip for now" → "Finish setup" when connected (`class-onboarding-wizard.php:903`). Because Playwright runs spec files alphabetically, the "mocked connected Bluesky details" test in `bluesky-provider.spec.ts` left `atmosphere_connection` set when `onboarding-wizard.spec.ts` ran next, breaking three wizard tests:

- `:84` — expects `#fosse-bsky-handle` (only rendered in the disconnected branch).
- `:99` — expects "Skip for now" link (now reads "Finish setup" when connected).
- `:111` — cascades from `:99` (without that click, the wizard never marks complete, and `step=complete` redirects to welcome).

The fourth test the trunk run flagged (`bluesky-provider.spec.ts:34`) is a pre-existing flake from PR #33: FOSSE's first-run activation redirect intercepts `/wp-admin/post-new.php` and bounces the browser to the wizard, which doesn't expose `wpApiSettings.nonce`. That's why pre-PR trunk e2e ran with a `×±············` pattern (one retry-and-pass) for several PRs.

This PR is test-only — no plugin code changes:

- `test.beforeAll`: visit `/wp-admin/admin.php?page=fosse-wizard` once so the one-shot activation-redirect option is consumed before per-test setup runs. Eliminates the `:34` flake.
- `test.afterAll`: call `setBlueskyState({ connected: false, auto_publish: true })` so the connected fixture set by the second test doesn't leak into `onboarding-wizard.spec.ts`. Fixes `:84/:99/:111`.

## Test plan

- [x] `pnpm exec playwright test --project=chromium` — full suite green locally (20 passed on warm Playground).
- [x] `CI=1 pnpm exec playwright test --project=chromium` — runs with retries=1; same `×±···················` first-test-flake pattern as pre-#47 trunk (Playground worker warm-up; retries handle it).
- [x] `pnpm exec prettier --check tests/e2e/bluesky-provider.spec.ts` — clean.
- [x] `pnpm run lint tests/e2e/bluesky-provider.spec.ts` — clean.
- [ ] CI Playwright job green on this PR.