### PR TITLE
chore: export-ignore .claude/ from build-zip artifact

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,8 @@
 # reports the attribute — matters for any tool that queries attrs per
 # file rather than walking the tree like git-archive does).
 
+/.claude               export-ignore
+/.claude/**            export-ignore
 /.github               export-ignore
 /.github/**            export-ignore
 /.gitattributes        export-ignore


### PR DESCRIPTION
## Summary

Editor/agent tooling under `.claude/` (currently the 467-byte `settings.json`, plus the gitignored `settings.local.json` / `scheduled_tasks.lock` / `worktrees/`) was bundled into `build/fosse.zip` via `git archive`. It's inert at plugin runtime but pollutes the release artifact with config that only matters in this checkout.

Two new `.gitattributes` entries match the existing convention — bare path prunes the dir from archives, `path/**` ensures `git check-attr` on individual files also reports the attribute (relevant for any tool that walks per-file rather than via `git-archive`).

## Verify

```
$ git check-attr export-ignore .claude/settings.json
.claude/settings.json: export-ignore: set
```

Surfaced as a follow-up note while reviewing a separate PR.