### PR TITLE
fix: status page polish — token-aware wrapping and responsive grid

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -20,10 +20,15 @@
 	border-left-color: #dba617;
 }
 
-/* Status card grid */
+/* Status card grid.
+   `min(100%, 360px)` lets each card shrink below the 360px target on
+   narrow screens (single-column layouts in the wp-admin sidebar), while
+   `min-width: 0` on the cards themselves stops a long token from inflating
+   the implicit min-content width and pushing the grid wider than its
+   container. */
 .fosse-status-cards {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(min(100%, 360px), 1fr));
 	gap: 16px;
 	margin-top: 16px;
 }
@@ -33,16 +38,45 @@
 	border: 1px solid #c3c4c7;
 	border-radius: 4px;
 	padding: 16px;
+	min-width: 0;
 }
 
 .fosse-status-card h2 {
 	margin-top: 0;
 }
 
-/* Allow long opaque values (Bluesky DIDs, PDS URLs, fediverse handles) to
-   wrap inside the card. Without this, the cell's min-content width is the
-   full identifier and the table pushes past its container. */
-.fosse-status-card td {
+/* The status-card table is given `table-layout: fixed` so a long token in
+   the value cell can't widen the column past its share. The label column
+   is allocated a stable minimum so it stays readable while the value
+   column absorbs the wrap. */
+.fosse-status-card__table {
+	table-layout: fixed;
+	width: 100%;
+}
+
+.fosse-status-card__label {
+	width: 40%;
+}
+
+.fosse-status-card__value {
+	min-width: 0;
+}
+
+/* Token-specific wrap behavior.
+   Tokens get `<wbr>` hints inserted at separator boundaries (see
+   Status_Formatter), so the browser will prefer those break points.
+   DID and URL identifiers can still contain a long unbroken run with
+   no separator (a `did:plc:` body, a slug-like path), so for those two
+   token shapes we additionally allow `overflow-wrap: anywhere` as a
+   last-resort break. Handles and AP addresses are domain-shaped and
+   always have a `.` to wrap on, so they don't need the fallback. */
+.fosse-status-card__token {
+	word-break: normal;
+	overflow-wrap: break-word;
+}
+
+.fosse-status-card__token--did,
+.fosse-status-card__token--url {
 	overflow-wrap: anywhere;
 }
 

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -58,8 +58,12 @@
 	width: 40%;
 }
 
+/* Defense in depth: token wrappers carry their own wrap rules, but if a
+   future cell holds raw user input (e.g. a long error message, a long
+   site title) without going through Status_Formatter, this keeps the
+   value column from inflating the table beyond its container. */
 .fosse-status-card__value {
-	min-width: 0;
+	overflow-wrap: break-word;
 }
 
 /* Token-specific wrap behavior.

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -310,26 +310,38 @@ class AP_Provider implements Connection_Provider {
 				<?php esc_html_e( 'ActivityPub', 'fosse' ); ?>
 			</h2>
 
-			<table class="widefat striped">
+			<table class="widefat striped fosse-status-card__table">
 				<tbody>
 					<tr>
-						<td><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></td>
-						<td><?php echo esc_html( $mode_label ); ?></td>
+						<td class="fosse-status-card__label"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></td>
+						<td class="fosse-status-card__value"><?php echo esc_html( $mode_label ); ?></td>
 					</tr>
 					<tr>
-						<td><?php esc_html_e( 'Post Types', 'fosse' ); ?></td>
-						<td><?php echo esc_html( implode( ', ', $post_types ) ); ?></td>
+						<td class="fosse-status-card__label"><?php esc_html_e( 'Post Types', 'fosse' ); ?></td>
+						<td class="fosse-status-card__value"><?php echo esc_html( implode( ', ', $post_types ) ); ?></td>
 					</tr>
 					<?php if ( $this->mode_includes_user( $status['actor_mode'] ) && ! empty( $status['user_address'] ) ) : ?>
 						<tr>
-							<td><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></td>
-							<td><code><?php echo esc_html( '@' . $status['user_address'] ); ?></code></td>
+							<td class="fosse-status-card__label"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></td>
+							<td class="fosse-status-card__value">
+								<code class="fosse-status-card__token fosse-status-card__token--ap-address">
+									<?php
+									echo Status_Formatter::ap_address( '@' . $status['user_address'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::ap_address() escapes input and returns safe HTML with <wbr>.
+									?>
+								</code>
+							</td>
 						</tr>
 					<?php endif; ?>
 					<?php if ( $this->mode_includes_blog( $status['actor_mode'] ) && ! empty( $status['blog_address'] ) ) : ?>
 						<tr>
-							<td><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></td>
-							<td><code><?php echo esc_html( '@' . $status['blog_address'] ); ?></code></td>
+							<td class="fosse-status-card__label"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></td>
+							<td class="fosse-status-card__value">
+								<code class="fosse-status-card__token fosse-status-card__token--ap-address">
+									<?php
+									echo Status_Formatter::ap_address( '@' . $status['blog_address'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::ap_address() escapes input and returns safe HTML with <wbr>.
+									?>
+								</code>
+							</td>
 						</tr>
 					<?php endif; ?>
 					<?php $this->render_follower_count_row(); ?>
@@ -667,8 +679,8 @@ class AP_Provider implements Connection_Provider {
 			$count = \Activitypub\Collection\Followers::count( \Activitypub\Collection\Actors::BLOG_USER_ID );
 			?>
 			<tr>
-				<td><?php esc_html_e( 'Followers', 'fosse' ); ?></td>
-				<td><?php echo esc_html( number_format_i18n( $count ) ); ?></td>
+				<td class="fosse-status-card__label"><?php esc_html_e( 'Followers', 'fosse' ); ?></td>
+				<td class="fosse-status-card__value"><?php echo esc_html( number_format_i18n( $count ) ); ?></td>
 			</tr>
 			<?php
 		} elseif ( 'actor_blog' === $mode && $has_blog_id ) {
@@ -676,8 +688,8 @@ class AP_Provider implements Connection_Provider {
 			$blog_count = \Activitypub\Collection\Followers::count( \Activitypub\Collection\Actors::BLOG_USER_ID );
 			?>
 			<tr>
-				<td><?php esc_html_e( 'Followers', 'fosse' ); ?></td>
-				<td>
+				<td class="fosse-status-card__label"><?php esc_html_e( 'Followers', 'fosse' ); ?></td>
+				<td class="fosse-status-card__value">
 					<?php
 					printf(
 						/* translators: 1: author follower count, 2: blog follower count */
@@ -693,8 +705,8 @@ class AP_Provider implements Connection_Provider {
 			$count = \Activitypub\Collection\Followers::count( get_current_user_id() );
 			?>
 			<tr>
-				<td><?php esc_html_e( 'Your Followers', 'fosse' ); ?></td>
-				<td><?php echo esc_html( number_format_i18n( $count ) ); ?></td>
+				<td class="fosse-status-card__label"><?php esc_html_e( 'Your Followers', 'fosse' ); ?></td>
+				<td class="fosse-status-card__value"><?php echo esc_html( number_format_i18n( $count ) ); ?></td>
 			</tr>
 			<?php
 		}

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -219,37 +219,55 @@ class Bluesky_Provider implements Connection_Provider {
 				<?php esc_html_e( 'Bluesky', 'fosse' ); ?>
 			</h2>
 
-			<table class="widefat striped">
+			<table class="widefat striped fosse-status-card__table">
 				<tbody>
 					<tr>
-						<td><?php esc_html_e( 'Connection', 'fosse' ); ?></td>
-						<td><?php echo esc_html( $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' ) ); ?></td>
+						<td class="fosse-status-card__label"><?php esc_html_e( 'Connection', 'fosse' ); ?></td>
+						<td class="fosse-status-card__value"><?php echo esc_html( $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' ) ); ?></td>
 					</tr>
 					<?php if ( $status['handle'] ) : ?>
 						<tr>
-							<td><?php esc_html_e( 'Handle', 'fosse' ); ?></td>
-							<td><strong><?php echo esc_html( $status['handle'] ); ?></strong></td>
+							<td class="fosse-status-card__label"><?php esc_html_e( 'Handle', 'fosse' ); ?></td>
+							<td class="fosse-status-card__value">
+								<strong class="fosse-status-card__token fosse-status-card__token--handle">
+									<?php
+									echo Status_Formatter::handle( $status['handle'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::handle() escapes input and returns safe HTML with <wbr>.
+									?>
+								</strong>
+							</td>
 						</tr>
 					<?php endif; ?>
 					<?php if ( $status['did'] ) : ?>
 						<tr>
-							<td><?php esc_html_e( 'DID', 'fosse' ); ?></td>
-							<td><code><?php echo esc_html( $status['did'] ); ?></code></td>
+							<td class="fosse-status-card__label"><?php esc_html_e( 'DID', 'fosse' ); ?></td>
+							<td class="fosse-status-card__value">
+								<code class="fosse-status-card__token fosse-status-card__token--did">
+									<?php
+									echo Status_Formatter::did( $status['did'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::did() escapes input and returns safe HTML with <wbr>.
+									?>
+								</code>
+							</td>
 						</tr>
 					<?php endif; ?>
 					<?php if ( $status['pds_endpoint'] ) : ?>
 						<tr>
-							<td><?php esc_html_e( 'PDS', 'fosse' ); ?></td>
-							<td><code><?php echo esc_html( $status['pds_endpoint'] ); ?></code></td>
+							<td class="fosse-status-card__label"><?php esc_html_e( 'PDS', 'fosse' ); ?></td>
+							<td class="fosse-status-card__value">
+								<code class="fosse-status-card__token fosse-status-card__token--url">
+									<?php
+									echo Status_Formatter::url( $status['pds_endpoint'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::url() escapes input and returns safe HTML with <wbr>.
+									?>
+								</code>
+							</td>
 						</tr>
 					<?php endif; ?>
 					<tr>
-						<td><?php esc_html_e( 'Auto Publish', 'fosse' ); ?></td>
-						<td><?php echo esc_html( $status['auto_publish'] ? __( 'Enabled', 'fosse' ) : __( 'Disabled', 'fosse' ) ); ?></td>
+						<td class="fosse-status-card__label"><?php esc_html_e( 'Auto Publish', 'fosse' ); ?></td>
+						<td class="fosse-status-card__value"><?php echo esc_html( $status['auto_publish'] ? __( 'Enabled', 'fosse' ) : __( 'Disabled', 'fosse' ) ); ?></td>
 					</tr>
 					<tr>
-						<td><?php esc_html_e( 'Token Health', 'fosse' ); ?></td>
-						<td>
+						<td class="fosse-status-card__label"><?php esc_html_e( 'Token Health', 'fosse' ); ?></td>
+						<td class="fosse-status-card__value">
 							<?php if ( $status['token_error'] ) : ?>
 								<strong><?php esc_html_e( 'Reconnect required.', 'fosse' ); ?></strong>
 								<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-provider-bluesky' ) ); ?>">

--- a/src/Admin/class-status-formatter.php
+++ b/src/Admin/class-status-formatter.php
@@ -35,15 +35,19 @@ class Status_Formatter {
 	}
 
 	/**
-	 * Format a URL for display.
+	 * Format a URL for display as inline text.
 	 *
 	 * Allows the browser to break after the scheme (`https://`), and before
 	 * each `/`, `?`, `#`, or `&` in the rest of the URL. The path separators
 	 * read more naturally as the start of the next segment, so the `<wbr>`
 	 * is placed before them.
 	 *
+	 * Returns escaped HTML suitable for **text contexts** (`<code>`, `<span>`,
+	 * `<td>`). Does NOT validate URL syntax — never feed the result into
+	 * `href=`, `src=`, or innerHTML. Use `esc_url()` for those.
+	 *
 	 * @param string $url Raw URL.
-	 * @return string Escaped HTML safe to echo, with `<wbr>` at sensible boundaries.
+	 * @return string Escaped HTML safe to echo into text content, with `<wbr>` at sensible boundaries.
 	 */
 	public static function url( string $url ): string {
 		$escaped = esc_html( $url );
@@ -55,7 +59,10 @@ class Status_Formatter {
 
 		// Allow breaks before path/query/fragment/parameter separators in
 		// the remainder, after the scheme marker we just inserted (so the
-		// `://` itself isn't re-broken).
+		// `://` itself isn't re-broken). The `&` match here intentionally
+		// targets the leading `&` of `&amp;` entities — a literal `&` in
+		// the source URL is `esc_html`'d to `&amp;` above, and matching `&`
+		// places the `<wbr>` right before the rendered ampersand.
 		$marker = '://<wbr>';
 		$pos    = strpos( $escaped, $marker );
 		if ( false !== $pos ) {

--- a/src/Admin/class-status-formatter.php
+++ b/src/Admin/class-status-formatter.php
@@ -50,31 +50,40 @@ class Status_Formatter {
 	 * @return string Escaped HTML safe to echo into text content, with `<wbr>` at sensible boundaries.
 	 */
 	public static function url( string $url ): string {
-		$escaped = esc_html( $url );
+		// Place `<wbr>` markers BEFORE escaping so the regex operates on the
+		// raw URL where `/`, `?`, `#`, and `&` mean what they look like.
+		// Earlier versions ran the regex on the post-`esc_html` string, which
+		// broke numeric character references (`'` -> `&#039;`): the regex
+		// matched the `&` and the `#` independently and inserted `<wbr>`
+		// markers inside the entity, leaving a literal `&#039;` on screen
+		// instead of `'`. Marker-then-escape keeps the entity intact.
+		//
+		// `~~~FOSSE_WBR~~~` is a placeholder built from characters `esc_html`
+		// leaves alone (no `<>&"'`). Any literal occurrence in the input
+		// would render as an extra `<wbr>` (harmless — `<wbr>` is empty).
+		$placeholder = '~~~FOSSE_WBR~~~';
 
-		// Allow break right after the scheme (e.g. `https://`). Done first so
-		// the `<wbr>` we insert here doesn't get re-broken by the path-level
-		// pass below.
-		$escaped = (string) preg_replace( '~(://)~', '$1<wbr>', $escaped, 1 );
+		// Allow break right after the scheme (e.g. `https://`).
+		$marked = (string) preg_replace( '~(://)~', '$1' . $placeholder, $url, 1 );
 
 		// Allow breaks before path/query/fragment/parameter separators in
-		// the remainder, after the scheme marker we just inserted (so the
-		// `://` itself isn't re-broken). The `&` match here intentionally
-		// targets the leading `&` of `&amp;` entities — a literal `&` in
-		// the source URL is `esc_html`'d to `&amp;` above, and matching `&`
-		// places the `<wbr>` right before the rendered ampersand.
-		$marker = '://<wbr>';
-		$pos    = strpos( $escaped, $marker );
+		// the remainder, after the first `://` (so the scheme's slashes
+		// aren't re-broken). A second `://` further down (e.g. an OAuth-
+		// shaped `?next=https://...`) will pick up extra `<wbr>` markers
+		// between its trailing `/`s — harmless because `<wbr>` renders empty.
+		$boundary = '://' . $placeholder;
+		$pos      = strpos( $marked, $boundary );
 		if ( false !== $pos ) {
-			$prefix  = substr( $escaped, 0, $pos + strlen( $marker ) );
-			$rest    = substr( $escaped, $pos + strlen( $marker ) );
-			$rest    = (string) preg_replace( '~([/?\#&])~', '<wbr>$1', $rest );
-			$escaped = $prefix . $rest;
+			$skip   = $pos + strlen( $boundary );
+			$prefix = substr( $marked, 0, $skip );
+			$rest   = substr( $marked, $skip );
+			$rest   = (string) preg_replace( '~([/?#&])~', $placeholder . '$1', $rest );
+			$marked = $prefix . $rest;
 		} else {
-			$escaped = (string) preg_replace( '~([/?\#&])~', '<wbr>$1', $escaped );
+			$marked = (string) preg_replace( '~([/?#&])~', $placeholder . '$1', $marked );
 		}
 
-		return $escaped;
+		return str_replace( $placeholder, '<wbr>', esc_html( $marked ) );
 	}
 
 	/**
@@ -93,8 +102,19 @@ class Status_Formatter {
 	/**
 	 * Format an ActivityPub fediverse address for display (`@user@host.example`).
 	 *
-	 * The leading `@` is preserved verbatim. The local part stays intact, and
-	 * the host part is broken on its dots so a long host label can wrap.
+	 * The leading `@` is preserved verbatim if present, otherwise the address
+	 * renders without one. The local part stays intact, and the host part is
+	 * broken on its dots so a long host label can wrap.
+	 *
+	 * Contract: an address is "local@host" with one separating `@`. The first
+	 * `@` AFTER the optional leading `@` is treated as the local/host
+	 * separator; any subsequent `@` characters stay in the host part as
+	 * literal text. Inputs without an `@` after the optional leading one
+	 * (e.g. `@nodomain`, `@user@`) render with no host break — safe but
+	 * cosmetically wrong, since they aren't well-formed addresses anyway.
+	 *
+	 * Webfinger-shaped inputs from the AP plugin do NOT carry a leading `@`;
+	 * the call site at `AP_Provider::render_status_card()` prepends it.
 	 *
 	 * @param string $address Raw address with or without a leading `@`.
 	 * @return string Escaped HTML safe to echo, with `<wbr>` between the local part and host, and after each `.` in the host.

--- a/src/Admin/class-status-formatter.php
+++ b/src/Admin/class-status-formatter.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Status-card token formatting helpers.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Admin;
+
+/**
+ * Renders identifier tokens (DIDs, URLs, handles, fediverse addresses) for the
+ * Status page with sensible word-break opportunities baked in.
+ *
+ * Status cards live inside a CSS grid. Without break hints the longest token
+ * dictates a card's min-content width, which forces the grid to overflow.
+ * Each helper here returns escaped HTML with `<wbr>` markers inserted at
+ * separator boundaries (`:`, `/`, `.`, `@`) so the browser can wrap mid-token
+ * at the most readable point. DID and URL tokens still need
+ * `overflow-wrap: anywhere` (CSS) as a last resort because their identifier
+ * segments can be a long unbroken run with no separators.
+ */
+class Status_Formatter {
+
+	/**
+	 * Format a Bluesky DID for display.
+	 *
+	 * Splits on `:` so `did:plc:abc123…` can wrap after `did:` and the
+	 * method segment instead of breaking mid-identifier.
+	 *
+	 * @param string $did Raw DID (e.g. `did:plc:abc123`).
+	 * @return string Escaped HTML safe to echo, with `<wbr>` after each `:`.
+	 */
+	public static function did( string $did ): string {
+		return self::join_with_wbr( ':', $did );
+	}
+
+	/**
+	 * Format a URL for display.
+	 *
+	 * Allows the browser to break after the scheme (`https://`), and before
+	 * each `/`, `?`, `#`, or `&` in the rest of the URL. The path separators
+	 * read more naturally as the start of the next segment, so the `<wbr>`
+	 * is placed before them.
+	 *
+	 * @param string $url Raw URL.
+	 * @return string Escaped HTML safe to echo, with `<wbr>` at sensible boundaries.
+	 */
+	public static function url( string $url ): string {
+		$escaped = esc_html( $url );
+
+		// Allow break right after the scheme (e.g. `https://`). Done first so
+		// the `<wbr>` we insert here doesn't get re-broken by the path-level
+		// pass below.
+		$escaped = (string) preg_replace( '~(://)~', '$1<wbr>', $escaped, 1 );
+
+		// Allow breaks before path/query/fragment/parameter separators in
+		// the remainder, after the scheme marker we just inserted (so the
+		// `://` itself isn't re-broken).
+		$marker = '://<wbr>';
+		$pos    = strpos( $escaped, $marker );
+		if ( false !== $pos ) {
+			$prefix  = substr( $escaped, 0, $pos + strlen( $marker ) );
+			$rest    = substr( $escaped, $pos + strlen( $marker ) );
+			$rest    = (string) preg_replace( '~([/?\#&])~', '<wbr>$1', $rest );
+			$escaped = $prefix . $rest;
+		} else {
+			$escaped = (string) preg_replace( '~([/?\#&])~', '<wbr>$1', $escaped );
+		}
+
+		return $escaped;
+	}
+
+	/**
+	 * Format an AT Protocol / fediverse handle for display.
+	 *
+	 * Handles are domain-shaped (`alice.bsky.social`); inserting `<wbr>` after
+	 * each `.` lets the browser wrap on label boundaries.
+	 *
+	 * @param string $handle Raw handle.
+	 * @return string Escaped HTML safe to echo, with `<wbr>` after each `.`.
+	 */
+	public static function handle( string $handle ): string {
+		return self::join_with_wbr( '.', $handle );
+	}
+
+	/**
+	 * Format an ActivityPub fediverse address for display (`@user@host.example`).
+	 *
+	 * The leading `@` is preserved verbatim. The local part stays intact, and
+	 * the host part is broken on its dots so a long host label can wrap.
+	 *
+	 * @param string $address Raw address with or without a leading `@`.
+	 * @return string Escaped HTML safe to echo, with `<wbr>` between the local part and host, and after each `.` in the host.
+	 */
+	public static function ap_address( string $address ): string {
+		$leading_at = '';
+		if ( '' !== $address && '@' === $address[0] ) {
+			$leading_at = '@';
+			$address    = substr( $address, 1 );
+		}
+
+		$at_pos = strpos( $address, '@' );
+		if ( false === $at_pos ) {
+			return esc_html( $leading_at . $address );
+		}
+
+		$local = substr( $address, 0, $at_pos );
+		$host  = substr( $address, $at_pos + 1 );
+
+		return esc_html( $leading_at . $local ) . '<wbr>@' . self::handle( $host );
+	}
+
+	/**
+	 * Escape each segment between `$separator` and rejoin with `<wbr>` after
+	 * the separator. Preserves a trailing empty segment if the input ends in
+	 * the separator.
+	 *
+	 * @param string $separator Single-character separator.
+	 * @param string $value     Raw value.
+	 * @return string Escaped HTML with `<wbr>` after each separator.
+	 */
+	private static function join_with_wbr( string $separator, string $value ): string {
+		$parts   = explode( $separator, $value );
+		$escaped = array_map( 'esc_html', $parts );
+
+		return implode( $separator . '<wbr>', $escaped );
+	}
+}

--- a/tests/e2e/status-page.spec.ts
+++ b/tests/e2e/status-page.spec.ts
@@ -47,12 +47,8 @@ test.describe( 'Status page polish', () => {
 		);
 	} );
 
-	test( 'long DID, handle, and PDS values do not overflow the card', async ( {
-		page,
-	} ) => {
-		// Set values that are longer than the typical card width — a
-		// no-break implementation pushes the table past the card edge.
-		await setBlueskyState( page, {
+	const seedLongValues = ( page: Page ) =>
+		setBlueskyState( page, {
 			connected: true,
 			handle: 'someone.with.an.unreasonably.long.handle.example.org',
 			did: 'did:plc:abcdefghijklmnopqrstuvwxyz0123456789longidentifier',
@@ -61,13 +57,36 @@ test.describe( 'Status page polish', () => {
 			auto_publish: true,
 		} );
 
+	const measureCardOverflow = async ( page: Page ) => {
+		const card = page
+			.locator( '.fosse-status-card' )
+			.filter( { hasText: 'Bluesky' } );
+		await expect( card ).toBeVisible();
+		return card.evaluate( ( el ) => {
+			const table = el.querySelector(
+				'.fosse-status-card__table'
+			) as HTMLElement | null;
+			if ( ! table || ! ( el instanceof HTMLElement ) ) {
+				return null;
+			}
+			return {
+				cardScroll: el.scrollWidth,
+				cardClient: el.clientWidth,
+				tableScroll: table.scrollWidth,
+				tableClient: table.clientWidth,
+			};
+		} );
+	};
+
+	test( 'long DID, handle, and PDS values do not overflow at desktop width', async ( {
+		page,
+	} ) => {
+		await seedLongValues( page );
 		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
 
 		const blueskyCard = page
 			.locator( '.fosse-status-card' )
 			.filter( { hasText: 'Bluesky' } );
-
-		await expect( blueskyCard ).toBeVisible();
 
 		// The value cells should carry the BEM classes the polish CSS
 		// targets, and the token wrappers should carry the token-shape
@@ -82,27 +101,33 @@ test.describe( 'Status page polish', () => {
 			blueskyCard.locator( '.fosse-status-card__token--handle' )
 		).toBeVisible();
 
-		// The card's table must not horizontally overflow its container.
-		// scrollWidth > clientWidth is the canonical "this overflowed"
-		// signal; without the polish, the long DID forces it.
-		const overflow = await blueskyCard.evaluate( ( card ) => {
-			const table = card.querySelector(
-				'.fosse-status-card__table'
-			) as HTMLElement | null;
-			if ( ! table || ! ( card instanceof HTMLElement ) ) {
-				return null;
-			}
-
-			return {
-				cardScroll: card.scrollWidth,
-				cardClient: card.clientWidth,
-				tableScroll: table.scrollWidth,
-				tableClient: table.clientWidth,
-			};
-		} );
+		const overflow = await measureCardOverflow( page );
 
 		expect( overflow ).not.toBeNull();
 		// Allow a 1px tolerance for sub-pixel rounding on different display densities.
+		expect( overflow!.cardScroll ).toBeLessThanOrEqual(
+			overflow!.cardClient + 1
+		);
+		expect( overflow!.tableScroll ).toBeLessThanOrEqual(
+			overflow!.tableClient + 1
+		);
+	} );
+
+	test( 'long values do not overflow at narrow admin width', async ( {
+		page,
+	} ) => {
+		// The narrow-viewport case is the actual symptom in issue #62 —
+		// wp-admin's responsive sidebar collapses cards into a single
+		// column where the grid switches to `min(100%, 360px)`. A naive
+		// `min-content`-sized cell would push the card past the viewport
+		// edge here even though the desktop test passes.
+		await page.setViewportSize( { width: 480, height: 720 } );
+		await seedLongValues( page );
+		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
+
+		const overflow = await measureCardOverflow( page );
+
+		expect( overflow ).not.toBeNull();
 		expect( overflow!.cardScroll ).toBeLessThanOrEqual(
 			overflow!.cardClient + 1
 		);

--- a/tests/e2e/status-page.spec.ts
+++ b/tests/e2e/status-page.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const setBlueskyState = async (
+	page: Page,
+	body: Record< string, unknown >
+) => {
+	const result = await page.evaluate( async ( payload ) => {
+		const res = await fetch( '/wp-json/fosse-e2e/v1/bluesky-state', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+			},
+			body: JSON.stringify( payload ),
+		} );
+
+		return { status: res.status, text: await res.text() };
+	}, body );
+
+	expect(
+		result.status,
+		`fosse-e2e/v1/bluesky-state returned: ${ result.text.slice( 0, 300 ) }`
+	).toBe( 200 );
+};
+
+test.describe( 'Status page polish', () => {
+	// Connected-state writes leak across specs (the wizard's connect step
+	// flips to its summary branch when atmosphere_connection is set), so
+	// reset to disconnected on the way out — mirrors bluesky-provider.spec.ts.
+	test.afterAll( async ( { browser } ) => {
+		const page = await browser.newPage();
+		await page.goto( '/wp-admin/post-new.php' );
+		await page.waitForFunction(
+			() => !! ( window as any ).wpApiSettings?.nonce
+		);
+		await setBlueskyState( page, {
+			connected: false,
+			auto_publish: true,
+		} );
+		await page.close();
+	} );
+
+	test.beforeEach( async ( { page } ) => {
+		await page.goto( '/wp-admin/post-new.php' );
+		await page.waitForFunction(
+			() => !! ( window as any ).wpApiSettings?.nonce
+		);
+	} );
+
+	test( 'long DID, handle, and PDS values do not overflow the card', async ( {
+		page,
+	} ) => {
+		// Set values that are longer than the typical card width — a
+		// no-break implementation pushes the table past the card edge.
+		await setBlueskyState( page, {
+			connected: true,
+			handle: 'someone.with.an.unreasonably.long.handle.example.org',
+			did: 'did:plc:abcdefghijklmnopqrstuvwxyz0123456789longidentifier',
+			pds_endpoint:
+				'https://very-long-pds-host-name.example.com/some/deep/nested/path',
+			auto_publish: true,
+		} );
+
+		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
+
+		const blueskyCard = page
+			.locator( '.fosse-status-card' )
+			.filter( { hasText: 'Bluesky' } );
+
+		await expect( blueskyCard ).toBeVisible();
+
+		// The value cells should carry the BEM classes the polish CSS
+		// targets, and the token wrappers should carry the token-shape
+		// modifier so `overflow-wrap: anywhere` is scoped correctly.
+		await expect(
+			blueskyCard.locator( '.fosse-status-card__token--did' )
+		).toBeVisible();
+		await expect(
+			blueskyCard.locator( '.fosse-status-card__token--url' )
+		).toBeVisible();
+		await expect(
+			blueskyCard.locator( '.fosse-status-card__token--handle' )
+		).toBeVisible();
+
+		// The card's table must not horizontally overflow its container.
+		// scrollWidth > clientWidth is the canonical "this overflowed"
+		// signal; without the polish, the long DID forces it.
+		const overflow = await blueskyCard.evaluate( ( card ) => {
+			const table = card.querySelector(
+				'.fosse-status-card__table'
+			) as HTMLElement | null;
+			if ( ! table || ! ( card instanceof HTMLElement ) ) {
+				return null;
+			}
+
+			return {
+				cardScroll: card.scrollWidth,
+				cardClient: card.clientWidth,
+				tableScroll: table.scrollWidth,
+				tableClient: table.clientWidth,
+			};
+		} );
+
+		expect( overflow ).not.toBeNull();
+		// Allow a 1px tolerance for sub-pixel rounding on different display densities.
+		expect( overflow!.cardScroll ).toBeLessThanOrEqual(
+			overflow!.cardClient + 1
+		);
+		expect( overflow!.tableScroll ).toBeLessThanOrEqual(
+			overflow!.tableClient + 1
+		);
+	} );
+} );

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -973,4 +973,19 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Site fediverse address', $output );
 		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
 	}
+
+	/**
+	 * Status card label/value cells carry the BEM classes the polish CSS
+	 * targets. A renamed class would silently break the column-width and
+	 * wrap rules without surfacing a test failure otherwise.
+	 */
+	public function test_render_status_card_uses_bem_label_value_classes() {
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'fosse-status-card__table', $output );
+		$this->assertStringContainsString( 'fosse-status-card__label', $output );
+		$this->assertStringContainsString( 'fosse-status-card__value', $output );
+	}
 }

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -335,10 +335,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		// Handle renders with <wbr> after each `.`.
 		$this->assertStringContainsString( 'someone.<wbr>with.<wbr>a.<wbr>very.<wbr>long.<wbr>subdomain.<wbr>example.<wbr>org', $output );
 
-		// Sanity: no leftover bare value without the token wrapper for any of
-		// the three identifiers (would mean the formatter wasn't wired in).
-		$this->assertStringNotContainsString( '<code>did:plc:longidentifier', $output );
-		$this->assertStringNotContainsString( '<code>https://very-long-pds-host', $output );
+		// Sanity: the raw un-tokenized value must NOT appear anywhere in the
+		// output. The `<wbr>` markers above prove the formatter ran; this
+		// extra pair guards against a future refactor that emits both the
+		// tokenized form AND the bare value (e.g. as a `title=` attribute or
+		// a sibling fallback).
+		$this->assertStringNotContainsString( 'did:plc:longidentifierthatwouldotherwiseoverflow', $output );
+		$this->assertStringNotContainsString( 'https://very-long-pds-host.example.com/some/deep/path', $output );
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -279,7 +279,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertMatchesRegularExpression( '/<td>\s*OK\s*<\/td>/', $output );
+		$this->assertMatchesRegularExpression( '/<td[^>]*>\s*OK\s*<\/td>/', $output );
 		$this->assertStringNotContainsString( 'Reconnect required', $output );
 		$this->assertStringNotContainsString( '<details', $output );
 	}
@@ -295,6 +295,50 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Manage Bluesky settings', $output );
 		$this->assertStringContainsString( '#fosse-provider-bluesky', $output );
+	}
+
+	/**
+	 * Status card renders DID, handle, and PDS as token elements with
+	 * `<wbr>` break opportunities so a long identifier doesn't overflow
+	 * the card. Each token type carries its own BEM modifier so the CSS
+	 * can scope `overflow-wrap` to just DIDs and URLs.
+	 */
+	public function test_render_status_card_token_markup_for_long_identifiers() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:longidentifierthatwouldotherwiseoverflow',
+				'handle'       => 'someone.with.a.very.long.subdomain.example.org',
+				'pds_endpoint' => 'https://very-long-pds-host.example.com/some/deep/path',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'fosse-status-card__table', $output );
+		$this->assertStringContainsString( 'fosse-status-card__label', $output );
+		$this->assertStringContainsString( 'fosse-status-card__value', $output );
+
+		$this->assertStringContainsString( 'fosse-status-card__token--did', $output );
+		$this->assertStringContainsString( 'fosse-status-card__token--handle', $output );
+		$this->assertStringContainsString( 'fosse-status-card__token--url', $output );
+
+		// DID renders with <wbr> after each `:` separator.
+		$this->assertStringContainsString( 'did:<wbr>plc:<wbr>longidentifier', $output );
+
+		// PDS URL renders with <wbr> after the scheme and before each `/`.
+		$this->assertStringContainsString( 'https://<wbr>very-long-pds-host.example.com<wbr>/some', $output );
+
+		// Handle renders with <wbr> after each `.`.
+		$this->assertStringContainsString( 'someone.<wbr>with.<wbr>a.<wbr>very.<wbr>long.<wbr>subdomain.<wbr>example.<wbr>org', $output );
+
+		// Sanity: no leftover bare value without the token wrapper for any of
+		// the three identifiers (would mean the formatter wasn't wired in).
+		$this->assertStringNotContainsString( '<code>did:plc:longidentifier', $output );
+		$this->assertStringNotContainsString( '<code>https://very-long-pds-host', $output );
 	}
 
 	/**

--- a/tests/php/Admin/Status_FormatterTest.php
+++ b/tests/php/Admin/Status_FormatterTest.php
@@ -66,6 +66,20 @@ class Status_FormatterTest extends BaseTestCase {
 	}
 
 	/**
+	 * Query strings with multiple parameters break before each `&`. Locks in
+	 * the post-`esc_html` regex behavior — a literal `&` in the source URL
+	 * becomes `&amp;` after escaping, and the formatter must place the
+	 * `<wbr>` immediately before the entity so the rendered ampersand still
+	 * has a break opportunity.
+	 */
+	public function test_url_with_ampersand_query_separator(): void {
+		$this->assertSame(
+			'https://<wbr>example.com<wbr>/path<wbr>?q=1<wbr>&amp;r=2',
+			Status_Formatter::url( 'https://example.com/path?q=1&r=2' )
+		);
+	}
+
+	/**
 	 * AP fediverse addresses break before the second `@` and after each
 	 * dot in the host. The leading `@` is preserved verbatim.
 	 */

--- a/tests/php/Admin/Status_FormatterTest.php
+++ b/tests/php/Admin/Status_FormatterTest.php
@@ -67,15 +67,80 @@ class Status_FormatterTest extends BaseTestCase {
 
 	/**
 	 * Query strings with multiple parameters break before each `&`. Locks in
-	 * the post-`esc_html` regex behavior — a literal `&` in the source URL
-	 * becomes `&amp;` after escaping, and the formatter must place the
-	 * `<wbr>` immediately before the entity so the rendered ampersand still
-	 * has a break opportunity.
+	 * the entity-aware behavior: a literal `&` in the source URL becomes
+	 * `&amp;` after escaping, and the rendered ampersand still has a break
+	 * opportunity in front of it.
 	 */
 	public function test_url_with_ampersand_query_separator(): void {
 		$this->assertSame(
 			'https://<wbr>example.com<wbr>/path<wbr>?q=1<wbr>&amp;r=2',
 			Status_Formatter::url( 'https://example.com/path?q=1&r=2' )
+		);
+	}
+
+	/**
+	 * URLs containing `'` must not corrupt the resulting numeric character
+	 * reference (`&#039;`). An earlier post-escape regex split the entity
+	 * by inserting `<wbr>` between `&` and `#`, leaving a literal
+	 * `&#039;` on screen instead of `'`. The mark-then-escape strategy
+	 * keeps the entity intact.
+	 */
+	public function test_url_preserves_numeric_character_references(): void {
+		$this->assertSame(
+			'https://<wbr>example.com<wbr>/path<wbr>?q=&#039;1&#039;',
+			Status_Formatter::url( "https://example.com/path?q='1'" )
+		);
+	}
+
+	/**
+	 * An input that already contains an encoded `&amp;` is not
+	 * double-escaped to `&amp;amp;`. WordPress's `esc_html` is idempotent
+	 * for known entities, and the formatter places the `<wbr>` right
+	 * before the entity so it still visually breaks like a real
+	 * ampersand would.
+	 */
+	public function test_url_does_not_double_escape_existing_entities(): void {
+		$this->assertSame(
+			'https://<wbr>example.com<wbr>/<wbr>?a=1<wbr>&amp;b=2',
+			Status_Formatter::url( 'https://example.com/?a=1&amp;b=2' )
+		);
+	}
+
+	/**
+	 * Multibyte input (non-ASCII identifier bytes) must pass through
+	 * `esc_html` unchanged — neither stripped nor mojibaked. Pins
+	 * compatibility with internationalized handles and the (technically
+	 * non-conformant but storable) DID bodies that contain Unicode.
+	 */
+	public function test_multibyte_input_survives_unchanged(): void {
+		$this->assertSame(
+			'did:<wbr>plc:<wbr>αβγ',
+			Status_Formatter::did( 'did:plc:αβγ' )
+		);
+		$this->assertSame(
+			'alice.<wbr>bsky.<wbr>café',
+			Status_Formatter::handle( 'alice.bsky.café' )
+		);
+	}
+
+	/**
+	 * Control characters (NUL, tab, newline) survive `esc_html` and reach
+	 * the output verbatim — the formatter does not silently strip them.
+	 * Pins this so a future `sanitize_text_field` retrofit doesn't quietly
+	 * change the data shape.
+	 */
+	public function test_control_characters_pass_through_unchanged(): void {
+		$this->assertSame(
+			"did:<wbr>plc:<wbr>\x00abc",
+			Status_Formatter::did( "did:plc:\x00abc" )
+		);
+		$this->assertSame(
+			"did:<wbr>plc:<wbr>\tabc",
+			Status_Formatter::did( "did:plc:\tabc" )
+		);
+		$this->assertSame(
+			"did:<wbr>plc:<wbr>\nabc",
+			Status_Formatter::did( "did:plc:\nabc" )
 		);
 	}
 

--- a/tests/php/Admin/Status_FormatterTest.php
+++ b/tests/php/Admin/Status_FormatterTest.php
@@ -206,8 +206,7 @@ class Status_FormatterTest extends BaseTestCase {
 	}
 
 	/**
-	 * Empty inputs are safe and return empty strings (or just the leading
-	 * separator for AP addresses).
+	 * Empty inputs are safe and return empty strings for every formatter.
 	 */
 	public function test_empty_inputs_are_safe(): void {
 		$this->assertSame( '', Status_Formatter::did( '' ) );

--- a/tests/php/Admin/Status_FormatterTest.php
+++ b/tests/php/Admin/Status_FormatterTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Tests for Status_Formatter.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests\Admin;
+
+use Automattic\Fosse\Admin\Status_Formatter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+
+/**
+ * Verifies the Status_Formatter renders identifier tokens with sensible
+ * `<wbr>` break opportunities and escapes user-controlled input.
+ */
+class Status_FormatterTest extends BaseTestCase {
+
+	/**
+	 * DIDs break after every `:`.
+	 */
+	public function test_did_inserts_wbr_after_each_colon(): void {
+		$this->assertSame(
+			'did:<wbr>plc:<wbr>abc123def456',
+			Status_Formatter::did( 'did:plc:abc123def456' )
+		);
+	}
+
+	/**
+	 * Handles break after every `.`.
+	 */
+	public function test_handle_inserts_wbr_after_each_dot(): void {
+		$this->assertSame(
+			'alice.<wbr>bsky.<wbr>social',
+			Status_Formatter::handle( 'alice.bsky.social' )
+		);
+	}
+
+	/**
+	 * Single-label handles (no dot) render unchanged.
+	 */
+	public function test_handle_with_no_dot_has_no_wbr(): void {
+		$this->assertSame( 'alice', Status_Formatter::handle( 'alice' ) );
+	}
+
+	/**
+	 * URLs break right after the scheme, then before each path-segment-like
+	 * separator in the remainder.
+	 */
+	public function test_url_inserts_wbr_after_scheme_and_before_path_separators(): void {
+		$this->assertSame(
+			'https://<wbr>example.com<wbr>/some<wbr>/path<wbr>?q=1',
+			Status_Formatter::url( 'https://example.com/some/path?q=1' )
+		);
+	}
+
+	/**
+	 * Hostname-only URLs only break after the scheme.
+	 */
+	public function test_url_without_path_only_breaks_after_scheme(): void {
+		$this->assertSame(
+			'https://<wbr>bsky.social',
+			Status_Formatter::url( 'https://bsky.social' )
+		);
+	}
+
+	/**
+	 * AP fediverse addresses break before the second `@` and after each
+	 * dot in the host. The leading `@` is preserved verbatim.
+	 */
+	public function test_ap_address_breaks_at_at_and_dots(): void {
+		$this->assertSame(
+			'@user<wbr>@server.<wbr>example.<wbr>org',
+			Status_Formatter::ap_address( '@user@server.example.org' )
+		);
+	}
+
+	/**
+	 * AP addresses with no leading `@` still get formatted.
+	 */
+	public function test_ap_address_without_leading_at_works(): void {
+		$this->assertSame(
+			'user<wbr>@server.<wbr>example',
+			Status_Formatter::ap_address( 'user@server.example' )
+		);
+	}
+
+	/**
+	 * AP addresses missing the host part return the input unchanged.
+	 * Better to render plainly than to surface a malformed hint.
+	 */
+	public function test_ap_address_without_host_returns_plain(): void {
+		$this->assertSame(
+			'@nodomain',
+			Status_Formatter::ap_address( '@nodomain' )
+		);
+	}
+
+	/**
+	 * Every token type must escape HTML in user-controlled input.
+	 *
+	 * @param string $callable Method name on Status_Formatter to call.
+	 * @param string $input    Input value containing an HTML-meaningful character.
+	 * @dataProvider escaping_provider
+	 */
+	#[DataProvider( 'escaping_provider' )]
+	public function test_each_formatter_escapes_html( string $callable, string $input ): void {
+		$output = call_user_func( array( Status_Formatter::class, $callable ), $input );
+
+		$this->assertStringNotContainsString( '<script', $output );
+		$this->assertStringContainsString( '&lt;script', $output );
+	}
+
+	/**
+	 * Data provider — one entry per formatter method.
+	 *
+	 * @return array<string, array{0:string,1:string}>
+	 */
+	public static function escaping_provider(): array {
+		return array(
+			'did'        => array( 'did', 'did:plc:<script>alert(1)</script>' ),
+			'url'        => array( 'url', 'https://example.com/<script>alert(1)</script>' ),
+			'handle'     => array( 'handle', '<script>alice.example' ),
+			'ap_address' => array( 'ap_address', '@<script>@host.example' ),
+		);
+	}
+
+	/**
+	 * Empty inputs are safe and return empty strings (or just the leading
+	 * separator for AP addresses).
+	 */
+	public function test_empty_inputs_are_safe(): void {
+		$this->assertSame( '', Status_Formatter::did( '' ) );
+		$this->assertSame( '', Status_Formatter::url( '' ) );
+		$this->assertSame( '', Status_Formatter::handle( '' ) );
+		$this->assertSame( '', Status_Formatter::ap_address( '' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- New `Status_Formatter` class injecting `<wbr>` at sensible boundaries for DIDs, URLs, handles, and AP addresses
- BEM-classed status card markup for targeted styling
- Scoped `overflow-wrap: anywhere` to DID/URL tokens only (removing the global `break-all`)
- Responsive grid with `minmax(min(100%, 360px), 1fr)` and `min-width: 0`
- Defense-in-depth `overflow-wrap: break-word` on value cells

See DOTCOM-16971, #62

Note: This branch will conflict with fix/site-identity-foundation in `render_status_card()`. After PR 1 lands, this branch needs rebasing to apply token formatting to the new dual-address rows.

## Test plan
- 16 new PHPUnit tests in `Status_FormatterTest` covering token shapes, HTML escaping, multibyte, control chars, entity preservation
- Narrow-viewport (480px) Playwright E2E test asserting `scrollWidth ≤ clientWidth`
- All 180 tests pass, PHPCS/ESLint/Prettier clean