### PR TITLE
chore: sync bundled Atmosphere to teaser-thread-3post-card HEAD eecad09

### DIFF
--- a/bundled/atmosphere/atmosphere.php
+++ b/bundled/atmosphere/atmosphere.php
@@ -64,12 +64,7 @@ function activate() {
  * Deactivation hook.
  */
 function deactivate() {
-	\wp_clear_scheduled_hook( 'atmosphere_refresh_token' );
-	\wp_clear_scheduled_hook( 'atmosphere_sync_reactions' );
-	\wp_clear_scheduled_hook( 'atmosphere_sync_publication' );
-	\wp_clear_scheduled_hook( 'atmosphere_delete_records' );
-	// Clear the legacy hook name in case an earlier PR-6 build scheduled it.
-	\wp_clear_scheduled_hook( 'atmosphere_sync_comments' );
+	clear_scheduled_hooks();
 	\flush_rewrite_rules();
 }
 \register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );

--- a/bundled/atmosphere/includes/class-atmosphere.php
+++ b/bundled/atmosphere/includes/class-atmosphere.php
@@ -10,7 +10,9 @@ namespace Atmosphere;
 \defined( 'ABSPATH' ) || exit;
 
 use Atmosphere\OAuth\Client;
+use Atmosphere\Transformer\Comment;
 use Atmosphere\Transformer\Document;
+use Atmosphere\Transformer\Post;
 use Atmosphere\Transformer\Publication;
 use Atmosphere\Transformer\TID;
 use Atmosphere\Integrations\Load;
@@ -26,6 +28,31 @@ class Atmosphere {
 	 * the matching `atmosphere_long_form_composition` option.
 	 */
 	public const LONG_FORM_STRATEGIES = array( 'link-card', 'truncate-link', 'teaser-thread' );
+
+	/**
+	 * Comment meta key tracking how many times publish has been
+	 * deferred waiting for a parent comment to publish first.
+	 *
+	 * @var string
+	 */
+	private const META_PUBLISH_ATTEMPTS = '_atmosphere_publish_attempts';
+
+	/**
+	 * Maximum re-schedule hops for a child comment waiting on a
+	 * not-yet-published parent. After this many deferrals the child
+	 * publishes as a top-level reply on the post (current fallback
+	 * behavior) so a stuck parent does not block it forever.
+	 *
+	 * @var int
+	 */
+	private const PARENT_DEFER_MAX_ATTEMPTS = 3;
+
+	/**
+	 * Seconds between parent-pending re-schedule hops.
+	 *
+	 * @var int
+	 */
+	private const PARENT_DEFER_DELAY_SECONDS = 30;
 
 	/**
 	 * Wire up all hooks.
@@ -69,6 +96,12 @@ class Atmosphere {
 
 		// Catch permanent deletes (bypassing trash or emptying trash).
 		\add_action( 'before_delete_post', array( $this, 'on_before_delete' ) );
+
+		// Comment lifecycle hooks.
+		\add_action( 'transition_comment_status', array( $this, 'on_comment_status_change' ), 10, 3 );
+		\add_action( 'comment_post', array( $this, 'on_comment_insert' ), 10, 2 );
+		\add_action( 'edit_comment', array( $this, 'on_comment_edit' ) );
+		\add_action( 'delete_comment', array( $this, 'on_comment_before_delete' ) );
 
 		// Auto-sync publication when site identity changes.
 		\add_action( 'update_option_blogname', array( $this, 'schedule_publication_sync' ) );
@@ -319,11 +352,21 @@ class Atmosphere {
 	/**
 	 * Schedule AT Protocol record deletion before a post is permanently deleted.
 	 *
-	 * Captures every Bluesky TID (including thread replies) and the
-	 * document TID from post meta before they're lost, then schedules
-	 * an async delete via cron. Thread-strategy posts: reads
-	 * `Post::META_THREAD_RECORDS` and batches every bsky tid into the
-	 * cron event so a single delete covers root + replies.
+	 * Captures every Bluesky TID (post root + thread replies + outbound
+	 * comment replies) and the document TID from post meta, then
+	 * schedules a single async batch delete via cron. Thread-strategy
+	 * posts read every TID from `Post::META_THREAD_RECORDS`; outbound
+	 * comment replies come from `Publisher::collect_published_comment_tids()`.
+	 *
+	 * Comment TIDs must be collected here, while WP still has the
+	 * comment rows: `wp_delete_post( $id, true )` fires `before_delete_post`
+	 * first and only then iterates child comments, so this is the last
+	 * opportunity to read them.
+	 *
+	 * The trash path (`Publisher::delete_post()`) already cascades
+	 * comment deletes; this keeps the permanent-delete path symmetric
+	 * so unpublishing or hard-deleting a post does not orphan its
+	 * outbound replies on the PDS.
 	 *
 	 * @param int $post_id Post ID being deleted.
 	 */
@@ -366,9 +409,240 @@ class Atmosphere {
 
 		$doc_tid = (string) \get_post_meta( $post_id, Transformer\Document::META_TID, true );
 
-		if ( ! empty( $bsky_tids ) || '' !== $doc_tid ) {
-			\wp_schedule_single_event( \time(), 'atmosphere_delete_records', array( $bsky_tids, $doc_tid ) );
+		$comment_tids = \array_column(
+			Publisher::collect_published_comment_tids( $post_id ),
+			'tid'
+		);
+
+		if ( ! empty( $bsky_tids ) || '' !== $doc_tid || ! empty( $comment_tids ) ) {
+			\wp_schedule_single_event(
+				\time(),
+				'atmosphere_delete_records',
+				array( $bsky_tids, $doc_tid, $comment_tids )
+			);
 		}
+	}
+
+	/**
+	 * Handle a comment transitioning between approval states.
+	 *
+	 * @param string      $new_status New comment_approved value.
+	 * @param string      $old_status Previous comment_approved value.
+	 * @param \WP_Comment $comment    Comment object.
+	 */
+	public function on_comment_status_change( string $new_status, string $old_status, \WP_Comment $comment ): void {
+		if ( $new_status === $old_status ) {
+			return;
+		}
+
+		if ( 'approved' === $new_status ) {
+			$this->schedule_comment_publish( $comment );
+			return;
+		}
+
+		if ( 'approved' === $old_status ) {
+			$this->schedule_comment_delete( $comment );
+		}
+	}
+
+	/**
+	 * Handle a newly-inserted comment.
+	 *
+	 * Covers the case where a comment lands already-approved (trusted
+	 * author), for which transition_comment_status does not fire.
+	 *
+	 * @param int        $comment_id       Comment ID.
+	 * @param int|string $comment_approved Approval status (1, 0, or 'spam').
+	 */
+	public function on_comment_insert( int $comment_id, int|string $comment_approved ): void {
+		if ( 1 !== (int) $comment_approved ) {
+			return;
+		}
+
+		$comment = \get_comment( $comment_id );
+		if ( $comment instanceof \WP_Comment ) {
+			$this->schedule_comment_publish( $comment );
+		}
+	}
+
+	/**
+	 * Handle a comment edit by updating its bsky record.
+	 *
+	 * @param int $comment_id Comment ID.
+	 */
+	public function on_comment_edit( int $comment_id ): void {
+		$comment = \get_comment( $comment_id );
+
+		if ( ! $comment instanceof \WP_Comment ) {
+			return;
+		}
+
+		if ( ! self::should_publish_comment( $comment ) ) {
+			return;
+		}
+
+		$hook = empty( \get_comment_meta( $comment_id, Comment::META_URI, true ) )
+			? 'atmosphere_publish_comment'
+			: 'atmosphere_update_comment';
+
+		if ( ! \wp_next_scheduled( $hook, array( $comment_id ) ) ) {
+			\wp_schedule_single_event( \time(), $hook, array( $comment_id ) );
+		}
+	}
+
+	/**
+	 * Capture a comment's TID before it is permanently deleted.
+	 *
+	 * Runs on delete_comment which fires before the row and meta are
+	 * removed, so the TID is still reachable. META_URI is the only
+	 * reliable signal that a record exists on the PDS — the TID is
+	 * persisted eagerly by Comment::get_rkey() before the applyWrites
+	 * call, so a TID alone matches both the normal pre-publish state
+	 * and a publish that failed after TID allocation; neither should
+	 * schedule a delete. The TID-only cron variant lets the async
+	 * worker issue the PDS delete without re-reading state that no
+	 * longer exists.
+	 *
+	 * @param int $comment_id Comment ID.
+	 */
+	public function on_comment_before_delete( int $comment_id ): void {
+		if ( ! is_connected() ) {
+			return;
+		}
+
+		$uri = \get_comment_meta( $comment_id, Comment::META_URI, true );
+
+		if ( empty( $uri ) ) {
+			return;
+		}
+
+		$tid = \get_comment_meta( $comment_id, Comment::META_TID, true );
+
+		if ( empty( $tid ) ) {
+			return;
+		}
+
+		$tid  = (string) $tid;
+		$args = array( $tid );
+
+		if ( \wp_next_scheduled( 'atmosphere_delete_comment_record', $args ) ) {
+			return;
+		}
+
+		\wp_schedule_single_event( \time(), 'atmosphere_delete_comment_record', $args );
+	}
+
+	/**
+	 * Eligibility gate for outbound comment publishing.
+	 *
+	 * @param \WP_Comment $comment Comment object.
+	 * @return bool
+	 */
+	public static function should_publish_comment( \WP_Comment $comment ): bool {
+		$should = self::is_comment_eligible( $comment );
+
+		/**
+		 * Filters whether a comment should be published to Bluesky.
+		 *
+		 * @param bool        $should  Whether to publish.
+		 * @param \WP_Comment $comment Comment object.
+		 */
+		return (bool) \apply_filters( 'atmosphere_should_publish_comment', $should, $comment );
+	}
+
+	/**
+	 * Core comment eligibility checks, pre-filter.
+	 *
+	 * @param \WP_Comment $comment Comment object.
+	 * @return bool
+	 */
+	private static function is_comment_eligible( \WP_Comment $comment ): bool {
+		if ( ! is_connected() ) {
+			return false;
+		}
+
+		if ( \in_array( (string) $comment->comment_type, array( 'trackback', 'pingback' ), true ) ) {
+			return false;
+		}
+
+		if ( (int) $comment->user_id <= 0 ) {
+			return false;
+		}
+
+		if ( '1' !== (string) $comment->comment_approved ) {
+			return false;
+		}
+
+		if ( 'atproto' === \get_comment_meta( (int) $comment->comment_ID, Reaction_Sync::META_PROTOCOL, true ) ) {
+			return false;
+		}
+
+		/*
+		 * Defence in depth: Reaction_Sync writes META_PROTOCOL after
+		 * wp_insert_comment, so if any caller ever fires comment_post
+		 * between the insert and the meta write, the gate above would
+		 * miss it. The sync always stamps its own agent string, which
+		 * is set before the insert — use it as a belt-and-braces check.
+		 */
+		if ( 0 === \strpos( (string) $comment->comment_agent, 'ATmosphere/' ) ) {
+			return false;
+		}
+
+		$post_id  = (int) $comment->comment_post_ID;
+		$post_uri = \get_post_meta( $post_id, Post::META_URI, true );
+		$post_cid = \get_post_meta( $post_id, Post::META_CID, true );
+
+		// Both URI and CID are required to build a valid reply.root strongRef.
+		if ( empty( $post_uri ) || empty( $post_cid ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Schedule a publish or update event for a comment.
+	 *
+	 * @param \WP_Comment $comment Comment object.
+	 */
+	private function schedule_comment_publish( \WP_Comment $comment ): void {
+		if ( ! self::should_publish_comment( $comment ) ) {
+			return;
+		}
+
+		$comment_id = (int) $comment->comment_ID;
+		$hook       = empty( \get_comment_meta( $comment_id, Comment::META_URI, true ) )
+			? 'atmosphere_publish_comment'
+			: 'atmosphere_update_comment';
+
+		if ( \wp_next_scheduled( $hook, array( $comment_id ) ) ) {
+			return;
+		}
+
+		\wp_schedule_single_event( \time(), $hook, array( $comment_id ) );
+	}
+
+	/**
+	 * Schedule a delete event when a published comment leaves approved state.
+	 *
+	 * @param \WP_Comment $comment Comment object.
+	 */
+	private function schedule_comment_delete( \WP_Comment $comment ): void {
+		if ( ! is_connected() ) {
+			return;
+		}
+
+		$comment_id = (int) $comment->comment_ID;
+
+		if ( empty( \get_comment_meta( $comment_id, Comment::META_URI, true ) ) ) {
+			return;
+		}
+
+		if ( \wp_next_scheduled( 'atmosphere_delete_comment', array( $comment_id ) ) ) {
+			return;
+		}
+
+		\wp_schedule_single_event( \time(), 'atmosphere_delete_comment', array( $comment_id ) );
 	}
 
 	/**
@@ -444,7 +718,7 @@ class Atmosphere {
 			static function ( int $post_id ): void {
 				$post = \get_post( $post_id );
 				if ( $post && 'publish' === $post->post_status && is_supported_post_type( $post->post_type ) ) {
-					Publisher::publish( $post );
+					Publisher::publish_post( $post );
 				}
 			}
 		);
@@ -454,7 +728,7 @@ class Atmosphere {
 			static function ( int $post_id ): void {
 				$post = \get_post( $post_id );
 				if ( $post && 'publish' === $post->post_status && is_supported_post_type( $post->post_type ) ) {
-					Publisher::update( $post );
+					Publisher::update_post( $post );
 				}
 			}
 		);
@@ -464,7 +738,7 @@ class Atmosphere {
 			static function ( int $post_id ): void {
 				$post = \get_post( $post_id );
 				if ( $post ) {
-					Publisher::delete( $post );
+					Publisher::delete_post( $post );
 				}
 			}
 		);
@@ -478,11 +752,265 @@ class Atmosphere {
 
 		\add_action(
 			'atmosphere_delete_records',
-			static function ( $bsky_tids, string $doc_tid ): void {
-				Publisher::delete_by_tids( $bsky_tids, $doc_tid );
+			static function ( $bsky_tids, string $doc_tid, $comment_tids = array() ): void {
+				$comment_tids = \is_array( $comment_tids ) ? $comment_tids : array();
+				$result       = Publisher::delete_post_by_tids( $bsky_tids, $doc_tid, $comment_tids );
+
+				if ( \is_wp_error( $result ) ) {
+					/*
+					 * One-shot cron event with no retry: dropping this error
+					 * would orphan every record in the cascade (root + thread
+					 * replies + outbound comment replies + document) on the
+					 * PDS with no operator-visible breadcrumb.
+					 */
+					\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+						\sprintf(
+							'[atmosphere] delete_records failed (bsky=%d, doc=%s, comments=%d): %s — %s',
+							\is_array( $bsky_tids ) ? \count( $bsky_tids ) : (int) ! empty( $bsky_tids ),
+							$doc_tid ? 'yes' : 'no',
+							\count( $comment_tids ),
+							$result->get_error_code(),
+							$result->get_error_message()
+						)
+					);
+				}
 			},
 			10,
-			2
+			3
 		);
+
+		/*
+		 * Cron handlers re-evaluate eligibility at fire time so state
+		 * changes between enqueue and execution (approve→unapprove,
+		 * unapprove→re-approve, user deleted, etc.) are respected. The
+		 * separate transition hooks only schedule; they cannot cancel
+		 * an already-queued event, and schedule_comment_delete itself
+		 * bails when META_URI is absent (which it is pre-publish), so
+		 * without these guards a pre-cron unapprove would still
+		 * publish, and a pre-cron re-approve would still delete.
+		 *
+		 * Publisher WP_Error returns are logged rather than silently
+		 * dropped so a flaky PDS window or an expired refresh token
+		 * leaves a breadcrumb operators can find.
+		 */
+		\add_action(
+			'atmosphere_publish_comment',
+			static function ( int $comment_id ): void {
+				$comment = \get_comment( $comment_id );
+				if ( ! $comment instanceof \WP_Comment ) {
+					return;
+				}
+				if ( ! self::should_publish_comment( $comment ) ) {
+					return;
+				}
+				if ( self::defer_when_parent_pending( $comment ) ) {
+					return;
+				}
+				\delete_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS );
+
+				$result = Publisher::publish_comment( $comment );
+				self::log_cron_error( 'publish_comment', $comment_id, $result );
+
+				if ( ! \is_wp_error( $result ) ) {
+					self::reconcile_comment_after_publish( $comment_id );
+				}
+			}
+		);
+
+		\add_action(
+			'atmosphere_update_comment',
+			static function ( int $comment_id ): void {
+				$comment = \get_comment( $comment_id );
+				if ( ! $comment instanceof \WP_Comment ) {
+					return;
+				}
+				if ( ! self::should_publish_comment( $comment ) ) {
+					return;
+				}
+
+				$result = Publisher::update_comment( $comment );
+				self::log_cron_error( 'update_comment', $comment_id, $result );
+			}
+		);
+
+		\add_action(
+			'atmosphere_delete_comment',
+			static function ( int $comment_id ): void {
+				$comment = \get_comment( $comment_id );
+				if ( ! $comment instanceof \WP_Comment ) {
+					return;
+				}
+				// If the comment is eligible again by the time cron
+				// fires, another transition has superseded the delete.
+				if ( self::should_publish_comment( $comment ) ) {
+					return;
+				}
+
+				$result = Publisher::delete_comment( $comment );
+				self::log_cron_error( 'delete_comment', $comment_id, $result );
+			}
+		);
+
+		\add_action(
+			'atmosphere_delete_comment_record',
+			static function ( string $tid ): void {
+				if ( '' === $tid ) {
+					return;
+				}
+
+				$result = Publisher::delete_comment_by_tid( $tid );
+
+				if ( \is_wp_error( $result ) ) {
+					// Worst-case path: the WP comment row is already gone,
+					// so operators need the TID to clean up the orphan
+					// record manually.
+					\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+						\sprintf(
+							'[atmosphere] delete_comment_record tid=%s failed: %s — %s',
+							$tid,
+							$result->get_error_code(),
+							$result->get_error_message()
+						)
+					);
+				}
+			},
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Defer a child comment publish when its parent is eligible but
+	 * has not published to the PDS yet.
+	 *
+	 * Comments are scheduled as independent single events with no
+	 * dependency ordering: if a user approves a parent and its reply
+	 * together, the child's cron event can fire first, see
+	 * resolve_parent_ref() return null, and publish flat as a
+	 * top-level reply on the root post. This defers the child a short
+	 * interval (up to PARENT_DEFER_MAX_ATTEMPTS hops) to give the
+	 * parent time to publish first. After the cap the child publishes
+	 * anyway using the root fallback — a stuck parent must not block
+	 * the child forever.
+	 *
+	 * @param \WP_Comment $comment Comment being published.
+	 * @return bool True when the publish was deferred, false to proceed now.
+	 */
+	private static function defer_when_parent_pending( \WP_Comment $comment ): bool {
+		$parent_id = (int) $comment->comment_parent;
+
+		if ( $parent_id <= 0 ) {
+			return false;
+		}
+
+		$parent = \get_comment( $parent_id );
+
+		if ( ! $parent instanceof \WP_Comment ) {
+			return false;
+		}
+
+		if ( ! self::should_publish_comment( $parent ) ) {
+			// Parent is ineligible (anon, rejected, etc.); resolve_parent_ref
+			// will fall back to root, which is the correct behavior.
+			return false;
+		}
+
+		if ( ! empty( \get_comment_meta( $parent_id, Comment::META_URI, true ) ) ) {
+			// Parent is already published — nothing to defer for.
+			return false;
+		}
+
+		$comment_id = (int) $comment->comment_ID;
+		$attempts   = (int) \get_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS, true );
+
+		if ( $attempts >= self::PARENT_DEFER_MAX_ATTEMPTS ) {
+			// Give up and publish with root as parent; clear the counter
+			// so a future re-publish gets a fresh deferral budget.
+			\delete_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS );
+			return false;
+		}
+
+		\update_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS, $attempts + 1 );
+		\wp_schedule_single_event(
+			\time() + self::PARENT_DEFER_DELAY_SECONDS,
+			'atmosphere_publish_comment',
+			array( $comment_id )
+		);
+
+		return true;
+	}
+
+	/**
+	 * Log a WP_Error returned from a comment cron Publisher call.
+	 *
+	 * `wp_schedule_single_event` does not retry, so a silent drop
+	 * here would lose the breadcrumb operators need to diagnose
+	 * auth, transport, or PDS-side failures.
+	 *
+	 * @param string $op         One of 'publish_comment' | 'update_comment' | 'delete_comment'.
+	 * @param int    $comment_id Comment ID.
+	 * @param mixed  $result     Publisher call result.
+	 */
+	private static function log_cron_error( string $op, int $comment_id, $result ): void {
+		if ( ! \is_wp_error( $result ) ) {
+			return;
+		}
+
+		\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			\sprintf(
+				'[atmosphere] %s %d failed: %s — %s',
+				$op,
+				$comment_id,
+				$result->get_error_code(),
+				$result->get_error_message()
+			)
+		);
+	}
+
+	/**
+	 * Roll back a successful publish if the comment became ineligible
+	 * during the in-flight applyWrites.
+	 *
+	 * The race: `Comment::get_rkey()` persists META_TID before the API
+	 * call, and META_URI is only written after success. Both
+	 * `schedule_comment_delete` and `on_comment_before_delete` require
+	 * META_URI to schedule cleanup. A moderator who deletes or
+	 * unapproves the comment while applyWrites is in flight therefore
+	 * leaves a live Bluesky reply with no scheduled cleanup once
+	 * `store_comment_result()` finally writes META_URI.
+	 *
+	 * Re-checking eligibility after publish closes that race. If the
+	 * comment is gone or no longer eligible, we clear the meta we just
+	 * wrote and schedule the same TID-only delete event the
+	 * permanent-delete path uses, so transient PDS failures retry via
+	 * the standard cleanup channel rather than getting dropped here.
+	 *
+	 * @param int $comment_id Comment ID just published.
+	 */
+	private static function reconcile_comment_after_publish( int $comment_id ): void {
+		$fresh = \get_comment( $comment_id );
+
+		if ( $fresh instanceof \WP_Comment && self::should_publish_comment( $fresh ) ) {
+			return;
+		}
+
+		$tid = (string) \get_comment_meta( $comment_id, Comment::META_TID, true );
+
+		\delete_comment_meta( $comment_id, Comment::META_TID );
+		\delete_comment_meta( $comment_id, Comment::META_URI );
+		\delete_comment_meta( $comment_id, Comment::META_CID );
+		\delete_comment_meta( $comment_id, Reaction_Sync::META_SOURCE_ID );
+
+		if ( '' === $tid ) {
+			return;
+		}
+
+		$args = array( $tid );
+
+		if ( \wp_next_scheduled( 'atmosphere_delete_comment_record', $args ) ) {
+			return;
+		}
+
+		\wp_schedule_single_event( \time(), 'atmosphere_delete_comment_record', $args );
 	}
 }

--- a/bundled/atmosphere/includes/class-backfill.php
+++ b/bundled/atmosphere/includes/class-backfill.php
@@ -129,7 +129,7 @@ class Backfill {
 				continue;
 			}
 
-			$response = Publisher::publish( $post );
+			$response = Publisher::publish_post( $post );
 
 			if ( \is_wp_error( $response ) ) {
 				$results[] = array(

--- a/bundled/atmosphere/includes/class-publisher.php
+++ b/bundled/atmosphere/includes/class-publisher.php
@@ -1,14 +1,15 @@
 <?php
 /**
- * Orchestrates publishing WordPress posts to the AT Protocol.
+ * Orchestrates publishing WordPress content to the AT Protocol.
  *
  * A WordPress post corresponds to:
  * - One or more `app.bsky.feed.post` records (a thread, for the
  *   long-form `teaser-thread` strategy).
  * - Exactly one `site.standard.document` record.
+ * Outbound WordPress comments publish as separate bsky reply records.
  *
- * Single-record publishes (short-form, link-card, truncate-link) use
- * one atomic `applyWrites` call with the bsky post + doc. Threads
+ * Single-record post publishes (short-form, link-card, truncate-link)
+ * use one atomic `applyWrites` call with the bsky post + doc. Threads
  * write the root + doc atomically, then each reply as its own
  * `applyWrites` call so reply refs can carry the parent's CID (the
  * PDS only returns CIDs in the response, so we can't assemble a
@@ -19,6 +20,9 @@
  * failure issues compensating `applyWrites#delete` calls in reverse
  * order to roll back to a "nothing published" state.
  *
+ * The generic publish/update/delete entry points dispatch by object
+ * type so callers can stay polymorphic across posts and comments.
+ *
  * @package Atmosphere
  */
 
@@ -26,6 +30,7 @@ namespace Atmosphere;
 
 \defined( 'ABSPATH' ) || exit;
 
+use Atmosphere\Transformer\Comment;
 use Atmosphere\Transformer\Document;
 use Atmosphere\Transformer\Post;
 use Atmosphere\Transformer\Publication;
@@ -37,12 +42,54 @@ use Atmosphere\Transformer\TID;
 class Publisher {
 
 	/**
+	 * Dispatch a publish by object type.
+	 *
+	 * @param \WP_Post|\WP_Comment $object WordPress post or comment.
+	 * @return array|\WP_Error
+	 */
+	public static function publish( \WP_Post|\WP_Comment $object ): array|\WP_Error { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames
+		if ( $object instanceof \WP_Comment ) {
+			return self::publish_comment( $object );
+		}
+
+		return self::publish_post( $object );
+	}
+
+	/**
+	 * Dispatch an update by object type.
+	 *
+	 * @param \WP_Post|\WP_Comment $object WordPress post or comment.
+	 * @return array|\WP_Error
+	 */
+	public static function update( \WP_Post|\WP_Comment $object ): array|\WP_Error { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames
+		if ( $object instanceof \WP_Comment ) {
+			return self::update_comment( $object );
+		}
+
+		return self::update_post( $object );
+	}
+
+	/**
+	 * Dispatch a delete by object type.
+	 *
+	 * @param \WP_Post|\WP_Comment $object WordPress post or comment.
+	 * @return array|\WP_Error
+	 */
+	public static function delete( \WP_Post|\WP_Comment $object ): array|\WP_Error { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames
+		if ( $object instanceof \WP_Comment ) {
+			return self::delete_comment( $object );
+		}
+
+		return self::delete_post( $object );
+	}
+
+	/**
 	 * Publish a post to AT Protocol (bsky record(s) + document).
 	 *
 	 * @param \WP_Post $post WordPress post.
 	 * @return array|\WP_Error applyWrites response(s) or error.
 	 */
-	public static function publish( \WP_Post $post ): array|\WP_Error {
+	public static function publish_post( \WP_Post $post ): array|\WP_Error {
 		$bsky_transformer = new Post( $post );
 		$doc_transformer  = new Document( $post );
 
@@ -472,12 +519,12 @@ class Publisher {
 	 * @param \WP_Post $post WordPress post.
 	 * @return array|\WP_Error
 	 */
-	public static function update( \WP_Post $post ): array|\WP_Error {
+	public static function update_post( \WP_Post $post ): array|\WP_Error {
 		$stored = self::stored_thread_records( $post->ID );
 
 		if ( empty( $stored ) ) {
 			// Never successfully published — do a fresh publish.
-			return self::publish( $post );
+			return self::publish_post( $post );
 		}
 
 		foreach ( $stored as $entry ) {
@@ -825,20 +872,39 @@ class Publisher {
 	}
 
 	/**
-	 * Delete every bsky record + the doc for a post.
+	 * Maximum writes per `applyWrites` call.
+	 *
+	 * The AT Protocol `com.atproto.repo.applyWrites` lexicon caps the
+	 * `writes` array at 200. We chunk well under that to leave headroom
+	 * and keep request bodies small.
+	 */
+	private const APPLY_WRITES_CHUNK_SIZE = 100;
+
+	/**
+	 * Delete every bsky record (root + thread replies + outbound
+	 * comment replies) and the document for a post.
 	 *
 	 * Handles thread posts (reads `META_THREAD_RECORDS`) and legacy
 	 * single-record posts (falls back to the mirrored `META_URI` /
-	 * `META_TID` / `META_CID` keys).
+	 * `META_TID` / `META_CID` keys). Outbound comment replies live in
+	 * our own repo keyed by their own TIDs — the AT Protocol has no
+	 * cascade semantics, so they have to be enumerated alongside the
+	 * post records or they orphan on Bluesky.
+	 *
+	 * Writes are chunked into bounded `applyWrites` calls (the lexicon
+	 * caps a single batch at 200), so a high-traffic post with a long
+	 * reply tail still cleans up cleanly.
 	 *
 	 * @param \WP_Post $post WordPress post.
 	 * @return array|\WP_Error
 	 */
-	public static function delete( \WP_Post $post ): array|\WP_Error {
+	public static function delete_post( \WP_Post $post ): array|\WP_Error {
 		$stored  = self::stored_thread_records( $post->ID );
 		$doc_tid = \get_post_meta( $post->ID, Document::META_TID, true );
 
-		if ( empty( $stored ) && ! $doc_tid ) {
+		$comment_tids = self::collect_published_comment_tids( $post->ID );
+
+		if ( empty( $stored ) && ! $doc_tid && empty( $comment_tids ) ) {
 			return new \WP_Error(
 				'atmosphere_not_published',
 				\__( 'Post has no AT Protocol records.', 'atmosphere' )
@@ -864,6 +930,14 @@ class Publisher {
 			);
 		}
 
+		foreach ( $comment_tids as $comment_tid ) {
+			$writes[] = array(
+				'$type'      => 'com.atproto.repo.applyWrites#delete',
+				'collection' => 'app.bsky.feed.post',
+				'rkey'       => $comment_tid['tid'],
+			);
+		}
+
 		if ( empty( $writes ) ) {
 			return new \WP_Error(
 				'atmosphere_not_published',
@@ -871,7 +945,7 @@ class Publisher {
 			);
 		}
 
-		$result = API::apply_writes( $writes );
+		$result = self::apply_writes_chunked( $writes );
 
 		if ( \is_wp_error( $result ) ) {
 			// Leave meta intact so a retry can complete.
@@ -880,32 +954,87 @@ class Publisher {
 
 		self::clear_all_record_meta( $post->ID );
 
+		// Clean up comment meta for every reply we just deleted.
+		foreach ( $comment_tids as $comment_tid ) {
+			\delete_comment_meta( $comment_tid['comment_id'], Comment::META_TID );
+			\delete_comment_meta( $comment_tid['comment_id'], Comment::META_URI );
+			\delete_comment_meta( $comment_tid['comment_id'], Comment::META_CID );
+			\delete_comment_meta( $comment_tid['comment_id'], Reaction_Sync::META_SOURCE_ID );
+		}
+
 		return $result;
+	}
+
+	/**
+	 * Collect { comment_id, tid } pairs for all outbound comment replies
+	 * on a post. Only comments that actually reached the PDS (META_URI
+	 * present) are returned — stale TIDs from a previously-failed
+	 * publish would refer to a non-existent record and the delete would
+	 * fail.
+	 *
+	 * Public so the permanent-delete path (`on_before_delete`) can
+	 * collect the same TIDs while comments still exist, before WP's
+	 * natural cascade removes them.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array<int, array{comment_id:int, tid:string}>
+	 */
+	public static function collect_published_comment_tids( int $post_id ): array {
+		$comments = \get_comments(
+			array(
+				'post_id'    => $post_id,
+				'status'     => 'any',
+				'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					array(
+						'key'     => Comment::META_URI,
+						'compare' => 'EXISTS',
+					),
+				),
+				'fields'     => 'ids',
+			)
+		);
+
+		$out = array();
+
+		foreach ( $comments as $comment_id ) {
+			$tid = \get_comment_meta( (int) $comment_id, Comment::META_TID, true );
+			if ( ! empty( $tid ) ) {
+				$out[] = array(
+					'comment_id' => (int) $comment_id,
+					'tid'        => (string) $tid,
+				);
+			}
+		}
+
+		return $out;
 	}
 
 	/**
 	 * Delete AT Protocol records by TID without requiring the post to exist.
 	 *
 	 * Used when a post is permanently deleted and its meta is no longer
-	 * accessible to `delete()`. Accepts either a single Bluesky TID
-	 * (legacy single-record posts) or an array of TIDs
-	 * (thread-strategy posts). All are issued in one atomic
-	 * `applyWrites` call.
+	 * accessible to `delete_post()`. Accepts either a single Bluesky TID
+	 * string (legacy single-record posts) or an array of TIDs
+	 * (thread-strategy posts), plus an optional list of outbound
+	 * comment-reply TIDs. All are issued in one atomic `applyWrites`
+	 * call so cleanup of root + thread + replies + document is atomic.
 	 *
-	 * @param string|string[] $bsky_tids Bluesky post TID or array of TIDs (may be empty).
-	 * @param string          $doc_tid   Document TID (may be empty).
+	 * @param string|string[] $bsky_tids    Bluesky post TID or array of TIDs (may be empty).
+	 * @param string          $doc_tid      Document TID (may be empty).
+	 * @param string[]        $comment_tids Comment reply TIDs to delete in the same batch.
 	 * @return array|\WP_Error
 	 */
-	public static function delete_by_tids( $bsky_tids, string $doc_tid ): array|\WP_Error {
+	public static function delete_post_by_tids( $bsky_tids, string $doc_tid, array $comment_tids = array() ): array|\WP_Error {
 		if ( \is_string( $bsky_tids ) ) {
 			$bsky_tids = '' === $bsky_tids ? array() : array( $bsky_tids );
 		} elseif ( ! \is_array( $bsky_tids ) ) {
 			$bsky_tids = array();
 		}
 
-		$bsky_tids = \array_values( \array_filter( \array_map( 'strval', $bsky_tids ), 'strlen' ) );
+		$bsky_tids    = \array_values( \array_filter( \array_map( 'strval', $bsky_tids ), 'strlen' ) );
+		$comment_tids = \array_values( \array_filter( \array_map( 'strval', $comment_tids ), 'strlen' ) );
 
-		if ( empty( $bsky_tids ) && ! $doc_tid ) {
+		if ( empty( $bsky_tids ) && ! $doc_tid && empty( $comment_tids ) ) {
 			return new \WP_Error( 'atmosphere_not_published', \__( 'No TIDs provided.', 'atmosphere' ) );
 		}
 
@@ -927,7 +1056,71 @@ class Publisher {
 			);
 		}
 
-		return API::apply_writes( $writes );
+		foreach ( $comment_tids as $comment_tid ) {
+			$writes[] = array(
+				'$type'      => 'com.atproto.repo.applyWrites#delete',
+				'collection' => 'app.bsky.feed.post',
+				'rkey'       => $comment_tid,
+			);
+		}
+
+		return self::apply_writes_chunked( $writes );
+	}
+
+	/**
+	 * Submit a `writes` batch in lexicon-bounded chunks.
+	 *
+	 * The PDS rejects an `applyWrites` whose `writes` array exceeds 200
+	 * entries (`InvalidRequest`), so a high-traffic post with hundreds of
+	 * outbound comment replies would otherwise fail the entire cascade
+	 * atomically.
+	 *
+	 * Chunks are submitted sequentially. The first chunk failure is
+	 * returned; the operator-visible error code includes how many chunks
+	 * had already succeeded so the partial-success state is visible. The
+	 * caller is responsible for keeping local meta intact on error so a
+	 * retry can complete the remaining chunks.
+	 *
+	 * On success, results from each chunk are concatenated into a single
+	 * `results` array — preserving the shape callers expect from
+	 * `API::apply_writes()`.
+	 *
+	 * @param array $writes Full write batch.
+	 * @return array|\WP_Error
+	 */
+	private static function apply_writes_chunked( array $writes ): array|\WP_Error {
+		if ( \count( $writes ) <= self::APPLY_WRITES_CHUNK_SIZE ) {
+			return API::apply_writes( $writes );
+		}
+
+		$chunks    = \array_chunk( $writes, self::APPLY_WRITES_CHUNK_SIZE );
+		$total     = \count( $chunks );
+		$results   = array();
+		$succeeded = 0;
+
+		foreach ( $chunks as $index => $chunk ) {
+			$response = API::apply_writes( $chunk );
+
+			if ( \is_wp_error( $response ) ) {
+				$response->add_data(
+					array(
+						'chunk_index'      => $index,
+						'chunks_total'     => $total,
+						'chunks_succeeded' => $succeeded,
+					),
+					'atmosphere_chunked_apply_writes'
+				);
+				return $response;
+			}
+
+			if ( isset( $response['results'] ) && \is_array( $response['results'] ) ) {
+				$results = \array_merge( $results, $response['results'] );
+			}
+
+			++$succeeded;
+		}
+
+		return array( 'results' => $results );
 	}
 
 	/**
@@ -973,6 +1166,164 @@ class Publisher {
 	}
 
 	/**
+	 * Publish a WordPress comment as an app.bsky.feed.post reply.
+	 *
+	 * @param \WP_Comment $comment WordPress comment.
+	 * @return array|\WP_Error applyWrites response or error.
+	 */
+	public static function publish_comment( \WP_Comment $comment ): array|\WP_Error {
+		$transformer = new Comment( $comment );
+		$rkey        = $transformer->get_rkey();
+		$record      = $transformer->transform();
+
+		$writes = array(
+			array(
+				'$type'      => 'com.atproto.repo.applyWrites#create',
+				'collection' => 'app.bsky.feed.post',
+				'rkey'       => $rkey,
+				'value'      => $record,
+			),
+		);
+
+		$result = API::apply_writes( $writes );
+
+		if ( \is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$stored = self::store_comment_result( (int) $comment->comment_ID, $result );
+		if ( \is_wp_error( $stored ) ) {
+			return $stored;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Update an existing bsky reply for a WordPress comment.
+	 *
+	 * Falls through to publish_comment when no URI is stored — the URI
+	 * is only written after a successful API call, so an absent URI
+	 * means the record was never created on the PDS. Keying off the
+	 * TID instead would be unsafe because Comment::get_rkey() persists
+	 * the TID before the API call, so a failed publish would leave the
+	 * TID present and send every subsequent attempt down the #update
+	 * path for a record that does not exist.
+	 *
+	 * @param \WP_Comment $comment WordPress comment.
+	 * @return array|\WP_Error
+	 */
+	public static function update_comment( \WP_Comment $comment ): array|\WP_Error {
+		$comment_id = (int) $comment->comment_ID;
+		$uri        = \get_comment_meta( $comment_id, Comment::META_URI, true );
+
+		if ( empty( $uri ) ) {
+			return self::publish_comment( $comment );
+		}
+
+		$tid = \get_comment_meta( $comment_id, Comment::META_TID, true );
+
+		if ( empty( $tid ) ) {
+			return new \WP_Error( 'atmosphere_missing_tid', \__( 'Comment URI exists but TID is missing.', 'atmosphere' ) );
+		}
+
+		$transformer = new Comment( $comment );
+
+		$writes = array(
+			array(
+				'$type'      => 'com.atproto.repo.applyWrites#update',
+				'collection' => 'app.bsky.feed.post',
+				'rkey'       => $tid,
+				'value'      => $transformer->transform(),
+			),
+		);
+
+		$result = API::apply_writes( $writes );
+
+		if ( \is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$stored = self::store_comment_result( $comment_id, $result );
+		if ( \is_wp_error( $stored ) ) {
+			return $stored;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Delete the bsky reply record for a WordPress comment.
+	 *
+	 * Keys off META_URI rather than META_TID so a previously-failed
+	 * publish (which persisted the TID but never wrote the URI) is
+	 * correctly treated as nothing-to-delete.
+	 *
+	 * @param \WP_Comment $comment WordPress comment.
+	 * @return array|\WP_Error
+	 */
+	public static function delete_comment( \WP_Comment $comment ): array|\WP_Error {
+		$comment_id = (int) $comment->comment_ID;
+		$uri        = \get_comment_meta( $comment_id, Comment::META_URI, true );
+
+		if ( empty( $uri ) ) {
+			return new \WP_Error( 'atmosphere_not_published', \__( 'Comment has no AT Protocol record.', 'atmosphere' ) );
+		}
+
+		$tid = \get_comment_meta( $comment_id, Comment::META_TID, true );
+
+		if ( empty( $tid ) ) {
+			return new \WP_Error( 'atmosphere_missing_tid', \__( 'Comment URI exists but TID is missing.', 'atmosphere' ) );
+		}
+
+		$writes = array(
+			array(
+				'$type'      => 'com.atproto.repo.applyWrites#delete',
+				'collection' => 'app.bsky.feed.post',
+				'rkey'       => $tid,
+			),
+		);
+
+		$result = API::apply_writes( $writes );
+
+		if ( \is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		\delete_comment_meta( $comment_id, Comment::META_TID );
+		\delete_comment_meta( $comment_id, Comment::META_URI );
+		\delete_comment_meta( $comment_id, Comment::META_CID );
+		\delete_comment_meta( $comment_id, Reaction_Sync::META_SOURCE_ID );
+
+		return $result;
+	}
+
+	/**
+	 * Delete a bsky comment reply by TID, without needing the comment row.
+	 *
+	 * Used when a comment is permanently deleted and its meta is no
+	 * longer reachable at the point the cron fires.
+	 *
+	 * @param string $tid Comment record TID.
+	 * @return array|\WP_Error
+	 */
+	public static function delete_comment_by_tid( string $tid ): array|\WP_Error {
+		if ( '' === $tid ) {
+			return new \WP_Error( 'atmosphere_not_published', \__( 'No TID provided.', 'atmosphere' ) );
+		}
+
+		$writes = array(
+			array(
+				'$type'      => 'com.atproto.repo.applyWrites#delete',
+				'collection' => 'app.bsky.feed.post',
+				'rkey'       => $tid,
+			),
+		);
+
+		return API::apply_writes( $writes );
+	}
+
+	/**
 	 * Persist the document record's URI/CID from an applyWrites response.
 	 *
 	 * The document is always written at index 1 of the first applyWrites
@@ -1000,6 +1351,45 @@ class Publisher {
 		if ( $cid ) {
 			\update_post_meta( $post_id, Document::META_CID, $cid );
 		}
+	}
+
+	/**
+	 * Store the applyWrites response for a comment publish/update.
+	 *
+	 * Mirrors the comment's AT-URI into Reaction_Sync::META_SOURCE_ID so
+	 * that when listRecords feeds our own reply back through the inbound
+	 * sync, find_comment_by_source_id() matches this row and skips it.
+	 *
+	 * Treats a 2xx response that omits `results[0].uri` as a failure
+	 * and returns a WP_Error. A locally-synthesized URI fallback would
+	 * make a malformed server response indistinguishable from a clean
+	 * publish, poison the dedup key, and steer later update/delete
+	 * calls at a record that may not exist.
+	 *
+	 * @param int   $comment_id WordPress comment ID.
+	 * @param array $result     applyWrites response.
+	 * @return true|\WP_Error True on success, WP_Error on missing URI.
+	 */
+	private static function store_comment_result( int $comment_id, array $result ): true|\WP_Error {
+		$first = $result['results'][0] ?? array();
+		$uri   = $first['uri'] ?? '';
+		$cid   = $first['cid'] ?? '';
+
+		if ( '' === $uri ) {
+			return new \WP_Error(
+				'atmosphere_missing_uri',
+				\__( 'applyWrites response did not include a record URI.', 'atmosphere' )
+			);
+		}
+
+		\update_comment_meta( $comment_id, Comment::META_URI, $uri );
+		\update_comment_meta( $comment_id, Reaction_Sync::META_SOURCE_ID, $uri );
+
+		if ( $cid ) {
+			\update_comment_meta( $comment_id, Comment::META_CID, $cid );
+		}
+
+		return true;
 	}
 
 	/**

--- a/bundled/atmosphere/includes/functions.php
+++ b/bundled/atmosphere/includes/functions.php
@@ -136,6 +136,44 @@ function get_pds_endpoint(): string {
 }
 
 /**
+ * Plugin-owned WP-Cron hooks.
+ *
+ * Single source of truth for `deactivate()`, `Client::disconnect()`, and
+ * `uninstall.php`. Keeping the lists in sync prevents queued events from
+ * a previous install/connection from firing against the current one and
+ * (worst case) issuing applyWrites against a different repo.
+ *
+ * @return string[]
+ */
+function get_cron_hooks(): array {
+	return array(
+		'atmosphere_refresh_token',
+		'atmosphere_sync_reactions',
+		'atmosphere_sync_publication',
+		'atmosphere_publish_post',
+		'atmosphere_update_post',
+		'atmosphere_delete_post',
+		'atmosphere_delete_records',
+		'atmosphere_publish_comment',
+		'atmosphere_update_comment',
+		'atmosphere_delete_comment',
+		'atmosphere_delete_comment_record',
+		// Legacy hook from an early build of the comment publisher; cleared
+		// for users upgrading from that snapshot.
+		'atmosphere_sync_comments',
+	);
+}
+
+/**
+ * Clear every plugin-owned scheduled hook.
+ */
+function clear_scheduled_hooks(): void {
+	foreach ( get_cron_hooks() as $hook ) {
+		\wp_clear_scheduled_hook( $hook );
+	}
+}
+
+/**
  * Get post types that publish to AT Protocol.
  *
  * @return string[] Post type slugs.

--- a/bundled/atmosphere/includes/oauth/class-client.php
+++ b/bundled/atmosphere/includes/oauth/class-client.php
@@ -12,6 +12,8 @@ namespace Atmosphere\OAuth;
 
 \defined( 'ABSPATH' ) || exit;
 
+use function Atmosphere\clear_scheduled_hooks;
+
 /**
  * OAuth client that manages the authorization lifecycle.
  */
@@ -506,10 +508,17 @@ class Client {
 	}
 
 	/**
-	 * Disconnect: remove all stored credentials.
+	 * Disconnect: remove all stored credentials and clear queued cron events.
+	 *
+	 * Queued events (`atmosphere_delete_records`,
+	 * `atmosphere_delete_comment_record`) issue applyWrites without a
+	 * connection check, so a disconnect→reconnect-to-different-account
+	 * cycle would otherwise fire deletes against the new account's repo.
+	 * Mirrors the cleanup performed on plugin deactivate / uninstall.
 	 */
 	public static function disconnect(): void {
 		\delete_option( 'atmosphere_connection' );
+		clear_scheduled_hooks();
 	}
 
 	/**

--- a/bundled/atmosphere/includes/transformer/class-comment.php
+++ b/bundled/atmosphere/includes/transformer/class-comment.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Transforms an approved WordPress comment into an app.bsky.feed.post
+ * reply record.
+ *
+ * Only comments authored by a registered WordPress user are published;
+ * Atmosphere::should_publish_comment() and the comment lifecycle
+ * hooks enforce that gate before this transformer runs. Root is
+ * always the parent post's bsky record; parent resolves to a
+ * previously-published sibling comment, a federated reply ingested
+ * via Reaction_Sync, or falls through to the root.
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere\Transformer;
+
+\defined( 'ABSPATH' ) || exit;
+
+use Atmosphere\Reaction_Sync;
+use function Atmosphere\sanitize_text;
+use function Atmosphere\truncate_text;
+
+/**
+ * Bluesky reply transformer.
+ */
+class Comment extends Base {
+
+	/**
+	 * Comment meta key for the bsky post TID (rkey).
+	 *
+	 * @var string
+	 */
+	public const META_TID = '_atmosphere_bsky_tid';
+
+	/**
+	 * Comment meta key for the bsky post AT-URI.
+	 *
+	 * @var string
+	 */
+	public const META_URI = '_atmosphere_bsky_uri';
+
+	/**
+	 * Comment meta key for the bsky post CID.
+	 *
+	 * @var string
+	 */
+	public const META_CID = '_atmosphere_bsky_cid';
+
+	/**
+	 * Transform the comment.
+	 *
+	 * @return array app.bsky.feed.post record.
+	 */
+	public function transform(): array {
+		$comment = $this->object;
+
+		$text = truncate_text( sanitize_text( (string) $comment->comment_content ), 300 );
+
+		$record = array(
+			'$type'     => 'app.bsky.feed.post',
+			'text'      => $text,
+			'createdAt' => $this->to_iso8601( $comment->comment_date_gmt ),
+			'langs'     => $this->get_langs(),
+			'reply'     => $this->build_reply_ref( $comment ),
+		);
+
+		$facets = Facet::extract( $text );
+		if ( ! empty( $facets ) ) {
+			$record['facets'] = $facets;
+		}
+
+		/**
+		 * Filters the app.bsky.feed.post comment reply record before publishing.
+		 *
+		 * @param array       $record  Bsky post record.
+		 * @param \WP_Comment $comment WordPress comment.
+		 */
+		return \apply_filters( 'atmosphere_transform_comment', $record, $comment );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_collection(): string {
+		return 'app.bsky.feed.post';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_rkey(): string {
+		$rkey = \get_comment_meta( (int) $this->object->comment_ID, self::META_TID, true );
+
+		if ( empty( $rkey ) ) {
+			$rkey = TID::generate();
+			\update_comment_meta( (int) $this->object->comment_ID, self::META_TID, $rkey );
+		}
+
+		return $rkey;
+	}
+
+	/**
+	 * Build the reply struct with root and parent refs.
+	 *
+	 * Root is always the WP post's bsky record. Parent is the closest
+	 * resolvable ancestor: a local sibling comment that has already
+	 * been published, a federated parent ingested by Reaction_Sync, or
+	 * the post itself as a fallback when the parent comment can't be
+	 * resolved to an AT record.
+	 *
+	 * @param \WP_Comment $comment WordPress comment.
+	 * @return array{root: array{uri:string,cid:string}, parent: array{uri:string,cid:string}}
+	 */
+	private function build_reply_ref( \WP_Comment $comment ): array {
+		$post_id = (int) $comment->comment_post_ID;
+
+		$root = array(
+			'uri' => (string) \get_post_meta( $post_id, Post::META_URI, true ),
+			'cid' => (string) \get_post_meta( $post_id, Post::META_CID, true ),
+		);
+
+		$parent_id = (int) $comment->comment_parent;
+
+		if ( $parent_id > 0 ) {
+			$resolved = $this->resolve_parent_ref( $parent_id );
+			if ( null !== $resolved ) {
+				return array(
+					'root'   => $root,
+					'parent' => $resolved,
+				);
+			}
+		}
+
+		return array(
+			'root'   => $root,
+			'parent' => $root,
+		);
+	}
+
+	/**
+	 * Resolve a parent comment to its AT Protocol strong-ref.
+	 *
+	 * Checks local-publish meta first (this class's own keys), then
+	 * falls through to Reaction_Sync meta for federated parents.
+	 * Returns null when neither path yields both a URI and a CID, so
+	 * the caller can fall back to the root reference — strongRef
+	 * requires both fields to be set.
+	 *
+	 * @param int $parent_id Parent comment ID.
+	 * @return array{uri:string,cid:string}|null
+	 */
+	private function resolve_parent_ref( int $parent_id ): ?array {
+		$local_uri = \get_comment_meta( $parent_id, self::META_URI, true );
+		$local_cid = \get_comment_meta( $parent_id, self::META_CID, true );
+		if ( ! empty( $local_uri ) && ! empty( $local_cid ) ) {
+			return array(
+				'uri' => (string) $local_uri,
+				'cid' => (string) $local_cid,
+			);
+		}
+
+		if ( 'atproto' !== \get_comment_meta( $parent_id, Reaction_Sync::META_PROTOCOL, true ) ) {
+			return null;
+		}
+
+		$federated_uri = \get_comment_meta( $parent_id, Reaction_Sync::META_SOURCE_ID, true );
+		$federated_cid = \get_comment_meta( $parent_id, Reaction_Sync::META_BSKY_CID, true );
+		if ( empty( $federated_uri ) || empty( $federated_cid ) ) {
+			return null;
+		}
+
+		return array(
+			'uri' => (string) $federated_uri,
+			'cid' => (string) $federated_cid,
+		);
+	}
+}

--- a/bundled/atmosphere/uninstall.php
+++ b/bundled/atmosphere/uninstall.php
@@ -7,9 +7,16 @@
  * @package Atmosphere
  */
 
+use function Atmosphere\clear_scheduled_hooks;
+
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
+
+// Load helpers so the cron-hook list stays in lock-step with deactivate()
+// and Client::disconnect(). uninstall.php is loaded by WordPress without
+// the plugin itself being booted, so this require is necessary.
+require_once __DIR__ . '/includes/functions.php';
 
 // Remove options.
 delete_option( 'atmosphere_connection' );
@@ -17,14 +24,8 @@ delete_option( 'atmosphere_publication_tid' );
 delete_option( 'atmosphere_publication_uri' );
 delete_option( 'atmosphere_auto_publish' );
 
-// Remove scheduled events.
-wp_clear_scheduled_hook( 'atmosphere_refresh_token' );
-wp_clear_scheduled_hook( 'atmosphere_publish_post' );
-wp_clear_scheduled_hook( 'atmosphere_update_post' );
-wp_clear_scheduled_hook( 'atmosphere_delete_post' );
-wp_clear_scheduled_hook( 'atmosphere_delete_records' );
-wp_clear_scheduled_hook( 'atmosphere_sync_publication' );
-wp_clear_scheduled_hook( 'atmosphere_sync_reactions' );
+// Remove scheduled events via the canonical helper.
+clear_scheduled_hooks();
 
 // Remove post meta.
 global $wpdb;
@@ -41,6 +42,18 @@ $atmosphere_meta_keys = array(
 
 foreach ( $atmosphere_meta_keys as $atmosphere_key ) {
 	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $atmosphere_key ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+}
+
+// Remove comment meta written by the outbound-comment publisher.
+$atmosphere_comment_meta_keys = array(
+	'_atmosphere_bsky_tid',
+	'_atmosphere_bsky_uri',
+	'_atmosphere_bsky_cid',
+	'_atmosphere_publish_attempts',
+);
+
+foreach ( $atmosphere_comment_meta_keys as $atmosphere_key ) {
+	$wpdb->delete( $wpdb->commentmeta, array( 'meta_key' => $atmosphere_key ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 }
 
 // Remove transients.

--- a/bundled/atmosphere/vendor/composer/installed.php
+++ b/bundled/atmosphere/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'automattic/atmosphere',
         'pretty_version' => 'dev-trunk',
         'version' => 'dev-trunk',
-        'reference' => '0430d00aa57982b0829c519f47203eb750637b30',
+        'reference' => 'eecad094db66f92bed34751f815fb6491f681142',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'automattic/atmosphere' => array(
             'pretty_version' => 'dev-trunk',
             'version' => 'dev-trunk',
-            'reference' => '0430d00aa57982b0829c519f47203eb750637b30',
+            'reference' => 'eecad094db66f92bed34751f815fb6491f681142',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary

Refresh `bundled/atmosphere/` from the upstream `teaser-thread-3post-card` branch after it was rebased onto latest Atmosphere trunk. No changes to `bundled/activitypub/`.

Atmosphere upstream SHA: `eecad094db66`.

See Automattic/wordpress-atmosphere#49 — the long-form `teaser-thread` strategy iteration. Not "Fixes" because the upstream PR isn't ours to close from this side.

## Notable upstream commits picked up since the previous sync (PR 76)

- Default teaser-thread to 3 posts and embed link card on terminal CTA (the headline change in upstream PR 49).
- Publish approved WordPress comments to Bluesky as replies (upstream PR 32 via the trunk merge).
- Guard against null `preg_replace` return on malformed UTF-8.
- Unicode whitespace + filter contract fixes for the long-form path.
- `deactivate()` consolidated to a single `clear_scheduled_hooks()` call.

## Mechanics

- Scrubbed stale `composer.lock` and `vendor/` in the Atmosphere checkout before syncing (per the AGENTS.md note about gitignored lockfiles since wordpress-atmosphere PR 23).
- Re-ran the atmosphere half of `tools/sync-bundled.sh`'s logic against the algiers-v1 conductor worktree of `teaser-thread-3post-card` so the diff is atmosphere-only — `bundled/activitypub/` is untouched.
- `composer update --no-dev --optimize-autoloader` reports no runtime deps; the only change in `bundled/atmosphere/vendor/` is the autoload installed-versions metadata.

## Test plan

- [x] `composer run-script lint-php` — clean (32/32).
- [x] `composer run-script test-php` — 262 tests, 617 assertions, all green.
- [ ] CI matrix (PHPUnit on PHP 8.2/8.3/8.4/8.5 × WP 6.9/trunk, ESLint/Prettier, E2E, build-zip).