### PR TITLE
fix: wizard polish — alignment, line breaks, deduped notices

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -509,6 +509,14 @@
 	margin-bottom: 16px;
 }
 
+/* On the Complete step, the description's narrower 560px max-width left it
+   visually offset from the title (700px) and summary card (also 700px).
+   Drop the narrower cap here so all three share the wizard's own
+   max-width and read as one centered column. */
+.fosse-wizard__complete-header .fosse-wizard__description {
+	max-width: none;
+}
+
 .fosse-complete-icon {
 	width: 64px;
 	height: 64px;
@@ -575,6 +583,14 @@
 
 .fosse-wizard__reset a:hover {
 	color: #1e1e1e;
+}
+
+/* WordPress's default `.button-hero` leaves anchor labels left-aligned, which
+   reads as off-center inside the wizard's wider hero CTAs. Force the label to
+   center within the button so it sits visually balanced with the surrounding
+   centered layout. */
+.fosse-wizard .button-hero {
+	text-align: center;
 }
 
 /* Completion publish CTA */

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -442,44 +442,29 @@ class Onboarding_Wizard {
 		switch ( $mode ) {
 			case 'actor':
 				if ( '' !== $user_handle ) {
-					return sprintf(
-						/* translators: %s: HTML <code> element wrapping a fediverse handle in @user@host form. */
-						esc_html__( 'As you (%s)', 'fosse' ),
-						'<code>' . esc_html( $user_handle ) . '</code>'
-					);
+					return esc_html__( 'As you', 'fosse' )
+						. '<br /><code>' . esc_html( $user_handle ) . '</code>';
 				}
 				return esc_html__( 'As you (author profiles)', 'fosse' );
 
 			case 'blog':
 				if ( '' !== $blog_handle ) {
-					return sprintf(
-						/* translators: %s: HTML <code> element wrapping a fediverse handle in @user@host form. */
-						esc_html__( 'As your site (%s)', 'fosse' ),
-						'<code>' . esc_html( $blog_handle ) . '</code>'
-					);
+					return esc_html__( 'As your site', 'fosse' )
+						. '<br /><code>' . esc_html( $blog_handle ) . '</code>';
 				}
 				$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
-				return sprintf(
-					/* translators: %s: site domain. */
-					esc_html__( 'As your site (%s)', 'fosse' ),
-					esc_html( $site_host ? $site_host : 'yoursite.com' )
-				);
+				return esc_html__( 'As your site', 'fosse' )
+					. '<br /><code>' . esc_html( $site_host ? $site_host : 'yoursite.com' ) . '</code>';
 
 			case 'actor_blog':
 				$lines = array( esc_html__( 'Both (site + authors)', 'fosse' ) );
 				if ( '' !== $user_handle ) {
-					$lines[] = sprintf(
-						/* translators: %s: HTML <code> element wrapping a fediverse handle in @user@host form. */
-						esc_html__( 'As you: %s', 'fosse' ),
-						'<code>' . esc_html( $user_handle ) . '</code>'
-					);
+					$lines[] = esc_html__( 'As you:', 'fosse' )
+						. '<br /><code>' . esc_html( $user_handle ) . '</code>';
 				}
 				if ( '' !== $blog_handle ) {
-					$lines[] = sprintf(
-						/* translators: %s: HTML <code> element wrapping a fediverse handle in @user@host form. */
-						esc_html__( 'As your site: %s', 'fosse' ),
-						'<code>' . esc_html( $blog_handle ) . '</code>'
-					);
+					$lines[] = esc_html__( 'As your site:', 'fosse' )
+						. '<br /><code>' . esc_html( $blog_handle ) . '</code>';
 				}
 				return implode( '<br />', $lines );
 		}
@@ -972,7 +957,26 @@ class Onboarding_Wizard {
 			<?php echo esc_html( $description ); ?>
 		</p>
 
-		<?php settings_errors( 'atmosphere' ); ?>
+		<?php
+		// Atmosphere posts a settings_error after every OAuth round-trip — a
+		// "Successfully connected" success notice on the happy path, and an
+		// error notice on failure. The wizard's in-card connected state
+		// already speaks for the success case, so rendering the top success
+		// notice would double-up the confirmation. Surface only error/warning
+		// here so a failed connect doesn't go silent on the Bluesky step.
+		foreach ( get_settings_errors( 'atmosphere' ) as $atmosphere_notice ) {
+			$notice_type = isset( $atmosphere_notice['type'] ) ? (string) $atmosphere_notice['type'] : 'error';
+			if ( in_array( $notice_type, array( 'success', 'updated', 'info' ), true ) ) {
+				continue;
+			}
+
+			printf(
+				'<div class="notice notice-%1$s inline"><p>%2$s</p></div>',
+				esc_attr( $notice_type ),
+				esc_html( isset( $atmosphere_notice['message'] ) ? (string) $atmosphere_notice['message'] : '' )
+			);
+		}
+		?>
 
 		<div class="fosse-wizard__card">
 			<?php if ( ! $status['available'] ) : ?>

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -527,9 +527,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Both (site + authors)', $output );
 		$this->assertStringContainsString( 'As you:', $output );
 		$this->assertStringContainsString( 'As your site:', $output );
-		// Fediverse handle markup should be wrapped in <code>, not bare text.
-		$this->assertMatchesRegularExpression( '~As you:\s*<code>@[^<]+@[^<]+</code>~', $output );
-		$this->assertMatchesRegularExpression( '~As your site:\s*<code>@[^<]+@[^<]+</code>~', $output );
+		// Fediverse handle markup should be wrapped in <code>, with a
+		// `<br />` between the label and the handle so long handles don't
+		// wrap mid-token (#72).
+		$this->assertMatchesRegularExpression( '~As you:<br\s*/?>\s*<code>@[^<]+@[^<]+</code>~', $output );
+		$this->assertMatchesRegularExpression( '~As your site:<br\s*/?>\s*<code>@[^<]+@[^<]+</code>~', $output );
 	}
 
 	/**
@@ -544,7 +546,32 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertStringContainsString( 'As your site', $output );
-		$this->assertMatchesRegularExpression( '~As your site \(<code>@[^<]+@[^<]+</code>\)~', $output );
+		// Long handles previously wrapped awkwardly mid-token; the label and
+		// handle now sit on separate lines with a `<br />` between them (#72).
+		$this->assertMatchesRegularExpression( '~As your site<br\s*/?>\s*<code>@[^<]+@[^<]+</code>~', $output );
+	}
+
+	/**
+	 * In `actor` mode the user handle drops to its own line (#72), so a long
+	 * `@user@host` token in a narrow summary cell can't push the row's
+	 * intrinsic width past the wizard column.
+	 */
+	public function test_complete_summary_breaks_handle_to_new_line_in_actor_mode(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_actor_mode', 'actor' );
+
+		add_filter( 'activitypub_user_can_activitypub', '__return_true' );
+		try {
+			$output = $this->render_wizard_step( 'complete' );
+		} finally {
+			remove_filter( 'activitypub_user_can_activitypub', '__return_true' );
+		}
+
+		$this->assertStringContainsString( 'As you', $output );
+		$this->assertMatchesRegularExpression( '~As you<br\s*/?>\s*<code>@[^<]+@[^<]+</code>~', $output );
+		// The pre-fix wrapper used parens around the handle on the same line;
+		// guard against the parenthesized shape regressing here.
+		$this->assertDoesNotMatchRegularExpression( '~As you \(<code>~', $output );
 	}
 
 	// --- Bluesky signup help (#58) ---
@@ -575,7 +602,64 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringNotContainsString( 'Need a Bluesky account', $output );
 	}
 
-	// --- Bluesky post-OAuth completion state (#59) ---
+	// --- Bluesky post-OAuth completion state (#59, #70) ---
+
+	/**
+	 * Atmosphere's OAuth callback adds a "Successfully connected" settings_error
+	 * that previously rendered as a top notice on the wizard's Bluesky step,
+	 * doubling up with the in-card "Bluesky is connected" copy. After #70 the
+	 * top success notice is suppressed; only the persistent in-card state
+	 * remains for the connected confirmation.
+	 */
+	public function test_render_bluesky_step_suppresses_top_success_notice(): void {
+		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
+
+		// Reset any cross-test residue and seed an atmosphere settings_error
+		// of the same shape Atmosphere emits on a successful OAuth callback.
+		global $wp_settings_errors;
+		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- isolating settings-error state for this test.
+		add_settings_error(
+			'atmosphere',
+			'connected',
+			'TOP_NOTICE_SUCCESS_FIXTURE',
+			'success'
+		);
+
+		try {
+			$output = $this->render_wizard_step( 'bluesky' );
+		} finally {
+			$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restoring state for the next test.
+		}
+
+		// The duplicate top success notice must not render on the wizard step.
+		$this->assertStringNotContainsString( 'TOP_NOTICE_SUCCESS_FIXTURE', $output );
+		// The in-card persistent state still speaks for the connected case.
+		$this->assertStringContainsString( 'Bluesky is connected', $output );
+	}
+
+	/**
+	 * Error-typed atmosphere notices still surface on the wizard's Bluesky step
+	 * — only success/info confirmations are dropped (#70). Without this, a
+	 * failed OAuth callback would re-render the connect form with no feedback.
+	 */
+	public function test_render_bluesky_step_preserves_top_error_notice(): void {
+		global $wp_settings_errors;
+		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- isolating settings-error state for this test.
+		add_settings_error(
+			'atmosphere',
+			'callback_failed',
+			'TOP_NOTICE_ERROR_FIXTURE',
+			'error'
+		);
+
+		try {
+			$output = $this->render_wizard_step( 'bluesky' );
+		} finally {
+			$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restoring state for the next test.
+		}
+
+		$this->assertStringContainsString( 'TOP_NOTICE_ERROR_FIXTURE', $output );
+	}
 
 	/**
 	 * After a successful Bluesky connection the wizard suppresses the

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -614,22 +614,20 @@ class Onboarding_WizardTest extends BaseTestCase {
 	public function test_render_bluesky_step_suppresses_top_success_notice(): void {
 		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
 
-		// Reset any cross-test residue and seed an atmosphere settings_error
+		// Snapshot prior settings_errors state so seeding the success-type
+		// fixture below can't leak into adjacent tests, then seed a notice
 		// of the same shape Atmosphere emits on a successful OAuth callback.
-		global $wp_settings_errors;
-		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- isolating settings-error state for this test.
-		add_settings_error(
-			'atmosphere',
-			'connected',
-			'TOP_NOTICE_SUCCESS_FIXTURE',
-			'success'
+		$output = $this->with_isolated_settings_errors(
+			function (): string {
+				add_settings_error(
+					'atmosphere',
+					'connected',
+					'TOP_NOTICE_SUCCESS_FIXTURE',
+					'success'
+				);
+				return $this->render_wizard_step( 'bluesky' );
+			}
 		);
-
-		try {
-			$output = $this->render_wizard_step( 'bluesky' );
-		} finally {
-			$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restoring state for the next test.
-		}
 
 		// The duplicate top success notice must not render on the wizard step.
 		$this->assertStringNotContainsString( 'TOP_NOTICE_SUCCESS_FIXTURE', $output );
@@ -643,20 +641,17 @@ class Onboarding_WizardTest extends BaseTestCase {
 	 * failed OAuth callback would re-render the connect form with no feedback.
 	 */
 	public function test_render_bluesky_step_preserves_top_error_notice(): void {
-		global $wp_settings_errors;
-		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- isolating settings-error state for this test.
-		add_settings_error(
-			'atmosphere',
-			'callback_failed',
-			'TOP_NOTICE_ERROR_FIXTURE',
-			'error'
+		$output = $this->with_isolated_settings_errors(
+			function (): string {
+				add_settings_error(
+					'atmosphere',
+					'callback_failed',
+					'TOP_NOTICE_ERROR_FIXTURE',
+					'error'
+				);
+				return $this->render_wizard_step( 'bluesky' );
+			}
 		);
-
-		try {
-			$output = $this->render_wizard_step( 'bluesky' );
-		} finally {
-			$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restoring state for the next test.
-		}
 
 		$this->assertStringContainsString( 'TOP_NOTICE_ERROR_FIXTURE', $output );
 	}
@@ -981,6 +976,39 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	// --- helpers ---
+
+	/**
+	 * Run a callback with an isolated `$wp_settings_errors` global.
+	 *
+	 * Snapshots the prior value (or unset state) before the callback runs and
+	 * restores it afterwards, so tests that seed a settings_error fixture
+	 * don't leak it into adjacent tests — the suite's `tear_down_state()`
+	 * doesn't reset this global, and `add_settings_error()` does not require
+	 * `register_setting()` so it would otherwise persist across tests.
+	 *
+	 * @param callable $callback Callback returning the rendered output.
+	 * @return string Whatever the callback returns.
+	 */
+	private function with_isolated_settings_errors( callable $callback ): string {
+		global $wp_settings_errors;
+
+		$had_prior = isset( $wp_settings_errors );
+		$prior     = $had_prior ? $wp_settings_errors : null;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- isolating settings-error state for the callback.
+		$wp_settings_errors = array();
+
+		try {
+			return (string) $callback();
+		} finally {
+			if ( $had_prior ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restoring snapshot taken above.
+				$wp_settings_errors = $prior;
+			} else {
+				unset( $wp_settings_errors );
+			}
+		}
+	}
 
 	/**
 	 * Authenticate as a non-administrator (subscriber).


### PR DESCRIPTION
## Summary

- **Issue 73** — Center hero CTA button text on Complete step
- **Issue 71** — Unify max-width on Complete step header/subhead/summary
- **Issue 72** — Break handle to new line in "Site appears as" summary for all actor modes
- **Issue 70** — Suppress duplicate top success notice on Bluesky step after OAuth (keep in-card confirmation)

Note: this retires the parenthesized \`As you (%s)\` / \`As your site (%s)\` translated strings in favor of line-broken \`As you\` + \`<code>handle</code>\`. Existing localizations of those forms will become stale.

Fixes #70, fixes #71, fixes #72, fixes #73

## Test plan

- 4 new PHPUnit tests covering line-break markup for all modes, notice suppression (success dropped, error preserved)
- All 231 tests pass, PHPCS/ESLint/Prettier clean