### PR TITLE
fix: settings page restructure — General section, unified save, auto-publish toggle

### DIFF
--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -11,7 +11,7 @@ namespace Automattic\Fosse\Admin;
  * Integrates the bundled ActivityPub plugin into FOSSE's admin UI.
  *
  * Self-registers on 'fosse_register_providers'. Reads and writes AP's stored
- * options directly so both surfaces (FOSSE's Setup page and the native AP
+ * options directly so both surfaces (FOSSE's Settings page and the native AP
  * settings page) stay in sync.
  */
 class AP_Provider implements Connection_Provider {
@@ -21,7 +21,7 @@ class AP_Provider implements Connection_Provider {
 	 *
 	 * @var string[]
 	 */
-	private const ACTOR_MODES = array( 'actor', 'blog', 'actor_blog' );
+	public const ACTOR_MODES = array( 'actor', 'blog', 'actor_blog' );
 
 	/**
 	 * Hook into fosse_register_providers to self-register.
@@ -107,16 +107,18 @@ class AP_Provider implements Connection_Provider {
 	}
 
 	/**
-	 * Render the AP setup section on the FOSSE Setup page.
+	 * Render the AP-specific fields inside the unified Settings form.
+	 *
+	 * Renders only AP-specific rows (site handle, fediverse address
+	 * displays). Cross-protocol fields (post types, actor mode) live in
+	 * the General section rendered by Setup_Page.
 	 *
 	 * @return void
 	 */
 	public function render_setup_section(): void {
-		$actor_mode     = get_option( 'activitypub_actor_mode', 'actor' );
-		$post_types     = get_option( 'activitypub_support_post_types', array( 'post' ) );
-		$all_post_types = get_post_types( array( 'public' => true ), 'objects' );
-		$shows_blog     = $this->mode_includes_blog( $actor_mode );
-		$shows_user     = $this->mode_includes_user( $actor_mode );
+		$actor_mode = get_option( 'activitypub_actor_mode', 'actor' );
+		$shows_blog = $this->mode_includes_blog( $actor_mode );
+		$shows_user = $this->mode_includes_user( $actor_mode );
 		// Defer handle resolution until after mode checks so we don't
 		// construct the user actor in `blog` mode or the blog actor in
 		// `actor` mode — those constructions dispatch
@@ -134,146 +136,47 @@ class AP_Provider implements Connection_Provider {
 		if ( '' === $blog_identifier && class_exists( '\Activitypub\Model\Blog' ) ) {
 			$blog_identifier_placeholder = (string) \Activitypub\Model\Blog::get_default_username();
 		}
-		$nonce = wp_create_nonce( 'fosse_save_ap_settings' );
 		?>
 		<div class="fosse-provider-section" id="fosse-provider-activitypub">
 			<h2><?php esc_html_e( 'ActivityPub', 'fosse' ); ?></h2>
 
-			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-				<input type="hidden" name="action" value="fosse_save_ap_settings" />
-				<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $nonce ); ?>" />
-
-				<table class="form-table">
+			<table class="form-table">
+				<?php if ( $shows_blog ) : ?>
 					<tr>
-						<th scope="row"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></th>
+						<th scope="row">
+							<label for="fosse-activitypub-blog-identifier"><?php esc_html_e( 'Site Handle', 'fosse' ); ?></label>
+						</th>
 						<td>
-							<fieldset>
-								<legend class="screen-reader-text"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></legend>
-								<label>
-									<input
-										type="radio"
-										id="fosse-activitypub-actor-mode-actor"
-										name="activitypub_actor_mode"
-										value="actor"
-										aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"
-										<?php checked( 'actor', $actor_mode ); ?>
-									/>
-									<?php esc_html_e( 'Author profiles', 'fosse' ); ?>
-								</label>
-								<p id="fosse-activitypub-actor-mode-actor-desc" class="description">
-									<?php esc_html_e( 'Each WordPress author publishes from their own fediverse profile. People follow individual authors, and posts appear under each author\'s name.', 'fosse' ); ?>
-								</p>
-								<label>
-									<input
-										type="radio"
-										id="fosse-activitypub-actor-mode-blog"
-										name="activitypub_actor_mode"
-										value="blog"
-										aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"
-										<?php checked( 'blog', $actor_mode ); ?>
-									/>
-									<?php esc_html_e( 'Blog profile', 'fosse' ); ?>
-								</label>
-								<p id="fosse-activitypub-actor-mode-blog-desc" class="description">
-									<?php esc_html_e( 'One site-wide profile publishes every post, regardless of author. Use this when people should follow the site as one account.', 'fosse' ); ?>
-								</p>
-								<label>
-									<input
-										type="radio"
-										id="fosse-activitypub-actor-mode-actor-blog"
-										name="activitypub_actor_mode"
-										value="actor_blog"
-										aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"
-										<?php checked( 'actor_blog', $actor_mode ); ?>
-									/>
-									<?php esc_html_e( 'Both', 'fosse' ); ?>
-								</label>
-								<p id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
-									<?php esc_html_e( 'Authors keep individual profiles, and the site also has its own blog profile. People can follow either.', 'fosse' ); ?>
-								</p>
-								<div class="fosse-activitypub-actor-mode-note">
-									<p id="fosse-activitypub-actor-mode-note" class="description">
-										<?php esc_html_e( 'Changing modes does not move followers between profiles. Future posts publish from the profiles enabled by the selected mode.', 'fosse' ); ?>
-									</p>
-									<p class="description">
-										<?php
-										echo wp_kses(
-											sprintf(
-												/* translators: %s: anchor link reading "Blog profile settings" pointing to the ActivityPub blog profile tab. */
-												__( 'Configure the site-wide blog profile name, image, and description in %s.', 'fosse' ),
-												'<a href="' . esc_url( admin_url( 'options-general.php?page=activitypub&tab=blog-profile' ) ) . '">' . esc_html__( 'Blog profile settings', 'fosse' ) . '</a>'
-											),
-											array(
-												'a' => array(
-													'href' => array(),
-												),
-											)
-										);
-										?>
-									</p>
-								</div>
-							</fieldset>
+							<input
+								type="text"
+								id="fosse-activitypub-blog-identifier"
+								name="activitypub_blog_identifier"
+								class="regular-text"
+								value="<?php echo esc_attr( $blog_identifier ); ?>"
+								placeholder="<?php echo esc_attr( $blog_identifier_placeholder ); ?>"
+								aria-describedby="fosse-activitypub-blog-identifier-desc"
+							/>
+							<p id="fosse-activitypub-blog-identifier-desc" class="description">
+								<?php esc_html_e( 'The username people use to follow your site from the fediverse. Cannot match an existing author login or nicename.', 'fosse' ); ?>
+							</p>
 						</td>
 					</tr>
+				<?php endif; ?>
 
+				<?php if ( $shows_user && $user_address ) : ?>
 					<tr>
-						<th scope="row"><?php esc_html_e( 'Post Types', 'fosse' ); ?></th>
-						<td>
-							<fieldset>
-								<?php foreach ( $all_post_types as $pt ) : ?>
-									<label>
-										<input
-											type="checkbox"
-											name="activitypub_support_post_types[]"
-											value="<?php echo esc_attr( $pt->name ); ?>"
-											<?php checked( in_array( $pt->name, $post_types, true ) ); ?>
-										/>
-										<?php echo esc_html( $pt->label ); ?>
-									</label><br />
-								<?php endforeach; ?>
-							</fieldset>
-						</td>
+						<th scope="row"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></th>
+						<td><code><?php echo esc_html( '@' . $user_address ); ?></code></td>
 					</tr>
+				<?php endif; ?>
 
-					<?php if ( $shows_blog ) : ?>
-						<tr>
-							<th scope="row">
-								<label for="fosse-activitypub-blog-identifier"><?php esc_html_e( 'Site Handle', 'fosse' ); ?></label>
-							</th>
-							<td>
-								<input
-									type="text"
-									id="fosse-activitypub-blog-identifier"
-									name="activitypub_blog_identifier"
-									class="regular-text"
-									value="<?php echo esc_attr( $blog_identifier ); ?>"
-									placeholder="<?php echo esc_attr( $blog_identifier_placeholder ); ?>"
-									aria-describedby="fosse-activitypub-blog-identifier-desc"
-								/>
-								<p id="fosse-activitypub-blog-identifier-desc" class="description">
-									<?php esc_html_e( 'The username people use to follow your site from the fediverse. Cannot match an existing author login or nicename.', 'fosse' ); ?>
-								</p>
-							</td>
-						</tr>
-					<?php endif; ?>
-
-					<?php if ( $shows_user && $user_address ) : ?>
-						<tr>
-							<th scope="row"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></th>
-							<td><code><?php echo esc_html( '@' . $user_address ); ?></code></td>
-						</tr>
-					<?php endif; ?>
-
-					<?php if ( $shows_blog && $blog_address ) : ?>
-						<tr>
-							<th scope="row"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></th>
-							<td><code><?php echo esc_html( '@' . $blog_address ); ?></code></td>
-						</tr>
-					<?php endif; ?>
-				</table>
-
-				<?php submit_button( __( 'Save ActivityPub Settings', 'fosse' ) ); ?>
-			</form>
+				<?php if ( $shows_blog && $blog_address ) : ?>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></th>
+						<td><code><?php echo esc_html( '@' . $blog_address ); ?></code></td>
+					</tr>
+				<?php endif; ?>
+			</table>
 
 			<p>
 				<a href="<?php echo esc_url( admin_url( 'options-general.php?page=activitypub' ) ); ?>">
@@ -282,6 +185,19 @@ class AP_Provider implements Connection_Provider {
 			</p>
 		</div>
 		<?php
+	}
+
+	/**
+	 * ActivityPub has no connect/disconnect flow.
+	 *
+	 * AP is always "connected" while the plugin is loaded, so there are
+	 * no out-of-band actions to render. Implemented as a no-op to satisfy
+	 * the {@see Connection_Provider} contract.
+	 *
+	 * @return void
+	 */
+	public function render_connection_actions(): void {
+		// Intentionally empty — AP has no out-of-band connect/disconnect step.
 	}
 
 	/**
@@ -347,12 +263,6 @@ class AP_Provider implements Connection_Provider {
 					<?php $this->render_follower_count_row(); ?>
 				</tbody>
 			</table>
-
-			<p class="fosse-status-card__manage">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-provider-activitypub' ) ); ?>">
-					<?php esc_html_e( 'Manage ActivityPub settings', 'fosse' ); ?>
-				</a>
-			</p>
 		</div>
 		<?php
 	}
@@ -360,36 +270,39 @@ class AP_Provider implements Connection_Provider {
 	/**
 	 * Register hooks for this provider.
 	 *
+	 * Settings save is centralized in {@see Setup_Page::handle_save()};
+	 * AP only registers protocol-specific hooks here.
+	 *
 	 * @return void
 	 */
 	public function register_hooks(): void {
-		add_action( 'admin_post_fosse_save_ap_settings', array( $this, 'handle_save' ) );
 		add_filter( 'activitypub_default_blog_username', array( static::class, 'filter_default_blog_username' ) );
 	}
 
 	/**
-	 * Handle the AP settings form submission.
+	 * Persist AP-side settings from the unified save submission.
 	 *
-	 * @return void
+	 * Validates actor mode, post types, and the optional site handle. The
+	 * post-types option is also consumed by Atmosphere via the FOSSE
+	 * post-type projector, so a single write here covers both networks.
+	 *
+	 * @param array<string, mixed> $post_data POST payload to read.
+	 * @return bool False when the site handle was rejected, otherwise true.
 	 */
-	public function handle_save(): void {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html__( 'You do not have permission to do this.', 'fosse' ) );
-		}
-
-		check_admin_referer( 'fosse_save_ap_settings' );
+	public function save_settings( array $post_data ): bool {
+		$ok = true;
 
 		// Sanitize actor mode against allowlist.
-		$mode       = sanitize_text_field( wp_unslash( $_POST['activitypub_actor_mode'] ?? '' ) );
-		$mode_valid = in_array( $mode, self::ACTOR_MODES, true );
-		if ( $mode_valid ) {
+		$mode = isset( $post_data['activitypub_actor_mode'] ) ? sanitize_text_field( wp_unslash( $post_data['activitypub_actor_mode'] ) ) : '';
+		if ( in_array( $mode, self::ACTOR_MODES, true ) ) {
 			update_option( 'activitypub_actor_mode', $mode );
 		} else {
 			add_settings_error( 'fosse', 'fosse_invalid_mode', __( 'Invalid actor mode. Setting was not changed.', 'fosse' ), 'error' );
+			$ok = false;
 		}
 
 		// Sanitize post types against registered public types.
-		$submitted   = array_map( 'sanitize_text_field', wp_unslash( (array) ( $_POST['activitypub_support_post_types'] ?? array() ) ) );
+		$submitted   = array_map( 'sanitize_text_field', wp_unslash( (array) ( $post_data['activitypub_support_post_types'] ?? array() ) ) );
 		$valid_types = get_post_types( array( 'public' => true ) );
 		$post_types  = array_values( array_intersect( $submitted, $valid_types ) );
 		update_option( 'activitypub_support_post_types', $post_types );
@@ -401,15 +314,14 @@ class AP_Provider implements Connection_Provider {
 		// `update_option` via AP's `sanitize_option_activitypub_blog_identifier`
 		// filter — calling `\Activitypub\Sanitize::blog_identifier` directly
 		// here would double-fire it and double-emit any collision notice.
-		$blog_identifier_rejected = false;
-		if ( array_key_exists( 'activitypub_blog_identifier', $_POST ) ) {
+		if ( array_key_exists( 'activitypub_blog_identifier', $post_data ) ) {
 			// Coerce to string defensively: a malformed POST that submits the
 			// field as an array would otherwise warn under sanitize_text_field
 			// (and trip phpunit's failOnWarning). is_string() guards the raw
 			// value before unslash and sanitize, satisfying both the PHPCS
 			// sanitization sniff and the runtime warning path.
-			$raw_input = is_string( $_POST['activitypub_blog_identifier'] )
-				? sanitize_text_field( wp_unslash( $_POST['activitypub_blog_identifier'] ) )
+			$raw_input = is_string( $post_data['activitypub_blog_identifier'] )
+				? sanitize_text_field( wp_unslash( $post_data['activitypub_blog_identifier'] ) )
 				: '';
 			$raw       = trim( $raw_input );
 			if ( '' !== $raw ) {
@@ -426,14 +338,14 @@ class AP_Provider implements Connection_Provider {
 
 				// AP's sanitizer raises settings errors under its own group
 				// when the input collides with an existing user_login /
-				// user_nicename. The FOSSE Setup page renders
+				// user_nicename. The FOSSE Settings page renders
 				// `settings_errors( 'fosse' )` only, so without this re-tag
 				// the user would see a generic "saved" success notice while
 				// their requested handle silently fell back to the default.
 				$ap_errors_after = get_settings_errors( 'activitypub_blog_identifier' );
 				$new_ap_errors   = array_slice( $ap_errors_after, $ap_error_count_before );
 				foreach ( $new_ap_errors as $ap_error ) {
-					$blog_identifier_rejected = true;
+					$ok = false;
 					add_settings_error(
 						'fosse',
 						$ap_error['code'],
@@ -444,18 +356,7 @@ class AP_Provider implements Connection_Provider {
 			}
 		}
 
-		// Redirect back with appropriate notice. Suppress the blanket
-		// "settings saved" success when the Site Handle update was rejected
-		// — pairing it with an error notice in the same response confuses
-		// the user about what actually saved. The mode + post type updates
-		// still landed; the surfaced AP error explains what didn't.
-		if ( $mode_valid && ! $blog_identifier_rejected ) {
-			add_settings_error( 'fosse', 'fosse_saved', __( 'ActivityPub settings saved.', 'fosse' ), 'success' );
-		}
-		set_transient( 'settings_errors', get_settings_errors(), 30 );
-
-		wp_safe_redirect( admin_url( 'admin.php?page=fosse&settings-updated=true' ) );
-		exit;
+		return $ok;
 	}
 
 	/**

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -282,11 +282,12 @@ class AP_Provider implements Connection_Provider {
 	/**
 	 * Persist AP-side settings from the unified save submission.
 	 *
-	 * Validates actor mode, post types, and the optional site handle. The
-	 * post-types option is also consumed by Atmosphere via the FOSSE
-	 * post-type projector, so a single write here covers both networks.
+	 * Validates actor mode and the optional site handle. The post-types
+	 * option is owned by {@see Setup_Page::handle_save()} since FOSSE
+	 * treats it as a cross-protocol General setting; this method only
+	 * touches AP-specific options.
 	 *
-	 * @param array<string, mixed> $post_data POST payload to read.
+	 * @param array<string, mixed> $post_data Raw, slashed POST payload.
 	 * @return bool False when the site handle was rejected, otherwise true.
 	 */
 	public function save_settings( array $post_data ): bool {
@@ -300,12 +301,6 @@ class AP_Provider implements Connection_Provider {
 			add_settings_error( 'fosse', 'fosse_invalid_mode', __( 'Invalid actor mode. Setting was not changed.', 'fosse' ), 'error' );
 			$ok = false;
 		}
-
-		// Sanitize post types against registered public types.
-		$submitted   = array_map( 'sanitize_text_field', wp_unslash( (array) ( $post_data['activitypub_support_post_types'] ?? array() ) ) );
-		$valid_types = get_post_types( array( 'public' => true ) );
-		$post_types  = array_values( array_intersect( $submitted, $valid_types ) );
-		update_option( 'activitypub_support_post_types', $post_types );
 
 		// Site Handle: only persist when the field was submitted with a non-
 		// empty value. Empty submissions preserve any existing stored value

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -333,7 +333,7 @@ class Bluesky_Provider implements Connection_Provider {
 							<?php if ( $status['token_error'] ) : ?>
 								<strong><?php esc_html_e( 'Reconnect required.', 'fosse' ); ?></strong>
 								<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-provider-bluesky' ) ); ?>">
-									<?php esc_html_e( 'Open Bluesky setup', 'fosse' ); ?>
+									<?php esc_html_e( 'Open Bluesky settings', 'fosse' ); ?>
 								</a>
 								<details class="fosse-status-card__error">
 									<summary><?php esc_html_e( 'Error details', 'fosse' ); ?></summary>
@@ -379,11 +379,20 @@ class Bluesky_Provider implements Connection_Provider {
 	 * `'0'` to match Atmosphere's own setting registration, where an unset
 	 * checkbox simply omits the field and reads as "disabled".
 	 *
+	 * Bails when disconnected so a Settings save can't silently flip
+	 * `atmosphere_auto_publish` to `'0'`: the toggle isn't rendered in that
+	 * state, so the omitted checkbox would otherwise be misread as an
+	 * intentional "uncheck".
+	 *
 	 * @param array<string, mixed> $post_data POST payload to read.
 	 * @return bool Always true — auto-publish input cannot be "rejected"; an
 	 *              omitted checkbox is the legitimate "disabled" submission.
 	 */
 	public function save_settings( array $post_data ): bool {
+		if ( ! $this->get_status()['connected'] ) {
+			return true;
+		}
+
 		$auto_publish = ! empty( $post_data['atmosphere_auto_publish'] ) ? '1' : '0';
 		update_option( 'atmosphere_auto_publish', $auto_publish );
 

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -126,16 +126,71 @@ class Bluesky_Provider implements Connection_Provider {
 	}
 
 	/**
-	 * Render the Bluesky setup section on the FOSSE Setup page.
+	 * Render Bluesky-specific settings inside the unified Settings form.
+	 *
+	 * Only renders the auto-publish toggle when Atmosphere is connected —
+	 * there is nothing protocol-specific to save while disconnected. The
+	 * connect/disconnect forms render outside the main Settings form via
+	 * {@see self::render_connection_actions()}.
 	 *
 	 * @return void
 	 */
 	public function render_setup_section(): void {
 		$status = $this->get_status();
 
+		if ( ! $status['connected'] ) {
+			return;
+		}
+
+		?>
+		<div class="fosse-provider-section" id="fosse-provider-bluesky-settings">
+			<h2><?php esc_html_e( 'Bluesky', 'fosse' ); ?></h2>
+
+			<table class="form-table">
+				<tr>
+					<th scope="row">
+						<?php esc_html_e( 'Auto-publish', 'fosse' ); ?>
+					</th>
+					<td>
+						<fieldset>
+							<legend class="screen-reader-text"><?php esc_html_e( 'Auto-publish', 'fosse' ); ?></legend>
+							<label for="fosse-bluesky-auto-publish">
+								<input
+									type="checkbox"
+									id="fosse-bluesky-auto-publish"
+									name="atmosphere_auto_publish"
+									value="1"
+									aria-describedby="fosse-bluesky-auto-publish-desc"
+									<?php checked( $status['auto_publish'] ); ?>
+								/>
+								<?php esc_html_e( 'Automatically publish new posts to Bluesky.', 'fosse' ); ?>
+							</label>
+							<p id="fosse-bluesky-auto-publish-desc" class="description">
+								<?php esc_html_e( 'When enabled, posts in your selected post types are sent to Bluesky as soon as they are published. Disable to keep Bluesky publishing manual.', 'fosse' ); ?>
+							</p>
+						</fieldset>
+					</td>
+				</tr>
+			</table>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the Bluesky connection panel outside the unified Settings form.
+	 *
+	 * The connect and disconnect actions post to their own admin-post
+	 * endpoints with their own nonces, so they cannot share the unified
+	 * Settings form. This is also where Atmosphere's settings errors
+	 * surface (OAuth failures, sync warnings).
+	 *
+	 * @return void
+	 */
+	public function render_connection_actions(): void {
+		$status = $this->get_status();
 		?>
 		<div class="fosse-provider-section" id="fosse-provider-bluesky">
-			<h2><?php esc_html_e( 'Bluesky', 'fosse' ); ?></h2>
+			<h2><?php esc_html_e( 'Bluesky connection', 'fosse' ); ?></h2>
 
 			<?php settings_errors( 'atmosphere' ); ?>
 
@@ -193,10 +248,6 @@ class Bluesky_Provider implements Connection_Provider {
 						<td><code><?php echo esc_html( $status['pds_endpoint'] ); ?></code></td>
 					</tr>
 					<tr>
-						<th scope="row"><?php esc_html_e( 'Auto Publish', 'fosse' ); ?></th>
-						<td><?php echo esc_html( $status['auto_publish'] ? __( 'Enabled', 'fosse' ) : __( 'Disabled', 'fosse' ) ); ?></td>
-					</tr>
-					<tr>
 						<th scope="row"><?php esc_html_e( 'Token Health', 'fosse' ); ?></th>
 						<td><?php echo esc_html( $status['token_error'] ? $status['token_error'] : __( 'OK', 'fosse' ) ); ?></td>
 					</tr>
@@ -208,7 +259,6 @@ class Bluesky_Provider implements Connection_Provider {
 					<?php submit_button( __( 'Disconnect Bluesky', 'fosse' ), 'secondary' ); ?>
 				</form>
 			<?php endif; ?>
-
 		</div>
 		<?php
 	}
@@ -296,12 +346,6 @@ class Bluesky_Provider implements Connection_Provider {
 					</tr>
 				</tbody>
 			</table>
-
-			<p class="fosse-status-card__manage">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-provider-bluesky' ) ); ?>">
-					<?php esc_html_e( 'Manage Bluesky settings', 'fosse' ); ?>
-				</a>
-			</p>
 		</div>
 		<?php
 	}
@@ -324,6 +368,26 @@ class Bluesky_Provider implements Connection_Provider {
 		// the auth server fetches client metadata in a separate public request
 		// and validates redirect_uri against it.
 		add_filter( 'atmosphere_oauth_redirect_uri', array( $this, 'filter_oauth_redirect_uri' ) );
+	}
+
+	/**
+	 * Persist Bluesky-side settings from the unified save submission.
+	 *
+	 * The auto-publish field is the only Bluesky-side setting that surfaces
+	 * on the FOSSE Settings page; connection state is managed via the
+	 * separate connect/disconnect flows. The toggle is stored as `'1'` /
+	 * `'0'` to match Atmosphere's own setting registration, where an unset
+	 * checkbox simply omits the field and reads as "disabled".
+	 *
+	 * @param array<string, mixed> $post_data POST payload to read.
+	 * @return bool Always true — auto-publish input cannot be "rejected"; an
+	 *              omitted checkbox is the legitimate "disabled" submission.
+	 */
+	public function save_settings( array $post_data ): bool {
+		$auto_publish = ! empty( $post_data['atmosphere_auto_publish'] ) ? '1' : '0';
+		update_option( 'atmosphere_auto_publish', $auto_publish );
+
+		return true;
 	}
 
 	/**

--- a/src/Admin/class-menu.php
+++ b/src/Admin/class-menu.php
@@ -26,6 +26,8 @@ class Menu {
 		add_action( 'admin_bar_menu', array( static::class, 'hide_bundled_admin_bar' ), 101 );
 		add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_styles' ) );
 		add_action( 'admin_init', array( static::class, 'maybe_redirect_to_wizard' ) );
+
+		Setup_Page::register_hooks();
 		// Suppress at two stages so plugins can't bypass us by registering
 		// notices in hooks that fire between current_screen and the notice
 		// hooks themselves. current_screen strips the typical case where
@@ -58,8 +60,8 @@ class Menu {
 
 		add_submenu_page(
 			'fosse',
-			__( 'Setup', 'fosse' ),
-			__( 'Setup', 'fosse' ),
+			__( 'Settings', 'fosse' ),
+			__( 'Settings', 'fosse' ),
 			'manage_options',
 			'fosse',
 			array( Setup_Page::class, 'render' )
@@ -226,9 +228,9 @@ class Menu {
 	}
 
 	/**
-	 * Suppress foreign admin notices on FOSSE Setup and Wizard screens.
+	 * Suppress foreign admin notices on FOSSE Settings and Wizard screens.
 	 *
-	 * The wizard and Setup page are focused flows; third-party notices
+	 * The wizard and Settings page are focused flows; third-party notices
 	 * (host banners, plugin upsells, "rate this plugin" prompts) inject
 	 * themselves into the wizard surface and break the orientation.
 	 * Strip the four core notice hooks on those screens only — the Status
@@ -278,7 +280,7 @@ class Menu {
 	}
 
 	/**
-	 * Whether the given screen is the FOSSE Setup page or Setup Wizard.
+	 * Whether the given screen is the FOSSE Settings page or Setup Wizard.
 	 *
 	 * Centralized so the suppression list and any future callers (e.g.
 	 * conditional asset enqueues) stay in sync. Status is excluded by

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -965,7 +965,7 @@ class Onboarding_Wizard {
 
 		$description = $is_connected
 			? __( 'Your posts will also appear on Bluesky. Review the details below before finishing setup.', 'fosse' )
-			: __( 'Link your Bluesky account so your posts also appear on Bluesky. This step is optional. You can always connect later from the FOSSE Setup page.', 'fosse' );
+			: __( 'Link your Bluesky account so your posts also appear on Bluesky. This step is optional. You can always connect later from the FOSSE Settings page.', 'fosse' );
 		?>
 		<h1 class="fosse-wizard__title"><?php echo esc_html( $title ); ?></h1>
 		<p class="fosse-wizard__description">
@@ -979,7 +979,7 @@ class Onboarding_Wizard {
 				<div class="notice notice-info inline fosse-wizard__notice">
 					<p>
 						<strong><?php esc_html_e( 'Bluesky setup is unavailable.', 'fosse' ); ?></strong>
-						<?php esc_html_e( 'Skip this step for now and connect from the FOSSE Setup page once Bluesky support is available.', 'fosse' ); ?>
+						<?php esc_html_e( 'Skip this step for now and connect from the FOSSE Settings page once Bluesky support is available.', 'fosse' ); ?>
 					</p>
 				</div>
 			<?php elseif ( $is_connected ) : ?>
@@ -1168,7 +1168,7 @@ class Onboarding_Wizard {
 			</table>
 
 			<div class="fosse-wizard__hint">
-				<p><?php esc_html_e( 'You can change any of these settings from the FOSSE Setup page at any time.', 'fosse' ); ?></p>
+				<p><?php esc_html_e( 'You can change any of these settings from the FOSSE Settings page at any time.', 'fosse' ); ?></p>
 			</div>
 		</div>
 
@@ -1190,7 +1190,7 @@ class Onboarding_Wizard {
 				<?php esc_html_e( 'View Status Dashboard', 'fosse' ); ?>
 			</a>
 			<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse' ) ); ?>" class="button">
-				<?php esc_html_e( 'Go to Setup', 'fosse' ); ?>
+				<?php esc_html_e( 'Go to Settings', 'fosse' ); ?>
 			</a>
 		</div>
 

--- a/src/Admin/class-setup-page.php
+++ b/src/Admin/class-setup-page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * FOSSE Setup page.
+ * FOSSE Settings page.
  *
  * @package Automattic\Fosse
  */
@@ -8,12 +8,37 @@
 namespace Automattic\Fosse\Admin;
 
 /**
- * Renders the FOSSE Setup page by iterating registered providers.
+ * Renders the FOSSE Settings page and handles the unified save.
+ *
+ * Owns the General (cross-protocol) section directly and delegates
+ * protocol-specific fields to each provider's `render_setup_section()`.
+ * A single submit button posts to {@see self::handle_save()}, which
+ * applies the General writes and then asks each provider to persist
+ * its own protocol-specific settings.
  */
 class Setup_Page {
 
 	/**
-	 * Render the Setup page.
+	 * Admin-post action and nonce action for the unified save.
+	 *
+	 * @var string
+	 */
+	public const SAVE_ACTION = 'fosse_save_settings';
+
+	/**
+	 * Register the unified save handler.
+	 *
+	 * Called by {@see Menu::register()} on every admin request so the
+	 * `admin_post_*` hook is wired before the form submission lands.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks(): void {
+		add_action( 'admin_post_' . self::SAVE_ACTION, array( static::class, 'handle_save' ) );
+	}
+
+	/**
+	 * Render the Settings page.
 	 *
 	 * @return void
 	 */
@@ -22,9 +47,62 @@ class Setup_Page {
 			return;
 		}
 
-		$providers         = Connection_Provider_Registry::get_providers(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in template.
-		$wizard_incomplete = ! Onboarding_Wizard::is_complete(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in template.
+		// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- consumed by templates/setup-page.php.
+		$providers         = Connection_Provider_Registry::get_providers();
+		$wizard_incomplete = ! Onboarding_Wizard::is_complete();
+		$ap_provider       = $providers['activitypub'] ?? null;
+		$ap_available      = $ap_provider instanceof Connection_Provider && $ap_provider->is_available();
+		$post_types        = (array) get_option( 'activitypub_support_post_types', array( 'post' ) );
+		$actor_mode        = $ap_available ? (string) get_option( 'activitypub_actor_mode', 'actor' ) : 'actor';
+		$all_post_types    = get_post_types( array( 'public' => true ), 'objects' );
+		$save_nonce        = wp_create_nonce( self::SAVE_ACTION );
+		// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
 		include __DIR__ . '/templates/setup-page.php';
+	}
+
+	/**
+	 * Handle the unified Settings save.
+	 *
+	 * Verifies the nonce and capability, then delegates per-protocol
+	 * persistence to each provider via {@see Connection_Provider::save_settings()}.
+	 * Suppresses the blanket success notice when any provider rejected
+	 * its input — providers add their own explanatory error notices in
+	 * that case so the redirected page surfaces what didn't save.
+	 *
+	 * @return void
+	 */
+	public static function handle_save(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'fosse' ) );
+		}
+
+		check_admin_referer( self::SAVE_ACTION );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce verified above via check_admin_referer.
+		$post_data = wp_unslash( $_POST );
+
+		$ok = true;
+
+		foreach ( Connection_Provider_Registry::get_providers() as $provider ) {
+			if ( ! $provider->is_available() ) {
+				continue;
+			}
+			if ( ! $provider->save_settings( $post_data ) ) {
+				$ok = false;
+			}
+		}
+
+		// Pair the success notice with a clean save: if any provider
+		// rejected an input it has already added an explanatory error
+		// notice, and a green "saved" banner would mislead the user about
+		// what actually persisted.
+		if ( $ok ) {
+			add_settings_error( 'fosse', 'fosse_saved', __( 'Settings saved.', 'fosse' ), 'success' );
+		}
+		set_transient( 'settings_errors', get_settings_errors(), 30 );
+
+		wp_safe_redirect( admin_url( 'admin.php?page=fosse&settings-updated=true' ) );
+		exit;
 	}
 }

--- a/src/Admin/class-setup-page.php
+++ b/src/Admin/class-setup-page.php
@@ -132,9 +132,16 @@ class Setup_Page {
 	 * @return void
 	 */
 	private static function save_general_settings( array $post_data ): void {
-		$submitted   = isset( $post_data['activitypub_support_post_types'] )
-			? array_map( 'sanitize_text_field', wp_unslash( (array) $post_data['activitypub_support_post_types'] ) )
+		// Filter to strings before `sanitize_text_field` so a crafted POST
+		// submitting nested arrays for an element can't trip the function's
+		// array-to-string warning (which `phpunit.xml.dist` promotes to a
+		// hard failure via `failOnWarning`, and which would otherwise emit
+		// a notice in production). Mirrors the defensive guard in
+		// {@see AP_Provider::save_settings()} for `activitypub_blog_identifier`.
+		$raw         = isset( $post_data['activitypub_support_post_types'] )
+			? wp_unslash( (array) $post_data['activitypub_support_post_types'] )
 			: array();
+		$submitted   = array_map( 'sanitize_text_field', array_filter( $raw, 'is_string' ) );
 		$valid_types = get_post_types( array( 'public' => true ) );
 		$post_types  = array_values( array_intersect( $submitted, $valid_types ) );
 		update_option( 'activitypub_support_post_types', $post_types );

--- a/src/Admin/class-setup-page.php
+++ b/src/Admin/class-setup-page.php
@@ -117,12 +117,16 @@ class Setup_Page {
 	/**
 	 * Persist the General (cross-protocol) options.
 	 *
-	 * Currently just `activitypub_support_post_types`, which AP reads
-	 * directly and Atmosphere consumes via FOSSE's post-type projector
-	 * (see {@see \Automattic\Fosse\Post_Types}). Owned by Setup_Page
-	 * rather than a provider so the write happens regardless of which
-	 * federation backends are loaded — keeping the Settings UI honest
-	 * even on installs where one or both providers are unavailable.
+	 * Currently just `activitypub_support_post_types`. ActivityPub reads
+	 * the option directly. When AP is loaded, FOSSE's post-type projector
+	 * ({@see \Automattic\Fosse\Post_Types}) mirrors the same value into
+	 * Atmosphere's `atmosphere_syncable_post_types` filter, so a single
+	 * write covers both networks. The projector is gated on AP being
+	 * loaded — on a (hypothetical, since AP is bundled) Bluesky-only
+	 * install Atmosphere falls back to its own
+	 * `atmosphere_support_post_types` option and this write is dead
+	 * weight. Owned by Setup_Page rather than a provider so the call
+	 * happens regardless of which federation backends are registered.
 	 *
 	 * @param array<string, mixed> $post_data Raw, slashed POST payload.
 	 * @return void

--- a/src/Admin/class-setup-page.php
+++ b/src/Admin/class-setup-page.php
@@ -13,8 +13,9 @@ namespace Automattic\Fosse\Admin;
  * Owns the General (cross-protocol) section directly and delegates
  * protocol-specific fields to each provider's `render_setup_section()`.
  * A single submit button posts to {@see self::handle_save()}, which
- * applies the General writes and then asks each provider to persist
- * its own protocol-specific settings.
+ * persists the General options itself (`activitypub_support_post_types`)
+ * and then asks each available provider to persist its own
+ * protocol-specific settings via {@see Connection_Provider::save_settings()}.
  */
 class Setup_Page {
 
@@ -64,11 +65,13 @@ class Setup_Page {
 	/**
 	 * Handle the unified Settings save.
 	 *
-	 * Verifies the nonce and capability, then delegates per-protocol
-	 * persistence to each provider via {@see Connection_Provider::save_settings()}.
-	 * Suppresses the blanket success notice when any provider rejected
-	 * its input — providers add their own explanatory error notices in
-	 * that case so the redirected page surfaces what didn't save.
+	 * Verifies the nonce and capability, persists the General (cross-
+	 * protocol) options directly, then delegates per-protocol persistence
+	 * to each available provider via
+	 * {@see Connection_Provider::save_settings()}. Suppresses the blanket
+	 * success notice when any provider rejected its input — providers add
+	 * their own explanatory error notices in that case so the redirected
+	 * page surfaces what didn't save.
 	 *
 	 * @return void
 	 */
@@ -79,11 +82,16 @@ class Setup_Page {
 
 		check_admin_referer( self::SAVE_ACTION );
 
+		// Pass the still-slashed POST through to providers so each
+		// implementation can `wp_unslash` per field at the same point as
+		// it sanitizes — matching the WordPress convention for handling
+		// raw `$_POST` input.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce verified above via check_admin_referer.
-		$post_data = wp_unslash( $_POST );
+		$post_data = (array) ( $_POST ?? array() );
+
+		self::save_general_settings( $post_data );
 
 		$ok = true;
-
 		foreach ( Connection_Provider_Registry::get_providers() as $provider ) {
 			if ( ! $provider->is_available() ) {
 				continue;
@@ -104,5 +112,27 @@ class Setup_Page {
 
 		wp_safe_redirect( admin_url( 'admin.php?page=fosse&settings-updated=true' ) );
 		exit;
+	}
+
+	/**
+	 * Persist the General (cross-protocol) options.
+	 *
+	 * Currently just `activitypub_support_post_types`, which AP reads
+	 * directly and Atmosphere consumes via FOSSE's post-type projector
+	 * (see {@see \Automattic\Fosse\Post_Types}). Owned by Setup_Page
+	 * rather than a provider so the write happens regardless of which
+	 * federation backends are loaded — keeping the Settings UI honest
+	 * even on installs where one or both providers are unavailable.
+	 *
+	 * @param array<string, mixed> $post_data Raw, slashed POST payload.
+	 * @return void
+	 */
+	private static function save_general_settings( array $post_data ): void {
+		$submitted   = isset( $post_data['activitypub_support_post_types'] )
+			? array_map( 'sanitize_text_field', wp_unslash( (array) $post_data['activitypub_support_post_types'] ) )
+			: array();
+		$valid_types = get_post_types( array( 'public' => true ) );
+		$post_types  = array_values( array_intersect( $submitted, $valid_types ) );
+		update_option( 'activitypub_support_post_types', $post_types );
 	}
 }

--- a/src/Admin/interface-connection-provider.php
+++ b/src/Admin/interface-connection-provider.php
@@ -88,9 +88,9 @@ interface Connection_Provider {
 	 * blanket "settings saved" success notice; the implementation is
 	 * responsible for adding any explanatory `add_settings_error` entries.
 	 *
-	 * @param array<string, mixed> $post_data Sanitized-by-WordPress superglobal copy
-	 *                                        (`wp_unslash`-ready). The handler is
-	 *                                        responsible for further sanitization.
+	 * @param array<string, mixed> $post_data Raw POST payload — still slashed.
+	 *                                        Implementations are responsible for
+	 *                                        `wp_unslash` and per-field sanitization.
 	 * @return bool
 	 */
 	public function save_settings( array $post_data ): bool;

--- a/src/Admin/interface-connection-provider.php
+++ b/src/Admin/interface-connection-provider.php
@@ -11,8 +11,9 @@ namespace Automattic\Fosse\Admin;
  * Contract for federation protocol providers.
  *
  * Each provider represents one federated protocol (ActivityPub, Bluesky, etc.)
- * and is responsible for rendering its own setup section and status card.
- * Providers self-register via the 'fosse_register_providers' action.
+ * and is responsible for rendering its own settings fields, connection actions,
+ * and status card. Providers self-register via the 'fosse_register_providers'
+ * action.
  */
 interface Connection_Provider {
 
@@ -48,11 +49,27 @@ interface Connection_Provider {
 	public function get_status(): array;
 
 	/**
-	 * Render the setup section for this provider on the FOSSE Setup page.
+	 * Render this provider's settings fields inside the unified Settings form.
+	 *
+	 * Implementations render protocol-specific form rows only — no opening
+	 * `<form>` tag, no submit button. The Settings page wraps every
+	 * provider's fields in a single form posting to `fosse_save_settings`.
 	 *
 	 * @return void
 	 */
 	public function render_setup_section(): void;
+
+	/**
+	 * Render this provider's connection actions outside the Settings form.
+	 *
+	 * Connect/disconnect flows post to their own admin-post endpoints with
+	 * their own nonces, so they cannot share the unified Settings form.
+	 * Providers without connection actions (e.g. ActivityPub, which is
+	 * always "connected" when the plugin is loaded) render nothing.
+	 *
+	 * @return void
+	 */
+	public function render_connection_actions(): void;
 
 	/**
 	 * Render the status card for this provider on the FOSSE Status page.
@@ -62,9 +79,29 @@ interface Connection_Provider {
 	public function render_status_card(): void;
 
 	/**
+	 * Persist this provider's settings from a unified save submission.
+	 *
+	 * Called by the Settings page's unified save handler after capability
+	 * and nonce checks have passed. Implementations validate and update
+	 * their own options. Returning `false` signals a hard rejection
+	 * (e.g. an input failed sanitization) so the caller can suppress the
+	 * blanket "settings saved" success notice; the implementation is
+	 * responsible for adding any explanatory `add_settings_error` entries.
+	 *
+	 * @param array<string, mixed> $post_data Sanitized-by-WordPress superglobal copy
+	 *                                        (`wp_unslash`-ready). The handler is
+	 *                                        responsible for further sanitization.
+	 * @return bool
+	 */
+	public function save_settings( array $post_data ): bool;
+
+	/**
 	 * Register any hooks this provider needs (admin_post handlers, filters, etc.).
 	 *
-	 * Called by Menu::register() after the provider is registered and available.
+	 * Called by Provider_Loader::boot() after the provider is registered and
+	 * available. Settings save is centralized in Setup_Page; providers only
+	 * register their own protocol-specific hooks here (OAuth callbacks,
+	 * connect/disconnect handlers, projection filters).
 	 *
 	 * @return void
 	 */

--- a/src/Admin/templates/setup-page.php
+++ b/src/Admin/templates/setup-page.php
@@ -69,7 +69,7 @@ defined( 'ABSPATH' ) || exit;
 									</label><br />
 								<?php endforeach; ?>
 								<p class="description">
-									<?php esc_html_e( 'Post types that federate to ActivityPub and to Bluesky via Atmosphere.', 'fosse' ); ?>
+									<?php esc_html_e( 'Post types that FOSSE federates to your configured providers.', 'fosse' ); ?>
 								</p>
 							</fieldset>
 						</td>

--- a/src/Admin/templates/setup-page.php
+++ b/src/Admin/templates/setup-page.php
@@ -1,19 +1,24 @@
 <?php
 /**
- * Setup page template.
+ * FOSSE Settings page template.
  *
  * @package Automattic\Fosse
  *
  * @var array<string, \Automattic\Fosse\Admin\Connection_Provider> $providers
- * @var bool                                                       $wizard_incomplete Whether the onboarding wizard has not yet been completed.
+ * @var bool                                                       $wizard_incomplete
+ * @var bool                                                       $ap_available
+ * @var array<int, string>                                         $post_types
+ * @var string                                                     $actor_mode
+ * @var array<string, \WP_Post_Type>                               $all_post_types
+ * @var string                                                     $save_nonce
  */
 
 defined( 'ABSPATH' ) || exit;
 
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- $providers and $wizard_incomplete are set by Setup_Page::render().
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- variables set by Setup_Page::render().
 ?>
 <div class="wrap">
-	<h1><?php esc_html_e( 'FOSSE Setup', 'fosse' ); ?></h1>
+	<h1><?php esc_html_e( 'FOSSE Settings', 'fosse' ); ?></h1>
 
 	<?php settings_errors( 'fosse' ); ?>
 
@@ -34,17 +39,137 @@ defined( 'ABSPATH' ) || exit;
 		</div>
 	<?php endif; ?>
 
-	<?php
-	foreach ( $providers as $provider ) {
-		if ( $provider->is_available() ) {
-			$provider->render_setup_section();
-		}
-	}
-	?>
-
 	<?php if ( empty( $providers ) ) : ?>
 		<div class="notice notice-warning">
 			<p><?php esc_html_e( 'No federation providers are available. Ensure ActivityPub and Atmosphere are installed.', 'fosse' ); ?></p>
 		</div>
+	<?php else : ?>
+		<form id="fosse-settings" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<input type="hidden" name="action" value="<?php echo esc_attr( \Automattic\Fosse\Admin\Setup_Page::SAVE_ACTION ); ?>" />
+			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $save_nonce ); ?>" />
+
+			<div class="fosse-provider-section" id="fosse-section-general">
+				<h2><?php esc_html_e( 'General', 'fosse' ); ?></h2>
+
+				<table class="form-table">
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Post Types', 'fosse' ); ?></th>
+						<td>
+							<fieldset>
+								<legend class="screen-reader-text"><?php esc_html_e( 'Post Types', 'fosse' ); ?></legend>
+								<?php foreach ( $all_post_types as $pt ) : ?>
+									<label>
+										<input
+											type="checkbox"
+											name="activitypub_support_post_types[]"
+											value="<?php echo esc_attr( $pt->name ); ?>"
+											<?php checked( in_array( $pt->name, $post_types, true ) ); ?>
+										/>
+										<?php echo esc_html( $pt->label ); ?>
+									</label><br />
+								<?php endforeach; ?>
+								<p class="description">
+									<?php esc_html_e( 'Post types that federate to ActivityPub and to Bluesky via Atmosphere.', 'fosse' ); ?>
+								</p>
+							</fieldset>
+						</td>
+					</tr>
+
+					<?php if ( $ap_available ) : ?>
+						<tr>
+							<th scope="row"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></th>
+							<td>
+								<fieldset>
+									<legend class="screen-reader-text"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></legend>
+									<label>
+										<input
+											type="radio"
+											id="fosse-activitypub-actor-mode-actor"
+											name="activitypub_actor_mode"
+											value="actor"
+											aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"
+											<?php checked( 'actor', $actor_mode ); ?>
+										/>
+										<?php esc_html_e( 'Author profiles', 'fosse' ); ?>
+									</label>
+									<p id="fosse-activitypub-actor-mode-actor-desc" class="description">
+										<?php esc_html_e( 'Each WordPress author publishes from their own fediverse profile. People follow individual authors, and posts appear under each author\'s name.', 'fosse' ); ?>
+									</p>
+									<label>
+										<input
+											type="radio"
+											id="fosse-activitypub-actor-mode-blog"
+											name="activitypub_actor_mode"
+											value="blog"
+											aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"
+											<?php checked( 'blog', $actor_mode ); ?>
+										/>
+										<?php esc_html_e( 'Blog profile', 'fosse' ); ?>
+									</label>
+									<p id="fosse-activitypub-actor-mode-blog-desc" class="description">
+										<?php esc_html_e( 'One site-wide profile publishes every post, regardless of author. Use this when people should follow the site as one account.', 'fosse' ); ?>
+									</p>
+									<label>
+										<input
+											type="radio"
+											id="fosse-activitypub-actor-mode-actor-blog"
+											name="activitypub_actor_mode"
+											value="actor_blog"
+											aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"
+											<?php checked( 'actor_blog', $actor_mode ); ?>
+										/>
+										<?php esc_html_e( 'Both', 'fosse' ); ?>
+									</label>
+									<p id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
+										<?php esc_html_e( 'Authors keep individual profiles, and the site also has its own blog profile. People can follow either.', 'fosse' ); ?>
+									</p>
+									<div class="fosse-activitypub-actor-mode-note">
+										<p id="fosse-activitypub-actor-mode-note" class="description">
+											<?php esc_html_e( 'Changing modes does not move followers between profiles. Future posts publish from the profiles enabled by the selected mode.', 'fosse' ); ?>
+										</p>
+										<p class="description">
+											<?php
+											echo wp_kses(
+												sprintf(
+													/* translators: %s: anchor link reading "Blog profile settings" pointing to the ActivityPub blog profile tab. */
+													__( 'Configure the site-wide blog profile name, image, and description in %s.', 'fosse' ),
+													'<a href="' . esc_url( admin_url( 'options-general.php?page=activitypub&tab=blog-profile' ) ) . '">' . esc_html__( 'Blog profile settings', 'fosse' ) . '</a>'
+												),
+												array(
+													'a' => array(
+														'href' => array(),
+													),
+												)
+											);
+											?>
+										</p>
+									</div>
+								</fieldset>
+							</td>
+						</tr>
+					<?php endif; ?>
+				</table>
+			</div>
+
+			<?php
+			foreach ( $providers as $provider ) {
+				if ( $provider->is_available() ) {
+					$provider->render_setup_section();
+				}
+			}
+			?>
+
+			<?php submit_button( __( 'Save settings', 'fosse' ) ); ?>
+		</form>
+
+		<?php
+		foreach ( $providers as $provider ) {
+			if ( $provider->is_available() ) {
+				$provider->render_connection_actions();
+			}
+		}
+		?>
 	<?php endif; ?>
 </div>
+<?php
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -34,19 +34,23 @@ test.describe( 'Bluesky provider UI', () => {
 
 		await page.goto( '/wp-admin/admin.php?page=fosse' );
 
-		const blueskySection = page
-			.locator( '.fosse-provider-section' )
-			.filter( { hasText: 'Bluesky' } );
+		// The Bluesky connection panel renders below the unified Settings
+		// form; the in-form `#fosse-provider-bluesky-settings` block is
+		// suppressed while disconnected (no auto-publish toggle to save).
+		const blueskyConnection = page.locator( '#fosse-provider-bluesky' );
 
 		await expect(
-			page.getByRole( 'heading', { name: 'Bluesky' } )
+			page.getByRole( 'heading', { name: 'Bluesky connection' } )
 		).toBeVisible();
 		await expect(
-			blueskySection.locator( '#fosse_bluesky_handle' )
+			blueskyConnection.locator( '#fosse_bluesky_handle' )
 		).toBeVisible();
 		await expect(
 			page.getByRole( 'button', { name: 'Connect Bluesky' } )
 		).toBeVisible();
+		await expect(
+			page.locator( '#fosse-provider-bluesky-settings' )
+		).toHaveCount( 0 );
 
 		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
 
@@ -70,16 +74,22 @@ test.describe( 'Bluesky provider UI', () => {
 
 		await page.goto( '/wp-admin/admin.php?page=fosse' );
 
-		const blueskySection = page
-			.locator( '.fosse-provider-section' )
-			.filter( { hasText: 'Bluesky' } );
+		// The connection details (handle, DID, PDS, token health) live in
+		// the connection panel; the auto-publish checkbox lives in the
+		// in-form settings block — separate sections, separate IDs.
+		const blueskyConnection = page.locator( '#fosse-provider-bluesky' );
+		const blueskySettings = page.locator(
+			'#fosse-provider-bluesky-settings'
+		);
 
 		await expect(
 			page.getByRole( 'button', { name: 'Disconnect Bluesky' } )
 		).toBeVisible();
-		await expect( blueskySection ).toContainText( 'alice.bsky.social' );
-		await expect( blueskySection ).toContainText( 'did:plc:alice123' );
-		await expect( blueskySection ).toContainText( 'Disabled' );
+		await expect( blueskyConnection ).toContainText( 'alice.bsky.social' );
+		await expect( blueskyConnection ).toContainText( 'did:plc:alice123' );
+		await expect(
+			blueskySettings.locator( 'input[name="atmosphere_auto_publish"]' )
+		).not.toBeChecked();
 
 		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
 

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -136,9 +136,9 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Setup section carries the fragment target id used by the Status-page
-	 * "Manage ActivityPub settings" deep link. Renaming the id without
-	 * updating the link would silently break navigation.
+	 * Setup section carries the fragment target id used by the wizard CTA
+	 * and any in-page anchor link. Renaming the id without updating those
+	 * call sites would silently break navigation.
 	 */
 	public function test_render_setup_section_has_anchor_id() {
 		ob_start();
@@ -149,146 +149,93 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Status card deep-links back to the ActivityPub setup section. The
-	 * fragment must match the id rendered by render_setup_section().
+	 * AP-specific render_setup_section produces only AP-specific rows —
+	 * no opening `<form>` tag and no submit button. The unified Settings
+	 * form wraps every provider's fields together.
 	 */
-	public function test_render_status_card_has_manage_settings_link() {
-		ob_start();
-		$this->provider->render_status_card();
-		$output = ob_get_clean();
+	public function test_render_setup_section_is_fields_only() {
+		update_option( 'activitypub_actor_mode', 'blog' );
 
-		$this->assertStringContainsString( 'Manage ActivityPub settings', $output );
-		$this->assertStringContainsString( '#fosse-provider-activitypub', $output );
-	}
-
-	/**
-	 * Setup UI explains the available actor modes and links to blog profile settings.
-	 */
-	public function test_render_setup_section_explains_actor_modes() {
 		ob_start();
 		$this->provider->render_setup_section();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'Each WordPress author publishes from their own fediverse profile.', $output );
-		$this->assertStringContainsString( 'One site-wide profile publishes every post, regardless of author.', $output );
-		$this->assertStringContainsString( 'Authors keep individual profiles, and the site also has its own blog profile.', $output );
-		$this->assertStringContainsString( 'Changing modes does not move followers between profiles.', $output );
-		$this->assertStringContainsString( 'Configure the site-wide blog profile name, image, and description', $output );
-		$this->assertStringNotContainsString( '<fieldset aria-describedby="fosse-activitypub-actor-mode-note">', $output );
-		$this->assertStringContainsString( '<legend class="screen-reader-text">Actor Mode</legend>', $output );
-		$this->assertMatchesRegularExpression(
-			'~<input[^>]+id="fosse-activitypub-actor-mode-actor"[^>]+aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"[^>]+/>~',
-			$output
-		);
-		$this->assertMatchesRegularExpression(
-			'~<input[^>]+id="fosse-activitypub-actor-mode-blog"[^>]+aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"[^>]+/>~',
-			$output
-		);
-		$this->assertMatchesRegularExpression(
-			'~<input[^>]+id="fosse-activitypub-actor-mode-actor-blog"[^>]+aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"[^>]+/>~',
-			$output
-		);
-		$this->assertStringContainsString( '<p id="fosse-activitypub-actor-mode-note" class="description">', $output );
-		$this->assertMatchesRegularExpression(
-			'~<a href="[^"]*options-general\.php\?page=activitypub(?:&#038;|&amp;)tab=blog-profile">Blog profile settings</a>~',
-			$output
-		);
+		$this->assertStringNotContainsString( '<form', $output );
+		$this->assertStringNotContainsString( 'name="action"', $output );
+		$this->assertStringNotContainsString( 'Save ActivityPub Settings', $output );
+		$this->assertStringNotContainsString( 'name="activitypub_actor_mode"', $output );
+		$this->assertStringNotContainsString( 'name="activitypub_support_post_types', $output );
 	}
 
 	/**
-	 * Setup UI selects the stored actor mode.
+	 * AP has no out-of-band connect/disconnect step, so its connection
+	 * actions output is empty.
 	 */
-	public function test_render_setup_section_checks_selected_actor_mode() {
-		$modes = array( 'actor', 'blog', 'actor_blog' );
+	public function test_render_connection_actions_is_empty() {
+		ob_start();
+		$this->provider->render_connection_actions();
+		$output = ob_get_clean();
 
-		foreach ( $modes as $selected_mode ) {
-			update_option( 'activitypub_actor_mode', $selected_mode );
-
-			ob_start();
-			$this->provider->render_setup_section();
-			$output = ob_get_clean();
-
-			foreach ( $modes as $mode ) {
-				$input = $this->get_actor_mode_input_markup( $output, $mode );
-
-				if ( $selected_mode === $mode ) {
-					$this->assertStringContainsString( "checked='checked'", $input );
-				} else {
-					$this->assertStringNotContainsString( "checked='checked'", $input );
-				}
-			}
-		}
+		$this->assertSame( '', trim( $output ) );
 	}
 
 	/**
-	 * Get the rendered radio input for an ActivityPub actor mode.
+	 * AP's render_setup_section preserves the Site Handle field in
+	 * `blog` mode and the "Show advanced ActivityPub settings" link.
+	 */
+	public function test_render_setup_section_renders_blog_mode_fields() {
+		update_option( 'activitypub_actor_mode', 'blog' );
+		update_option( 'activitypub_blog_identifier', 'my-site' );
+
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
+		$this->assertStringContainsString( 'value="my-site"', $output );
+		$this->assertStringContainsString( 'Show advanced ActivityPub settings', $output );
+	}
+
+	/**
+	 * Status card exposes the BEM table classes and no longer renders a
+	 * "Manage ActivityPub settings" deep link (issue #74) — the sidebar
+	 * Settings menu entry replaces those per-card links.
+	 */
+	public function test_render_status_card_omits_manage_settings_link() {
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'fosse-status-card__table', $output );
+		$this->assertStringContainsString( 'fosse-status-card__label', $output );
+		$this->assertStringContainsString( 'fosse-status-card__value', $output );
+		$this->assertStringNotContainsString( 'Manage ActivityPub settings', $output );
+		$this->assertStringNotContainsString( 'fosse-status-card__manage', $output );
+	}
+
+	// --- save_settings tests ---------------------------------------------------
+
+	/**
+	 * Stable POST defaults that mirror a clean unified-save submission.
 	 *
-	 * @param string $output Rendered setup section markup.
-	 * @param string $mode   Actor mode value.
-	 * @return string
+	 * @param array<string, mixed> $overrides POST overrides.
+	 * @return array<string, mixed>
 	 */
-	private function get_actor_mode_input_markup( string $output, string $mode ): string {
-		preg_match(
-			'~<input\b(?=[^>]*\bname="activitypub_actor_mode")(?=[^>]*\bvalue="' . preg_quote( $mode, '~' ) . '")[^>]*>~s',
-			$output,
-			$matches
-		);
-
-		$this->assertNotEmpty( $matches, 'Expected actor mode input to be present.' );
-
-		return $matches[0];
-	}
-
-	// --- handle_save tests ---------------------------------------------------
-
-	/**
-	 * Create an admin user and set up a simulated save request.
-	 *
-	 * @param array<string, mixed> $post_data POST data to merge in.
-	 * @return void
-	 */
-	private function simulate_save_request( array $post_data = array() ): void {
-		$user_id = wp_insert_user(
+	private function build_post( array $overrides = array() ): array {
+		return array_merge(
 			array(
-				'user_login' => 'fosse_admin_' . uniqid( '', true ),
-				'user_pass'  => 'test',
-				'role'       => 'administrator',
-			)
-		);
-		wp_set_current_user( $user_id );
-
-		$defaults = array(
-			'action'                         => 'fosse_save_ap_settings',
-			'_wpnonce'                       => wp_create_nonce( 'fosse_save_ap_settings' ),
-			'activitypub_actor_mode'         => 'blog',
-			'activitypub_support_post_types' => array( 'post' ),
-		);
-
-		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup, nonce is in the data.
-		$_POST    = array_merge( $defaults, $post_data );
-		$_REQUEST = $_POST;
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
-
-		// Catch the redirect so exit doesn't kill the test.
-		add_filter(
-			'wp_redirect',
-			static function () {
-				throw new \Exception( 'redirect' );
-			}
+				'activitypub_actor_mode'         => 'blog',
+				'activitypub_support_post_types' => array( 'post' ),
+			),
+			$overrides
 		);
 	}
 
 	/**
 	 * Valid save stores the actor mode option.
 	 */
-	public function test_handle_save_stores_actor_mode() {
-		$this->simulate_save_request( array( 'activitypub_actor_mode' => 'actor_blog' ) );
-
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
+	public function test_save_settings_stores_actor_mode() {
+		$this->assertTrue( $this->provider->save_settings( $this->build_post( array( 'activitypub_actor_mode' => 'actor_blog' ) ) ) );
 
 		$this->assertSame( 'actor_blog', get_option( 'activitypub_actor_mode' ) );
 	}
@@ -296,14 +243,8 @@ class AP_ProviderTest extends BaseTestCase {
 	/**
 	 * Valid save stores the post types option.
 	 */
-	public function test_handle_save_stores_post_types() {
-		$this->simulate_save_request( array( 'activitypub_support_post_types' => array( 'post', 'page' ) ) );
-
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
+	public function test_save_settings_stores_post_types() {
+		$this->provider->save_settings( $this->build_post( array( 'activitypub_support_post_types' => array( 'post', 'page' ) ) ) );
 
 		$this->assertSame( array( 'post', 'page' ), get_option( 'activitypub_support_post_types' ) );
 	}
@@ -311,35 +252,23 @@ class AP_ProviderTest extends BaseTestCase {
 	/**
 	 * Invalid actor mode is rejected — option is not updated.
 	 */
-	public function test_handle_save_rejects_invalid_actor_mode() {
+	public function test_save_settings_rejects_invalid_actor_mode() {
 		update_option( 'activitypub_actor_mode', 'actor' );
-		$this->simulate_save_request( array( 'activitypub_actor_mode' => 'evil_mode' ) );
 
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
+		$ok = $this->provider->save_settings( $this->build_post( array( 'activitypub_actor_mode' => 'evil_mode' ) ) );
 
+		$this->assertFalse( $ok );
 		$this->assertSame( 'actor', get_option( 'activitypub_actor_mode' ) );
 	}
 
 	/**
-	 * Invalid actor mode produces an error notice, not a success notice.
+	 * Invalid actor mode produces an error notice on the FOSSE group.
 	 */
-	public function test_handle_save_error_notice_on_invalid_mode() {
-		$this->simulate_save_request( array( 'activitypub_actor_mode' => 'evil_mode' ) );
+	public function test_save_settings_error_notice_on_invalid_mode() {
+		$this->provider->save_settings( $this->build_post( array( 'activitypub_actor_mode' => 'evil_mode' ) ) );
 
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
-
-		$errors = get_settings_errors( 'fosse' );
-		$codes  = array_column( $errors, 'code' );
+		$codes = array_column( get_settings_errors( 'fosse' ), 'code' );
 		$this->assertContains( 'fosse_invalid_mode', $codes );
-		$this->assertNotContains( 'fosse_saved', $codes );
 	}
 
 	/**
@@ -347,7 +276,7 @@ class AP_ProviderTest extends BaseTestCase {
 	 * change. WordPress fires add_option_<name> on first save and
 	 * update_option_<name> on subsequent value changes; AP hooks both.
 	 */
-	public function test_handle_save_notifies_ap_actor_mode_scheduler() {
+	public function test_save_settings_notifies_ap_actor_mode_scheduler() {
 		$fired = false;
 		$mark  = static function () use ( &$fired ) {
 			$fired = true;
@@ -356,38 +285,22 @@ class AP_ProviderTest extends BaseTestCase {
 		add_action( 'update_option_activitypub_actor_mode', $mark );
 
 		// First save (option does not yet exist) fires add_option_*.
-		$this->simulate_save_request( array( 'activitypub_actor_mode' => 'blog' ) );
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
+		$this->provider->save_settings( $this->build_post( array( 'activitypub_actor_mode' => 'blog' ) ) );
 		$this->assertTrue( $fired, 'add_option_activitypub_actor_mode should fire on first save.' );
 
 		// Second save (value change) fires update_option_*.
 		$fired = false;
-		$this->simulate_save_request( array( 'activitypub_actor_mode' => 'actor_blog' ) );
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
+		$this->provider->save_settings( $this->build_post( array( 'activitypub_actor_mode' => 'actor_blog' ) ) );
 		$this->assertTrue( $fired, 'update_option_activitypub_actor_mode should fire on value change.' );
 	}
 
 	/**
 	 * Invalid post types are filtered out.
 	 */
-	public function test_handle_save_filters_invalid_post_types() {
-		$this->simulate_save_request(
-			array( 'activitypub_support_post_types' => array( 'post', 'nonexistent_type', 'page' ) )
+	public function test_save_settings_filters_invalid_post_types() {
+		$this->provider->save_settings(
+			$this->build_post( array( 'activitypub_support_post_types' => array( 'post', 'nonexistent_type', 'page' ) ) )
 		);
-
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
 
 		$saved = get_option( 'activitypub_support_post_types' );
 		$this->assertContains( 'post', $saved );
@@ -398,14 +311,8 @@ class AP_ProviderTest extends BaseTestCase {
 	/**
 	 * Non-array post types input is safely handled.
 	 */
-	public function test_handle_save_handles_non_array_post_types() {
-		$this->simulate_save_request( array( 'activitypub_support_post_types' => 'not_an_array' ) );
-
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
+	public function test_save_settings_handles_non_array_post_types() {
+		$this->provider->save_settings( $this->build_post( array( 'activitypub_support_post_types' => 'not_an_array' ) ) );
 
 		$this->assertIsArray( get_option( 'activitypub_support_post_types' ) );
 	}
@@ -667,19 +574,15 @@ class AP_ProviderTest extends BaseTestCase {
 	 * Saving a site handle persists it through AP's sanitizer so the same
 	 * value is stored regardless of which surface accepted the input.
 	 */
-	public function test_handle_save_persists_blog_identifier() {
-		$this->simulate_save_request(
-			array(
-				'activitypub_actor_mode'      => 'blog',
-				'activitypub_blog_identifier' => 'my-fosse-site',
+	public function test_save_settings_persists_blog_identifier() {
+		$this->provider->save_settings(
+			$this->build_post(
+				array(
+					'activitypub_actor_mode'      => 'blog',
+					'activitypub_blog_identifier' => 'my-fosse-site',
+				)
 			)
 		);
-
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
 
 		$this->assertSame( 'my-fosse-site', get_option( 'activitypub_blog_identifier' ) );
 	}
@@ -696,26 +599,22 @@ class AP_ProviderTest extends BaseTestCase {
 	 * itself is asserted via the unit-tested
 	 * `filter_default_blog_username` collision tests above.
 	 */
-	public function test_handle_save_blog_identifier_runs_through_ap_sanitizer() {
-		$this->simulate_save_request(
-			array(
-				'activitypub_actor_mode'      => 'blog',
-				'activitypub_blog_identifier' => 'Has Spaces & Caps',
+	public function test_save_settings_blog_identifier_runs_through_ap_sanitizer() {
+		$this->provider->save_settings(
+			$this->build_post(
+				array(
+					'activitypub_actor_mode'      => 'blog',
+					'activitypub_blog_identifier' => 'Has Spaces & Caps',
+				)
 			)
 		);
-
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
 
 		$this->assertSame( 'has-spaces-caps', get_option( 'activitypub_blog_identifier' ) );
 	}
 
 	/**
 	 * AP's sanitizer adds settings errors under `activitypub_blog_identifier`
-	 * when the input collides with an existing user. The FOSSE Setup page
+	 * when the input collides with an existing user. The FOSSE Settings page
 	 * only renders `settings_errors('fosse')`, so we re-tag fresh AP errors
 	 * into our group so users actually see why their handle was rejected.
 	 *
@@ -724,7 +623,7 @@ class AP_ProviderTest extends BaseTestCase {
 	 * search, so seeding a real colliding user wouldn't trigger AP's
 	 * collision path).
 	 */
-	public function test_handle_save_rewires_ap_settings_errors_to_fosse_group() {
+	public function test_save_settings_rewires_ap_settings_errors_to_fosse_group() {
 		add_filter(
 			'sanitize_option_activitypub_blog_identifier',
 			static function ( $value ) {
@@ -739,18 +638,14 @@ class AP_ProviderTest extends BaseTestCase {
 			11 // After AP's own callback.
 		);
 
-		$this->simulate_save_request(
-			array(
-				'activitypub_actor_mode'      => 'blog',
-				'activitypub_blog_identifier' => 'whatever',
+		$this->provider->save_settings(
+			$this->build_post(
+				array(
+					'activitypub_actor_mode'      => 'blog',
+					'activitypub_blog_identifier' => 'whatever',
+				)
 			)
 		);
-
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
 
 		$fosse_codes = array_column( get_settings_errors( 'fosse' ), 'code' );
 		$this->assertContains( 'collision_test', $fosse_codes );
@@ -763,7 +658,7 @@ class AP_ProviderTest extends BaseTestCase {
 	 * code for every rejection, so a code-only snapshot would mask the
 	 * fresh entry.
 	 */
-	public function test_handle_save_captures_fresh_collision_when_code_already_queued() {
+	public function test_save_settings_captures_fresh_collision_when_code_already_queued() {
 		// Pre-seed an unrelated error using AP's constant code.
 		add_settings_error(
 			'activitypub_blog_identifier',
@@ -786,18 +681,14 @@ class AP_ProviderTest extends BaseTestCase {
 			11
 		);
 
-		$this->simulate_save_request(
-			array(
-				'activitypub_actor_mode'      => 'blog',
-				'activitypub_blog_identifier' => 'whatever',
+		$this->provider->save_settings(
+			$this->build_post(
+				array(
+					'activitypub_actor_mode'      => 'blog',
+					'activitypub_blog_identifier' => 'whatever',
+				)
 			)
 		);
-
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
 
 		$fosse_messages = array_column( get_settings_errors( 'fosse' ), 'message' );
 		$this->assertContains( 'Fresh collision rejection.', $fosse_messages );
@@ -805,13 +696,12 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * The success notice is suppressed when AP's sanitizer rejected the
-	 * Site Handle. Pairing a green "settings saved" with a red collision
-	 * error in the same response confuses users about what actually saved.
-	 * Mode and post-type writes still landed; the AP error explains what
-	 * didn't.
+	 * `save_settings()` returns false when AP's sanitizer rejected the
+	 * Site Handle, so the unified Settings handler can suppress the
+	 * blanket "settings saved" success notice. Mode and post-type writes
+	 * still landed; the AP error explains what didn't.
 	 */
-	public function test_handle_save_suppresses_success_notice_on_blog_identifier_rejection() {
+	public function test_save_settings_returns_false_on_blog_identifier_rejection() {
 		add_filter(
 			'sanitize_option_activitypub_blog_identifier',
 			static function ( $value ) {
@@ -826,22 +716,20 @@ class AP_ProviderTest extends BaseTestCase {
 			11
 		);
 
-		$this->simulate_save_request(
-			array(
-				'activitypub_actor_mode'      => 'blog',
-				'activitypub_blog_identifier' => 'whatever',
+		$ok = $this->provider->save_settings(
+			$this->build_post(
+				array(
+					'activitypub_actor_mode'      => 'blog',
+					'activitypub_blog_identifier' => 'whatever',
+				)
 			)
 		);
 
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
-
-		$fosse_codes = array_column( get_settings_errors( 'fosse' ), 'code' );
-		$this->assertNotContains( 'fosse_saved', $fosse_codes );
-		$this->assertContains( 'rejection_test', $fosse_codes );
+		$this->assertFalse( $ok );
+		$this->assertContains(
+			'rejection_test',
+			array_column( get_settings_errors( 'fosse' ), 'code' )
+		);
 	}
 
 	/**
@@ -849,21 +737,17 @@ class AP_ProviderTest extends BaseTestCase {
 	 * rather than tripping `sanitize_text_field`'s array-to-string warning
 	 * (which `phpunit.xml.dist` promotes to a failure via `failOnWarning`).
 	 */
-	public function test_handle_save_array_blog_identifier_is_rejected_safely() {
+	public function test_save_settings_array_blog_identifier_is_rejected_safely() {
 		update_option( 'activitypub_blog_identifier', 'preserved-handle' );
 
-		$this->simulate_save_request(
-			array(
-				'activitypub_actor_mode'      => 'blog',
-				'activitypub_blog_identifier' => array( 'malicious', 'array' ),
+		$this->provider->save_settings(
+			$this->build_post(
+				array(
+					'activitypub_actor_mode'      => 'blog',
+					'activitypub_blog_identifier' => array( 'malicious', 'array' ),
+				)
 			)
 		);
-
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
 
 		$this->assertSame( 'preserved-handle', get_option( 'activitypub_blog_identifier' ) );
 	}
@@ -872,21 +756,17 @@ class AP_ProviderTest extends BaseTestCase {
 	 * An empty submitted handle leaves any prior value intact rather than
 	 * stomping the option with an empty string.
 	 */
-	public function test_handle_save_empty_blog_identifier_does_not_clobber_existing_value() {
+	public function test_save_settings_empty_blog_identifier_does_not_clobber_existing_value() {
 		update_option( 'activitypub_blog_identifier', 'preserved-handle' );
 
-		$this->simulate_save_request(
-			array(
-				'activitypub_actor_mode'      => 'blog',
-				'activitypub_blog_identifier' => '',
+		$this->provider->save_settings(
+			$this->build_post(
+				array(
+					'activitypub_actor_mode'      => 'blog',
+					'activitypub_blog_identifier' => '',
+				)
 			)
 		);
-
-		try {
-			$this->provider->handle_save();
-		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
 
 		$this->assertSame( 'preserved-handle', get_option( 'activitypub_blog_identifier' ) );
 	}

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -241,15 +241,6 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Valid save stores the post types option.
-	 */
-	public function test_save_settings_stores_post_types() {
-		$this->provider->save_settings( $this->build_post( array( 'activitypub_support_post_types' => array( 'post', 'page' ) ) ) );
-
-		$this->assertSame( array( 'post', 'page' ), get_option( 'activitypub_support_post_types' ) );
-	}
-
-	/**
 	 * Invalid actor mode is rejected — option is not updated.
 	 */
 	public function test_save_settings_rejects_invalid_actor_mode() {
@@ -292,29 +283,6 @@ class AP_ProviderTest extends BaseTestCase {
 		$fired = false;
 		$this->provider->save_settings( $this->build_post( array( 'activitypub_actor_mode' => 'actor_blog' ) ) );
 		$this->assertTrue( $fired, 'update_option_activitypub_actor_mode should fire on value change.' );
-	}
-
-	/**
-	 * Invalid post types are filtered out.
-	 */
-	public function test_save_settings_filters_invalid_post_types() {
-		$this->provider->save_settings(
-			$this->build_post( array( 'activitypub_support_post_types' => array( 'post', 'nonexistent_type', 'page' ) ) )
-		);
-
-		$saved = get_option( 'activitypub_support_post_types' );
-		$this->assertContains( 'post', $saved );
-		$this->assertContains( 'page', $saved );
-		$this->assertNotContains( 'nonexistent_type', $saved );
-	}
-
-	/**
-	 * Non-array post types input is safely handled.
-	 */
-	public function test_save_settings_handles_non_array_post_types() {
-		$this->provider->save_settings( $this->build_post( array( 'activitypub_support_post_types' => 'not_an_array' ) ) );
-
-		$this->assertIsArray( get_option( 'activitypub_support_post_types' ) );
 	}
 
 	// --- Default blog username filter ---------------------------------------

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -190,21 +190,26 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Disconnected setup UI renders the connect action.
+	 * The settings section is empty while disconnected — no auto-publish
+	 * toggle, no connect form. Connect/disconnect actions render via
+	 * `render_connection_actions()` outside the unified Settings form.
 	 */
-	public function test_render_setup_section_disconnected_contains_connect_form() {
+	public function test_render_setup_section_disconnected_is_empty() {
 		ob_start();
 		$this->provider->render_setup_section();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'fosse_connect_bluesky', $output );
-		$this->assertStringContainsString( 'bluesky_handle', $output );
+		$this->assertSame( '', trim( $output ) );
+		$this->assertStringNotContainsString( 'fosse_connect_bluesky', $output );
+		$this->assertStringNotContainsString( 'fosse_disconnect_bluesky', $output );
 	}
 
 	/**
-	 * Connected setup UI renders the disconnect action.
+	 * Connected settings section exposes the auto-publish toggle as a
+	 * fields-only fragment (no opening `<form>` tag) so it can sit inside
+	 * the unified Settings form alongside General + AP fields.
 	 */
-	public function test_render_setup_section_connected_contains_disconnect_form() {
+	public function test_render_setup_section_connected_renders_auto_publish_toggle() {
 		update_option(
 			'atmosphere_connection',
 			array(
@@ -219,30 +224,122 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_setup_section();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'fosse_disconnect_bluesky', $output );
-		$this->assertStringContainsString( 'alice.bsky.social', $output );
+		$this->assertStringContainsString( 'name="atmosphere_auto_publish"', $output );
+		$this->assertStringContainsString( 'Auto-publish', $output );
+		$this->assertStringNotContainsString( '<form', $output );
+		$this->assertStringNotContainsString( 'fosse_connect_bluesky', $output );
+		$this->assertStringNotContainsString( 'fosse_disconnect_bluesky', $output );
 	}
 
 	/**
-	 * Setup section carries the fragment target id used by the Status-page
-	 * "Manage Bluesky settings" deep link. Renaming the id without updating
-	 * the link would silently break navigation.
+	 * Auto-publish checkbox reflects the stored option. With Atmosphere's
+	 * default ('1' = enabled), an unset option still renders the box checked.
 	 */
-	public function test_render_setup_section_has_anchor_id() {
+	public function test_render_setup_section_auto_publish_checked_by_default() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+		delete_option( 'atmosphere_auto_publish' );
+
 		ob_start();
 		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		// `checked()` emits `checked='checked'` (single-quoted) on WP < 6.x
+		// and `checked` (bare attribute) on newer cores. Match either.
+		$this->assertMatchesRegularExpression(
+			'~<input[^>]+name="atmosphere_auto_publish"[^>]+(checked(?:=\'checked\'|="checked")?)~',
+			$output
+		);
+	}
+
+	/**
+	 * When auto-publish is explicitly disabled ('0'), the checkbox renders
+	 * unchecked.
+	 */
+	public function test_render_setup_section_auto_publish_unchecked_when_disabled() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+		update_option( 'atmosphere_auto_publish', '0' );
+
+		ob_start();
+		$this->provider->render_setup_section();
+		$output = ob_get_clean();
+
+		$this->assertDoesNotMatchRegularExpression(
+			'~<input[^>]+name="atmosphere_auto_publish"[^>]+(checked(?:=\'checked\'|="checked")?)~',
+			$output
+		);
+	}
+
+	/**
+	 * Connection panel carries the fragment target id (`fosse-provider-bluesky`)
+	 * referenced from the Status page reconnect link. Renaming the id without
+	 * updating that link would silently break navigation.
+	 */
+	public function test_render_connection_actions_has_anchor_id() {
+		ob_start();
+		$this->provider->render_connection_actions();
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'id="fosse-provider-bluesky"', $output );
 	}
 
 	/**
-	 * Disconnected setup UI links out to bsky.app so users without an
-	 * account aren't dead-ended at the connect form.
+	 * Disconnected connection panel renders the connect action.
 	 */
-	public function test_render_setup_section_disconnected_links_to_bluesky_signup() {
+	public function test_render_connection_actions_disconnected_contains_connect_form() {
 		ob_start();
-		$this->provider->render_setup_section();
+		$this->provider->render_connection_actions();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'fosse_connect_bluesky', $output );
+		$this->assertStringContainsString( 'bluesky_handle', $output );
+	}
+
+	/**
+	 * Connected connection panel renders the disconnect action and exposes
+	 * the connection details (handle, DID, PDS, token health).
+	 */
+	public function test_render_connection_actions_connected_contains_disconnect_form() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'fosse_disconnect_bluesky', $output );
+		$this->assertStringContainsString( 'alice.bsky.social', $output );
+	}
+
+	/**
+	 * Disconnected connection panel links out to bsky.app so users without
+	 * an account aren't dead-ended at the connect form.
+	 */
+	public function test_render_connection_actions_disconnected_links_to_bluesky_signup() {
+		ob_start();
+		$this->provider->render_connection_actions();
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'fosse-bluesky-signup', $output );
@@ -251,10 +348,10 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Connected setup UI omits the sign-up affordance — the user already
-	 * has an account, so prompting to create one is noise.
+	 * Connected connection panel omits the sign-up affordance — the user
+	 * already has an account, so prompting to create one is noise.
 	 */
-	public function test_render_setup_section_connected_omits_signup_link() {
+	public function test_render_connection_actions_connected_omits_signup_link() {
 		update_option(
 			'atmosphere_connection',
 			array(
@@ -266,7 +363,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		);
 
 		ob_start();
-		$this->provider->render_setup_section();
+		$this->provider->render_connection_actions();
 		$output = ob_get_clean();
 
 		$this->assertStringNotContainsString( 'fosse-bluesky-signup', $output );
@@ -322,16 +419,17 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Status card deep-links back to the Bluesky setup section. The fragment
-	 * must match the id rendered by render_setup_section().
+	 * Status card no longer carries a "Manage Bluesky settings" deep link
+	 * (issue #74) — the sidebar Settings menu entry replaces those per-card
+	 * navigation affordances.
 	 */
-	public function test_render_status_card_has_manage_settings_link() {
+	public function test_render_status_card_omits_manage_settings_link() {
 		ob_start();
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'Manage Bluesky settings', $output );
-		$this->assertStringContainsString( '#fosse-provider-bluesky', $output );
+		$this->assertStringNotContainsString( 'Manage Bluesky settings', $output );
+		$this->assertStringNotContainsString( 'fosse-status-card__manage', $output );
 	}
 
 	/**
@@ -1375,7 +1473,9 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Provider registers the expected hooks.
+	 * Provider registers the expected hooks. Settings save is centralized
+	 * in {@see Setup_Page::handle_save()} so the provider's own
+	 * `register_hooks()` does NOT register an admin-post handler for it.
 	 */
 	public function test_register_hooks_adds_actions() {
 		$this->provider->register_hooks();
@@ -1386,6 +1486,46 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertSame( 1, has_action( 'init', array( $this->provider, 'serve_atproto_did_well_known' ) ) );
 		$this->assertSame( 1, has_action( 'template_redirect', array( $this->provider, 'maybe_suppress_atmosphere_well_known' ) ) );
 		$this->assertNotFalse( has_filter( 'atmosphere_oauth_redirect_uri', array( $this->provider, 'filter_oauth_redirect_uri' ) ) );
+	}
+
+	// --- save_settings ----------------------------------------------------
+
+	/**
+	 * A submitted, checked auto-publish input persists `'1'` so Atmosphere's
+	 * publish flow remains enabled after save.
+	 */
+	public function test_save_settings_stores_auto_publish_when_checked() {
+		$ok = $this->provider->save_settings( array( 'atmosphere_auto_publish' => '1' ) );
+
+		$this->assertTrue( $ok );
+		$this->assertSame( '1', get_option( 'atmosphere_auto_publish' ) );
+	}
+
+	/**
+	 * An omitted checkbox is the legitimate "disabled" submission — HTML
+	 * forms drop unchecked checkboxes from the POST body, so absence must
+	 * persist `'0'` instead of preserving the previous value.
+	 */
+	public function test_save_settings_disables_auto_publish_when_unchecked() {
+		update_option( 'atmosphere_auto_publish', '1' );
+
+		$ok = $this->provider->save_settings( array() );
+
+		$this->assertTrue( $ok );
+		$this->assertSame( '0', get_option( 'atmosphere_auto_publish' ) );
+	}
+
+	/**
+	 * An empty-string value (defensive) reads as "unchecked" and disables
+	 * auto-publish — guards against malformed POST bodies that submit the
+	 * field name without a value.
+	 */
+	public function test_save_settings_disables_auto_publish_for_empty_value() {
+		update_option( 'atmosphere_auto_publish', '1' );
+
+		$this->provider->save_settings( array( 'atmosphere_auto_publish' => '' ) );
+
+		$this->assertSame( '0', get_option( 'atmosphere_auto_publish' ) );
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -251,8 +251,9 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_setup_section();
 		$output = ob_get_clean();
 
-		// `checked()` emits `checked='checked'` (single-quoted) on WP < 6.x
-		// and `checked` (bare attribute) on newer cores. Match either.
+		// WordPress's `checked()` may emit `checked='checked'` or a bare
+		// `checked` attribute depending on core version; match either form
+		// so the assertion stays stable across the supported floor.
 		$this->assertMatchesRegularExpression(
 			'~<input[^>]+name="atmosphere_auto_publish"[^>]+(checked(?:=\'checked\'|="checked")?)~',
 			$output
@@ -1495,6 +1496,8 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	 * publish flow remains enabled after save.
 	 */
 	public function test_save_settings_stores_auto_publish_when_checked() {
+		$this->seed_connected_atmosphere_connection();
+
 		$ok = $this->provider->save_settings( array( 'atmosphere_auto_publish' => '1' ) );
 
 		$this->assertTrue( $ok );
@@ -1502,11 +1505,12 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * An omitted checkbox is the legitimate "disabled" submission — HTML
-	 * forms drop unchecked checkboxes from the POST body, so absence must
-	 * persist `'0'` instead of preserving the previous value.
+	 * An omitted checkbox while connected is the legitimate "disabled"
+	 * submission — HTML forms drop unchecked checkboxes from the POST body,
+	 * so absence must persist `'0'` instead of preserving the previous value.
 	 */
 	public function test_save_settings_disables_auto_publish_when_unchecked() {
+		$this->seed_connected_atmosphere_connection();
 		update_option( 'atmosphere_auto_publish', '1' );
 
 		$ok = $this->provider->save_settings( array() );
@@ -1521,11 +1525,29 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	 * field name without a value.
 	 */
 	public function test_save_settings_disables_auto_publish_for_empty_value() {
+		$this->seed_connected_atmosphere_connection();
 		update_option( 'atmosphere_auto_publish', '1' );
 
 		$this->provider->save_settings( array( 'atmosphere_auto_publish' => '' ) );
 
 		$this->assertSame( '0', get_option( 'atmosphere_auto_publish' ) );
+	}
+
+	/**
+	 * A Settings save while disconnected must NOT touch
+	 * `atmosphere_auto_publish` — the toggle isn't rendered in that state,
+	 * so an omitted checkbox is the absence of a setting, not an
+	 * intentional "uncheck". Without this guard a routine General-section
+	 * save would silently flip the option to `'0'`.
+	 */
+	public function test_save_settings_disconnected_preserves_auto_publish() {
+		// Provider is disconnected by set_up_provider() (no connection seed).
+		update_option( 'atmosphere_auto_publish', '1' );
+
+		$ok = $this->provider->save_settings( array() );
+
+		$this->assertTrue( $ok );
+		$this->assertSame( '1', get_option( 'atmosphere_auto_publish' ) );
 	}
 
 	/**

--- a/tests/php/Admin/Connection_Provider_RegistryTest.php
+++ b/tests/php/Admin/Connection_Provider_RegistryTest.php
@@ -120,8 +120,13 @@ class Connection_Provider_RegistryTest extends BaseTestCase {
 				return array( 'connected' => true );
 			}
 			public function render_setup_section(): void {}
+			public function render_connection_actions(): void {}
 			public function render_status_card(): void {}
 			public function register_hooks(): void {}
+			public function save_settings( array $post_data ): bool {
+				unset( $post_data );
+				return true;
+			}
 		};
 		// phpcs:enable Squiz.Commenting
 	}

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -457,6 +457,13 @@ class Onboarding_WizardTest extends BaseTestCase {
 				public function render_setup_section(): void {}
 
 				/**
+				 * Render connection actions.
+				 *
+				 * @return void
+				 */
+				public function render_connection_actions(): void {}
+
+				/**
 				 * Render status UI.
 				 *
 				 * @return void
@@ -469,6 +476,17 @@ class Onboarding_WizardTest extends BaseTestCase {
 				 * @return void
 				 */
 				public function register_hooks(): void {}
+
+				/**
+				 * Persist provider settings.
+				 *
+				 * @param array<string, mixed> $post_data POST payload.
+				 * @return bool
+				 */
+				public function save_settings( array $post_data ): bool {
+					unset( $post_data );
+					return true;
+				}
 			}
 		);
 

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -223,6 +223,39 @@ class Setup_PageTest extends BaseTestCase {
 	}
 
 	/**
+	 * A nested-array element inside the post-types list is dropped before
+	 * sanitization rather than tripping `sanitize_text_field`'s array-to-
+	 * string warning (`failOnWarning` would turn that into a test failure
+	 * here, and it would surface as a PHP notice in production). Real
+	 * string elements alongside the nested junk still survive.
+	 */
+	public function test_handle_save_drops_nested_array_post_types(): void {
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_actor_mode'         => 'blog',
+				'activitypub_support_post_types' => array(
+					'post',
+					array( 'malicious', 'nested' ),
+					'page',
+				),
+			)
+		);
+
+		$this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$saved = get_option( 'activitypub_support_post_types' );
+		$this->assertSame( array( 'post', 'page' ), $saved );
+	}
+
+	/**
 	 * A non-array POST value for post types collapses cleanly to an empty
 	 * list rather than tripping a type warning (`failOnWarning` would turn
 	 * one into a test failure).

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -1,0 +1,405 @@
+<?php
+/**
+ * Tests for the unified Settings page handler.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests\Admin;
+
+use Atmosphere\OAuth\Encryption;
+use Automattic\Fosse\Admin\AP_Provider;
+use Automattic\Fosse\Admin\Bluesky_Provider;
+use Automattic\Fosse\Admin\Connection_Provider_Registry;
+use Automattic\Fosse\Admin\Setup_Page;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use WorDBless\BaseTestCase;
+
+/**
+ * Verifies the unified save handler drives every available provider's
+ * `save_settings()` and emits the right notice/redirect on completion.
+ */
+class Setup_PageTest extends BaseTestCase {
+
+	/**
+	 * Reset registry, options, and global state before each test.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function set_up_state(): void {
+		if ( ! defined( 'AUTH_KEY' ) ) {
+			define( 'AUTH_KEY', 'fosse-test-auth-key' );
+		}
+		if ( ! defined( 'AUTH_SALT' ) ) {
+			define( 'AUTH_SALT', 'fosse-test-auth-salt' );
+		}
+
+		Connection_Provider_Registry::reset();
+		AP_Provider::register_provider();
+		Bluesky_Provider::register_provider();
+
+		delete_option( 'activitypub_actor_mode' );
+		delete_option( 'activitypub_support_post_types' );
+		delete_option( 'activitypub_blog_identifier' );
+		delete_option( 'atmosphere_connection' );
+		delete_option( 'atmosphere_auto_publish' );
+
+		global $wp_settings_errors;
+		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- reset core settings-error storage for test isolation.
+
+		remove_all_filters( 'wp_redirect' );
+
+		// AP registers its sanitize callback during `admin_init`; tests don't
+		// fire that. Wire the filter manually so the unified save exercises
+		// the full AP path.
+		remove_all_filters( 'sanitize_option_activitypub_blog_identifier' );
+		if ( class_exists( '\Activitypub\Sanitize' ) ) {
+			add_filter(
+				'sanitize_option_activitypub_blog_identifier',
+				array( '\Activitypub\Sanitize', 'blog_identifier' )
+			);
+		}
+	}
+
+	/**
+	 * Tear down request-scoped state.
+	 *
+	 * @after
+	 */
+	#[After]
+	public function tear_down_state(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- test cleanup.
+		$_POST    = array();
+		$_REQUEST = array();
+		remove_all_filters( 'wp_redirect' );
+		remove_all_filters( 'sanitize_option_activitypub_blog_identifier' );
+	}
+
+	/**
+	 * The class exposes the canonical save action slug — the template,
+	 * Menu wiring, and any tests that simulate the form submission read
+	 * from this constant so a renamed action stays consistent everywhere.
+	 */
+	public function test_save_action_constant_is_canonical(): void {
+		$this->assertSame( 'fosse_save_settings', Setup_Page::SAVE_ACTION );
+	}
+
+	/**
+	 * The register_hooks() call wires the unified admin-post handler so
+	 * the form submission can find it.
+	 */
+	public function test_register_hooks_attaches_admin_post_handler(): void {
+		remove_all_actions( 'admin_post_' . Setup_Page::SAVE_ACTION );
+
+		Setup_Page::register_hooks();
+
+		$this->assertNotFalse(
+			has_action( 'admin_post_' . Setup_Page::SAVE_ACTION, array( Setup_Page::class, 'handle_save' ) )
+		);
+	}
+
+	/**
+	 * A clean unified save persists post types (the cross-protocol option),
+	 * actor mode (AP-side), and auto-publish (Atmosphere-side) in one shot
+	 * and posts the success notice to the FOSSE settings group.
+	 */
+	public function test_handle_save_persists_general_and_per_provider_settings(): void {
+		$this->seed_connected_atmosphere_connection();
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_actor_mode'         => 'actor_blog',
+				'activitypub_support_post_types' => array( 'post', 'page' ),
+				'atmosphere_auto_publish'        => '1',
+			)
+		);
+
+		$this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'actor_blog', get_option( 'activitypub_actor_mode' ) );
+		$this->assertSame( array( 'post', 'page' ), get_option( 'activitypub_support_post_types' ) );
+		$this->assertSame( '1', get_option( 'atmosphere_auto_publish' ) );
+
+		$codes = array_column( get_settings_errors( 'fosse' ), 'code' );
+		$this->assertContains( 'fosse_saved', $codes );
+	}
+
+	/**
+	 * Unchecking the auto-publish box drops the field from the POST body —
+	 * the unified save must persist `'0'` instead of preserving the prior
+	 * value. Mirrors the Bluesky_Provider unit test through the full handler.
+	 */
+	public function test_handle_save_disables_auto_publish_when_field_omitted(): void {
+		$this->seed_connected_atmosphere_connection();
+		update_option( 'atmosphere_auto_publish', '1' );
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_actor_mode'         => 'actor',
+				'activitypub_support_post_types' => array( 'post' ),
+				// `atmosphere_auto_publish` intentionally omitted (unchecked).
+			)
+		);
+
+		$this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( '0', get_option( 'atmosphere_auto_publish' ) );
+	}
+
+	/**
+	 * A provider-side rejection (here: AP's blog-identifier sanitizer
+	 * adding an error) suppresses the blanket `fosse_saved` success notice
+	 * so the user isn't told everything saved while a sibling field
+	 * silently failed. The provider's own error notice still surfaces.
+	 */
+	public function test_handle_save_suppresses_success_notice_on_provider_failure(): void {
+		add_filter(
+			'sanitize_option_activitypub_blog_identifier',
+			static function ( $value ) {
+				add_settings_error(
+					'activitypub_blog_identifier',
+					'forced_failure',
+					'Forced rejection.',
+					'error'
+				);
+				return $value;
+			},
+			11
+		);
+
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_actor_mode'         => 'blog',
+				'activitypub_support_post_types' => array( 'post' ),
+				'activitypub_blog_identifier'    => 'whatever',
+			)
+		);
+
+		$this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$codes = array_column( get_settings_errors( 'fosse' ), 'code' );
+		$this->assertContains( 'forced_failure', $codes );
+		$this->assertNotContains( 'fosse_saved', $codes );
+	}
+
+	/**
+	 * Non-administrators cannot trigger the save handler; `wp_die` fires
+	 * before any option write happens.
+	 */
+	public function test_handle_save_rejects_non_admin(): void {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'fosse_setup_subscriber_' . uniqid( '', true ),
+				'user_pass'  => 'test',
+				'role'       => 'subscriber',
+			)
+		);
+		$this->assertNotWPError( $user_id );
+		wp_set_current_user( $user_id );
+
+		$this->simulate_post( array( 'activitypub_actor_mode' => 'blog' ) );
+
+		add_filter(
+			'wp_die_handler',
+			static function () {
+				return static function ( $message ) {
+					throw new \RuntimeException( wp_kses( (string) $message, array() ) );
+				};
+			}
+		);
+
+		$this->expectException( \RuntimeException::class );
+		Setup_Page::handle_save();
+	}
+
+	/**
+	 * Saved redirect lands back on the FOSSE Settings page so users see the
+	 * post-save notice.
+	 */
+	public function test_handle_save_redirects_back_to_settings_page(): void {
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_actor_mode'         => 'blog',
+				'activitypub_support_post_types' => array( 'post' ),
+			)
+		);
+
+		$captured = $this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull( $captured->location );
+		$this->assertStringContainsString( 'page=fosse', (string) $captured->location );
+	}
+
+	// --- render() — General section ---------------------------------------
+
+	/**
+	 * The Settings page heading reads "FOSSE Settings" (issue #75) so it
+	 * matches the renamed sidebar entry.
+	 */
+	public function test_render_uses_settings_heading(): void {
+		$this->become_admin();
+
+		$output = $this->capture_render();
+
+		$this->assertStringContainsString( 'FOSSE Settings', $output );
+	}
+
+	/**
+	 * The unified Settings form posts to admin-post.php with the canonical
+	 * action and a fresh nonce.
+	 */
+	public function test_render_emits_unified_form_with_save_action_and_nonce(): void {
+		$this->become_admin();
+
+		$output = $this->capture_render();
+
+		$this->assertStringContainsString( 'id="fosse-settings"', $output );
+		$this->assertStringContainsString( 'name="action" value="' . Setup_Page::SAVE_ACTION . '"', $output );
+		$this->assertStringContainsString( 'name="_wpnonce"', $output );
+		$this->assertStringContainsString( 'Save settings', $output );
+	}
+
+	/**
+	 * The General section renders post-types checkboxes and (when AP is
+	 * available) the actor-mode radios. These cross-protocol controls
+	 * moved up from the per-provider sections in issue #36.
+	 */
+	public function test_render_general_section_contains_post_types_and_actor_mode(): void {
+		$this->become_admin();
+
+		$output = $this->capture_render();
+
+		$this->assertStringContainsString( 'id="fosse-section-general"', $output );
+		$this->assertStringContainsString( 'name="activitypub_support_post_types[]"', $output );
+		$this->assertStringContainsString( 'name="activitypub_actor_mode"', $output );
+	}
+
+	// --- helpers ----------------------------------------------------------
+
+	/**
+	 * Render the Settings page and return its output.
+	 *
+	 * @return string
+	 */
+	private function capture_render(): string {
+		ob_start();
+		Setup_Page::render();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Seed the POST superglobal with `_wpnonce` and the supplied fields.
+	 *
+	 * @param array<string, mixed> $fields POST fields.
+	 * @return void
+	 */
+	private function simulate_post( array $fields ): void {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array_merge(
+			array(
+				'_wpnonce' => wp_create_nonce( Setup_Page::SAVE_ACTION ),
+				'action'   => Setup_Page::SAVE_ACTION,
+			),
+			$fields
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+	}
+
+	/**
+	 * Capture the next wp_redirect into a returned object's `location`.
+	 *
+	 * @return object
+	 */
+	private function arm_redirect_trap(): object {
+		$capture           = new \stdClass();
+		$capture->location = null;
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( $capture ) {
+				$capture->location = (string) $location;
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+		return $capture;
+	}
+
+	/**
+	 * Create and authenticate an administrator.
+	 *
+	 * @return void
+	 */
+	private function become_admin(): void {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'fosse_setup_admin_' . uniqid( '', true ),
+				'user_pass'  => 'test',
+				'role'       => 'administrator',
+			)
+		);
+		$this->assertNotWPError( $user_id );
+		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Seed a connected Atmosphere connection (handle, did, encrypted token).
+	 *
+	 * @return void
+	 */
+	private function seed_connected_atmosphere_connection(): void {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+	}
+
+	/**
+	 * Fail the test if the value is a WP_Error.
+	 *
+	 * @param mixed $value Value to check.
+	 * @return void
+	 */
+	private function assertNotWPError( $value ): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- camelCase mirrors PHPUnit's assertion style.
+		if ( is_wp_error( $value ) ) {
+			$this->fail( 'Unexpected WP_Error: ' . $value->get_error_message() );
+		}
+		$this->assertFalse( is_wp_error( $value ) );
+	}
+}

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -163,6 +163,123 @@ class Setup_PageTest extends BaseTestCase {
 	}
 
 	/**
+	 * A Settings save while Bluesky is disconnected does NOT flip
+	 * `atmosphere_auto_publish` to `'0'` even though the toggle isn't in
+	 * the form. The Bluesky provider's disconnect guard owns the policy;
+	 * this test exercises it through the full unified handler.
+	 */
+	public function test_handle_save_disconnected_preserves_auto_publish(): void {
+		// No `seed_connected_atmosphere_connection()` — provider stays
+		// disconnected so save_settings() should bail out.
+		update_option( 'atmosphere_auto_publish', '1' );
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_actor_mode'         => 'actor',
+				'activitypub_support_post_types' => array( 'post' ),
+			)
+		);
+
+		$this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( '1', get_option( 'atmosphere_auto_publish' ) );
+	}
+
+	/**
+	 * General-section post-type save filters out post types that aren't
+	 * registered as public — anything submitted via a crafted POST that
+	 * isn't a valid public type is silently dropped before the option
+	 * write.
+	 */
+	public function test_handle_save_filters_invalid_post_types(): void {
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_actor_mode'         => 'blog',
+				'activitypub_support_post_types' => array( 'post', 'nonexistent_type', 'page' ),
+			)
+		);
+
+		$this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$saved = get_option( 'activitypub_support_post_types' );
+		$this->assertContains( 'post', $saved );
+		$this->assertContains( 'page', $saved );
+		$this->assertNotContains( 'nonexistent_type', $saved );
+	}
+
+	/**
+	 * A non-array POST value for post types collapses cleanly to an empty
+	 * list rather than tripping a type warning (`failOnWarning` would turn
+	 * one into a test failure).
+	 */
+	public function test_handle_save_handles_non_array_post_types(): void {
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_actor_mode'         => 'blog',
+				'activitypub_support_post_types' => 'not_an_array',
+			)
+		);
+
+		$this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertIsArray( get_option( 'activitypub_support_post_types' ) );
+	}
+
+	/**
+	 * The General post-types option is owned by Setup_Page itself, not by
+	 * any provider — so the save lands even on a hypothetical install
+	 * where ActivityPub is missing. Re-asserts the architectural contract
+	 * that General writes don't depend on the AP provider being available.
+	 */
+	public function test_handle_save_persists_post_types_without_ap_provider(): void {
+		Connection_Provider_Registry::reset();
+		// Deliberately do NOT register AP so save_settings() can't write
+		// the option indirectly. Bluesky stays registered but disconnected.
+		Bluesky_Provider::register_provider();
+
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_support_post_types' => array( 'post', 'page' ),
+			)
+		);
+
+		$this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( array( 'post', 'page' ), get_option( 'activitypub_support_post_types' ) );
+	}
+
+	/**
 	 * A provider-side rejection (here: AP's blog-identifier sanitizer
 	 * adding an error) suppresses the blanket `fosse_saved` success notice
 	 * so the user isn't told everything saved while a sibling field


### PR DESCRIPTION
## Summary

Reorganize the FOSSE admin settings page so cross-protocol controls live in a top-level **General** section, render protocol-specific sections beneath it, and consolidate the per-protocol "Save ActivityPub Settings" button (and the missing Bluesky auto-publish control) into a single **Save settings** button backed by one nonce and one admin-post handler.

Fixes #75 (rename Setup → Settings), fixes #74 (drop per-card status links), fixes #36 (General section + unified save), fixes #38 (auto-publish toggle).

## Changes

### Issue 75 — "Setup" → "Settings"
- `class-menu.php`: submenu label is now `Settings`.
- `class-onboarding-wizard.php`: copy and the "Go to Setup" CTA both updated.
- `templates/setup-page.php`: page heading reads "FOSSE Settings".

### Issue 74 — Drop per-card "Manage X settings" links
- `class-ap-provider.php` and `class-bluesky-provider.php`: removed the trailing `<p class="fosse-status-card__manage">` link from each `render_status_card()`. The Bluesky reconnect link still lands on `#fosse-provider-bluesky` (anchor preserved on the connection panel).

### Issue 36 — General section + unified save
- Added a top-level General block in `templates/setup-page.php` (post types + actor mode when AP is available).
- Each provider's `render_setup_section()` is now fields-only — no `<form>` tag, no submit button. A single `<form id="fosse-settings">` wraps General + AP + Bluesky and posts to `admin_post_fosse_save_settings` with one **Save settings** button and one nonce.
- New interface method `render_connection_actions()` renders Bluesky's connect/disconnect forms (their own forms, own nonces) outside the unified Settings form. AP returns nothing — there is no out-of-band step.
- New interface method `save_settings(array): bool`. `Setup_Page::handle_save()` verifies cap + nonce and asks each available provider to persist its own settings. A `false` return suppresses the blanket "Settings saved." notice so the per-field error is the only surfaced banner.

### Issue 38 — Auto-publish toggle
- `Bluesky_Provider::render_setup_section()` renders a checkbox bound to `atmosphere_auto_publish` (default `'1'`) when connected, with a one-line description.
- `Bluesky_Provider::save_settings()` writes `'1'` / `'0'` per Atmosphere's expectation. An unchecked checkbox correctly persists `'0'` (HTML omits unchecked checkboxes from POST).

## Tests

- `AP_ProviderTest`: replaced `handle_save` tests with `save_settings` tests; removed actor-mode rendering assertions (moved to General); added `test_render_setup_section_is_fields_only`, `test_render_connection_actions_is_empty`, `test_render_status_card_omits_manage_settings_link`.
- `Bluesky_ProviderTest`: split connect/disconnect form assertions onto `render_connection_actions`; added auto-publish toggle render and state tests; added `save_settings` tests for checked, omitted, and empty cases; replaced manage-link test with omits-link assertion.
- New `Setup_PageTest`: covers unified handler (persists general + provider settings, suppresses success notice on rejection, redirects back to settings, rejects non-admins) and General section rendering.
- `Connection_Provider_RegistryTest` and `Onboarding_WizardTest` anonymous stubs updated for the two new interface methods.

All checks green:
- PHPUnit: 246 tests / 572 assertions.
- PHPCS (Jetpack ruleset): clean.
- Prettier `--check`: clean.
- ESLint: clean.

## Test plan

- [ ] Activate FOSSE on a fresh install. Sidebar shows **FOSSE → Settings / Status**.
- [ ] Visit Settings. The page heading reads "FOSSE Settings". A General section sits at the top with post types and actor mode (when ActivityPub is loaded).
- [ ] Toggle a post type or change actor mode, click **Save settings**. The success notice appears and the values persist on reload.
- [ ] Submit an invalid actor mode (via crafted POST). Error notice surfaces; success notice does not.
- [ ] In `blog` mode, set a Site Handle that collides with a real user. The AP rejection surfaces under FOSSE's group; success notice is suppressed.
- [ ] Connect Bluesky from the Bluesky connection panel below the form. After OAuth, the Bluesky settings section appears with the auto-publish checkbox checked by default.
- [ ] Uncheck auto-publish, save. `atmosphere_auto_publish` flips to `'0'`. Recheck, save. It flips back to `'1'`.
- [ ] On the Status page, no per-card "Manage … settings" links are present. The Bluesky token-error reconnect link still works.
- [ ] Run wizard once-through. CTAs and copy reference "Settings" rather than "Setup".