### PR TITLE
fix: site identity foundation — author and site fediverse handles

### DIFF
--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -115,8 +115,15 @@ class AP_Provider implements Connection_Provider {
 		$shows_blog      = $this->mode_includes_blog( $actor_mode );
 		$shows_user      = $this->mode_includes_user( $actor_mode );
 		$blog_identifier = (string) get_option( 'activitypub_blog_identifier', '' );
+		// Show the dynamic default as a placeholder rather than pre-filling
+		// the input with `value="..."`. Saving the form when the user never
+		// touched the field would otherwise freeze a literal copy of the
+		// then-current default into the option, breaking AP's normal flow
+		// (where an unset option resolves to `Blog::get_default_username()`
+		// at read time and follows host changes / collision shifts).
+		$blog_identifier_placeholder = '';
 		if ( '' === $blog_identifier && class_exists( '\Activitypub\Model\Blog' ) ) {
-			$blog_identifier = (string) \Activitypub\Model\Blog::get_default_username();
+			$blog_identifier_placeholder = (string) \Activitypub\Model\Blog::get_default_username();
 		}
 		$nonce = wp_create_nonce( 'fosse_save_ap_settings' );
 		?>
@@ -231,6 +238,7 @@ class AP_Provider implements Connection_Provider {
 									name="activitypub_blog_identifier"
 									class="regular-text"
 									value="<?php echo esc_attr( $blog_identifier ); ?>"
+									placeholder="<?php echo esc_attr( $blog_identifier_placeholder ); ?>"
 									aria-describedby="fosse-activitypub-blog-identifier-desc"
 								/>
 								<p id="fosse-activitypub-blog-identifier-desc" class="description">
@@ -372,6 +380,7 @@ class AP_Provider implements Connection_Provider {
 		// `update_option` via AP's `sanitize_option_activitypub_blog_identifier`
 		// filter — calling `\Activitypub\Sanitize::blog_identifier` directly
 		// here would double-fire it and double-emit any collision notice.
+		$blog_identifier_rejected = false;
 		if ( array_key_exists( 'activitypub_blog_identifier', $_POST ) ) {
 			// Coerce to string defensively: a malformed POST that submits the
 			// field as an array would otherwise warn under sanitize_text_field
@@ -399,6 +408,7 @@ class AP_Provider implements Connection_Provider {
 					if ( in_array( $ap_error['code'], $ap_errors_before, true ) ) {
 						continue;
 					}
+					$blog_identifier_rejected = true;
 					add_settings_error(
 						'fosse',
 						$ap_error['code'],
@@ -409,8 +419,12 @@ class AP_Provider implements Connection_Provider {
 			}
 		}
 
-		// Redirect back with appropriate notice.
-		if ( $mode_valid ) {
+		// Redirect back with appropriate notice. Suppress the blanket
+		// "settings saved" success when the Site Handle update was rejected
+		// — pairing it with an error notice in the same response confuses
+		// the user about what actually saved. The mode + post type updates
+		// still landed; the surfaced AP error explains what didn't.
+		if ( $mode_valid && ! $blog_identifier_rejected ) {
 			add_settings_error( 'fosse', 'fosse_saved', __( 'ActivityPub settings saved.', 'fosse' ), 'success' );
 		}
 		set_transient( 'settings_errors', get_settings_errors(), 30 );

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -86,10 +86,15 @@ class AP_Provider implements Connection_Provider {
 	 * @return array<string, mixed>
 	 */
 	public function get_status(): array {
-		$actor_mode   = get_option( 'activitypub_actor_mode', 'actor' );
-		$post_types   = get_option( 'activitypub_support_post_types', array( 'post' ) );
-		$user_address = $this->get_user_address();
-		$blog_address = $this->get_blog_address();
+		$actor_mode = get_option( 'activitypub_actor_mode', 'actor' );
+		$post_types = get_option( 'activitypub_support_post_types', array( 'post' ) );
+		// Gate handle resolution by mode. Constructing AP's actor models is
+		// not free — it dispatches the `activitypub_construct_model_actor`
+		// filter and runs whatever third-party code is hooked there. There's
+		// no point paying that cost for a handle the caller can't render in
+		// the current mode (e.g. the blog actor in `actor` mode).
+		$user_address = $this->mode_includes_user( $actor_mode ) ? $this->get_user_address() : '';
+		$blog_address = $this->mode_includes_blog( $actor_mode ) ? $this->get_blog_address() : '';
 
 		return array(
 			'connected'    => true,
@@ -107,13 +112,17 @@ class AP_Provider implements Connection_Provider {
 	 * @return void
 	 */
 	public function render_setup_section(): void {
-		$actor_mode      = get_option( 'activitypub_actor_mode', 'actor' );
-		$post_types      = get_option( 'activitypub_support_post_types', array( 'post' ) );
-		$all_post_types  = get_post_types( array( 'public' => true ), 'objects' );
-		$user_address    = $this->get_user_address();
-		$blog_address    = $this->get_blog_address();
-		$shows_blog      = $this->mode_includes_blog( $actor_mode );
-		$shows_user      = $this->mode_includes_user( $actor_mode );
+		$actor_mode     = get_option( 'activitypub_actor_mode', 'actor' );
+		$post_types     = get_option( 'activitypub_support_post_types', array( 'post' ) );
+		$all_post_types = get_post_types( array( 'public' => true ), 'objects' );
+		$shows_blog     = $this->mode_includes_blog( $actor_mode );
+		$shows_user     = $this->mode_includes_user( $actor_mode );
+		// Defer handle resolution until after mode checks so we don't
+		// construct the user actor in `blog` mode or the blog actor in
+		// `actor` mode — those constructions dispatch
+		// `activitypub_construct_model_actor` and aren't free.
+		$user_address    = $shows_user ? $this->get_user_address() : '';
+		$blog_address    = $shows_blog ? $this->get_blog_address() : '';
 		$blog_identifier = (string) get_option( 'activitypub_blog_identifier', '' );
 		// Show the dynamic default as a placeholder rather than pre-filling
 		// the input with `value="..."`. Saving the form when the user never
@@ -392,9 +401,14 @@ class AP_Provider implements Connection_Provider {
 				: '';
 			$raw       = trim( $raw_input );
 			if ( '' !== $raw ) {
-				// Snapshot AP error codes already on the queue so we only
-				// re-tag freshly-raised ones below.
-				$ap_errors_before = wp_list_pluck( get_settings_errors( 'activitypub_blog_identifier' ), 'code' );
+				// Snapshot the queue length, not the codes. AP's sanitizer
+				// reuses a constant code (`activitypub_blog_identifier`) for
+				// every collision rejection — comparing by code would mask a
+				// fresh rejection if any error with that code happened to be
+				// on the queue already. Settings errors are append-only, so
+				// `array_slice` from the pre-update count reliably captures
+				// only the entries this `update_option` call appended.
+				$ap_error_count_before = count( get_settings_errors( 'activitypub_blog_identifier' ) );
 
 				update_option( 'activitypub_blog_identifier', $raw );
 
@@ -404,10 +418,9 @@ class AP_Provider implements Connection_Provider {
 				// `settings_errors( 'fosse' )` only, so without this re-tag
 				// the user would see a generic "saved" success notice while
 				// their requested handle silently fell back to the default.
-				foreach ( get_settings_errors( 'activitypub_blog_identifier' ) as $ap_error ) {
-					if ( in_array( $ap_error['code'], $ap_errors_before, true ) ) {
-						continue;
-					}
+				$ap_errors_after = get_settings_errors( 'activitypub_blog_identifier' );
+				$new_ap_errors   = array_slice( $ap_errors_after, $ap_error_count_before );
+				foreach ( $new_ap_errors as $ap_error ) {
 					$blog_identifier_rejected = true;
 					add_settings_error(
 						'fosse',

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -373,7 +373,16 @@ class AP_Provider implements Connection_Provider {
 		// colliding submission is rejected and falls back to the default
 		// (this keeps FOSSE's surface aligned with AP's).
 		if ( array_key_exists( 'activitypub_blog_identifier', $_POST ) && class_exists( '\Activitypub\Sanitize' ) ) {
-			$raw = trim( sanitize_text_field( wp_unslash( $_POST['activitypub_blog_identifier'] ) ) );
+			// Coerce to string defensively: a malformed POST that submits the
+			// field as an array would otherwise warn under sanitize_text_field
+			// (and trip phpunit's failOnWarning) before we ever reach AP's
+			// sanitizer. is_string() guards the raw value before unslash and
+			// sanitize, satisfying both the PHPCS sanitization sniff and the
+			// runtime warning path.
+			$raw_input = is_string( $_POST['activitypub_blog_identifier'] )
+				? sanitize_text_field( wp_unslash( $_POST['activitypub_blog_identifier'] ) )
+				: '';
+			$raw       = trim( $raw_input );
 			if ( '' !== $raw ) {
 				$sanitized = (string) \Activitypub\Sanitize::blog_identifier( $raw );
 				if ( '' !== $sanitized ) {

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -366,27 +366,45 @@ class AP_Provider implements Connection_Provider {
 		update_option( 'activitypub_support_post_types', $post_types );
 
 		// Site Handle: only persist when the field was submitted with a non-
-		// empty value and AP's sanitizer is loadable. Empty submissions
-		// preserve any existing stored value rather than reverting to AP's
-		// default. The sanitizer applies the same collision/canonicalization
-		// rules used by AP's native Settings → ActivityPub page, so a
-		// colliding submission is rejected and falls back to the default
-		// (this keeps FOSSE's surface aligned with AP's).
-		if ( array_key_exists( 'activitypub_blog_identifier', $_POST ) && class_exists( '\Activitypub\Sanitize' ) ) {
+		// empty value. Empty submissions preserve any existing stored value
+		// rather than reverting to AP's default. The actual sanitization
+		// (collision rejection, slug canonicalization) runs inside
+		// `update_option` via AP's `sanitize_option_activitypub_blog_identifier`
+		// filter — calling `\Activitypub\Sanitize::blog_identifier` directly
+		// here would double-fire it and double-emit any collision notice.
+		if ( array_key_exists( 'activitypub_blog_identifier', $_POST ) ) {
 			// Coerce to string defensively: a malformed POST that submits the
 			// field as an array would otherwise warn under sanitize_text_field
-			// (and trip phpunit's failOnWarning) before we ever reach AP's
-			// sanitizer. is_string() guards the raw value before unslash and
-			// sanitize, satisfying both the PHPCS sanitization sniff and the
-			// runtime warning path.
+			// (and trip phpunit's failOnWarning). is_string() guards the raw
+			// value before unslash and sanitize, satisfying both the PHPCS
+			// sanitization sniff and the runtime warning path.
 			$raw_input = is_string( $_POST['activitypub_blog_identifier'] )
 				? sanitize_text_field( wp_unslash( $_POST['activitypub_blog_identifier'] ) )
 				: '';
 			$raw       = trim( $raw_input );
 			if ( '' !== $raw ) {
-				$sanitized = (string) \Activitypub\Sanitize::blog_identifier( $raw );
-				if ( '' !== $sanitized ) {
-					update_option( 'activitypub_blog_identifier', $sanitized );
+				// Snapshot AP error codes already on the queue so we only
+				// re-tag freshly-raised ones below.
+				$ap_errors_before = wp_list_pluck( get_settings_errors( 'activitypub_blog_identifier' ), 'code' );
+
+				update_option( 'activitypub_blog_identifier', $raw );
+
+				// AP's sanitizer raises settings errors under its own group
+				// when the input collides with an existing user_login /
+				// user_nicename. The FOSSE Setup page renders
+				// `settings_errors( 'fosse' )` only, so without this re-tag
+				// the user would see a generic "saved" success notice while
+				// their requested handle silently fell back to the default.
+				foreach ( get_settings_errors( 'activitypub_blog_identifier' ) as $ap_error ) {
+					if ( in_array( $ap_error['code'], $ap_errors_before, true ) ) {
+						continue;
+					}
+					add_settings_error(
+						'fosse',
+						$ap_error['code'],
+						$ap_error['message'],
+						$ap_error['type']
+					);
 				}
 			}
 		}

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -76,19 +76,28 @@ class AP_Provider implements Connection_Provider {
 	 *
 	 * AP is "connected" whenever the plugin is active — there's no external
 	 * auth step. Status includes actor mode, supported post types, and the
-	 * fediverse address.
+	 * separate user / blog fediverse handles surfaced for the active mode.
+	 *
+	 * Both `user_address` and `blog_address` are populated independently of
+	 * mode where the underlying actor exists; callers decide which to show
+	 * based on `actor_mode`. The legacy `address` key is kept for backwards
+	 * compatibility and prefers the user handle in `actor_blog` mode.
 	 *
 	 * @return array<string, mixed>
 	 */
 	public function get_status(): array {
-		$actor_mode = get_option( 'activitypub_actor_mode', 'actor' );
-		$post_types = get_option( 'activitypub_support_post_types', array( 'post' ) );
+		$actor_mode   = get_option( 'activitypub_actor_mode', 'actor' );
+		$post_types   = get_option( 'activitypub_support_post_types', array( 'post' ) );
+		$user_address = $this->get_user_address();
+		$blog_address = $this->get_blog_address();
 
 		return array(
-			'connected'  => true,
-			'actor_mode' => $actor_mode,
-			'post_types' => $post_types,
-			'address'    => $this->get_fediverse_address(),
+			'connected'    => true,
+			'actor_mode'   => $actor_mode,
+			'post_types'   => $post_types,
+			'user_address' => $user_address,
+			'blog_address' => $blog_address,
+			'address'      => $this->resolve_legacy_address( $actor_mode, $user_address, $blog_address ),
 		);
 	}
 
@@ -98,11 +107,18 @@ class AP_Provider implements Connection_Provider {
 	 * @return void
 	 */
 	public function render_setup_section(): void {
-		$actor_mode     = get_option( 'activitypub_actor_mode', 'actor' );
-		$post_types     = get_option( 'activitypub_support_post_types', array( 'post' ) );
-		$all_post_types = get_post_types( array( 'public' => true ), 'objects' );
-		$address        = $this->get_fediverse_address();
-		$nonce          = wp_create_nonce( 'fosse_save_ap_settings' );
+		$actor_mode      = get_option( 'activitypub_actor_mode', 'actor' );
+		$post_types      = get_option( 'activitypub_support_post_types', array( 'post' ) );
+		$all_post_types  = get_post_types( array( 'public' => true ), 'objects' );
+		$user_address    = $this->get_user_address();
+		$blog_address    = $this->get_blog_address();
+		$shows_blog      = $this->mode_includes_blog( $actor_mode );
+		$shows_user      = $this->mode_includes_user( $actor_mode );
+		$blog_identifier = (string) get_option( 'activitypub_blog_identifier', '' );
+		if ( '' === $blog_identifier && class_exists( '\Activitypub\Model\Blog' ) ) {
+			$blog_identifier = (string) \Activitypub\Model\Blog::get_default_username();
+		}
+		$nonce = wp_create_nonce( 'fosse_save_ap_settings' );
 		?>
 		<div class="fosse-provider-section" id="fosse-provider-activitypub">
 			<h2><?php esc_html_e( 'ActivityPub', 'fosse' ); ?></h2>
@@ -203,10 +219,38 @@ class AP_Provider implements Connection_Provider {
 						</td>
 					</tr>
 
-					<?php if ( $address ) : ?>
+					<?php if ( $shows_blog ) : ?>
 						<tr>
-							<th scope="row"><?php esc_html_e( 'Fediverse Address', 'fosse' ); ?></th>
-							<td><code><?php echo esc_html( '@' . $address ); ?></code></td>
+							<th scope="row">
+								<label for="fosse-activitypub-blog-identifier"><?php esc_html_e( 'Site Handle', 'fosse' ); ?></label>
+							</th>
+							<td>
+								<input
+									type="text"
+									id="fosse-activitypub-blog-identifier"
+									name="activitypub_blog_identifier"
+									class="regular-text"
+									value="<?php echo esc_attr( $blog_identifier ); ?>"
+									aria-describedby="fosse-activitypub-blog-identifier-desc"
+								/>
+								<p id="fosse-activitypub-blog-identifier-desc" class="description">
+									<?php esc_html_e( 'The username people use to follow your site from the fediverse. Cannot match an existing author login or nicename.', 'fosse' ); ?>
+								</p>
+							</td>
+						</tr>
+					<?php endif; ?>
+
+					<?php if ( $shows_user && $user_address ) : ?>
+						<tr>
+							<th scope="row"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></th>
+							<td><code><?php echo esc_html( '@' . $user_address ); ?></code></td>
+						</tr>
+					<?php endif; ?>
+
+					<?php if ( $shows_blog && $blog_address ) : ?>
+						<tr>
+							<th scope="row"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></th>
+							<td><code><?php echo esc_html( '@' . $blog_address ); ?></code></td>
 						</tr>
 					<?php endif; ?>
 				</table>
@@ -259,10 +303,16 @@ class AP_Provider implements Connection_Provider {
 						<td><?php esc_html_e( 'Post Types', 'fosse' ); ?></td>
 						<td><?php echo esc_html( implode( ', ', $post_types ) ); ?></td>
 					</tr>
-					<?php if ( $status['address'] ) : ?>
+					<?php if ( $this->mode_includes_user( $status['actor_mode'] ) && ! empty( $status['user_address'] ) ) : ?>
 						<tr>
-							<td><?php esc_html_e( 'Fediverse Address', 'fosse' ); ?></td>
-							<td><code><?php echo esc_html( '@' . $status['address'] ); ?></code></td>
+							<td><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></td>
+							<td><code><?php echo esc_html( '@' . $status['user_address'] ); ?></code></td>
+						</tr>
+					<?php endif; ?>
+					<?php if ( $this->mode_includes_blog( $status['actor_mode'] ) && ! empty( $status['blog_address'] ) ) : ?>
+						<tr>
+							<td><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></td>
+							<td><code><?php echo esc_html( '@' . $status['blog_address'] ); ?></code></td>
 						</tr>
 					<?php endif; ?>
 					<?php $this->render_follower_count_row(); ?>
@@ -285,6 +335,7 @@ class AP_Provider implements Connection_Provider {
 	 */
 	public function register_hooks(): void {
 		add_action( 'admin_post_fosse_save_ap_settings', array( $this, 'handle_save' ) );
+		add_filter( 'activitypub_default_blog_username', array( static::class, 'filter_default_blog_username' ) );
 	}
 
 	/**
@@ -314,6 +365,23 @@ class AP_Provider implements Connection_Provider {
 		$post_types  = array_values( array_intersect( $submitted, $valid_types ) );
 		update_option( 'activitypub_support_post_types', $post_types );
 
+		// Site Handle: only persist when the field was submitted with a non-
+		// empty value and AP's sanitizer is loadable. Empty submissions
+		// preserve any existing stored value rather than reverting to AP's
+		// default. The sanitizer applies the same collision/canonicalization
+		// rules used by AP's native Settings → ActivityPub page, so a
+		// colliding submission is rejected and falls back to the default
+		// (this keeps FOSSE's surface aligned with AP's).
+		if ( array_key_exists( 'activitypub_blog_identifier', $_POST ) && class_exists( '\Activitypub\Sanitize' ) ) {
+			$raw = trim( sanitize_text_field( wp_unslash( $_POST['activitypub_blog_identifier'] ) ) );
+			if ( '' !== $raw ) {
+				$sanitized = (string) \Activitypub\Sanitize::blog_identifier( $raw );
+				if ( '' !== $sanitized ) {
+					update_option( 'activitypub_blog_identifier', $sanitized );
+				}
+			}
+		}
+
 		// Redirect back with appropriate notice.
 		if ( $mode_valid ) {
 			add_settings_error( 'fosse', 'fosse_saved', __( 'ActivityPub settings saved.', 'fosse' ), 'success' );
@@ -325,42 +393,185 @@ class AP_Provider implements Connection_Provider {
 	}
 
 	/**
-	 * Get the fediverse address for the active actor(s).
+	 * Get the current user's fediverse address.
 	 *
-	 * Returns the blog webfinger in blog mode, the current user's
-	 * webfinger in actor mode, or the user's in actor_blog mode
-	 * (falling back to blog if the user actor is unavailable).
+	 * Always queries AP's user model, regardless of actor mode. Returns
+	 * an empty string when the user model is unavailable or the current
+	 * user can't have an actor (e.g. logged-out callers, subscribers
+	 * filtered out by `user_can_activitypub`).
 	 *
-	 * @return string Empty string if AP models are unavailable.
+	 * @return string `user@host` form, or empty string.
 	 */
-	private function get_fediverse_address(): string {
-		$mode = get_option( 'activitypub_actor_mode', 'actor' );
-
-		// Blog mode: blog webfinger only.
-		if ( 'blog' === $mode ) {
-			if ( class_exists( '\Activitypub\Model\Blog' ) ) {
-				$blog = new \Activitypub\Model\Blog();
-				return $blog->get_webfinger();
-			}
-
+	public function get_user_address(): string {
+		if ( ! class_exists( '\Activitypub\Model\User' ) ) {
 			return '';
 		}
 
-		// Actor or actor_blog mode: try the user webfinger.
-		if ( class_exists( '\Activitypub\Model\User' ) ) {
-			$user = \Activitypub\Model\User::from_wp_user( get_current_user_id() );
-			if ( $user && ! is_wp_error( $user ) ) {
-				return $user->get_webfinger();
-			}
+		$user = \Activitypub\Model\User::from_wp_user( get_current_user_id() );
+		if ( ! $user || is_wp_error( $user ) ) {
+			return '';
 		}
 
-		// In actor_blog mode, fall back to blog if user is unavailable.
-		if ( 'actor_blog' === $mode && class_exists( '\Activitypub\Model\Blog' ) ) {
-			$blog = new \Activitypub\Model\Blog();
-			return $blog->get_webfinger();
+		return (string) $user->get_webfinger();
+	}
+
+	/**
+	 * Get the site (blog) fediverse address.
+	 *
+	 * Always queries AP's blog model, regardless of actor mode. Returns
+	 * an empty string when the blog model is unavailable. Callers that
+	 * only render the blog identity in `blog` / `actor_blog` modes are
+	 * responsible for that mode check — this helper does not gate.
+	 *
+	 * @return string `blog@host` form, or empty string.
+	 */
+	public function get_blog_address(): string {
+		if ( ! class_exists( '\Activitypub\Model\Blog' ) ) {
+			return '';
+		}
+
+		$blog = new \Activitypub\Model\Blog();
+		return (string) $blog->get_webfinger();
+	}
+
+	/**
+	 * Resolve a single legacy address for `get_status()['address']`.
+	 *
+	 * Preserves the pre-split shape: blog mode → blog handle, actor mode
+	 * → user handle, actor_blog → user handle (or blog as a fallback).
+	 *
+	 * @param string $mode         Actor mode value.
+	 * @param string $user_address Pre-resolved user handle.
+	 * @param string $blog_address Pre-resolved blog handle.
+	 * @return string
+	 */
+	private function resolve_legacy_address( string $mode, string $user_address, string $blog_address ): string {
+		if ( 'blog' === $mode ) {
+			return $blog_address;
+		}
+
+		if ( '' !== $user_address ) {
+			return $user_address;
+		}
+
+		if ( 'actor_blog' === $mode ) {
+			return $blog_address;
 		}
 
 		return '';
+	}
+
+	/**
+	 * Filter callback for `activitypub_default_blog_username`.
+	 *
+	 * Replaces AP's built-in default (the full site host with `www.`
+	 * stripped) with the host's first label, so a Jurassic Ninja site
+	 * like `increasing-king-tuna.jurassic.ninja` defaults to
+	 * `increasing-king-tuna` rather than the full hostname. Only the
+	 * default is filtered — once a site owner saves a value to
+	 * `activitypub_blog_identifier`, AP's `Blog::get_preferred_username()`
+	 * uses that and never asks for a default again.
+	 *
+	 * Collisions with existing `user_login` / `user_nicename` values are
+	 * resolved by appending a numeric suffix (`-1`, `-2`, …). AP's own
+	 * sanitizer also rejects collisions, but enforcing it here means the
+	 * proposed default that surfaces in admin forms is already collision-
+	 * free instead of a value that would be rewritten on save.
+	 *
+	 * @param mixed $host Default username supplied by AP (the site host).
+	 * @return string
+	 */
+	public static function filter_default_blog_username( $host ): string {
+		if ( ! is_string( $host ) || '' === $host ) {
+			return is_string( $host ) ? $host : '';
+		}
+
+		$first_label = strtok( $host, '.' );
+		if ( ! is_string( $first_label ) || '' === $first_label ) {
+			$first_label = $host;
+		}
+
+		$candidate = sanitize_title( $first_label );
+		if ( '' === $candidate ) {
+			$candidate = sanitize_title( $host );
+		}
+		if ( '' === $candidate ) {
+			return $host;
+		}
+
+		return self::resolve_blog_username_collision( $candidate );
+	}
+
+	/**
+	 * Append a numeric suffix to the candidate until it stops colliding
+	 * with an existing `user_login` or `user_nicename`.
+	 *
+	 * Bails after 100 attempts with the last candidate so a degenerate
+	 * install with thousands of `foo-N` users can't spin forever.
+	 *
+	 * @param string $candidate Initial sanitized username.
+	 * @return string
+	 */
+	private static function resolve_blog_username_collision( string $candidate ): string {
+		if ( ! self::blog_username_in_use( $candidate ) ) {
+			return $candidate;
+		}
+
+		$base = $candidate;
+		for ( $suffix = 1; $suffix <= 100; $suffix++ ) {
+			$next = $base . '-' . $suffix;
+			if ( ! self::blog_username_in_use( $next ) ) {
+				return $next;
+			}
+		}
+
+		return $base . '-' . 100;
+	}
+
+	/**
+	 * Check whether a candidate string matches an existing user.
+	 *
+	 * Uses exact `get_user_by()` lookups against `login` and `slug`
+	 * (`user_nicename`) — the same fields AP's `Sanitize::blog_identifier`
+	 * checks before accepting a site handle.
+	 *
+	 * @param string $candidate Candidate username.
+	 * @return bool
+	 */
+	private static function blog_username_in_use( string $candidate ): bool {
+		if ( '' === $candidate ) {
+			return false;
+		}
+
+		if ( get_user_by( 'login', $candidate ) ) {
+			return true;
+		}
+
+		if ( get_user_by( 'slug', $candidate ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether the given actor mode publishes from per-author profiles.
+	 *
+	 * @param string $mode Actor mode value.
+	 * @return bool
+	 */
+	public function mode_includes_user( string $mode ): bool {
+		return 'actor' === $mode || 'actor_blog' === $mode;
+	}
+
+	/**
+	 * Whether the given actor mode publishes from a single blog profile.
+	 *
+	 * @param string $mode Actor mode value.
+	 * @return bool
+	 */
+	public function mode_includes_blog( string $mode ): bool {
+		return 'blog' === $mode || 'actor_blog' === $mode;
 	}
 
 	/**

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -1033,16 +1033,16 @@ class Onboarding_Wizard {
 				<tr>
 					<td class="fosse-summary__label"><?php esc_html_e( 'Site appears as', 'fosse' ); ?></td>
 					<td class="fosse-summary__value">
-					<?php
-					echo wp_kses(
-						$mode_label,
-						array(
-							'code' => array(),
-							'br'   => array(),
-						)
-					);
-					?>
-														</td>
+						<?php
+						echo wp_kses(
+							$mode_label,
+							array(
+								'code' => array(),
+								'br'   => array(),
+							)
+						);
+						?>
+					</td>
 				</tr>
 				<tr>
 					<td class="fosse-summary__label"><?php esc_html_e( 'Sharing', 'fosse' ); ?></td>

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -443,7 +443,7 @@ class Onboarding_Wizard {
 			case 'actor':
 				if ( '' !== $user_handle ) {
 					return sprintf(
-						/* translators: %s: fediverse handle in @user@host form. */
+						/* translators: %s: HTML <code> element wrapping a fediverse handle in @user@host form. */
 						esc_html__( 'As you (%s)', 'fosse' ),
 						'<code>' . esc_html( $user_handle ) . '</code>'
 					);
@@ -453,7 +453,7 @@ class Onboarding_Wizard {
 			case 'blog':
 				if ( '' !== $blog_handle ) {
 					return sprintf(
-						/* translators: %s: fediverse handle in @user@host form. */
+						/* translators: %s: HTML <code> element wrapping a fediverse handle in @user@host form. */
 						esc_html__( 'As your site (%s)', 'fosse' ),
 						'<code>' . esc_html( $blog_handle ) . '</code>'
 					);
@@ -469,14 +469,14 @@ class Onboarding_Wizard {
 				$lines = array( esc_html__( 'Both (site + authors)', 'fosse' ) );
 				if ( '' !== $user_handle ) {
 					$lines[] = sprintf(
-						/* translators: %s: fediverse handle in @user@host form. */
+						/* translators: %s: HTML <code> element wrapping a fediverse handle in @user@host form. */
 						esc_html__( 'As you: %s', 'fosse' ),
 						'<code>' . esc_html( $user_handle ) . '</code>'
 					);
 				}
 				if ( '' !== $blog_handle ) {
 					$lines[] = sprintf(
-						/* translators: %s: fediverse handle in @user@host form. */
+						/* translators: %s: HTML <code> element wrapping a fediverse handle in @user@host form. */
 						esc_html__( 'As your site: %s', 'fosse' ),
 						'<code>' . esc_html( $blog_handle ) . '</code>'
 					);
@@ -778,7 +778,7 @@ class Onboarding_Wizard {
 					</div>
 				<?php elseif ( '' !== $preview_blog ) : ?>
 					<div class="fosse-address-preview">
-						<span class="fosse-address-preview__label"><?php esc_html_e( 'Your fediverse address:', 'fosse' ); ?></span>
+						<span class="fosse-address-preview__label"><?php esc_html_e( 'Site fediverse address:', 'fosse' ); ?></span>
 						<code class="fosse-address-preview__address"><?php echo esc_html( $preview_blog ); ?></code>
 					</div>
 				<?php endif; ?>

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -389,52 +389,102 @@ class Onboarding_Wizard {
 	}
 
 	/**
-	 * Build a fediverse handle preview for the selected actor mode.
+	 * Build fediverse handle previews for the selected actor mode.
 	 *
-	 * Defers to ActivityPub's own actor models so the preview matches the
-	 * webfinger that Mastodon-style clients will actually resolve (blog
-	 * `preferred_username@host`, user nicename, etc.). Returns an empty
-	 * string when AP isn't loaded, the actor can't be resolved, or the
-	 * upstream value is malformed — callers hide the row in that case
-	 * rather than showing a synthetic placeholder like `@example.com`.
+	 * Defers to the ActivityPub provider's helpers so the preview matches
+	 * the webfinger that Mastodon-style clients will actually resolve
+	 * (blog `preferred_username@host`, user nicename, etc.). Returns an
+	 * associative array keyed by `'user'` and `'blog'`, with each value
+	 * either a normalized `@user@host` string or an empty string when
+	 * the actor can't be resolved or the upstream value is malformed.
+	 * Modes that do not surface a given identity simply omit it (e.g.
+	 * `actor` mode never returns a `'blog'` entry).
 	 *
 	 * @param string $mode Selected actor mode (`actor`, `blog`, `actor_blog`).
+	 * @return array{user?: string, blog?: string}
+	 */
+	private static function get_handle_previews( string $mode ): array {
+		$provider = Connection_Provider_Registry::get_provider( 'activitypub' );
+		if ( ! $provider instanceof AP_Provider ) {
+			return array();
+		}
+
+		$previews = array();
+
+		if ( $provider->mode_includes_user( $mode ) ) {
+			$previews['user'] = self::normalize_handle_preview( $provider->get_user_address() );
+		}
+
+		if ( $provider->mode_includes_blog( $mode ) ) {
+			$previews['blog'] = self::normalize_handle_preview( $provider->get_blog_address() );
+		}
+
+		return $previews;
+	}
+
+	/**
+	 * Format the "Site appears as" summary label for the completion step.
+	 *
+	 * Embeds the resolved fediverse handle(s) so users see the actual
+	 * identity they just stood up rather than just the bare host. Falls
+	 * back gracefully when a handle is missing (AP not loaded, user
+	 * actor unavailable) — never shows an `@` with no local-part.
+	 *
+	 * Returns an HTML string; the consumer escapes via `wp_kses` with
+	 * `code` and `br` allowed.
+	 *
+	 * @param string $mode        Actor mode value.
+	 * @param string $user_handle Normalized `@user@host` for the current user, or empty.
+	 * @param string $blog_handle Normalized `@blog@host` for the site, or empty.
 	 * @return string
 	 */
-	private static function get_handle_preview( string $mode ): string {
-		// Blog mode: blog webfinger only.
-		if ( 'blog' === $mode ) {
-			if ( class_exists( '\Activitypub\Model\Blog' ) ) {
-				$blog       = new \Activitypub\Model\Blog();
-				$normalized = self::normalize_handle_preview( (string) $blog->get_webfinger() );
-				if ( '' !== $normalized ) {
-					return $normalized;
+	private static function format_mode_label( string $mode, string $user_handle, string $blog_handle ): string {
+		switch ( $mode ) {
+			case 'actor':
+				if ( '' !== $user_handle ) {
+					return sprintf(
+						/* translators: %s: fediverse handle in @user@host form. */
+						esc_html__( 'As you (%s)', 'fosse' ),
+						'<code>' . esc_html( $user_handle ) . '</code>'
+					);
 				}
-			}
-			return '';
-		}
+				return esc_html__( 'As you (author profiles)', 'fosse' );
 
-		// Actor or actor_blog: prefer the user webfinger.
-		if ( class_exists( '\Activitypub\Model\User' ) ) {
-			$user = \Activitypub\Model\User::from_wp_user( get_current_user_id() );
-			if ( $user && ! is_wp_error( $user ) ) {
-				$normalized = self::normalize_handle_preview( (string) $user->get_webfinger() );
-				if ( '' !== $normalized ) {
-					return $normalized;
+			case 'blog':
+				if ( '' !== $blog_handle ) {
+					return sprintf(
+						/* translators: %s: fediverse handle in @user@host form. */
+						esc_html__( 'As your site (%s)', 'fosse' ),
+						'<code>' . esc_html( $blog_handle ) . '</code>'
+					);
 				}
-			}
+				$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
+				return sprintf(
+					/* translators: %s: site domain. */
+					esc_html__( 'As your site (%s)', 'fosse' ),
+					esc_html( $site_host ? $site_host : 'yoursite.com' )
+				);
+
+			case 'actor_blog':
+				$lines = array( esc_html__( 'Both (site + authors)', 'fosse' ) );
+				if ( '' !== $user_handle ) {
+					$lines[] = sprintf(
+						/* translators: %s: fediverse handle in @user@host form. */
+						esc_html__( 'As you: %s', 'fosse' ),
+						'<code>' . esc_html( $user_handle ) . '</code>'
+					);
+				}
+				if ( '' !== $blog_handle ) {
+					$lines[] = sprintf(
+						/* translators: %s: fediverse handle in @user@host form. */
+						esc_html__( 'As your site: %s', 'fosse' ),
+						'<code>' . esc_html( $blog_handle ) . '</code>'
+					);
+				}
+				return implode( '<br />', $lines );
 		}
 
-		// actor_blog falls back to the blog handle when the user actor isn't available.
-		if ( 'actor_blog' === $mode && class_exists( '\Activitypub\Model\Blog' ) ) {
-			$blog       = new \Activitypub\Model\Blog();
-			$normalized = self::normalize_handle_preview( (string) $blog->get_webfinger() );
-			if ( '' !== $normalized ) {
-				return $normalized;
-			}
-		}
-
-		return '';
+		return esc_html( $mode );
 	}
 
 	/**
@@ -669,7 +719,10 @@ class Onboarding_Wizard {
 			),
 		);
 
-		$preview_handle = self::get_handle_preview( $current_mode );
+		$preview_handles = self::get_handle_previews( $current_mode );
+		$preview_user    = $preview_handles['user'] ?? '';
+		$preview_blog    = $preview_handles['blog'] ?? '';
+		$preview_both    = 'actor_blog' === $current_mode && '' !== $preview_user && '' !== $preview_blog;
 
 		?>
 		<h1 class="fosse-wizard__title"><?php esc_html_e( 'How should your site appear?', 'fosse' ); ?></h1>
@@ -707,10 +760,26 @@ class Onboarding_Wizard {
 					<?php endforeach; ?>
 				</div>
 
-				<?php if ( $preview_handle ) : ?>
+				<?php if ( $preview_both ) : ?>
+					<div class="fosse-address-preview">
+						<div class="fosse-address-preview__row">
+							<span class="fosse-address-preview__label"><?php esc_html_e( 'As you:', 'fosse' ); ?></span>
+							<code class="fosse-address-preview__address"><?php echo esc_html( $preview_user ); ?></code>
+						</div>
+						<div class="fosse-address-preview__row">
+							<span class="fosse-address-preview__label"><?php esc_html_e( 'As your site:', 'fosse' ); ?></span>
+							<code class="fosse-address-preview__address"><?php echo esc_html( $preview_blog ); ?></code>
+						</div>
+					</div>
+				<?php elseif ( '' !== $preview_user ) : ?>
 					<div class="fosse-address-preview">
 						<span class="fosse-address-preview__label"><?php esc_html_e( 'Your fediverse address:', 'fosse' ); ?></span>
-						<code class="fosse-address-preview__address"><?php echo esc_html( $preview_handle ); ?></code>
+						<code class="fosse-address-preview__address"><?php echo esc_html( $preview_user ); ?></code>
+					</div>
+				<?php elseif ( '' !== $preview_blog ) : ?>
+					<div class="fosse-address-preview">
+						<span class="fosse-address-preview__label"><?php esc_html_e( 'Your fediverse address:', 'fosse' ); ?></span>
+						<code class="fosse-address-preview__address"><?php echo esc_html( $preview_blog ); ?></code>
 					</div>
 				<?php endif; ?>
 			</div>
@@ -922,19 +991,12 @@ class Onboarding_Wizard {
 
 		$actor_mode = get_option( 'activitypub_actor_mode', 'actor' );
 		$post_types = get_option( 'activitypub_support_post_types', array( 'post' ) );
-		$site_host  = wp_parse_url( home_url(), PHP_URL_HOST );
-		$site_url   = $site_host ? $site_host : 'yoursite.com';
 		$bluesky    = self::get_bluesky_status();
 
-		$mode_labels = array(
-			'actor'      => __( 'As you (author profiles)', 'fosse' ),
-			'blog'       => sprintf(
-				/* translators: %s: site domain */
-				__( 'As your site (%s)', 'fosse' ),
-				$site_url
-			),
-			'actor_blog' => __( 'Both (site + authors)', 'fosse' ),
-		);
+		$handles     = self::get_handle_previews( $actor_mode );
+		$user_handle = $handles['user'] ?? '';
+		$blog_handle = $handles['blog'] ?? '';
+		$mode_label  = self::format_mode_label( $actor_mode, $user_handle, $blog_handle );
 
 		$type_labels = array_map(
 			static function ( $pt_name ) {
@@ -970,7 +1032,17 @@ class Onboarding_Wizard {
 			<table class="fosse-summary">
 				<tr>
 					<td class="fosse-summary__label"><?php esc_html_e( 'Site appears as', 'fosse' ); ?></td>
-					<td class="fosse-summary__value"><?php echo esc_html( $mode_labels[ $actor_mode ] ?? $actor_mode ); ?></td>
+					<td class="fosse-summary__value">
+					<?php
+					echo wp_kses(
+						$mode_label,
+						array(
+							'code' => array(),
+							'br'   => array(),
+						)
+					);
+					?>
+														</td>
 				</tr>
 				<tr>
 					<td class="fosse-summary__label"><?php esc_html_e( 'Sharing', 'fosse' ); ?></td>

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -651,6 +651,30 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Array-shaped POST input for the blog identifier is rejected silently
+	 * rather than tripping `sanitize_text_field`'s array-to-string warning
+	 * (which `phpunit.xml.dist` promotes to a failure via `failOnWarning`).
+	 */
+	public function test_handle_save_array_blog_identifier_is_rejected_safely() {
+		update_option( 'activitypub_blog_identifier', 'preserved-handle' );
+
+		$this->simulate_save_request(
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => array( 'malicious', 'array' ),
+			)
+		);
+
+		try {
+			$this->provider->handle_save();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'preserved-handle', get_option( 'activitypub_blog_identifier' ) );
+	}
+
+	/**
 	 * An empty submitted handle leaves any prior value intact rather than
 	 * stomping the option with an empty string.
 	 */

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -42,6 +42,17 @@ class AP_ProviderTest extends BaseTestCase {
 
 		// Clear stale AP filter state so register_hooks() doesn't double-register.
 		remove_all_filters( 'activitypub_default_blog_username' );
+		remove_all_filters( 'sanitize_option_activitypub_blog_identifier' );
+
+		// AP registers its sanitize callback during `admin_init`, which the
+		// test bootstrap never fires. Wire the filter manually so tests
+		// exercise the same path production hits when `update_option` runs.
+		if ( class_exists( '\Activitypub\Sanitize' ) ) {
+			add_filter(
+				'sanitize_option_activitypub_blog_identifier',
+				array( '\Activitypub\Sanitize', 'blog_identifier' )
+			);
+		}
 
 		$this->provider->register_hooks();
 	}
@@ -56,6 +67,7 @@ class AP_ProviderTest extends BaseTestCase {
 	#[\PHPUnit\Framework\Attributes\After]
 	public function tear_down_provider(): void {
 		remove_all_filters( 'activitypub_default_blog_username' );
+		remove_all_filters( 'sanitize_option_activitypub_blog_identifier' );
 	}
 
 	/**
@@ -648,6 +660,49 @@ class AP_ProviderTest extends BaseTestCase {
 		}
 
 		$this->assertSame( 'has-spaces-caps', get_option( 'activitypub_blog_identifier' ) );
+	}
+
+	/**
+	 * AP's sanitizer adds settings errors under `activitypub_blog_identifier`
+	 * when the input collides with an existing user. The FOSSE Setup page
+	 * only renders `settings_errors('fosse')`, so we re-tag fresh AP errors
+	 * into our group so users actually see why their handle was rejected.
+	 *
+	 * The test forces the colliding-input branch directly via AP's filter
+	 * (WorDBless's dbless engine doesn't satisfy `WP_User_Query`'s LIKE
+	 * search, so seeding a real colliding user wouldn't trigger AP's
+	 * collision path).
+	 */
+	public function test_handle_save_rewires_ap_settings_errors_to_fosse_group() {
+		add_filter(
+			'sanitize_option_activitypub_blog_identifier',
+			static function ( $value ) {
+				add_settings_error(
+					'activitypub_blog_identifier',
+					'collision_test',
+					'Collision test error.',
+					'error'
+				);
+				return $value;
+			},
+			11 // After AP's own callback.
+		);
+
+		$this->simulate_save_request(
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => 'whatever',
+			)
+		);
+
+		try {
+			$this->provider->handle_save();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$fosse_codes = array_column( get_settings_errors( 'fosse' ), 'code' );
+		$this->assertContains( 'collision_test', $fosse_codes );
 	}
 
 	/**

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -34,12 +34,28 @@ class AP_ProviderTest extends BaseTestCase {
 
 		delete_option( 'activitypub_actor_mode' );
 		delete_option( 'activitypub_support_post_types' );
+		delete_option( 'activitypub_blog_identifier' );
 
 		// Clear stale settings errors from prior tests.
 		global $wp_settings_errors;
 		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- WP core global reset for testing.
 
+		// Clear stale AP filter state so register_hooks() doesn't double-register.
+		remove_all_filters( 'activitypub_default_blog_username' );
+
 		$this->provider->register_hooks();
+	}
+
+	/**
+	 * Drop AP filter registrations between tests so re-running the test
+	 * suite (or PHPUnit's data providers) doesn't accumulate stacked
+	 * callbacks that race the bundled AP defaults.
+	 *
+	 * @after
+	 */
+	#[\PHPUnit\Framework\Attributes\After]
+	public function tear_down_provider(): void {
+		remove_all_filters( 'activitypub_default_blog_username' );
 	}
 
 	/**
@@ -380,5 +396,339 @@ class AP_ProviderTest extends BaseTestCase {
 		}
 
 		$this->assertIsArray( get_option( 'activitypub_support_post_types' ) );
+	}
+
+	// --- Default blog username filter ---------------------------------------
+
+	/**
+	 * Default username strips multi-label hosts down to the first label so
+	 * Jurassic-Ninja-style hostnames stop bleeding into the site handle.
+	 */
+	public function test_filter_default_blog_username_uses_first_host_label() {
+		$this->assertSame(
+			'increasing-king-tuna',
+			AP_Provider::filter_default_blog_username( 'increasing-king-tuna.jurassic.ninja' )
+		);
+	}
+
+	/**
+	 * A two-label host still yields its first label, not the FQDN.
+	 */
+	public function test_filter_default_blog_username_two_label_host() {
+		$this->assertSame( 'example', AP_Provider::filter_default_blog_username( 'example.com' ) );
+	}
+
+	/**
+	 * Hosts that already lack dots (single-label `localhost`-style installs)
+	 * pass through unchanged so AP keeps a usable default.
+	 */
+	public function test_filter_default_blog_username_single_label_host_passthrough() {
+		$this->assertSame( 'localhost', AP_Provider::filter_default_blog_username( 'localhost' ) );
+	}
+
+	/**
+	 * Empty input returns an empty string rather than mangling AP's fallback.
+	 */
+	public function test_filter_default_blog_username_empty_passthrough() {
+		$this->assertSame( '', AP_Provider::filter_default_blog_username( '' ) );
+	}
+
+	/**
+	 * Non-string input (rare, but filters can receive arbitrary types) is
+	 * coerced to a string without throwing.
+	 */
+	public function test_filter_default_blog_username_non_string_input() {
+		$this->assertSame( '', AP_Provider::filter_default_blog_username( null ) );
+	}
+
+	/**
+	 * When the candidate collides with an existing user_login, the filter
+	 * appends a numeric suffix until it finds a free slot.
+	 */
+	public function test_filter_default_blog_username_collides_with_user_login() {
+		wp_insert_user(
+			array(
+				'user_login' => 'example',
+				'user_email' => 'example@example.test',
+				'user_pass'  => 'test-pass',
+			)
+		);
+
+		$this->assertSame(
+			'example-1',
+			AP_Provider::filter_default_blog_username( 'example.com' )
+		);
+	}
+
+	/**
+	 * Collisions stack: with `example` and `example-1` both taken, the
+	 * filter keeps walking until it finds an unused suffix.
+	 */
+	public function test_filter_default_blog_username_walks_collision_suffixes() {
+		wp_insert_user(
+			array(
+				'user_login' => 'example',
+				'user_email' => 'example@example.test',
+				'user_pass'  => 'test-pass',
+			)
+		);
+		wp_insert_user(
+			array(
+				'user_login' => 'example-1',
+				'user_email' => 'example-1@example.test',
+				'user_pass'  => 'test-pass',
+			)
+		);
+
+		$this->assertSame(
+			'example-2',
+			AP_Provider::filter_default_blog_username( 'example.com' )
+		);
+	}
+
+	/**
+	 * Collisions with `user_nicename` (the slug) are also avoided.
+	 */
+	public function test_filter_default_blog_username_collides_with_user_nicename() {
+		wp_insert_user(
+			array(
+				'user_login'    => 'unrelated_login_aaa',
+				'user_nicename' => 'example',
+				'user_email'    => 'aaa@example.test',
+				'user_pass'     => 'test-pass',
+			)
+		);
+
+		$this->assertSame(
+			'example-1',
+			AP_Provider::filter_default_blog_username( 'example.com' )
+		);
+	}
+
+	/**
+	 * Registering hooks attaches the default-username filter so AP's
+	 * `Blog::get_default_username()` invocations pick up our shortened
+	 * default end-to-end.
+	 */
+	public function test_register_hooks_attaches_default_blog_username_filter() {
+		// register_hooks() already ran in set_up_provider(); make sure the
+		// filter actually fires when AP applies it.
+		$result = apply_filters( 'activitypub_default_blog_username', 'foo.example.com' );
+		$this->assertSame( 'foo', $result );
+	}
+
+	// --- User / blog address helpers ----------------------------------------
+
+	/**
+	 * `get_user_address()` resolves to the current user's webfinger when an
+	 * AP-eligible user is signed in. AP's `user_can_activitypub` filter is
+	 * stubbed because WorDBless doesn't fire AP's activation, so the
+	 * `activitypub` capability isn't granted to admins by default.
+	 */
+	public function test_get_user_address_returns_webfinger_for_current_user() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'fosse_address_user',
+				'user_email' => 'address@example.test',
+				'user_pass'  => 'test-pass',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		add_filter( 'activitypub_user_can_activitypub', '__return_true' );
+		$address = $this->provider->get_user_address();
+		remove_filter( 'activitypub_user_can_activitypub', '__return_true' );
+
+		$this->assertNotSame( '', $address );
+		$this->assertStringContainsString( '@', $address );
+	}
+
+	/**
+	 * `get_blog_address()` returns the blog webfinger regardless of the
+	 * stored actor mode — the helper is mode-agnostic so callers can
+	 * combine it freely.
+	 */
+	public function test_get_blog_address_returns_blog_webfinger_in_actor_mode() {
+		update_option( 'activitypub_actor_mode', 'actor' );
+
+		$address = $this->provider->get_blog_address();
+
+		$this->assertNotSame( '', $address );
+		$this->assertStringContainsString( '@', $address );
+	}
+
+	/**
+	 * Status exposes both `user_address` and `blog_address` keys so the UI
+	 * can render the dual identity in `actor_blog` mode.
+	 */
+	public function test_status_exposes_separate_user_and_blog_addresses() {
+		$status = $this->provider->get_status();
+
+		$this->assertArrayHasKey( 'user_address', $status );
+		$this->assertArrayHasKey( 'blog_address', $status );
+	}
+
+	/**
+	 * In `blog` mode, the legacy `address` key prefers the blog handle so
+	 * existing callers keep their current behavior.
+	 */
+	public function test_status_legacy_address_in_blog_mode_uses_blog_handle() {
+		update_option( 'activitypub_actor_mode', 'blog' );
+
+		$status = $this->provider->get_status();
+
+		$this->assertNotEmpty( $status['blog_address'] );
+		$this->assertSame( $status['blog_address'], $status['address'] );
+	}
+
+	// --- Mode helpers --------------------------------------------------------
+
+	/**
+	 * Mode helpers correctly classify `actor`, `blog`, and `actor_blog`.
+	 */
+	public function test_mode_helpers_classify_modes() {
+		$this->assertTrue( $this->provider->mode_includes_user( 'actor' ) );
+		$this->assertFalse( $this->provider->mode_includes_blog( 'actor' ) );
+
+		$this->assertFalse( $this->provider->mode_includes_user( 'blog' ) );
+		$this->assertTrue( $this->provider->mode_includes_blog( 'blog' ) );
+
+		$this->assertTrue( $this->provider->mode_includes_user( 'actor_blog' ) );
+		$this->assertTrue( $this->provider->mode_includes_blog( 'actor_blog' ) );
+	}
+
+	// --- Site Handle persistence --------------------------------------------
+
+	/**
+	 * Saving a site handle persists it through AP's sanitizer so the same
+	 * value is stored regardless of which surface accepted the input.
+	 */
+	public function test_handle_save_persists_blog_identifier() {
+		$this->simulate_save_request(
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => 'my-fosse-site',
+			)
+		);
+
+		try {
+			$this->provider->handle_save();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'my-fosse-site', get_option( 'activitypub_blog_identifier' ) );
+	}
+
+	/**
+	 * Submitted handles run through AP's `Sanitize::blog_identifier` so the
+	 * same canonicalization rules apply as on AP's native settings page.
+	 * Underscores in the raw input become dashes on the way through
+	 * `sanitize_title`, which proves the upstream sanitizer ran rather than
+	 * us storing the input verbatim.
+	 *
+	 * Collision rejection uses `WP_User_Query`'s LIKE search internally,
+	 * which WorDBless's dbless engine can't satisfy — so collision behavior
+	 * itself is asserted via the unit-tested
+	 * `filter_default_blog_username` collision tests above.
+	 */
+	public function test_handle_save_blog_identifier_runs_through_ap_sanitizer() {
+		$this->simulate_save_request(
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => 'Has Spaces & Caps',
+			)
+		);
+
+		try {
+			$this->provider->handle_save();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'has-spaces-caps', get_option( 'activitypub_blog_identifier' ) );
+	}
+
+	/**
+	 * An empty submitted handle leaves any prior value intact rather than
+	 * stomping the option with an empty string.
+	 */
+	public function test_handle_save_empty_blog_identifier_does_not_clobber_existing_value() {
+		update_option( 'activitypub_blog_identifier', 'preserved-handle' );
+
+		$this->simulate_save_request(
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => '',
+			)
+		);
+
+		try {
+			$this->provider->handle_save();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'preserved-handle', get_option( 'activitypub_blog_identifier' ) );
+	}
+
+	/**
+	 * The Site Handle field renders in `blog` mode with the current saved
+	 * value pre-filled so site owners can edit it from FOSSE's surface.
+	 */
+	public function test_render_setup_section_shows_site_handle_field_in_blog_mode() {
+		update_option( 'activitypub_actor_mode', 'blog' );
+		update_option( 'activitypub_blog_identifier', 'my-site' );
+
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
+		$this->assertStringContainsString( 'value="my-site"', $output );
+		$this->assertStringContainsString( 'Site Handle', $output );
+	}
+
+	/**
+	 * The Site Handle field is hidden in `actor` mode where there is no
+	 * site identity to configure.
+	 */
+	public function test_render_setup_section_hides_site_handle_field_in_actor_mode() {
+		update_option( 'activitypub_actor_mode', 'actor' );
+
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'name="activitypub_blog_identifier"', $output );
+	}
+
+	/**
+	 * In `actor_blog` mode the setup section surfaces both the user handle
+	 * and the site handle row so neither identity is hidden by the UI.
+	 */
+	public function test_render_setup_section_in_actor_blog_mode_shows_both_addresses() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'fosse_dual_user',
+				'user_email' => 'dual@example.test',
+				'user_pass'  => 'test-pass',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		update_option( 'activitypub_actor_mode', 'actor_blog' );
+
+		add_filter( 'activitypub_user_can_activitypub', '__return_true' );
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+		remove_filter( 'activitypub_user_can_activitypub', '__return_true' );
+
+		$this->assertStringContainsString( 'Your fediverse address', $output );
+		$this->assertStringContainsString( 'Site fediverse address', $output );
+		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
 	}
 }

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -706,6 +706,46 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * The success notice is suppressed when AP's sanitizer rejected the
+	 * Site Handle. Pairing a green "settings saved" with a red collision
+	 * error in the same response confuses users about what actually saved.
+	 * Mode and post-type writes still landed; the AP error explains what
+	 * didn't.
+	 */
+	public function test_handle_save_suppresses_success_notice_on_blog_identifier_rejection() {
+		add_filter(
+			'sanitize_option_activitypub_blog_identifier',
+			static function ( $value ) {
+				add_settings_error(
+					'activitypub_blog_identifier',
+					'rejection_test',
+					'Rejected.',
+					'error'
+				);
+				return $value;
+			},
+			11
+		);
+
+		$this->simulate_save_request(
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => 'whatever',
+			)
+		);
+
+		try {
+			$this->provider->handle_save();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$fosse_codes = array_column( get_settings_errors( 'fosse' ), 'code' );
+		$this->assertNotContains( 'fosse_saved', $fosse_codes );
+		$this->assertContains( 'rejection_test', $fosse_codes );
+	}
+
+	/**
 	 * Array-shaped POST input for the blog identifier is rejected silently
 	 * rather than tripping `sanitize_text_field`'s array-to-string warning
 	 * (which `phpunit.xml.dist` promotes to a failure via `failOnWarning`).
@@ -767,6 +807,30 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
 		$this->assertStringContainsString( 'value="my-site"', $output );
 		$this->assertStringContainsString( 'Site Handle', $output );
+	}
+
+	/**
+	 * When the option is empty, the dynamic default appears as a
+	 * `placeholder` rather than a `value`. Pre-filling `value` would
+	 * freeze the proposed default into the option as soon as the user
+	 * saved any other field — breaking AP's "unset → recompute on read"
+	 * contract.
+	 */
+	public function test_render_setup_section_uses_placeholder_for_unset_blog_identifier() {
+		update_option( 'activitypub_actor_mode', 'blog' );
+		delete_option( 'activitypub_blog_identifier' );
+
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
+		$this->assertStringContainsString( 'value=""', $output );
+		$this->assertMatchesRegularExpression(
+			'~placeholder="[^"]+"~',
+			$output,
+			'Setup field should expose the dynamic default as a placeholder when no value is stored.'
+		);
 	}
 
 	/**

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -582,6 +582,57 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * `get_status()` only resolves the handle for the active mode. Building
+	 * AP's actor models dispatches `activitypub_construct_model_actor` and
+	 * runs whatever third-party code is hooked there — paying that cost for
+	 * a handle the caller can't render in the current mode is wasteful.
+	 */
+	public function test_status_does_not_resolve_blog_address_in_actor_mode() {
+		update_option( 'activitypub_actor_mode', 'actor' );
+
+		$blog_constructed = false;
+		add_action(
+			'activitypub_construct_model_actor',
+			static function ( $actor ) use ( &$blog_constructed ) {
+				if ( $actor instanceof \Activitypub\Model\Blog ) {
+					$blog_constructed = true;
+				}
+			}
+		);
+
+		$status = $this->provider->get_status();
+
+		remove_all_actions( 'activitypub_construct_model_actor' );
+
+		$this->assertSame( '', $status['blog_address'] );
+		$this->assertFalse( $blog_constructed, 'Blog actor should not be constructed in actor mode.' );
+	}
+
+	/**
+	 * Mirror of the above for the user actor in `blog` mode.
+	 */
+	public function test_status_does_not_resolve_user_address_in_blog_mode() {
+		update_option( 'activitypub_actor_mode', 'blog' );
+
+		$user_constructed = false;
+		add_action(
+			'activitypub_construct_model_actor',
+			static function ( $actor ) use ( &$user_constructed ) {
+				if ( $actor instanceof \Activitypub\Model\User ) {
+					$user_constructed = true;
+				}
+			}
+		);
+
+		$status = $this->provider->get_status();
+
+		remove_all_actions( 'activitypub_construct_model_actor' );
+
+		$this->assertSame( '', $status['user_address'] );
+		$this->assertFalse( $user_constructed, 'User actor should not be constructed in blog mode.' );
+	}
+
+	/**
 	 * In `blog` mode, the legacy `address` key prefers the blog handle so
 	 * existing callers keep their current behavior.
 	 */
@@ -703,6 +754,54 @@ class AP_ProviderTest extends BaseTestCase {
 
 		$fosse_codes = array_column( get_settings_errors( 'fosse' ), 'code' );
 		$this->assertContains( 'collision_test', $fosse_codes );
+	}
+
+	/**
+	 * Fresh rejections are captured by queue-position even when an error
+	 * with the same `activitypub_blog_identifier` code already sits on the
+	 * queue from earlier in the request. AP's sanitizer reuses a constant
+	 * code for every rejection, so a code-only snapshot would mask the
+	 * fresh entry.
+	 */
+	public function test_handle_save_captures_fresh_collision_when_code_already_queued() {
+		// Pre-seed an unrelated error using AP's constant code.
+		add_settings_error(
+			'activitypub_blog_identifier',
+			'activitypub_blog_identifier',
+			'Pre-existing unrelated error.',
+			'error'
+		);
+
+		add_filter(
+			'sanitize_option_activitypub_blog_identifier',
+			static function ( $value ) {
+				add_settings_error(
+					'activitypub_blog_identifier',
+					'activitypub_blog_identifier',
+					'Fresh collision rejection.',
+					'error'
+				);
+				return $value;
+			},
+			11
+		);
+
+		$this->simulate_save_request(
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => 'whatever',
+			)
+		);
+
+		try {
+			$this->provider->handle_save();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$fosse_messages = array_column( get_settings_errors( 'fosse' ), 'message' );
+		$this->assertContains( 'Fresh collision rejection.', $fosse_messages );
+		$this->assertNotContains( 'Pre-existing unrelated error.', $fosse_messages );
 	}
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -509,6 +509,44 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringNotContainsString( 'Not connected', $output );
 	}
 
+	/**
+	 * In `actor_blog` mode, the completion screen shows both the user and
+	 * site fediverse handles instead of dropping them in favor of a bare
+	 * mode label. Stub `activitypub_user_can_activitypub` because WorDBless
+	 * doesn't fire AP's activation, so the admin lacks the
+	 * `activitypub` capability by default.
+	 */
+	public function test_complete_summary_shows_user_and_blog_handles_in_both_mode(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_actor_mode', 'actor_blog' );
+
+		add_filter( 'activitypub_user_can_activitypub', '__return_true' );
+		$output = $this->render_wizard_step( 'complete' );
+		remove_filter( 'activitypub_user_can_activitypub', '__return_true' );
+
+		$this->assertStringContainsString( 'Both (site + authors)', $output );
+		$this->assertStringContainsString( 'As you:', $output );
+		$this->assertStringContainsString( 'As your site:', $output );
+		// Fediverse handle markup should be wrapped in <code>, not bare text.
+		$this->assertMatchesRegularExpression( '~As you:\s*<code>@[^<]+@[^<]+</code>~', $output );
+		$this->assertMatchesRegularExpression( '~As your site:\s*<code>@[^<]+@[^<]+</code>~', $output );
+	}
+
+	/**
+	 * In `blog` mode, the completion summary embeds the resolved blog
+	 * handle in the "As your site" line — fixing #60 where the line
+	 * previously dropped to the bare host.
+	 */
+	public function test_complete_summary_shows_blog_handle_in_blog_mode(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_actor_mode', 'blog' );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'As your site', $output );
+		$this->assertMatchesRegularExpression( '~As your site \(<code>@[^<]+@[^<]+</code>\)~', $output );
+	}
+
 	// --- audit hook: handler cap/nonce failures (parameterized) ---
 
 	/**


### PR DESCRIPTION
## Summary
- Splits `get_fediverse_address()` into separate `get_user_address()` / `get_blog_address()` helpers for mode-agnostic identity resolution
- Adds Site Handle field (backed by `activitypub_blog_identifier`) to setup page for blog/actor_blog modes
- Hooks `activitypub_default_blog_username` to derive defaults from site hostname with collision avoidance
- Surfaces dual addresses in setup page, status card, and wizard completion
- Re-tags AP collision errors into FOSSE's settings-error group so users see validation failures

See DOTCOM-16971, issue 57, issue 60, issue 61.

Fixes #57
Fixes #60
Fixes #61

## Test plan
- 28 new PHPUnit tests covering default handle generation, collision suffixes, address helpers, mode classification, blog identifier persistence, array-input defense, wizard completion rendering
- All 184 tests pass, PHPCS clean