### PR TITLE
fix: wizard Appearance step dynamic preview and editable site handle

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -441,6 +441,38 @@
 	border: 1px solid #e0e0e0;
 }
 
+/* Wizard Appearance step swaps which fediverse-address preview is visible
+   based on the selected actor mode; inactive containers and the site
+   handle row (which only applies in blog/actor_blog modes) carry
+   `is-hidden`. The class is also used as a no-JS fallback so the server
+   render of the active mode stays visible without the script. */
+.fosse-address-preview.is-hidden,
+.fosse-wizard__blog-handle.is-hidden {
+	display: none;
+}
+
+/* Inline site handle field on the Appearance step. Mirrors the Setup
+   page treatment but slimmer — sits inside the wizard card next to the
+   address preview. */
+.fosse-wizard__blog-handle {
+	margin-top: 16px;
+}
+
+.fosse-wizard__blog-handle-label {
+	display: block;
+	font-size: 11px;
+	font-weight: 500;
+	text-transform: uppercase;
+	color: #757575;
+	margin-bottom: 8px;
+}
+
+.fosse-wizard__blog-handle .description {
+	margin-top: 6px;
+	font-size: 12px;
+	color: #757575;
+}
+
 /* Post type selection */
 .fosse-post-types {
 	display: flex;

--- a/src/Admin/assets/js/wizard-appearance.js
+++ b/src/Admin/assets/js/wizard-appearance.js
@@ -1,0 +1,85 @@
+/**
+ * Wizard Appearance step — live preview swap.
+ *
+ * Toggles which fediverse-address preview container is visible based on the
+ * currently selected actor-mode radio. Also toggles the inline Site Handle
+ * row, which is only meaningful when the selected mode includes the blog
+ * actor (`blog` or `actor_blog`).
+ *
+ * Progressive enhancement: the server renders all three preview containers
+ * with the inactive ones tagged `is-hidden`. With JS off, the active mode's
+ * container stays visible and the form still updates on submit.
+ */
+( function () {
+	'use strict';
+
+	const HIDDEN_CLASS = 'is-hidden';
+	const BLOG_MODES = [ 'blog', 'actor_blog' ];
+
+	function modeIncludesBlog( mode ) {
+		return BLOG_MODES.indexOf( mode ) !== -1;
+	}
+
+	/**
+	 * Apply the visibility state for a given mode value.
+	 *
+	 * @param {string}       mode       Selected actor mode (`actor`/`blog`/`actor_blog`).
+	 * @param {NodeList}     previews   Preview containers tagged with `data-fosse-mode`.
+	 * @param {Element|null} blogHandle The site handle row, if present.
+	 */
+	function applyMode( mode, previews, blogHandle ) {
+		previews.forEach( function ( el ) {
+			const matches = el.getAttribute( 'data-fosse-mode' ) === mode;
+			el.classList.toggle( HIDDEN_CLASS, ! matches );
+		} );
+
+		if ( blogHandle ) {
+			blogHandle.classList.toggle(
+				HIDDEN_CLASS,
+				! modeIncludesBlog( mode )
+			);
+		}
+	}
+
+	function init( root ) {
+		const scope = root || document;
+		const radios = scope.querySelectorAll( '.fosse-mode-card__input' );
+		if ( ! radios.length ) {
+			return;
+		}
+
+		const previews = scope.querySelectorAll(
+			'.fosse-address-preview[data-fosse-mode]'
+		);
+		const blogHandle = scope.querySelector(
+			'[data-fosse-when="includes-blog"]'
+		);
+
+		function handleChange() {
+			const checked = scope.querySelector(
+				'.fosse-mode-card__input:checked'
+			);
+			if ( ! checked ) {
+				return;
+			}
+			applyMode( checked.value, previews, blogHandle );
+		}
+
+		radios.forEach( function ( radio ) {
+			radio.addEventListener( 'change', handleChange );
+		} );
+
+		// Run once on init so the visible state matches the checked radio
+		// even if the server rendered a stale snapshot (e.g. after a back
+		// button reload that restored a different selection from history).
+		handleChange();
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', function () {
+			init();
+		} );
+	} else {
+		init();
+	}
+} )();

--- a/src/Admin/class-menu.php
+++ b/src/Admin/class-menu.php
@@ -24,7 +24,7 @@ class Menu {
 		add_action( 'admin_menu', array( static::class, 'add_menu' ), 9 );
 		add_action( 'admin_menu', array( static::class, 'hide_bundled_menus' ), 99 );
 		add_action( 'admin_bar_menu', array( static::class, 'hide_bundled_admin_bar' ), 101 );
-		add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_assets' ) );
 		add_action( 'admin_init', array( static::class, 'maybe_redirect_to_wizard' ) );
 		// Suppress at two stages so plugins can't bypass us by registering
 		// notices in hooks that fire between current_screen and the notice
@@ -207,12 +207,12 @@ class Menu {
 	}
 
 	/**
-	 * Enqueue admin styles on FOSSE pages.
+	 * Enqueue admin styles and scripts on FOSSE pages.
 	 *
 	 * @param string $hook_suffix The current admin page hook suffix.
 	 * @return void
 	 */
-	public static function enqueue_styles( string $hook_suffix ): void {
+	public static function enqueue_assets( string $hook_suffix ): void {
 		if ( ! str_starts_with( $hook_suffix, 'toplevel_page_fosse' ) && ! str_starts_with( $hook_suffix, 'fosse_page_' ) && 'admin_page_fosse-wizard' !== $hook_suffix ) {
 			return;
 		}

--- a/src/Admin/class-menu.php
+++ b/src/Admin/class-menu.php
@@ -223,6 +223,20 @@ class Menu {
 			array(),
 			filemtime( __DIR__ . '/assets/css/admin.css' )
 		);
+
+		// The wizard's Appearance step swaps the visible address preview
+		// when the actor-mode radio changes. Loaded only on the wizard
+		// hook to avoid shipping the script on the Setup/Status pages
+		// where the markup it targets isn't rendered.
+		if ( 'admin_page_fosse-wizard' === $hook_suffix ) {
+			wp_enqueue_script(
+				'fosse-wizard-appearance',
+				plugins_url( 'src/Admin/assets/js/wizard-appearance.js', dirname( __DIR__, 2 ) . '/fosse.php' ),
+				array(),
+				filemtime( __DIR__ . '/assets/js/wizard-appearance.js' ),
+				array( 'in_footer' => true )
+			);
+		}
 	}
 
 	/**

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -200,6 +200,22 @@ class Onboarding_Wizard {
 			if ( in_array( $mode, self::ACTOR_MODES, true ) ) {
 				update_option( 'activitypub_actor_mode', $mode );
 			}
+
+			// Persist the inline Site Handle when submitted. Only write when
+			// the field arrived non-empty so the no-touch path preserves any
+			// existing stored value (matches AP_Provider::handle_save). AP's
+			// `sanitize_option_activitypub_blog_identifier` filter handles
+			// collision rejection at update_option time.
+			if ( array_key_exists( 'activitypub_blog_identifier', $_POST ) ) {
+				$raw_input = is_string( $_POST['activitypub_blog_identifier'] )
+					? sanitize_text_field( wp_unslash( $_POST['activitypub_blog_identifier'] ) )
+					: '';
+				$raw       = trim( $raw_input );
+				if ( '' !== $raw ) {
+					update_option( 'activitypub_blog_identifier', $raw );
+				}
+			}
+
 			self::redirect_to_step( 'content' );
 		}
 
@@ -791,10 +807,23 @@ class Onboarding_Wizard {
 			),
 		);
 
-		$preview_handles = self::get_handle_previews( $current_mode );
-		$preview_user    = $preview_handles['user'] ?? '';
-		$preview_blog    = $preview_handles['blog'] ?? '';
-		$preview_both    = 'actor_blog' === $current_mode && '' !== $preview_user && '' !== $preview_blog;
+		// Resolve handles for every mode up front so all three preview
+		// containers can be rendered server-side. JS then toggles which is
+		// visible on radio change; the no-JS fallback keeps only the saved
+		// mode's container visible (matches the pre-#68 behavior).
+		$ap_provider = Connection_Provider_Registry::get_provider( 'activitypub' );
+		$user_handle = $ap_provider instanceof AP_Provider
+			? self::normalize_handle_preview( $ap_provider->get_user_address() )
+			: '';
+		$blog_handle = $ap_provider instanceof AP_Provider
+			? self::normalize_handle_preview( $ap_provider->get_blog_address() )
+			: '';
+
+		$blog_identifier             = (string) get_option( 'activitypub_blog_identifier', '' );
+		$blog_identifier_placeholder = '';
+		if ( '' === $blog_identifier && class_exists( '\Activitypub\Model\Blog' ) ) {
+			$blog_identifier_placeholder = (string) \Activitypub\Model\Blog::get_default_username();
+		}
 
 		?>
 		<h1 class="fosse-wizard__title"><?php esc_html_e( 'How should your site appear?', 'fosse' ); ?></h1>
@@ -832,28 +861,65 @@ class Onboarding_Wizard {
 					<?php endforeach; ?>
 				</div>
 
-				<?php if ( $preview_both ) : ?>
-					<div class="fosse-address-preview">
-						<div class="fosse-address-preview__row">
-							<span class="fosse-address-preview__label"><?php esc_html_e( 'As you:', 'fosse' ); ?></span>
-							<code class="fosse-address-preview__address"><?php echo esc_html( $preview_user ); ?></code>
-						</div>
-						<div class="fosse-address-preview__row">
-							<span class="fosse-address-preview__label"><?php esc_html_e( 'As your site:', 'fosse' ); ?></span>
-							<code class="fosse-address-preview__address"><?php echo esc_html( $preview_blog ); ?></code>
-						</div>
+				<?php
+				// Render all three preview containers regardless of saved
+				// mode. Inactive containers carry `is-hidden`; a small JS
+				// helper swaps that class on radio change. With JS off the
+				// page still surfaces the active mode's preview.
+				$preview_modes = array( 'actor', 'blog', 'actor_blog' );
+				foreach ( $preview_modes as $preview_mode ) :
+					$preview_classes = 'fosse-address-preview';
+					if ( $preview_mode !== $current_mode ) {
+						$preview_classes .= ' is-hidden';
+					}
+					?>
+					<div class="<?php echo esc_attr( $preview_classes ); ?>" data-fosse-mode="<?php echo esc_attr( $preview_mode ); ?>">
+						<?php if ( 'actor_blog' === $preview_mode ) : ?>
+							<?php if ( '' !== $user_handle ) : ?>
+								<div class="fosse-address-preview__row">
+									<span class="fosse-address-preview__label"><?php esc_html_e( 'As you:', 'fosse' ); ?></span>
+									<code class="fosse-address-preview__address"><?php echo esc_html( $user_handle ); ?></code>
+								</div>
+							<?php endif; ?>
+							<?php if ( '' !== $blog_handle ) : ?>
+								<div class="fosse-address-preview__row">
+									<span class="fosse-address-preview__label"><?php esc_html_e( 'As your site:', 'fosse' ); ?></span>
+									<code class="fosse-address-preview__address"><?php echo esc_html( $blog_handle ); ?></code>
+								</div>
+							<?php endif; ?>
+						<?php elseif ( 'actor' === $preview_mode && '' !== $user_handle ) : ?>
+							<span class="fosse-address-preview__label"><?php esc_html_e( 'Your fediverse address:', 'fosse' ); ?></span>
+							<code class="fosse-address-preview__address"><?php echo esc_html( $user_handle ); ?></code>
+						<?php elseif ( 'blog' === $preview_mode && '' !== $blog_handle ) : ?>
+							<span class="fosse-address-preview__label"><?php esc_html_e( 'Site fediverse address:', 'fosse' ); ?></span>
+							<code class="fosse-address-preview__address"><?php echo esc_html( $blog_handle ); ?></code>
+						<?php endif; ?>
 					</div>
-				<?php elseif ( '' !== $preview_user ) : ?>
-					<div class="fosse-address-preview">
-						<span class="fosse-address-preview__label"><?php esc_html_e( 'Your fediverse address:', 'fosse' ); ?></span>
-						<code class="fosse-address-preview__address"><?php echo esc_html( $preview_user ); ?></code>
-					</div>
-				<?php elseif ( '' !== $preview_blog ) : ?>
-					<div class="fosse-address-preview">
-						<span class="fosse-address-preview__label"><?php esc_html_e( 'Site fediverse address:', 'fosse' ); ?></span>
-						<code class="fosse-address-preview__address"><?php echo esc_html( $preview_blog ); ?></code>
-					</div>
-				<?php endif; ?>
+					<?php
+				endforeach;
+
+				$blog_handle_classes = 'fosse-wizard__blog-handle';
+				if ( 'blog' !== $current_mode && 'actor_blog' !== $current_mode ) {
+					$blog_handle_classes .= ' is-hidden';
+				}
+				?>
+				<div class="<?php echo esc_attr( $blog_handle_classes ); ?>" data-fosse-when="includes-blog">
+					<label for="fosse-wizard-blog-identifier" class="fosse-wizard__blog-handle-label">
+						<?php esc_html_e( 'Site Handle', 'fosse' ); ?>
+					</label>
+					<input
+						type="text"
+						id="fosse-wizard-blog-identifier"
+						name="activitypub_blog_identifier"
+						class="regular-text"
+						value="<?php echo esc_attr( $blog_identifier ); ?>"
+						placeholder="<?php echo esc_attr( $blog_identifier_placeholder ); ?>"
+						aria-describedby="fosse-wizard-blog-identifier-desc"
+					/>
+					<p id="fosse-wizard-blog-identifier-desc" class="description">
+						<?php esc_html_e( 'The username people use to follow your site from the fediverse. Cannot match an existing author login or nicename.', 'fosse' ); ?>
+					</p>
+				</div>
 			</div>
 
 			<div class="fosse-wizard__actions">

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -206,14 +206,48 @@ class Onboarding_Wizard {
 			// existing stored value (matches AP_Provider::handle_save). AP's
 			// `sanitize_option_activitypub_blog_identifier` filter handles
 			// collision rejection at update_option time.
+			$blog_identifier_rejected = false;
 			if ( array_key_exists( 'activitypub_blog_identifier', $_POST ) ) {
 				$raw_input = is_string( $_POST['activitypub_blog_identifier'] )
 					? sanitize_text_field( wp_unslash( $_POST['activitypub_blog_identifier'] ) )
 					: '';
 				$raw       = trim( $raw_input );
 				if ( '' !== $raw ) {
+					// Snapshot the queue length, not the codes — AP's sanitizer
+					// reuses a constant code (`activitypub_blog_identifier`) for
+					// every collision rejection, so a code-only check would mask
+					// a fresh rejection if any error with that code already sat
+					// on the queue. Mirrors AP_Provider::handle_save().
+					$ap_error_count_before = count( get_settings_errors( 'activitypub_blog_identifier' ) );
+
 					update_option( 'activitypub_blog_identifier', $raw );
+
+					// Re-tag any fresh AP errors under our own group so the
+					// appearance step's `settings_errors( 'fosse' )` render
+					// surfaces them — without re-tagging the user would land
+					// back on the wizard with no feedback at all.
+					$ap_errors_after = get_settings_errors( 'activitypub_blog_identifier' );
+					$new_ap_errors   = array_slice( $ap_errors_after, $ap_error_count_before );
+					foreach ( $new_ap_errors as $ap_error ) {
+						$blog_identifier_rejected = true;
+						add_settings_error(
+							'fosse',
+							$ap_error['code'],
+							$ap_error['message'],
+							$ap_error['type']
+						);
+					}
 				}
+			}
+
+			// On rejection, persist the surfaced errors via the
+			// `settings_errors` transient and bounce back to the appearance
+			// step so the user can correct the input. Without this the wizard
+			// would silently advance to Content with no feedback and no way
+			// to fix the colliding handle.
+			if ( $blog_identifier_rejected ) {
+				set_transient( 'settings_errors', get_settings_errors(), 30 );
+				self::redirect_to_step( 'appearance', array( 'settings-updated' => 'true' ) );
 			}
 
 			self::redirect_to_step( 'content' );
@@ -830,6 +864,8 @@ class Onboarding_Wizard {
 		<p class="fosse-wizard__description">
 			<?php esc_html_e( 'Choose how people on the social web will see your site. This affects who they follow and how your posts appear in their feeds.', 'fosse' ); ?>
 		</p>
+
+		<?php settings_errors( 'fosse' ); ?>
 
 		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 			<input type="hidden" name="action" value="fosse_wizard_save" />

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -898,12 +898,24 @@ class Onboarding_Wizard {
 				</div>
 
 				<?php
-				// Render all three preview containers regardless of saved
-				// mode. Inactive containers carry `is-hidden`; a small JS
-				// helper swaps that class on radio change. With JS off the
-				// page still surfaces the active mode's preview.
-				$preview_modes = array( 'actor', 'blog', 'actor_blog' );
+				// Render preview containers for every mode that has content
+				// to show. Skip empty modes entirely so the active container
+				// never renders as an empty styled grey box (`get_user_address`
+				// can legitimately return '' when the current user can't have
+				// an actor; the same applies to the blog handle when AP isn't
+				// fully configured). Inactive containers carry `is-hidden`; a
+				// small JS helper swaps that class on radio change. With JS
+				// off the page still surfaces the active mode's preview.
+				$preview_modes       = array( 'actor', 'blog', 'actor_blog' );
+				$preview_has_content = array(
+					'actor'      => '' !== $user_handle,
+					'blog'       => '' !== $blog_handle,
+					'actor_blog' => '' !== $user_handle || '' !== $blog_handle,
+				);
 				foreach ( $preview_modes as $preview_mode ) :
+					if ( ! $preview_has_content[ $preview_mode ] ) {
+						continue;
+					}
 					$preview_classes = 'fosse-address-preview';
 					if ( $preview_mode !== $current_mode ) {
 						$preview_classes .= ' is-hidden';

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -44,6 +44,84 @@ test( 'Appearance step has three actor mode cards', async ( { page } ) => {
 	await expect( page.locator( '.fosse-mode-card' ) ).toHaveCount( 3 );
 } );
 
+test( 'Appearance step swaps the visible address preview when the actor mode changes', async ( {
+	page,
+} ) => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=appearance' );
+
+	// Three preview containers render server-side, one per mode. JS toggles
+	// `is-hidden` on radio change; only the matching container should be
+	// visible at any given time.
+	await expect(
+		page.locator( '.fosse-address-preview[data-fosse-mode]' )
+	).toHaveCount( 3 );
+
+	// Selecting "As your site" exposes the blog preview and the inline
+	// Site Handle row, and hides the personal address preview.
+	await page
+		.locator( '.fosse-mode-card', {
+			has: page.locator( '.fosse-mode-card__title', {
+				hasText: /^As your site$/,
+			} ),
+		} )
+		.click();
+
+	await expect(
+		page.locator( '.fosse-address-preview[data-fosse-mode="blog"]' )
+	).toBeVisible();
+	await expect(
+		page.locator( '.fosse-address-preview[data-fosse-mode="actor"]' )
+	).toBeHidden();
+	await expect(
+		page.locator( '.fosse-address-preview[data-fosse-mode="actor_blog"]' )
+	).toBeHidden();
+	await expect(
+		page.locator( '[data-fosse-when="includes-blog"]' )
+	).toBeVisible();
+	await expect(
+		page.locator( '#fosse-wizard-blog-identifier' )
+	).toBeVisible();
+
+	// "Both" reveals the actor_blog container instead.
+	await page
+		.locator( '.fosse-mode-card', {
+			has: page.locator( '.fosse-mode-card__title', {
+				hasText: /^Both$/,
+			} ),
+		} )
+		.click();
+
+	await expect(
+		page.locator( '.fosse-address-preview[data-fosse-mode="actor_blog"]' )
+	).toBeVisible();
+	await expect(
+		page.locator( '.fosse-address-preview[data-fosse-mode="blog"]' )
+	).toBeHidden();
+	await expect(
+		page.locator( '[data-fosse-when="includes-blog"]' )
+	).toBeVisible();
+
+	// Returning to "As you" hides the inline site handle row again — it
+	// only applies when the mode publishes from a blog actor.
+	await page
+		.locator( '.fosse-mode-card', {
+			has: page.locator( '.fosse-mode-card__title', {
+				hasText: /^As you$/,
+			} ),
+		} )
+		.click();
+
+	await expect(
+		page.locator( '.fosse-address-preview[data-fosse-mode="actor"]' )
+	).toBeVisible();
+	await expect(
+		page.locator( '.fosse-address-preview[data-fosse-mode="blog"]' )
+	).toBeHidden();
+	await expect(
+		page.locator( '[data-fosse-when="includes-blog"]' )
+	).toBeHidden();
+} );
+
 test( 'Selecting a mode and continuing saves the option', async ( {
 	page,
 } ) => {

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -71,7 +71,6 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		remove_all_filters( 'wp_redirect' );
 		remove_all_filters( 'wp_die_handler' );
-		remove_all_filters( 'sanitize_option_activitypub_blog_identifier' );
 		remove_all_actions( 'fosse_wizard_unauthorized' );
 
 		global $wp_settings_errors;
@@ -362,7 +361,12 @@ class Onboarding_WizardTest extends BaseTestCase {
 	public function test_render_appearance_renders_all_three_preview_containers(): void {
 		update_option( 'activitypub_actor_mode', 'actor' );
 
+		// Grant AP eligibility so `get_user_address()` returns a real
+		// webfinger; without it the wrapper for that mode renders empty
+		// and is now suppressed to avoid an empty styled grey box.
+		add_filter( 'activitypub_user_can_activitypub', '__return_true' );
 		$output = $this->render_wizard_step( 'appearance' );
+		remove_filter( 'activitypub_user_can_activitypub', '__return_true' );
 
 		$this->assertMatchesRegularExpression(
 			'/<div[^>]*\bclass="[^"]*\bfosse-address-preview\b[^"]*"[^>]*\bdata-fosse-mode="actor"/i',
@@ -390,7 +394,13 @@ class Onboarding_WizardTest extends BaseTestCase {
 	public function test_render_appearance_marks_inactive_previews_hidden(): void {
 		update_option( 'activitypub_actor_mode', 'blog' );
 
+		// Grant AP eligibility so `get_user_address()` returns a real
+		// webfinger; without it the actor / actor_blog wrappers would be
+		// suppressed (empty-content path) and the inactive-hidden assertion
+		// would have nothing to match.
+		add_filter( 'activitypub_user_can_activitypub', '__return_true' );
 		$output = $this->render_wizard_step( 'appearance' );
+		remove_filter( 'activitypub_user_can_activitypub', '__return_true' );
 
 		$this->assertMatchesRegularExpression(
 			'/<div[^>]*\bclass="[^"]*\bfosse-address-preview\b(?:(?!is-hidden)[^"])*"[^>]*\bdata-fosse-mode="blog"/i',
@@ -406,6 +416,26 @@ class Onboarding_WizardTest extends BaseTestCase {
 			'/<div[^>]*\bclass="[^"]*\bfosse-address-preview\b[^"]*\bis-hidden\b[^"]*"[^>]*\bdata-fosse-mode="actor_blog"/i',
 			$output,
 			'Inactive containers must be marked is-hidden.'
+		);
+	}
+
+	/**
+	 * Modes whose handle resolves to an empty string suppress their preview
+	 * wrapper entirely. Without this, the active mode would render as an
+	 * empty styled grey box (the `.fosse-address-preview` rule applies
+	 * background + padding even when no inner row is emitted).
+	 */
+	public function test_render_appearance_skips_actor_preview_when_user_handle_empty(): void {
+		update_option( 'activitypub_actor_mode', 'actor' );
+		// No `activitypub_user_can_activitypub` filter — `get_user_address()`
+		// returns '' so the actor wrapper has nothing to render.
+
+		$output = $this->render_wizard_step( 'appearance' );
+
+		$this->assertDoesNotMatchRegularExpression(
+			'/<div[^>]*\bdata-fosse-mode="actor"[^>]*>/i',
+			$output,
+			'Actor wrapper must not render when the user handle is empty.'
 		);
 	}
 
@@ -513,19 +543,19 @@ class Onboarding_WizardTest extends BaseTestCase {
 	 * a colliding user wouldn't trip AP's collision path.
 	 */
 	public function test_handle_save_appearance_rewires_ap_settings_errors_to_fosse_group(): void {
-		add_filter(
-			'sanitize_option_activitypub_blog_identifier',
-			static function ( $value ) {
-				add_settings_error(
-					'activitypub_blog_identifier',
-					'collision_test',
-					'Collision test error.',
-					'error'
-				);
-				return $value;
-			},
-			11 // After AP's own callback.
-		);
+		// Capture the closure so cleanup can target only this callback —
+		// `remove_all_filters` would also wipe AP's own sanitizer (and any
+		// other registered callbacks), affecting unrelated tests.
+		$rejector = static function ( $value ) {
+			add_settings_error(
+				'activitypub_blog_identifier',
+				'collision_test',
+				'Collision test error.',
+				'error'
+			);
+			return $value;
+		};
+		add_filter( 'sanitize_option_activitypub_blog_identifier', $rejector, 11 );
 
 		$this->simulate_save_request(
 			'appearance',
@@ -541,6 +571,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 			unset( $e );
 		}
 
+		remove_filter( 'sanitize_option_activitypub_blog_identifier', $rejector, 11 );
+
 		$fosse_codes = array_column( get_settings_errors( 'fosse' ), 'code' );
 		$this->assertContains( 'collision_test', $fosse_codes );
 	}
@@ -551,19 +583,16 @@ class Onboarding_WizardTest extends BaseTestCase {
 	 * surfaced error and correct the input.
 	 */
 	public function test_handle_save_appearance_redirects_back_on_blog_identifier_rejection(): void {
-		add_filter(
-			'sanitize_option_activitypub_blog_identifier',
-			static function ( $value ) {
-				add_settings_error(
-					'activitypub_blog_identifier',
-					'collision_test',
-					'Collision test error.',
-					'error'
-				);
-				return $value;
-			},
-			11
-		);
+		$rejector = static function ( $value ) {
+			add_settings_error(
+				'activitypub_blog_identifier',
+				'collision_test',
+				'Collision test error.',
+				'error'
+			);
+			return $value;
+		};
+		add_filter( 'sanitize_option_activitypub_blog_identifier', $rejector, 11 );
 
 		$captured = null;
 		$this->simulate_save_request(
@@ -587,6 +616,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
 			unset( $e );
 		}
+
+		remove_filter( 'sanitize_option_activitypub_blog_identifier', $rejector, 11 );
 
 		$this->assertNotNull( $captured );
 		$this->assertStringContainsString( 'step=appearance', $captured );

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -41,6 +41,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		delete_option( Onboarding_Wizard::COMPLETED_OPTION );
 		delete_option( 'activitypub_actor_mode' );
+		delete_option( 'activitypub_blog_identifier' );
 		delete_option( 'activitypub_support_post_types' );
 		delete_option( 'atmosphere_connection' );
 		delete_option( 'atmosphere_auto_publish' );
@@ -341,6 +342,158 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Setup is unavailable', $output );
 		$this->assertStringContainsString( 'ActivityPub', $output );
+	}
+
+	// --- Appearance step render ---
+
+	/**
+	 * The appearance step renders all three actor-mode preview containers
+	 * up front so a small JS toggle can swap visibility without a page
+	 * reload. Each container is tagged with `data-fosse-mode` so the JS
+	 * can target it. Saved mode is `actor` here, so only that one stays
+	 * visible — the others render with the `is-hidden` class for
+	 * progressive enhancement.
+	 */
+	public function test_render_appearance_renders_all_three_preview_containers(): void {
+		update_option( 'activitypub_actor_mode', 'actor' );
+
+		$output = $this->render_wizard_step( 'appearance' );
+
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*\bclass="[^"]*\bfosse-address-preview\b[^"]*"[^>]*\bdata-fosse-mode="actor"/i',
+			$output,
+			'Expected an actor-mode preview container.'
+		);
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*\bclass="[^"]*\bfosse-address-preview\b[^"]*"[^>]*\bdata-fosse-mode="blog"/i',
+			$output,
+			'Expected a blog-mode preview container.'
+		);
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*\bclass="[^"]*\bfosse-address-preview\b[^"]*"[^>]*\bdata-fosse-mode="actor_blog"/i',
+			$output,
+			'Expected an actor_blog-mode preview container.'
+		);
+	}
+
+	/**
+	 * Only the container matching the saved mode renders without
+	 * `is-hidden`; the inactive ones are rendered hidden so JS can swap
+	 * them in without a reload, and so a no-JS fallback still matches the
+	 * pre-#68 behavior of showing only the active mode's preview.
+	 */
+	public function test_render_appearance_marks_inactive_previews_hidden(): void {
+		update_option( 'activitypub_actor_mode', 'blog' );
+
+		$output = $this->render_wizard_step( 'appearance' );
+
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*\bclass="[^"]*\bfosse-address-preview\b(?:(?!is-hidden)[^"])*"[^>]*\bdata-fosse-mode="blog"/i',
+			$output,
+			'The active mode container must not be marked is-hidden.'
+		);
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*\bclass="[^"]*\bfosse-address-preview\b[^"]*\bis-hidden\b[^"]*"[^>]*\bdata-fosse-mode="actor"/i',
+			$output,
+			'Inactive containers must be marked is-hidden.'
+		);
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*\bclass="[^"]*\bfosse-address-preview\b[^"]*\bis-hidden\b[^"]*"[^>]*\bdata-fosse-mode="actor_blog"/i',
+			$output,
+			'Inactive containers must be marked is-hidden.'
+		);
+	}
+
+	/**
+	 * The appearance step exposes an inline Site Handle input keyed to the
+	 * AP option, so users can edit the site username from the wizard rather
+	 * than bouncing to the Setup page.
+	 */
+	public function test_render_appearance_renders_inline_site_handle_input(): void {
+		update_option( 'activitypub_actor_mode', 'blog' );
+		update_option( 'activitypub_blog_identifier', 'mysite' );
+
+		$output = $this->render_wizard_step( 'appearance' );
+
+		$this->assertMatchesRegularExpression(
+			'/<input[^>]*\bname="activitypub_blog_identifier"[^>]*\bvalue="mysite"/i',
+			$output,
+			'Expected the site handle input to render with the saved value.'
+		);
+		// The input should be inside the form so it submits with the rest
+		// of the appearance step.
+		$this->assertMatchesRegularExpression(
+			'~<form\b[^>]*>.*name="activitypub_blog_identifier".*</form>~is',
+			$output,
+			'Site handle input must be inside the appearance form.'
+		);
+	}
+
+	/**
+	 * The site handle row is hidden when the saved mode does not include
+	 * the blog actor, so the no-JS fallback matches the old behavior of
+	 * not surfacing the field. JS reveals it when the user picks `blog`
+	 * or `actor_blog`.
+	 */
+	public function test_render_appearance_marks_site_handle_hidden_when_actor_mode(): void {
+		update_option( 'activitypub_actor_mode', 'actor' );
+
+		$output = $this->render_wizard_step( 'appearance' );
+
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*\bclass="[^"]*\bfosse-wizard__blog-handle\b[^"]*\bis-hidden\b[^"]*"[^>]*\bdata-fosse-when="includes-blog"/i',
+			$output,
+			'Site handle row must be marked is-hidden when actor mode is selected.'
+		);
+	}
+
+	/**
+	 * Saving the appearance step persists a non-empty site handle into the
+	 * shared `activitypub_blog_identifier` option, mirroring the Setup
+	 * page behavior. AP's own option sanitizer enforces collisions.
+	 */
+	public function test_handle_save_appearance_stores_blog_identifier(): void {
+		$this->simulate_save_request(
+			'appearance',
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => 'newsroom',
+			)
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'newsroom', get_option( 'activitypub_blog_identifier' ) );
+	}
+
+	/**
+	 * Empty handle submissions preserve any existing stored value rather
+	 * than reverting to AP's default — matches AP_Provider::handle_save()
+	 * so users who haven't touched the field don't accidentally freeze
+	 * the dynamic default into the option.
+	 */
+	public function test_handle_save_appearance_preserves_existing_handle_when_empty(): void {
+		update_option( 'activitypub_blog_identifier', 'sticky' );
+
+		$this->simulate_save_request(
+			'appearance',
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => '   ',
+			)
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'sticky', get_option( 'activitypub_blog_identifier' ) );
 	}
 
 	// --- Bluesky step render ---

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -71,7 +71,12 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		remove_all_filters( 'wp_redirect' );
 		remove_all_filters( 'wp_die_handler' );
+		remove_all_filters( 'sanitize_option_activitypub_blog_identifier' );
 		remove_all_actions( 'fosse_wizard_unauthorized' );
+
+		global $wp_settings_errors;
+		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- WP core global reset for testing.
+		delete_transient( 'settings_errors' );
 
 		Connection_Provider_Registry::reset();
 		AP_Provider::register_provider();
@@ -494,6 +499,116 @@ class Onboarding_WizardTest extends BaseTestCase {
 		}
 
 		$this->assertSame( 'sticky', get_option( 'activitypub_blog_identifier' ) );
+	}
+
+	/**
+	 * AP's sanitizer adds settings errors under `activitypub_blog_identifier`
+	 * when the input collides with an existing user. The wizard re-tags them
+	 * under the `fosse` group so `settings_errors( 'fosse' )` on the
+	 * appearance step renders the message — without re-tagging the user
+	 * would land back on the wizard with no feedback.
+	 *
+	 * Forces the rejection branch directly via AP's filter; WorDBless's
+	 * dbless engine doesn't satisfy `WP_User_Query`'s LIKE search so seeding
+	 * a colliding user wouldn't trip AP's collision path.
+	 */
+	public function test_handle_save_appearance_rewires_ap_settings_errors_to_fosse_group(): void {
+		add_filter(
+			'sanitize_option_activitypub_blog_identifier',
+			static function ( $value ) {
+				add_settings_error(
+					'activitypub_blog_identifier',
+					'collision_test',
+					'Collision test error.',
+					'error'
+				);
+				return $value;
+			},
+			11 // After AP's own callback.
+		);
+
+		$this->simulate_save_request(
+			'appearance',
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => 'whatever',
+			)
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$fosse_codes = array_column( get_settings_errors( 'fosse' ), 'code' );
+		$this->assertContains( 'collision_test', $fosse_codes );
+	}
+
+	/**
+	 * On collision rejection the wizard redirects back to the appearance
+	 * step instead of advancing to content, so the user can read the
+	 * surfaced error and correct the input.
+	 */
+	public function test_handle_save_appearance_redirects_back_on_blog_identifier_rejection(): void {
+		add_filter(
+			'sanitize_option_activitypub_blog_identifier',
+			static function ( $value ) {
+				add_settings_error(
+					'activitypub_blog_identifier',
+					'collision_test',
+					'Collision test error.',
+					'error'
+				);
+				return $value;
+			},
+			11
+		);
+
+		$captured = null;
+		$this->simulate_save_request(
+			'appearance',
+			array(
+				'activitypub_actor_mode'      => 'blog',
+				'activitypub_blog_identifier' => 'whatever',
+			)
+		);
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new RedirectFired( 'redirect' );
+			},
+			9
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull( $captured );
+		$this->assertStringContainsString( 'step=appearance', $captured );
+		$this->assertStringNotContainsString( 'step=content', $captured );
+	}
+
+	/**
+	 * The appearance step renders `settings_errors( 'fosse' )` so a fresh
+	 * collision message persisted via the `settings_errors` transient on
+	 * redirect surfaces above the form on page load.
+	 */
+	public function test_render_appearance_renders_fosse_settings_errors(): void {
+		add_settings_error(
+			'fosse',
+			'collision_test',
+			'Pretend collision message.',
+			'error'
+		);
+
+		$output = $this->render_wizard_step( 'appearance' );
+
+		$this->assertStringContainsString( 'Pretend collision message.', $output );
 	}
 
 	// --- Bluesky step render ---


### PR DESCRIPTION
## Summary

- Renders all three actor-mode preview containers server-side on the Appearance step and toggles visibility live via a small vanilla-JS helper when the user changes the radio. Inactive containers carry `is-hidden` so the no-JS fallback still matches the pre-issue 68 behavior of showing only the saved mode's preview.
- Brings PR 65's inline Site Handle field (`activitypub_blog_identifier`) onto the wizard's Appearance step. The row is hidden when the selected mode does not include the blog actor; JS reveals it when the user picks **As your site** or **Both**.
- Saves the submitted Site Handle alongside the actor mode in `handle_save`, only persisting non-empty values so a no-touch submit preserves the existing stored handle (mirrors `AP_Provider::handle_save`).

Fixes #68.

## Implementation notes

- `src/Admin/assets/js/wizard-appearance.js` is a small IIFE that listens for `change` on `.fosse-mode-card__input` and toggles `is-hidden` on `.fosse-address-preview[data-fosse-mode="..."]` containers and the `[data-fosse-when="includes-blog"]` row. Enqueued only on the wizard hook (`admin_page_fosse-wizard`).
- The wizard now resolves both user and blog handles on every render (instead of mode-gating). One extra AP actor-model construction per wizard render — acceptable for a one-time onboarding flow.
- AP's `sanitize_option_activitypub_blog_identifier` filter still owns collision rejection at `update_option` time; the wizard does not duplicate that logic.

## Test plan

- [x] `composer run-script test-php` — full PHPUnit suite (234 tests) passes; six new tests cover the three preview containers, hidden-state markup, the inline site handle input rendering, and POST persistence (write + empty-input preserves existing).
- [x] `composer run-script lint-php` — PHPCS clean (Jetpack ruleset).
- [x] `pnpm run lint` and `pnpm run format:check` — ESLint and Prettier clean.
- [x] `pnpm test` — Jest passes.
- [ ] `pnpm run test:e2e` — Playwright suite (CI). New spec asserts the live preview swap on radio change and the Site Handle row visibility per mode.
- [ ] Manual: open `wp-admin/admin.php?page=fosse-wizard&step=appearance`, switch between **As you** / **As your site** / **Both** and confirm the preview updates without a reload.