### PR TITLE
docs: add wp.com Simple load contract note to fosse.php

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -23,6 +23,21 @@ if ( file_exists( __DIR__ . '/vendor/autoload_packages.php' ) ) {
 }
 
 /*
+ * wp.com Simple load contract.
+ *
+ * On wp.com Simple, FOSSE is included by `wp-content/mu-plugins/fosse-loader.php`
+ * at `plugins_loaded` priority 8 — one tick before the platform's
+ * `wpcom-activitypub-load.php` (priority 9). Bundled ActivityPub defines
+ * `ACTIVITYPUB_PLUGIN_DIR` during its own boot, which trips the
+ * `wpcom_activitypub_is_loaded()` early-bail and suppresses the platform AP load.
+ *
+ * The skip-when-standalone checks below (`ACTIVITYPUB_PLUGIN_VERSION` /
+ * `ATMOSPHERE_VERSION`) MUST stay intact: if the wp.com loader ever defined
+ * those constants itself, FOSSE would silently skip its own bundle and the
+ * rollout would no-op. See DOTCOM-16981.
+ */
+
+/*
  * Bundled federation backends.
  *
  * FOSSE ships release-build copies of wordpress-activitypub and


### PR DESCRIPTION
Fixes DOTCOM-16985
Parent epic: DOTCOM-16981

## Summary

Adds a short defensive-documentation comment block above the bundled-backends bootstrap in `fosse.php` so the existing skip-when-standalone checks at `fosse.php:42-43` (ActivityPub) and `fosse.php:50-51` (Atmosphere) don't get accidentally regressed.

The lever for the wp.com Simple rollout is **load-order, not constant-defining**. On wp.com Simple, FOSSE will be included by `wp-content/mu-plugins/fosse-loader.php` at `plugins_loaded` priority 8 — one tick before the platform's `wpcom-activitypub-load.php` (priority 9). Bundled ActivityPub defines `ACTIVITYPUB_PLUGIN_DIR` during its own boot, which trips `wpcom_activitypub_is_loaded()`'s early-bail and suppresses the duplicate platform AP load.

If a future contributor refactored the wp.com loader to define `ACTIVITYPUB_PLUGIN_VERSION` / `ATMOSPHERE_VERSION` itself, FOSSE's existing skip-when-standalone checks would silently skip its own bundle and the rollout would no-op invisibly. The comment block exists to keep that from happening.

This is the only piece of the wp.com Simple rollout (DOTCOM-16981) that touches the public repo. Comment-only — no behavior change.

## Test plan

- [x] `composer lint-php` clean.
- [x] `git diff` shows comment-only change to `fosse.php`.