### PR TITLE
fix: setup completion UX — notices, signup help, completion state, CTA

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -576,3 +576,24 @@
 .fosse-wizard__reset a:hover {
 	color: #1e1e1e;
 }
+
+/* Completion publish CTA */
+.fosse-wizard__cta-publish {
+	min-width: 240px;
+}
+
+.fosse-wizard__cta-help {
+	text-align: center;
+	margin: 8px 0 16px;
+	font-size: 13px;
+	color: #50575e;
+}
+
+.fosse-wizard__actions--secondary {
+	margin-top: 8px;
+}
+
+/* Bluesky signup affordance */
+.fosse-bluesky-signup__link {
+	font-weight: 500;
+}

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -160,6 +160,18 @@ class Bluesky_Provider implements Connection_Provider {
 									placeholder="alice.bsky.social"
 								/>
 								<p class="description"><?php esc_html_e( 'Your AT Protocol handle, e.g. alice.bsky.social or your own domain.', 'fosse' ); ?></p>
+								<p class="description fosse-bluesky-signup">
+									<?php
+									echo wp_kses_post(
+										sprintf(
+											/* translators: 1: opening anchor tag, 2: closing anchor tag */
+											__( 'Need a Bluesky account? %1$sCreate one at bsky.app%2$s, then come back here to connect.', 'fosse' ),
+											'<a href="' . esc_url( 'https://bsky.app/' ) . '" target="_blank" rel="noopener noreferrer" class="fosse-bluesky-signup__link">',
+											'</a>'
+										)
+									);
+									?>
+								</p>
 							</td>
 						</tr>
 					</table>

--- a/src/Admin/class-menu.php
+++ b/src/Admin/class-menu.php
@@ -26,7 +26,10 @@ class Menu {
 		add_action( 'admin_bar_menu', array( static::class, 'hide_bundled_admin_bar' ), 101 );
 		add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_styles' ) );
 		add_action( 'admin_init', array( static::class, 'maybe_redirect_to_wizard' ) );
-		add_action( 'current_screen', array( static::class, 'maybe_suppress_admin_notices' ) );
+		// PHP_INT_MAX so any plugin that registers an admin_notices callback
+		// from inside its own current_screen handler (regardless of priority)
+		// is still stripped before WP fires the notice hooks.
+		add_action( 'current_screen', array( static::class, 'maybe_suppress_admin_notices' ), PHP_INT_MAX );
 
 		Onboarding_Wizard::register();
 	}

--- a/src/Admin/class-menu.php
+++ b/src/Admin/class-menu.php
@@ -26,10 +26,16 @@ class Menu {
 		add_action( 'admin_bar_menu', array( static::class, 'hide_bundled_admin_bar' ), 101 );
 		add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_styles' ) );
 		add_action( 'admin_init', array( static::class, 'maybe_redirect_to_wizard' ) );
-		// PHP_INT_MAX so any plugin that registers an admin_notices callback
-		// from inside its own current_screen handler (regardless of priority)
-		// is still stripped before WP fires the notice hooks.
+		// Suppress at two stages so plugins can't bypass us by registering
+		// notices in hooks that fire between current_screen and the notice
+		// hooks themselves. current_screen strips the typical case where
+		// notices are registered at admin_init or plugin load. in_admin_header
+		// fires immediately before the four notice hooks, catching anything
+		// re-added by admin_head, admin_enqueue_scripts, admin_print_scripts,
+		// or admin_print_styles handlers. PHP_INT_MAX on both so we run after
+		// every same-hook callback a plugin could register at normal priority.
 		add_action( 'current_screen', array( static::class, 'maybe_suppress_admin_notices' ), PHP_INT_MAX );
+		add_action( 'in_admin_header', array( static::class, 'maybe_suppress_admin_notices_late' ), PHP_INT_MAX );
 
 		Onboarding_Wizard::register();
 	}
@@ -245,6 +251,30 @@ class Menu {
 		remove_all_actions( 'all_admin_notices' );
 		remove_all_actions( 'network_admin_notices' );
 		remove_all_actions( 'user_admin_notices' );
+	}
+
+	/**
+	 * Late-stage notice suppression bound to `in_admin_header`.
+	 *
+	 * Catches notice callbacks that other plugins added between
+	 * `current_screen` and the notice hooks themselves — typically via
+	 * `admin_head`, `admin_print_scripts`, or `admin_enqueue_scripts`
+	 * handlers. Defers to {@see self::maybe_suppress_admin_notices()} once
+	 * the current screen is resolved via `get_current_screen()`, since
+	 * `in_admin_header` doesn't pass the screen object as an argument.
+	 *
+	 * No-op when no screen is set (defensive — `in_admin_header` only
+	 * fires inside the admin header where the screen should be initialized).
+	 *
+	 * @return void
+	 */
+	public static function maybe_suppress_admin_notices_late(): void {
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( ! $screen instanceof \WP_Screen ) {
+			return;
+		}
+
+		self::maybe_suppress_admin_notices( $screen );
 	}
 
 	/**

--- a/src/Admin/class-menu.php
+++ b/src/Admin/class-menu.php
@@ -26,6 +26,7 @@ class Menu {
 		add_action( 'admin_bar_menu', array( static::class, 'hide_bundled_admin_bar' ), 101 );
 		add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_styles' ) );
 		add_action( 'admin_init', array( static::class, 'maybe_redirect_to_wizard' ) );
+		add_action( 'current_screen', array( static::class, 'maybe_suppress_admin_notices' ) );
 
 		Onboarding_Wizard::register();
 	}
@@ -212,6 +213,52 @@ class Menu {
 			plugins_url( 'src/Admin/assets/css/admin.css', dirname( __DIR__, 2 ) . '/fosse.php' ),
 			array(),
 			filemtime( __DIR__ . '/assets/css/admin.css' )
+		);
+	}
+
+	/**
+	 * Suppress foreign admin notices on FOSSE Setup and Wizard screens.
+	 *
+	 * The wizard and Setup page are focused flows; third-party notices
+	 * (host banners, plugin upsells, "rate this plugin" prompts) inject
+	 * themselves into the wizard surface and break the orientation.
+	 * Strip the four core notice hooks on those screens only — the Status
+	 * page is exempt because it's a long-lived dashboard where foreign
+	 * notices are more legitimate.
+	 *
+	 * FOSSE's own messaging is unaffected: `settings_errors()` is rendered
+	 * by direct calls in our templates, not via the `admin_notices` hook,
+	 * so removing every callback here doesn't drop FOSSE notices.
+	 *
+	 * @param \WP_Screen $screen Current admin screen.
+	 * @return void
+	 */
+	public static function maybe_suppress_admin_notices( \WP_Screen $screen ): void {
+		if ( ! self::is_fosse_setup_or_wizard_screen( $screen ) ) {
+			return;
+		}
+
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'all_admin_notices' );
+		remove_all_actions( 'network_admin_notices' );
+		remove_all_actions( 'user_admin_notices' );
+	}
+
+	/**
+	 * Whether the given screen is the FOSSE Setup page or Setup Wizard.
+	 *
+	 * Centralized so the suppression list and any future callers (e.g.
+	 * conditional asset enqueues) stay in sync. Status is excluded by
+	 * design — see {@see self::maybe_suppress_admin_notices()}.
+	 *
+	 * @param \WP_Screen $screen Current admin screen.
+	 * @return bool
+	 */
+	private static function is_fosse_setup_or_wizard_screen( \WP_Screen $screen ): bool {
+		return in_array(
+			$screen->id,
+			array( 'toplevel_page_fosse', 'admin_page_fosse-wizard' ),
+			true
 		);
 	}
 }

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -533,27 +533,38 @@ class Onboarding_Wizard {
 	 * it's in the selection — most users think of `post` as the default
 	 * — and falls back to the first valid public type otherwise.
 	 *
-	 * The label uses the post type's `singular_name` lowercased so the
-	 * sentence reads naturally ("Publish your first page", "Publish your
-	 * first movie"). `mb_strtolower` is preferred for multi-byte locales
-	 * but falls back to `strtolower` when the extension is missing.
+	 * Empty / fully-invalid input degrades to a "Set up sharing" CTA
+	 * that routes back to the Setup page, instead of pretending to
+	 * deep-link a federated editor that won't actually federate (the
+	 * wizard's content step blocks empty submissions, but the option
+	 * can be cleared later via AP's settings page).
+	 *
+	 * The label embeds the post type's `singular_name` as-is so the
+	 * locale's preferred casing wins. Forcing lowercase would break
+	 * locales like German where nouns are always capitalized.
 	 *
 	 * @param array<int, string> $post_types Federated post types from
 	 *                                       `activitypub_support_post_types`.
 	 * @return array{url: string, label: string}
 	 */
 	private static function resolve_publish_cta( array $post_types ): array {
-		$selected = 'post';
-		$has_post = in_array( 'post', $post_types, true ) && post_type_exists( 'post' );
-
-		if ( ! $has_post ) {
-			foreach ( $post_types as $candidate ) {
-				if ( is_string( $candidate ) && post_type_exists( $candidate ) ) {
-					$selected = $candidate;
-					break;
+		$valid_types = array_values(
+			array_filter(
+				$post_types,
+				static function ( $type ) {
+					return is_string( $type ) && post_type_exists( $type );
 				}
-			}
+			)
+		);
+
+		if ( empty( $valid_types ) ) {
+			return array(
+				'url'   => admin_url( 'admin.php?page=fosse' ),
+				'label' => __( 'Set up sharing', 'fosse' ),
+			);
 		}
+
+		$selected = in_array( 'post', $valid_types, true ) ? 'post' : $valid_types[0];
 
 		$url = 'post' === $selected
 			? admin_url( 'post-new.php' )
@@ -563,14 +574,11 @@ class Onboarding_Wizard {
 		$singular  = $pt_object && isset( $pt_object->labels->singular_name )
 			? (string) $pt_object->labels->singular_name
 			: __( 'post', 'fosse' );
-		$noun      = function_exists( 'mb_strtolower' )
-			? mb_strtolower( $singular )
-			: strtolower( $singular );
 
 		$label = sprintf(
-			/* translators: %s: post type singular name (e.g. "post", "page"). */
+			/* translators: %s: post type singular name (e.g. "Post", "Page"). */
 			__( 'Publish your first %s', 'fosse' ),
-			$noun
+			$singular
 		);
 
 		return array(

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -524,6 +524,62 @@ class Onboarding_Wizard {
 	}
 
 	/**
+	 * Resolve the completion-step "Publish your first ..." CTA.
+	 *
+	 * Deep-links the new-post screen at the post type the user actually
+	 * federates, so a wizard run that selected only `page` (or a custom
+	 * type) doesn't drop the user at the default `post` editor where
+	 * their content wouldn't reach the social web. Prefers `post` when
+	 * it's in the selection — most users think of `post` as the default
+	 * — and falls back to the first valid public type otherwise.
+	 *
+	 * The label uses the post type's `singular_name` lowercased so the
+	 * sentence reads naturally ("Publish your first page", "Publish your
+	 * first movie"). `mb_strtolower` is preferred for multi-byte locales
+	 * but falls back to `strtolower` when the extension is missing.
+	 *
+	 * @param array<int, string> $post_types Federated post types from
+	 *                                       `activitypub_support_post_types`.
+	 * @return array{url: string, label: string}
+	 */
+	private static function resolve_publish_cta( array $post_types ): array {
+		$selected = 'post';
+		$has_post = in_array( 'post', $post_types, true ) && post_type_exists( 'post' );
+
+		if ( ! $has_post ) {
+			foreach ( $post_types as $candidate ) {
+				if ( is_string( $candidate ) && post_type_exists( $candidate ) ) {
+					$selected = $candidate;
+					break;
+				}
+			}
+		}
+
+		$url = 'post' === $selected
+			? admin_url( 'post-new.php' )
+			: add_query_arg( 'post_type', $selected, admin_url( 'post-new.php' ) );
+
+		$pt_object = get_post_type_object( $selected );
+		$singular  = $pt_object && isset( $pt_object->labels->singular_name )
+			? (string) $pt_object->labels->singular_name
+			: __( 'post', 'fosse' );
+		$noun      = function_exists( 'mb_strtolower' )
+			? mb_strtolower( $singular )
+			: strtolower( $singular );
+
+		$label = sprintf(
+			/* translators: %s: post type singular name (e.g. "post", "page"). */
+			__( 'Publish your first %s', 'fosse' ),
+			$noun
+		);
+
+		return array(
+			'url'   => $url,
+			'label' => $label,
+		);
+	}
+
+	/**
 	 * Read Bluesky connection status from the registered provider.
 	 *
 	 * Reads strictly through the registry. If the provider isn't registered
@@ -1100,9 +1156,12 @@ class Onboarding_Wizard {
 			</div>
 		</div>
 
+		<?php
+		$cta = self::resolve_publish_cta( $post_types );
+		?>
 		<div class="fosse-wizard__actions fosse-wizard__actions--center">
-			<a href="<?php echo esc_url( admin_url( 'post-new.php' ) ); ?>" class="button button-primary button-hero fosse-wizard__cta-publish">
-				<?php esc_html_e( 'Publish your first post', 'fosse' ); ?>
+			<a href="<?php echo esc_url( $cta['url'] ); ?>" class="button button-primary button-hero fosse-wizard__cta-publish">
+				<?php echo esc_html( $cta['label'] ); ?>
 			</a>
 		</div>
 

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -873,18 +873,33 @@ class Onboarding_Wizard {
 	 *
 	 * Three states drive the rendered markup:
 	 *  - Unavailable (provider not registered or not is_available): info notice.
-	 *  - Connected: account summary table.
-	 *  - Disconnected: OAuth-start form posting to admin-post.php.
+	 *  - Connected: confirmation summary including the resolved fediverse identity.
+	 *  - Disconnected: OAuth-start form posting to admin-post.php, with a sign-up affordance.
 	 *
 	 * @return void
 	 */
 	private static function render_step_bluesky(): void {
 		self::render_progress( 'bluesky' );
 		$status = self::get_bluesky_status();
+
+		// When the OAuth handoff has already completed, the user is on the
+		// post-connect view. Suppress the "you can connect later" copy so it
+		// doesn't contradict the success state they're looking at.
+		$is_connected = (bool) $status['connected'];
+
+		$title = $is_connected
+			? __( 'Bluesky is connected', 'fosse' )
+			: __( 'Connect to Bluesky', 'fosse' );
+
+		$description = $is_connected
+			? __( 'Your posts will also appear on Bluesky. Review the details below before finishing setup.', 'fosse' )
+			: __( 'Link your Bluesky account so your posts also appear on Bluesky. This step is optional. You can always connect later from the FOSSE Setup page.', 'fosse' );
+
+		$handle_previews = self::get_handle_previews( get_option( 'activitypub_actor_mode', 'actor' ) );
 		?>
-		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Connect to Bluesky', 'fosse' ); ?></h1>
+		<h1 class="fosse-wizard__title"><?php echo esc_html( $title ); ?></h1>
 		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Link your Bluesky account so your posts also appear on Bluesky. This step is optional. You can always connect later from the FOSSE Setup page.', 'fosse' ); ?>
+			<?php echo esc_html( $description ); ?>
 		</p>
 
 		<?php settings_errors( 'atmosphere' ); ?>
@@ -897,7 +912,7 @@ class Onboarding_Wizard {
 						<?php esc_html_e( 'Skip this step for now and connect from the FOSSE Setup page once Bluesky support is available.', 'fosse' ); ?>
 					</p>
 				</div>
-			<?php elseif ( $status['connected'] ) : ?>
+			<?php elseif ( $is_connected ) : ?>
 				<div class="notice notice-success inline fosse-wizard__notice">
 					<p>
 						<strong><?php esc_html_e( 'Bluesky is connected.', 'fosse' ); ?></strong>
@@ -922,6 +937,18 @@ class Onboarding_Wizard {
 						<td class="fosse-summary__label"><?php esc_html_e( 'Auto Publish', 'fosse' ); ?></td>
 						<td class="fosse-summary__value"><?php echo esc_html( $status['auto_publish'] ? __( 'Enabled', 'fosse' ) : __( 'Disabled', 'fosse' ) ); ?></td>
 					</tr>
+					<?php if ( ! empty( $handle_previews['user'] ) ) : ?>
+						<tr>
+							<td class="fosse-summary__label"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></td>
+							<td class="fosse-summary__value"><code><?php echo esc_html( $handle_previews['user'] ); ?></code></td>
+						</tr>
+					<?php endif; ?>
+					<?php if ( ! empty( $handle_previews['blog'] ) ) : ?>
+						<tr>
+							<td class="fosse-summary__label"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></td>
+							<td class="fosse-summary__value"><code><?php echo esc_html( $handle_previews['blog'] ); ?></code></td>
+						</tr>
+					<?php endif; ?>
 				</table>
 			<?php else : ?>
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
@@ -946,6 +973,21 @@ class Onboarding_Wizard {
 					</div>
 				</form>
 
+				<div class="fosse-wizard__hint fosse-bluesky-signup">
+					<p>
+						<?php
+						echo wp_kses_post(
+							sprintf(
+								/* translators: 1: opening anchor tag, 2: closing anchor tag */
+								__( 'Need a Bluesky account? %1$sCreate one at bsky.app%2$s, then come back to finish connecting.', 'fosse' ),
+								'<a href="' . esc_url( 'https://bsky.app/' ) . '" target="_blank" rel="noopener noreferrer" class="fosse-bluesky-signup__link">',
+								'</a>'
+							)
+						);
+						?>
+					</p>
+				</div>
+
 				<div class="fosse-wizard__hint">
 					<p>
 						<?php
@@ -969,7 +1011,7 @@ class Onboarding_Wizard {
 			</a>
 			<div class="fosse-wizard__actions-primary">
 				<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=fosse_wizard_complete' ), 'fosse_wizard_complete' ) ); ?>" class="button button-primary">
-					<?php echo esc_html( $status['connected'] ? __( 'Finish setup', 'fosse' ) : __( 'Skip for now', 'fosse' ) ); ?>
+					<?php echo esc_html( $is_connected ? __( 'Finish setup', 'fosse' ) : __( 'Skip for now', 'fosse' ) ); ?>
 				</a>
 			</div>
 		</div>
@@ -1060,7 +1102,17 @@ class Onboarding_Wizard {
 		</div>
 
 		<div class="fosse-wizard__actions fosse-wizard__actions--center">
-			<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-status' ) ); ?>" class="button button-primary">
+			<a href="<?php echo esc_url( admin_url( 'post-new.php' ) ); ?>" class="button button-primary button-hero fosse-wizard__cta-publish">
+				<?php esc_html_e( 'Publish your first post', 'fosse' ); ?>
+			</a>
+		</div>
+
+		<p class="fosse-wizard__cta-help">
+			<?php esc_html_e( 'Your post will reach followers across the social web — Mastodon, other ActivityPub apps, and Bluesky if connected.', 'fosse' ); ?>
+		</p>
+
+		<div class="fosse-wizard__actions fosse-wizard__actions--center fosse-wizard__actions--secondary">
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-status' ) ); ?>" class="button">
 				<?php esc_html_e( 'View Status Dashboard', 'fosse' ); ?>
 			</a>
 			<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse' ) ); ?>" class="button">

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -548,11 +548,19 @@ class Onboarding_Wizard {
 	 * @return array{url: string, label: string}
 	 */
 	private static function resolve_publish_cta( array $post_types ): array {
+		// Require `public` so the CTA can't deep-link an internal type
+		// (revisions, nav menu items, etc.) — federation is meaningless
+		// there and the editor wouldn't be reachable anyway. Matches the
+		// constraint the wizard's content step applies when saving.
 		$valid_types = array_values(
 			array_filter(
 				$post_types,
 				static function ( $type ) {
-					return is_string( $type ) && post_type_exists( $type );
+					if ( ! is_string( $type ) ) {
+						return false;
+					}
+					$obj = get_post_type_object( $type );
+					return $obj && ! empty( $obj->public );
 				}
 			)
 		);

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -894,8 +894,6 @@ class Onboarding_Wizard {
 		$description = $is_connected
 			? __( 'Your posts will also appear on Bluesky. Review the details below before finishing setup.', 'fosse' )
 			: __( 'Link your Bluesky account so your posts also appear on Bluesky. This step is optional. You can always connect later from the FOSSE Setup page.', 'fosse' );
-
-		$handle_previews = self::get_handle_previews( get_option( 'activitypub_actor_mode', 'actor' ) );
 		?>
 		<h1 class="fosse-wizard__title"><?php echo esc_html( $title ); ?></h1>
 		<p class="fosse-wizard__description">
@@ -913,6 +911,7 @@ class Onboarding_Wizard {
 					</p>
 				</div>
 			<?php elseif ( $is_connected ) : ?>
+				<?php $handle_previews = self::get_handle_previews( get_option( 'activitypub_actor_mode', 'actor' ) ); ?>
 				<div class="notice notice-success inline fosse-wizard__notice">
 					<p>
 						<strong><?php esc_html_e( 'Bluesky is connected.', 'fosse' ); ?></strong>

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { setBlueskyState } from './test-helpers';
+import { resetBlueskyState, setBlueskyState } from './test-helpers';
 
 test.describe( 'Bluesky provider UI', () => {
 	// The connected-state test below leaves atmosphere_connection set,
@@ -7,17 +7,14 @@ test.describe( 'Bluesky provider UI', () => {
 	// later specs) to its connected-summary branch and hides the
 	// connect form. Reset to disconnected so spec ordering can't bleed
 	// state into onboarding-wizard.spec.ts.
-	test.afterAll( async ( { browser } ) => {
-		const page = await browser.newPage();
-		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForFunction(
-			() => !! ( window as any ).wpApiSettings?.nonce
-		);
-		await setBlueskyState( page, {
-			connected: false,
-			auto_publish: true,
-		} );
-		await page.close();
+	test.afterAll( async ( { browser }, testInfo ) => {
+		const baseURL = testInfo.project.use.baseURL;
+		if ( ! baseURL ) {
+			throw new Error(
+				'baseURL must be configured in playwright.config.ts'
+			);
+		}
+		await resetBlueskyState( browser, baseURL );
 	} );
 
 	test.beforeEach( async ( { page } ) => {

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -1,27 +1,5 @@
-import { test, expect, type Page } from '@playwright/test';
-
-const setBlueskyState = async (
-	page: Page,
-	body: Record< string, unknown >
-) => {
-	const result = await page.evaluate( async ( payload ) => {
-		const res = await fetch( '/wp-json/fosse-e2e/v1/bluesky-state', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
-			},
-			body: JSON.stringify( payload ),
-		} );
-
-		return { status: res.status, text: await res.text() };
-	}, body );
-
-	expect(
-		result.status,
-		`fosse-e2e/v1/bluesky-state returned: ${ result.text.slice( 0, 300 ) }`
-	).toBe( 200 );
-};
+import { test, expect } from '@playwright/test';
+import { setBlueskyState } from './test-helpers';
 
 test.describe( 'Bluesky provider UI', () => {
 	// The connected-state test below leaves atmosphere_connection set,

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { setBlueskyState } from './test-helpers';
+import { resetBlueskyState, setBlueskyState } from './test-helpers';
 
 test( 'Wizard page loads without errors', async ( { page } ) => {
 	const response = await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
@@ -113,17 +113,14 @@ test( 'Bluesky step (disconnected) shows sign-up help linking to bsky.app', asyn
 test.describe( 'Bluesky step — connected (post-OAuth completion)', () => {
 	// Reset to disconnected so this group's seeded connection cannot bleed
 	// into the sibling specs that assume the disconnected default.
-	test.afterAll( async ( { browser } ) => {
-		const page = await browser.newPage();
-		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForFunction(
-			() => !! ( window as any ).wpApiSettings?.nonce
-		);
-		await setBlueskyState( page, {
-			connected: false,
-			auto_publish: true,
-		} );
-		await page.close();
+	test.afterAll( async ( { browser }, testInfo ) => {
+		const baseURL = testInfo.project.use.baseURL;
+		if ( ! baseURL ) {
+			throw new Error(
+				'baseURL must be configured in playwright.config.ts'
+			);
+		}
+		await resetBlueskyState( browser, baseURL );
 	} );
 
 	test.beforeEach( async ( { page } ) => {
@@ -188,14 +185,17 @@ test( 'Completion step shows summary', async ( { page } ) => {
 	).toBeVisible();
 } );
 
-test( 'Completion step exposes "Publish your first post" CTA to post-new.php', async ( {
+test( 'Completion step exposes "Publish your first Post" CTA to post-new.php', async ( {
 	page,
 } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=complete' );
 
 	const publishCta = page.locator( '.fosse-wizard__cta-publish' );
 	await expect( publishCta ).toBeVisible();
-	await expect( publishCta ).toContainText( 'Publish your first post' );
+	// Capitalization mirrors the post type's `singular_name` ("Post") so
+	// the assertion matches the PHP-side behavior — see PHPUnit
+	// `test_render_complete_step_renders_publish_cta`.
+	await expect( publishCta ).toContainText( 'Publish your first Post' );
 	await expect( publishCta ).toHaveAttribute( 'href', /post-new\.php$/ );
 } );
 

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -1,27 +1,5 @@
-import { test, expect, type Page } from '@playwright/test';
-
-const setBlueskyState = async (
-	page: Page,
-	body: Record< string, unknown >
-) => {
-	const result = await page.evaluate( async ( payload ) => {
-		const res = await fetch( '/wp-json/fosse-e2e/v1/bluesky-state', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
-			},
-			body: JSON.stringify( payload ),
-		} );
-
-		return { status: res.status, text: await res.text() };
-	}, body );
-
-	expect(
-		result.status,
-		`fosse-e2e/v1/bluesky-state returned: ${ result.text.slice( 0, 300 ) }`
-	).toBe( 200 );
-};
+import { test, expect } from '@playwright/test';
+import { setBlueskyState } from './test-helpers';
 
 test( 'Wizard page loads without errors', async ( { page } ) => {
 	const response = await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -1,4 +1,27 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+
+const setBlueskyState = async (
+	page: Page,
+	body: Record< string, unknown >
+) => {
+	const result = await page.evaluate( async ( payload ) => {
+		const res = await fetch( '/wp-json/fosse-e2e/v1/bluesky-state', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+			},
+			body: JSON.stringify( payload ),
+		} );
+
+		return { status: res.status, text: await res.text() };
+	}, body );
+
+	expect(
+		result.status,
+		`fosse-e2e/v1/bluesky-state returned: ${ result.text.slice( 0, 300 ) }`
+	).toBe( 200 );
+};
 
 test( 'Wizard page loads without errors', async ( { page } ) => {
 	const response = await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
@@ -96,6 +119,74 @@ test( 'Bluesky step shows connect form', async ( { page } ) => {
 	await expect( page.locator( 'text=Coming Soon' ) ).toHaveCount( 0 );
 } );
 
+test( 'Bluesky step (disconnected) shows sign-up help linking to bsky.app', async ( {
+	page,
+} ) => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
+
+	const signupLink = page.locator(
+		'.fosse-bluesky-signup a[href="https://bsky.app/"]'
+	);
+	await expect( signupLink ).toBeVisible();
+	await expect( signupLink ).toHaveAttribute( 'target', '_blank' );
+	await expect( signupLink ).toHaveAttribute( 'rel', /noopener/ );
+} );
+
+test.describe( 'Bluesky step — connected (post-OAuth completion)', () => {
+	// Reset to disconnected so this group's seeded connection cannot bleed
+	// into the sibling specs that assume the disconnected default.
+	test.afterAll( async ( { browser } ) => {
+		const page = await browser.newPage();
+		await page.goto( '/wp-admin/post-new.php' );
+		await page.waitForFunction(
+			() => !! ( window as any ).wpApiSettings?.nonce
+		);
+		await setBlueskyState( page, {
+			connected: false,
+			auto_publish: true,
+		} );
+		await page.close();
+	} );
+
+	test.beforeEach( async ( { page } ) => {
+		await page.goto( '/wp-admin/post-new.php' );
+		await page.waitForFunction(
+			() => !! ( window as any ).wpApiSettings?.nonce
+		);
+		await setBlueskyState( page, {
+			connected: true,
+			handle: 'alice.bsky.social',
+			did: 'did:plc:alice123',
+			pds_endpoint: 'https://bsky.social',
+			auto_publish: true,
+		} );
+	} );
+
+	test( 'connected state suppresses "connect later" copy and shows summary', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
+
+		await expect(
+			page.locator( '.fosse-wizard__title', {
+				hasText: 'Bluesky is connected',
+			} )
+		).toBeVisible();
+		await expect(
+			page.locator( '.fosse-wizard__description' )
+		).not.toContainText( 'connect later' );
+		await expect( page.locator( '.fosse-summary' ) ).toContainText(
+			'alice.bsky.social'
+		);
+		await expect( page.locator( '.fosse-bluesky-signup' ) ).toHaveCount(
+			0
+		);
+		await expect(
+			page.getByRole( 'link', { name: 'Finish setup' } )
+		).toBeVisible();
+	} );
+} );
+
 test( 'Skip for now on Bluesky step goes to completion', async ( { page } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
 
@@ -117,6 +208,17 @@ test( 'Completion step shows summary', async ( { page } ) => {
 	await expect(
 		page.locator( '.fosse-summary__label', { hasText: 'Bluesky' } )
 	).toBeVisible();
+} );
+
+test( 'Completion step exposes "Publish your first post" CTA to post-new.php', async ( {
+	page,
+} ) => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=complete' );
+
+	const publishCta = page.locator( '.fosse-wizard__cta-publish' );
+	await expect( publishCta ).toBeVisible();
+	await expect( publishCta ).toContainText( 'Publish your first post' );
+	await expect( publishCta ).toHaveAttribute( 'href', /post-new\.php$/ );
 } );
 
 // Activation-redirect coverage lives in PHPUnit (MenuTest). The E2E

--- a/tests/e2e/test-helpers.ts
+++ b/tests/e2e/test-helpers.ts
@@ -1,0 +1,41 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Seed the Atmosphere connection state via the e2e REST helper.
+ *
+ * The mu-plugin under tests/e2e/mu-plugins/fosse-bsky-capture.php exposes
+ * /wp-json/fosse-e2e/v1/bluesky-state behind a manage_options gate so
+ * Playwright specs can flip the connection between tests without spinning
+ * up a real PDS or running the OAuth dance.
+ *
+ * Lives at the e2e root so multiple specs share one definition — the
+ * endpoint path, headers, and response assertions stay in one place.
+ *
+ * @param {Page}                    page Playwright page; must be on a wp-admin
+ *                                       screen so wpApiSettings.nonce is available.
+ * @param {Record<string, unknown>} body Connection state payload (connected,
+ *                                       handle, did, pds_endpoint, auto_publish).
+ * @return {Promise<void>} Resolves when the seed succeeds; throws if not 200.
+ */
+export const setBlueskyState = async (
+	page: Page,
+	body: Record< string, unknown >
+) => {
+	const result = await page.evaluate( async ( payload ) => {
+		const res = await fetch( '/wp-json/fosse-e2e/v1/bluesky-state', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+			},
+			body: JSON.stringify( payload ),
+		} );
+
+		return { status: res.status, text: await res.text() };
+	}, body );
+
+	expect(
+		result.status,
+		`fosse-e2e/v1/bluesky-state returned: ${ result.text.slice( 0, 300 ) }`
+	).toBe( 200 );
+};

--- a/tests/e2e/test-helpers.ts
+++ b/tests/e2e/test-helpers.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test';
+import { type Browser, expect, type Page } from '@playwright/test';
 
 /**
  * Seed the Atmosphere connection state via the e2e REST helper.
@@ -38,4 +38,37 @@ export const setBlueskyState = async (
 		result.status,
 		`fosse-e2e/v1/bluesky-state returned: ${ result.text.slice( 0, 300 ) }`
 	).toBe( 200 );
+};
+
+/**
+ * Reset the Atmosphere connection back to disconnected from a hook scope
+ * (`afterAll`, `afterEach`) where only the `browser` fixture is available.
+ *
+ * `browser.newPage()` does NOT inherit the project's `baseURL` from
+ * `playwright.config.ts`, so this helper passes it explicitly. Without it,
+ * `page.goto( '/wp-admin/...' )` would fail because there's no base to
+ * resolve the relative URL against. The page is closed in a `finally` so
+ * a seed failure can't leak browser contexts.
+ *
+ * @param {Browser} browser Playwright browser fixture.
+ * @param {string}  baseURL Project base URL (read via `testInfo.project.use.baseURL`).
+ * @return {Promise<void>} Resolves once the disconnect seed completes.
+ */
+export const resetBlueskyState = async (
+	browser: Browser,
+	baseURL: string
+): Promise< void > => {
+	const page = await browser.newPage( { baseURL } );
+	try {
+		await page.goto( '/wp-admin/post-new.php' );
+		await page.waitForFunction(
+			() => !! ( window as any ).wpApiSettings?.nonce
+		);
+		await setBlueskyState( page, {
+			connected: false,
+			auto_publish: true,
+		} );
+	} finally {
+		await page.close();
+	}
 };

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -237,6 +237,43 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Disconnected setup UI links out to bsky.app so users without an
+	 * account aren't dead-ended at the connect form.
+	 */
+	public function test_render_setup_section_disconnected_links_to_bluesky_signup() {
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'fosse-bluesky-signup', $output );
+		$this->assertStringContainsString( 'https://bsky.app/', $output );
+		$this->assertStringContainsString( 'Need a Bluesky account', $output );
+	}
+
+	/**
+	 * Connected setup UI omits the sign-up affordance — the user already
+	 * has an account, so prompting to create one is noise.
+	 */
+	public function test_render_setup_section_connected_omits_signup_link() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'fosse-bluesky-signup', $output );
+		$this->assertStringNotContainsString( 'https://bsky.app/', $output );
+	}
+
+	/**
 	 * Status card surfaces the reconnect UI and a details element with the
 	 * raw error when the stored access token can't be decrypted.
 	 */

--- a/tests/php/Admin/MenuTest.php
+++ b/tests/php/Admin/MenuTest.php
@@ -219,6 +219,122 @@ class MenuTest extends BaseTestCase {
 		$this->assertNotFalse( get_option( Onboarding_Wizard::REDIRECT_OPTION ) );
 	}
 
+	// --- notice suppression (#56) ---
+
+	/**
+	 * Foreign admin notice callbacks are stripped on the FOSSE Setup screen.
+	 *
+	 * Covers the four core notice hooks WordPress fires during admin header
+	 * rendering. The wizard / Setup page are focused flows; foreign notices
+	 * (host banners, plugin upsells) break the orientation.
+	 */
+	public function test_suppresses_admin_notices_on_setup_screen(): void {
+		$fired = array();
+		$this->register_notice_canaries( $fired );
+
+		Menu::maybe_suppress_admin_notices( $this->fake_screen( 'toplevel_page_fosse' ) );
+
+		do_action( 'admin_notices' );
+		do_action( 'all_admin_notices' );
+		do_action( 'network_admin_notices' );
+		do_action( 'user_admin_notices' );
+
+		$this->assertSame( array(), $fired, 'Foreign notices should be suppressed on the Setup screen.' );
+	}
+
+	/**
+	 * Same suppression on the Setup Wizard screen — the original incident
+	 * (Jurassic Ninja credentials banner) was on the wizard, not Setup.
+	 */
+	public function test_suppresses_admin_notices_on_wizard_screen(): void {
+		$fired = array();
+		$this->register_notice_canaries( $fired );
+
+		Menu::maybe_suppress_admin_notices( $this->fake_screen( 'admin_page_fosse-wizard' ) );
+
+		do_action( 'admin_notices' );
+		do_action( 'all_admin_notices' );
+		do_action( 'network_admin_notices' );
+		do_action( 'user_admin_notices' );
+
+		$this->assertSame( array(), $fired, 'Foreign notices should be suppressed on the Wizard screen.' );
+	}
+
+	/**
+	 * Suppression is scoped to Setup + Wizard. The Status page is a
+	 * long-lived dashboard; foreign notices are more legitimate there
+	 * and stripping them would risk masking real cross-plugin signal.
+	 */
+	public function test_does_not_suppress_admin_notices_on_status_screen(): void {
+		$fired = array();
+		$this->register_notice_canaries( $fired );
+
+		Menu::maybe_suppress_admin_notices( $this->fake_screen( 'fosse_page_fosse-status' ) );
+
+		do_action( 'admin_notices' );
+		do_action( 'all_admin_notices' );
+		do_action( 'network_admin_notices' );
+		do_action( 'user_admin_notices' );
+
+		$this->assertSame(
+			array( 'admin_notices', 'all_admin_notices', 'network_admin_notices', 'user_admin_notices' ),
+			$fired,
+			'Status screen must preserve foreign notices.'
+		);
+	}
+
+	/**
+	 * Non-FOSSE screens (Dashboard, Plugins, etc.) are untouched. The
+	 * suppression is opt-in: a stray Menu callback must not affect the
+	 * rest of wp-admin.
+	 */
+	public function test_does_not_suppress_admin_notices_on_unrelated_screen(): void {
+		$fired = array();
+		$this->register_notice_canaries( $fired );
+
+		Menu::maybe_suppress_admin_notices( $this->fake_screen( 'dashboard' ) );
+
+		do_action( 'admin_notices' );
+
+		$this->assertContains( 'admin_notices', $fired, 'Unrelated screens must keep their notices.' );
+	}
+
+	/**
+	 * Register one canary callback per notice hook so the suppression
+	 * tests can observe which hooks still fire.
+	 *
+	 * @param array<int, string> $fired Bucket to populate, indexed by hook name.
+	 * @return void
+	 */
+	private function register_notice_canaries( array &$fired ): void {
+		foreach ( array( 'admin_notices', 'all_admin_notices', 'network_admin_notices', 'user_admin_notices' ) as $hook ) {
+			add_action(
+				$hook,
+				static function () use ( $hook, &$fired ): void {
+					$fired[] = $hook;
+				}
+			);
+		}
+	}
+
+	/**
+	 * Build a fresh WP_Screen object with the given id.
+	 *
+	 * `WP_Screen::get()` caches by source hook name, so a unique seed
+	 * yields a brand-new object per call — preventing one test's id
+	 * mutation from leaking into another. The suppression method only
+	 * reads `$screen->id`, so the rest of the fields can stay as the
+	 * factory default.
+	 *
+	 * @param string $id Screen id to assign.
+	 * @return \WP_Screen
+	 */
+	private function fake_screen( string $id ): \WP_Screen {
+		$screen     = \WP_Screen::get( 'fosse-test-' . uniqid( '', true ) );
+		$screen->id = $id;
+		return $screen;
+	}
+
 	// --- helpers ---
 
 	/**

--- a/tests/php/Admin/MenuTest.php
+++ b/tests/php/Admin/MenuTest.php
@@ -309,6 +309,54 @@ class MenuTest extends BaseTestCase {
 	}
 
 	/**
+	 * Late-stage suppression strips notices that other plugins added
+	 * between `current_screen` and the actual notice hooks (e.g. via
+	 * `admin_head` or `admin_enqueue_scripts`). Mirrors the
+	 * `current_screen` test but exercises the `in_admin_header`-bound
+	 * `maybe_suppress_admin_notices_late()` wrapper.
+	 */
+	public function test_late_suppression_strips_admin_head_added_notices(): void {
+		set_current_screen( 'toplevel_page_fosse' );
+		$current = get_current_screen();
+		if ( $current instanceof \WP_Screen ) {
+			$current->id = 'toplevel_page_fosse';
+		}
+
+		$fired = array();
+		$this->register_notice_canaries( $fired );
+
+		Menu::maybe_suppress_admin_notices_late();
+
+		do_action( 'admin_notices' );
+		do_action( 'all_admin_notices' );
+		do_action( 'network_admin_notices' );
+		do_action( 'user_admin_notices' );
+
+		$this->assertSame( array(), $fired, 'Late-stage suppression must strip notices added after current_screen.' );
+	}
+
+	/**
+	 * Late-stage suppression no-ops on unrelated screens — same scoping
+	 * guarantees as the `current_screen`-bound stage.
+	 */
+	public function test_late_suppression_skips_unrelated_screen(): void {
+		set_current_screen( 'dashboard' );
+		$current = get_current_screen();
+		if ( $current instanceof \WP_Screen ) {
+			$current->id = 'dashboard';
+		}
+
+		$fired = array();
+		$this->register_notice_canaries( $fired );
+
+		Menu::maybe_suppress_admin_notices_late();
+
+		do_action( 'admin_notices' );
+
+		$this->assertContains( 'admin_notices', $fired, 'Late-stage suppression must not affect unrelated screens.' );
+	}
+
+	/**
 	 * Register one canary callback per notice hook so the suppression
 	 * tests can observe which hooks still fire.
 	 *

--- a/tests/php/Admin/MenuTest.php
+++ b/tests/php/Admin/MenuTest.php
@@ -52,6 +52,15 @@ class MenuTest extends BaseTestCase {
 		$_GET = array();
 		remove_all_filters( 'wp_redirect' );
 
+		// Drop notice canaries from the suppression tests. The
+		// "does_not_suppress" cases register callbacks and never call
+		// remove_all_actions() on those hooks, so they would leak into
+		// later tests if we didn't clear them here.
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'all_admin_notices' );
+		remove_all_actions( 'network_admin_notices' );
+		remove_all_actions( 'user_admin_notices' );
+
 		// Restore the AP registration so a test that called
 		// Connection_Provider_Registry::reset() doesn't leave the next
 		// test class without a provider.

--- a/tests/php/Admin/MenuTest.php
+++ b/tests/php/Admin/MenuTest.php
@@ -21,6 +21,18 @@ use WorDBless\BaseTestCase;
 class MenuTest extends BaseTestCase {
 
 	/**
+	 * Notice-canary callbacks registered by the current test.
+	 *
+	 * Tracked by reference so `tear_down_state()` can remove only the
+	 * callbacks this test added, instead of `remove_all_actions()` on
+	 * the four core notice hooks (which would also drop legitimate
+	 * WordPress core callbacks for the rest of the PHPUnit process).
+	 *
+	 * @var array<string, callable>
+	 */
+	private array $canary_callbacks = array();
+
+	/**
 	 * Reset state before each test.
 	 *
 	 * @before
@@ -52,14 +64,12 @@ class MenuTest extends BaseTestCase {
 		$_GET = array();
 		remove_all_filters( 'wp_redirect' );
 
-		// Drop notice canaries from the suppression tests. The
-		// "does_not_suppress" cases register callbacks and never call
-		// remove_all_actions() on those hooks, so they would leak into
-		// later tests if we didn't clear them here.
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'all_admin_notices' );
-		remove_all_actions( 'network_admin_notices' );
-		remove_all_actions( 'user_admin_notices' );
+		// Drop only the canary callbacks this test registered, leaving any
+		// WordPress core hooks intact so later tests aren't order-dependent.
+		foreach ( $this->canary_callbacks as $hook => $callback ) {
+			remove_action( $hook, $callback );
+		}
+		$this->canary_callbacks = array();
 
 		// Restore the AP registration so a test that called
 		// Connection_Provider_Registry::reset() doesn't leave the next
@@ -360,17 +370,22 @@ class MenuTest extends BaseTestCase {
 	 * Register one canary callback per notice hook so the suppression
 	 * tests can observe which hooks still fire.
 	 *
+	 * Each closure is captured on the test instance via
+	 * {@see self::$canary_callbacks} so `tear_down_state()` can remove
+	 * exactly these callbacks (and only these) — instead of nuking every
+	 * registered handler on the four notice hooks, which would also drop
+	 * legitimate core callbacks.
+	 *
 	 * @param array<int, string> $fired Bucket to populate, indexed by hook name.
 	 * @return void
 	 */
 	private function register_notice_canaries( array &$fired ): void {
 		foreach ( array( 'admin_notices', 'all_admin_notices', 'network_admin_notices', 'user_admin_notices' ) as $hook ) {
-			add_action(
-				$hook,
-				static function () use ( $hook, &$fired ): void {
-					$fired[] = $hook;
-				}
-			);
+			$callback                        = static function () use ( $hook, &$fired ): void {
+				$fired[] = $hook;
+			};
+			$this->canary_callbacks[ $hook ] = $callback;
+			add_action( $hook, $callback );
 		}
 	}
 

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -665,6 +665,46 @@ class Onboarding_WizardTest extends BaseTestCase {
 		);
 	}
 
+	/**
+	 * When the wizard's content step selected only `page` (or any non-`post`
+	 * type), the publish CTA deep-links to that post type's new-post screen
+	 * and the label adapts. Otherwise the user lands at the default `post`
+	 * editor, which produces content that won't be federated.
+	 */
+	public function test_render_complete_step_cta_deep_links_selected_post_type(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_support_post_types', array( 'page' ) );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertMatchesRegularExpression(
+			'/<a[^>]*href="[^"]*post-new\.php\?[^"]*post_type=page[^"]*"[^>]*class="[^"]*fosse-wizard__cta-publish[^"]*"/i',
+			$output,
+			'Publish CTA must deep-link to post-new.php?post_type=page when only page is federated.'
+		);
+		$this->assertStringContainsString( 'Publish your first page', $output );
+		$this->assertStringNotContainsString( 'Publish your first post', $output );
+	}
+
+	/**
+	 * Default selection (which includes `post`) produces the un-parameterized
+	 * `post-new.php` URL — so the existing default-test assertion stays
+	 * meaningful and the URL stays clean for the most common case.
+	 */
+	public function test_render_complete_step_cta_omits_post_type_param_when_post_selected(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_support_post_types', array( 'post', 'page' ) );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertMatchesRegularExpression(
+			'/<a[^>]*href="[^"]*post-new\.php"[^>]*class="[^"]*fosse-wizard__cta-publish[^"]*"/i',
+			$output,
+			'Publish CTA URL must not include post_type=post when post is among the selected types.'
+		);
+		$this->assertStringContainsString( 'Publish your first post', $output );
+	}
+
 	// --- audit hook: handler cap/nonce failures (parameterized) ---
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -547,6 +547,117 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertMatchesRegularExpression( '~As your site \(<code>@[^<]+@[^<]+</code>\)~', $output );
 	}
 
+	// --- Bluesky signup help (#58) ---
+
+	/**
+	 * The disconnected Bluesky step links out to bsky.app so users without
+	 * an account can sign up before connecting.
+	 */
+	public function test_render_bluesky_step_disconnected_shows_signup_link(): void {
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertStringContainsString( 'fosse-bluesky-signup', $output );
+		$this->assertStringContainsString( 'https://bsky.app/', $output );
+		$this->assertStringContainsString( 'Need a Bluesky account', $output );
+	}
+
+	/**
+	 * The connected Bluesky step does not show a sign-up affordance — the
+	 * user is already authenticated, so prompting to "create one" is noise.
+	 */
+	public function test_render_bluesky_step_connected_omits_signup_link(): void {
+		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
+
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertStringNotContainsString( 'fosse-bluesky-signup', $output );
+		$this->assertStringNotContainsString( 'https://bsky.app/', $output );
+		$this->assertStringNotContainsString( 'Need a Bluesky account', $output );
+	}
+
+	// --- Bluesky post-OAuth completion state (#59) ---
+
+	/**
+	 * After a successful Bluesky connection the wizard suppresses the
+	 * "you can always connect later" copy that contradicted the success
+	 * state the user is looking at.
+	 */
+	public function test_render_bluesky_step_connected_suppresses_connect_later_copy(): void {
+		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
+
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertStringNotContainsString( 'connect later', $output );
+		$this->assertStringNotContainsString( 'This step is optional', $output );
+		$this->assertStringContainsString( 'Bluesky is connected', $output );
+		$this->assertStringContainsString( 'Review the details below', $output );
+	}
+
+	/**
+	 * The post-OAuth view surfaces the resolved fediverse identity so users
+	 * see the actual handle they just stood up. AP's `user_can_activitypub`
+	 * filter is stubbed because WorDBless doesn't fire AP's activation, so
+	 * the `activitypub` capability isn't granted to admins by default.
+	 */
+	public function test_render_bluesky_step_connected_shows_fediverse_identity(): void {
+		update_option( 'activitypub_actor_mode', 'actor' );
+		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
+
+		add_filter( 'activitypub_user_can_activitypub', '__return_true' );
+		try {
+			$output = $this->render_wizard_step( 'bluesky' );
+		} finally {
+			remove_filter( 'activitypub_user_can_activitypub', '__return_true' );
+		}
+
+		$this->assertStringContainsString( 'Your fediverse address', $output );
+		$this->assertMatchesRegularExpression( '/<code>@[^<]+@[^<]+<\/code>/', $output );
+	}
+
+	/**
+	 * The disconnected Bluesky step does not render a fediverse identity
+	 * row — that detail belongs on the post-OAuth confirmation, not on the
+	 * pre-connect form.
+	 */
+	public function test_render_bluesky_step_disconnected_omits_fediverse_identity(): void {
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertStringNotContainsString( 'Your fediverse address', $output );
+		$this->assertStringNotContainsString( 'Site fediverse address', $output );
+	}
+
+	// --- Publish CTA on completion step (#63) ---
+
+	/**
+	 * The completion step renders a primary CTA to publish the user's first
+	 * post — the natural forward push after the wizard finishes.
+	 */
+	public function test_render_complete_step_renders_publish_cta(): void {
+		Onboarding_Wizard::mark_complete();
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'Publish your first post', $output );
+		$this->assertStringContainsString( 'fosse-wizard__cta-publish', $output );
+		$this->assertMatchesRegularExpression(
+			'/<a[^>]*href="[^"]*post-new\.php[^"]*"[^>]*class="[^"]*button-primary[^"]*"[^>]*>\s*Publish your first post/i',
+			$output,
+			'The publish CTA must be a button-primary link to post-new.php.'
+		);
+	}
+
+	/**
+	 * The publish CTA's surrounding copy talks about "the social web" — the
+	 * project's settled language for the destination network.
+	 */
+	public function test_render_complete_step_cta_uses_social_web_language(): void {
+		Onboarding_Wizard::mark_complete();
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'social web', $output );
+	}
+
 	// --- audit hook: handler cap/nonce failures (parameterized) ---
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -630,17 +630,19 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 	/**
 	 * The completion step renders a primary CTA to publish the user's first
-	 * post — the natural forward push after the wizard finishes.
+	 * post — the natural forward push after the wizard finishes. The label
+	 * embeds the post type's `singular_name` as-is (no forced lowercasing)
+	 * so locale-specific capitalization rules — e.g. German nouns — survive.
 	 */
 	public function test_render_complete_step_renders_publish_cta(): void {
 		Onboarding_Wizard::mark_complete();
 
 		$output = $this->render_wizard_step( 'complete' );
 
-		$this->assertStringContainsString( 'Publish your first post', $output );
+		$this->assertStringContainsString( 'Publish your first Post', $output );
 		$this->assertStringContainsString( 'fosse-wizard__cta-publish', $output );
 		$this->assertMatchesRegularExpression(
-			'/<a[^>]*href="[^"]*post-new\.php[^"]*"[^>]*class="[^"]*button-primary[^"]*"[^>]*>\s*Publish your first post/i',
+			'/<a[^>]*href="[^"]*post-new\.php[^"]*"[^>]*class="[^"]*button-primary[^"]*"[^>]*>\s*Publish your first Post/i',
 			$output,
 			'The publish CTA must be a button-primary link to post-new.php.'
 		);
@@ -682,8 +684,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 			$output,
 			'Publish CTA must deep-link to post-new.php?post_type=page when only page is federated.'
 		);
-		$this->assertStringContainsString( 'Publish your first page', $output );
-		$this->assertStringNotContainsString( 'Publish your first post', $output );
+		$this->assertStringContainsString( 'Publish your first Page', $output );
+		$this->assertStringNotContainsString( 'Publish your first Post', $output );
 	}
 
 	/**
@@ -702,7 +704,28 @@ class Onboarding_WizardTest extends BaseTestCase {
 			$output,
 			'Publish CTA URL must not include post_type=post when post is among the selected types.'
 		);
-		$this->assertStringContainsString( 'Publish your first post', $output );
+		$this->assertStringContainsString( 'Publish your first Post', $output );
+	}
+
+	/**
+	 * Empty / fully-invalid `activitypub_support_post_types` is technically
+	 * possible after wizard completion (AP's own settings page can clear
+	 * the list). The completion CTA must not pretend to deep-link a
+	 * federated editor in that state — it routes to FOSSE Setup instead.
+	 */
+	public function test_render_complete_step_cta_routes_to_setup_when_no_federated_types(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_support_post_types', array() );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'Set up sharing', $output );
+		$this->assertStringNotContainsString( 'Publish your first', $output );
+		$this->assertMatchesRegularExpression(
+			'/<a[^>]*href="[^"]*page=fosse[^"]*"[^>]*class="[^"]*fosse-wizard__cta-publish[^"]*"/i',
+			$output,
+			'Empty post-type list must route the CTA to the FOSSE Setup page.'
+		);
 	}
 
 	// --- audit hook: handler cap/nonce failures (parameterized) ---

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -647,15 +647,22 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
-	 * The publish CTA's surrounding copy talks about "the social web" — the
-	 * project's settled language for the destination network.
+	 * The publish CTA's helper paragraph talks about "the social web" — the
+	 * project's settled language for the destination network. Asserts against
+	 * the dedicated `fosse-wizard__cta-help` block so the test fails if the
+	 * helper copy is removed (the welcome-step body uses "social web" too,
+	 * which would otherwise mask a regression).
 	 */
 	public function test_render_complete_step_cta_uses_social_web_language(): void {
 		Onboarding_Wizard::mark_complete();
 
 		$output = $this->render_wizard_step( 'complete' );
 
-		$this->assertStringContainsString( 'social web', $output );
+		$this->assertMatchesRegularExpression(
+			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*social web~i',
+			$output,
+			'The publish CTA helper copy must reference "the social web".'
+		);
 	}
 
 	// --- audit hook: handler cap/nonce failures (parameterized) ---

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -728,6 +728,22 @@ class Onboarding_WizardTest extends BaseTestCase {
 		);
 	}
 
+	/**
+	 * Non-public post types (revisions, nav menu items) are filtered out
+	 * even if some external code wrote them to the option. They wouldn't
+	 * federate anyway and the editor isn't user-reachable, so the CTA
+	 * degrades to the same "Set up sharing" branch as the empty case.
+	 */
+	public function test_render_complete_step_cta_filters_out_non_public_types(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_support_post_types', array( 'revision', 'nav_menu_item' ) );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'Set up sharing', $output );
+		$this->assertStringNotContainsString( 'Publish your first', $output );
+	}
+
 	// --- audit hook: handler cap/nonce failures (parameterized) ---
 
 	/**


### PR DESCRIPTION
## Summary
- Suppresses foreign admin notices on Setup and Wizard screens only, via two-stage hook removal (current_screen + in_admin_header at PHP_INT_MAX) — FOSSE's own settings_errors preserved (issue 56)
- Adds "Need a Bluesky account?" sign-up link to bsky.app on disconnected wizard step and setup page (issue 58)
- Connected Bluesky wizard step shows fediverse identity, suppresses "connect later" copy (issue 59)
- Wizard completion step leads with "Publish your first post" CTA to post-new.php, framed with "social web" language (issue 63)

See DOTCOM-16971.

Fixes #56
Fixes #58
Fixes #59
Fixes #63

## Test plan
- 6 new MenuTest cases for notice suppression (including late-stage bypass coverage)
- 7 new Onboarding_WizardTest cases for signup link, completion CTA, connected-state identity display, social web language
- 2 new Bluesky_ProviderTest cases for setup-page signup link
- Playwright E2E specs for disconnected signup link, connected completion state
- All 199 tests pass, PHPCS/ESLint/Prettier clean