### PR TITLE
docs: sync SDD task statuses

### DIFF
--- a/sdd/long-form-bluesky-strategy/plan.md
+++ b/sdd/long-form-bluesky-strategy/plan.md
@@ -25,17 +25,17 @@ Decision context:
 
 ## Progress
 
-- [ ] Task 1 [UPSTREAM-AT]: Composition helpers + `atmosphere_long_form_composition` filter + Publisher thread redesign (one upstream PR, opens draft first)
-- [ ] Task 2 [FOSSE]: Refresh `bundled/atmosphere/` after Task 1 merges
-- [ ] Task 3 [FOSSE]: `Long_Form_Strategy` projector + `fosse_long_form_strategy` option
+- [x] Task 1 [UPSTREAM-AT]: Composition helpers + `atmosphere_long_form_composition` filter + Publisher thread redesign (one upstream PR, opens draft first)
+- [x] Task 2 [FOSSE]: Refresh `bundled/atmosphere/` after Task 1 merges
+- [x] Task 3 [FOSSE]: `Long_Form_Strategy` projector + `fosse_long_form_strategy` option
 - [ ] Task 4 [FOSSE]: Rewrite e2e capture helper as `pre_http_request` interceptor + teaser-thread Playwright spec
-- [ ] Task 5 [FOSSE]: Changelog + AGENTS.md note
+- [x] Task 5 [FOSSE]: Changelog + AGENTS.md note
 
 ## Tasks
 
 ### Task 1 [UPSTREAM-AT]: Composition helpers + `atmosphere_long_form_composition` filter + Publisher thread redesign
 
-- **Status**: Not started
+- **Status**: ✅ Done (Automattic/wordpress-atmosphere#34)
 - **Repo**: `Automattic/wordpress-atmosphere`
 - **Linear**: [DOTCOM-16810](https://linear.app/a8c/issue/DOTCOM-16810)
 - **Files**:
@@ -156,7 +156,7 @@ Decision context:
 
 ### Task 2 [FOSSE]: Refresh `bundled/atmosphere/` after Task 1 merges
 
-- **Status**: Not started
+- **Status**: ✅ Done (#76, #82)
 - **Repo**: `Automattic/fosse`
 - **Files**: [`bundled/atmosphere/**`](https://github.com/Automattic/fosse/tree/trunk/bundled/atmosphere)
 - **Do**:
@@ -182,7 +182,7 @@ Decision context:
 
 ### Task 3 [FOSSE]: `Long_Form_Strategy` projector + `fosse_long_form_strategy` option
 
-- **Status**: Not started
+- **Status**: ✅ Done (#29)
 - **Repo**: `Automattic/fosse`
 - **Linear**: [DOTCOM-16810](https://linear.app/a8c/issue/DOTCOM-16810)
 - **Files**:
@@ -276,7 +276,7 @@ Decision context:
 
 ### Task 5 [FOSSE]: Changelog + AGENTS.md note
 
-- **Status**: Not started
+- **Status**: ✅ Done (#28; FOSSE `readme.txt` step skipped because the repo has no `readme.txt`)
 - **Repo**: `Automattic/fosse`
 - **Files**:
   - `readme.txt` (upstream convention; FOSSE does not have a `CHANGELOG.md`).

--- a/sdd/onboarding-setup-ux/plan.md
+++ b/sdd/onboarding-setup-ux/plan.md
@@ -10,7 +10,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - [x] Task 4: Open upstream Atmosphere PRs
 - [x] Task 5: Create Bluesky_Provider
 - [x] Task 5.5: Create first-run onboarding wizard
-- [ ] Task 5.6: Replace Bluesky wizard placeholder with live connect form
+- [x] Task 5.6: Replace Bluesky wizard placeholder with live connect form
 - [x] Task 6: Create Status_Page with provider status cards
 - [x] Task 7: Add admin CSS
 - [x] Task 8: Write tests
@@ -116,7 +116,7 @@ Based on: sdd/onboarding-setup-ux/spec.md
 - **Depends on**: Task 3
 
 ### Task 5.6: Replace Bluesky wizard placeholder with live connect form
-- **Status**: In progress
+- **Status**: ✅ Done (#47)
 - **Files**: `src/Admin/class-onboarding-wizard.php`, `src/Admin/class-bluesky-provider.php`, `src/Admin/assets/css/admin.css`, `tests/php/Admin/Onboarding_WizardTest.php`, `tests/php/Admin/Bluesky_ProviderTest.php`, `tests/e2e/onboarding-wizard.spec.ts`, `sdd/onboarding-setup-ux/spec.md`, `sdd/onboarding-setup-ux/planned-decisions.md`
 - **Do**:
   1. Have the wizard Bluesky step read Bluesky provider status through the provider registry, with a direct provider fallback for tests and early admin boot.

--- a/sdd/unified-reactions-display/plan.md
+++ b/sdd/unified-reactions-display/plan.md
@@ -17,7 +17,7 @@ Based on: sdd/unified-reactions-display/spec.md
 
 ### Task 1: Add `Reactions_Label` skeleton + matching-block PHPUnit case
 
-- **Status**: ✅ Done (4c9426d)
+- **Status**: ✅ Done (#40)
 - **Files**:
   - `src/class-reactions-label.php` (new)
   - `tests/php/Reactions_LabelTest.php` (new)
@@ -34,7 +34,7 @@ Based on: sdd/unified-reactions-display/spec.md
 
 ### Task 2: Add non-matching-block + `register()` idempotency PHPUnit cases
 
-- **Status**: ✅ Done (ae0cf7b)
+- **Status**: ✅ Done (#40)
 - **Files**:
   - `tests/php/Reactions_LabelTest.php` (modify)
 - **Do**:
@@ -49,7 +49,7 @@ Based on: sdd/unified-reactions-display/spec.md
 
 ### Task 3: Wire `Reactions_Label::register()` into `fosse.php`
 
-- **Status**: ✅ Done (9edc46f)
+- **Status**: ✅ Done (#40)
 - **Files**:
   - `fosse.php` (modify)
 - **Do**:
@@ -62,7 +62,7 @@ Based on: sdd/unified-reactions-display/spec.md
 
 ### Task 4: Add `fosse-reactions-seed` e2e mu-plugin
 
-- **Status**: ✅ Done (e874d27)
+- **Status**: ✅ Done (#40)
 - **Files**:
   - `tests/e2e/mu-plugins/fosse-reactions-seed.php` (new)
 - **Do**:
@@ -81,7 +81,7 @@ Based on: sdd/unified-reactions-display/spec.md
 
 ### Task 5: Add `reactions-display` Playwright e2e spec
 
-- **Status**: ✅ Done (4b94f65)
+- **Status**: ✅ Done (#40)
 - **Files**:
   - `tests/e2e/reactions-display.spec.ts` (new)
   - `tests/e2e/blueprint.json` (possibly modify — only if the new mu-plugin is not already auto-mounted by the existing blueprint logic)
@@ -98,7 +98,7 @@ Based on: sdd/unified-reactions-display/spec.md
 
 ### Task 6: Run verification, capture `implementation.md`, mark plan complete
 
-- **Status**: ✅ Done (this commit)
+- **Status**: ✅ Done (#40)
 - **Files**:
   - `sdd/unified-reactions-display/implementation.md` (new)
   - `sdd/unified-reactions-display/plan.md` (modify — Progress checkboxes + per-task Status fields)


### PR DESCRIPTION
## Summary
- Mark the shipped onboarding Bluesky wizard task done via #47.
- Mark shipped long-form strategy tasks done while keeping the unshipped teaser-thread e2e task open.
- Normalize unified-reactions statuses to the merged PR #40.

## Test Plan
- [x] git diff --check HEAD~1 HEAD
- [x] rg "Status\*\*: In progress|this commit" sdd