### PR TITLE
Clear FOSSE activation redirect in e2e blueprint

### DIFF
--- a/tests/e2e/blueprint.json
+++ b/tests/e2e/blueprint.json
@@ -32,7 +32,8 @@
 			"step": "setSiteOptions",
 			"options": {
 				"fosse_object_type": "note",
-				"activitypub_reader_ui": "1"
+				"activitypub_reader_ui": "1",
+				"fosse_activation_redirect": 0
 			}
 		}
 	]

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -24,17 +24,6 @@ const setBlueskyState = async (
 };
 
 test.describe( 'Bluesky provider UI', () => {
-	// FOSSE's first-run activation redirect intercepts the first hit to
-	// /wp-admin/post-new.php and bounces the browser to the onboarding
-	// wizard, which doesn't expose wpApiSettings.nonce. Visit the wizard
-	// once up front so the one-shot redirect option is consumed before
-	// the per-test setup runs.
-	test.beforeAll( async ( { browser } ) => {
-		const page = await browser.newPage();
-		await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
-		await page.close();
-	} );
-
 	// The connected-state test below leaves atmosphere_connection set,
 	// which flips the onboarding wizard's Bluesky step (rendered by
 	// later specs) to its connected-summary branch and hides the


### PR DESCRIPTION
## Summary

Follow-up to PR #50. Codex's adversarial review surfaced a residual gap: PR #50 consumed FOSSE's first-run activation redirect inside `bluesky-provider.spec.ts::beforeAll`, which is fine for the full alphabetical CI run but doesn't help anyone running another spec in isolation against a fresh Playground. The first admin-page hit in that other spec still gets bounced to the wizard and times out waiting for `wpApiSettings.nonce`.

Move the consume to the blueprint itself so every spec starts from a clean slate:

- `tests/e2e/blueprint.json` adds `"fosse_activation_redirect": 0` to the existing `setSiteOptions` step. The `register_activation_hook` in `fosse.php` writes `1` during `activatePlugin`; this step runs after activation and overrides it with `0`, which `Menu::maybe_redirect_to_wizard()` reads as falsy and short-circuits on (`class-menu.php:147`).
- `tests/e2e/bluesky-provider.spec.ts` drops the now-redundant `test.beforeAll`. The `test.afterAll` for `atmosphere_connection` cleanup stays — it addresses a separate concern (state leak from the connected-fixture test into `onboarding-wizard.spec.ts`'s wizard-Bluesky-step rendering).

## Test plan

- [x] `CI=1 pnpm exec playwright test --project=chromium` locally — all 4 previously-regressed tests (`bluesky-provider.spec.ts:23`, `onboarding-wizard.spec.ts:84/99/111`) pass without retries. The unrelated `reactions-display.spec.ts:17` flake is pre-existing on trunk.
- [x] `pnpm exec prettier --check` clean.
- [x] `pnpm run lint` clean.
- [ ] CI Playwright job green on this PR.

## Notes

This only addresses Finding 1 from the adversarial review. Findings 2–4 (workers > 1 race, interrupted-run state leak with `reuseExistingServer`, hook-scope fragility under reorganization) remain as known limitations of the current per-spec teardown pattern but aren't in scope here.