### PR TITLE
fix: honor actor-mode constant locks in setup + wizard

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -116,6 +116,21 @@ add_action(
 );
 
 /*
+ * ActivityPub actor-mode lock enforcement.
+ *
+ * When the host defines `ACTIVITYPUB_SINGLE_USER_MODE`,
+ * `ACTIVITYPUB_DISABLE_USER`, or `ACTIVITYPUB_DISABLE_BLOG_USER`, any
+ * write to `activitypub_actor_mode` (admin form, REST `/wp/v2/settings`,
+ * or direct options.php POST) is coerced to the forced mode. Mirrors
+ * what bundled AP serves on read so the stored value can't drift out
+ * of sync with the runtime contract — and so removing the lock later
+ * never surfaces a stale value as the new active mode.
+ */
+if ( class_exists( \Automattic\Fosse\Admin\Actor_Mode_Lock::class ) ) {
+	\Automattic\Fosse\Admin\Actor_Mode_Lock::register_hooks();
+}
+
+/*
  * Cross-network object-type projector.
  *
  * Translates the single `fosse_object_type` option into per-network

--- a/fosse.php
+++ b/fosse.php
@@ -121,10 +121,16 @@ add_action(
  * When the host defines `ACTIVITYPUB_SINGLE_USER_MODE`,
  * `ACTIVITYPUB_DISABLE_USER`, or `ACTIVITYPUB_DISABLE_BLOG_USER`, any
  * write to `activitypub_actor_mode` (admin form, REST `/wp/v2/settings`,
- * or direct options.php POST) is coerced to the forced mode. Mirrors
- * what bundled AP serves on read so the stored value can't drift out
- * of sync with the runtime contract — and so removing the lock later
- * never surfaces a stale value as the new active mode.
+ * or direct options.php POST) is coerced to the forced mode, and an
+ * `admin_init` repair pass rewrites the stored value when it disagrees
+ * with the forced mode. The repair runs on admin requests only — not
+ * on frontend page views — so a high-traffic spike on a corrupted
+ * install doesn't multiply into write attempts on every request.
+ * Together these keep what bundled AP serves on read aligned with
+ * what's actually in the database, so removing the lock later never
+ * surfaces a stale value as the new active mode. Degrades cleanly if
+ * FOSSE's own composer autoload is missing — the `class_exists` guard
+ * skips registration entirely.
  */
 if ( class_exists( \Automattic\Fosse\Admin\Actor_Mode_Lock::class ) ) {
 	\Automattic\Fosse\Admin\Actor_Mode_Lock::register_hooks();

--- a/src/Admin/class-actor-mode-lock.php
+++ b/src/Admin/class-actor-mode-lock.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Detects when the ActivityPub actor mode is constant-locked.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Admin;
+
+/**
+ * Mirrors the constant checks bundled ActivityPub uses in its
+ * `pre_option_activitypub_actor_mode` filter (see
+ * `bundled/activitypub/includes/class-options.php:501-515`). FOSSE's
+ * own admin UI must honor the same locks, otherwise users see controls
+ * they can interact with that have no effect on the saved option (the
+ * pre_option filter overrides the read regardless).
+ *
+ * On wp.com, `ACTIVITYPUB_SINGLE_USER_MODE = true` is defined
+ * unconditionally in `wpcom-activitypub-load.php`, so any FOSSE
+ * deployment on wp.com Simple is permanently locked to blog mode.
+ */
+class Actor_Mode_Lock {
+
+	/**
+	 * Returns the actor mode the host's constants force, or null if free.
+	 *
+	 * @return string|null One of 'blog', 'actor', or null when no constant lock is set.
+	 */
+	public static function forced_mode(): ?string {
+		if ( defined( 'ACTIVITYPUB_SINGLE_USER_MODE' ) && ACTIVITYPUB_SINGLE_USER_MODE ) {
+			return 'blog';
+		}
+
+		if ( defined( 'ACTIVITYPUB_DISABLE_USER' ) && ACTIVITYPUB_DISABLE_USER ) {
+			return 'blog';
+		}
+
+		if ( defined( 'ACTIVITYPUB_DISABLE_BLOG_USER' ) && ACTIVITYPUB_DISABLE_BLOG_USER ) {
+			return 'actor';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether actor mode is locked by host constants.
+	 *
+	 * @return bool
+	 */
+	public static function is_locked(): bool {
+		return null !== self::forced_mode();
+	}
+
+	/**
+	 * The user-facing notice explaining the lock. Mirrors the wording
+	 * bundled ActivityPub uses on its own settings page so users see a
+	 * consistent message across both surfaces.
+	 *
+	 * @return string
+	 */
+	public static function locked_notice(): string {
+		return __( '⚠ This setting is defined through server configuration by your blog\'s administrator.', 'fosse' );
+	}
+}

--- a/src/Admin/class-actor-mode-lock.php
+++ b/src/Admin/class-actor-mode-lock.php
@@ -108,25 +108,48 @@ final class Actor_Mode_Lock {
 	 * the FOSSE handlers, a direct submission to options.php (the
 	 * bundled AP page is reachable by URL), or a REST PUT to
 	 * `/wp/v2/settings` (bundled AP registers `activitypub_actor_mode`
-	 * as a REST-visible setting with no sanitize guard). All three
-	 * end up in `update_option()`, where this filter coerces the
-	 * incoming value back to the forced mode.
+	 * as a REST-visible setting with no sanitize guard).
 	 *
-	 * Without this, the stored value can disagree with what bundled
-	 * AP serves on read, and removing the lock later would surface
-	 * the stale tampered value as the new active mode.
+	 * Two hooks are wired:
+	 *
+	 * - `pre_update_option_activitypub_actor_mode` coerces the incoming
+	 *   value passed to `update_option()`. This shapes what callers
+	 *   reading the in-memory `$value` see, but does NOT by itself fix
+	 *   the stored row: `update_option()` calls `get_option()` to
+	 *   compute `$old_value`, AP's `pre_option` mask makes that return
+	 *   the forced mode, and the new vs old comparison short-circuits
+	 *   before the row is touched.
+	 *
+	 * - `admin_init` runs `repair_stored_value()`, which writes the
+	 *   forced value through to the stored row when it disagrees.
+	 *   Hooked on `admin_init` rather than `init` so the repair only
+	 *   runs on admin requests — frontend page views (which AP's read
+	 *   mask already serves the forced value to) skip it entirely.
+	 *   That avoids hammering the DB with repair attempts under
+	 *   high-traffic spikes and confines write activity to the surface
+	 *   where an admin would actually observe the stored value.
+	 *
+	 * Both hooks are guarded for idempotency so repeat registration
+	 * (a re-initializing test, a stray double-load) is harmless.
 	 *
 	 * @return void
 	 */
 	public static function register_hooks(): void {
+		if ( false !== has_filter( 'pre_update_option_activitypub_actor_mode', array( self::class, 'coerce_to_forced_mode' ) ) ) {
+			return;
+		}
+
 		add_filter( 'pre_update_option_activitypub_actor_mode', array( self::class, 'coerce_to_forced_mode' ) );
+		add_action( 'admin_init', array( self::class, 'repair_stored_value' ) );
 	}
 
 	/**
 	 * Coerce an incoming actor-mode write to the forced mode when locked.
 	 *
-	 * Callback for `pre_update_option_activitypub_actor_mode`. Pass-through
-	 * when no lock is set, so non-locked installs see no behavior change.
+	 * Pass-through when no lock is set, so non-locked installs see no
+	 * behavior change.
+	 *
+	 * @internal Filter callback for `pre_update_option_activitypub_actor_mode`. Not for direct callers.
 	 *
 	 * @param mixed $value The incoming value being written.
 	 * @return mixed The forced mode when locked, otherwise the original value.
@@ -134,5 +157,60 @@ final class Actor_Mode_Lock {
 	public static function coerce_to_forced_mode( $value ) {
 		$forced = self::forced_mode();
 		return null === $forced ? $value : $forced;
+	}
+
+	/**
+	 * Reconcile the raw stored `activitypub_actor_mode` value with the
+	 * constant-forced value.
+	 *
+	 * The pre_update filter alone cannot do this. When bundled AP's
+	 * `pre_option_activitypub_actor_mode` mask is active,
+	 * `get_option('activitypub_actor_mode')` returns the forced mode
+	 * regardless of what's stored. `update_option()` then sees the
+	 * coerced incoming value === old value and short-circuits without
+	 * touching the row, so a value written before the lock activated
+	 * (or a prior tampered POST that landed before this code shipped)
+	 * stays in the database. Removing the lock later would surface
+	 * that stale value as the active mode.
+	 *
+	 * Repair: temporarily remove the bundled AP read mask so
+	 * `update_option()` sees the actual stored value as the old value,
+	 * write the forced value through if it disagrees, then restore the
+	 * mask. The unhooking targets bundled AP's exact static callable
+	 * (`Activitypub\Options::pre_option_activitypub_actor_mode`) — which
+	 * is the canonical registration in our vendored AP copy
+	 * (`bundled/activitypub/includes/class-options.php`). If the mask
+	 * isn't registered (e.g., bundled AP didn't load or a third-party
+	 * AP fork is active under a different class), the repair still
+	 * runs harmlessly: `get_option()` returns the raw stored value
+	 * directly and the comparison/write proceeds normally.
+	 *
+	 * One option-read per request on locked installs; the actual write
+	 * only fires when the stored value disagrees with the forced mode.
+	 * Unlocked installs return early before any work.
+	 *
+	 * @internal Action callback for `admin_init`. Not for direct callers.
+	 *
+	 * @return void
+	 */
+	public static function repair_stored_value(): void {
+		$forced = self::forced_mode();
+		if ( null === $forced ) {
+			return;
+		}
+
+		$ap_mask     = array( 'Activitypub\Options', 'pre_option_activitypub_actor_mode' );
+		$ap_priority = has_filter( 'pre_option_activitypub_actor_mode', $ap_mask );
+		if ( false !== $ap_priority ) {
+			remove_filter( 'pre_option_activitypub_actor_mode', $ap_mask, $ap_priority );
+		}
+
+		if ( $forced !== get_option( 'activitypub_actor_mode' ) ) {
+			update_option( 'activitypub_actor_mode', $forced );
+		}
+
+		if ( false !== $ap_priority ) {
+			add_filter( 'pre_option_activitypub_actor_mode', $ap_mask, $ap_priority );
+		}
 	}
 }

--- a/src/Admin/class-actor-mode-lock.php
+++ b/src/Admin/class-actor-mode-lock.php
@@ -8,35 +8,66 @@
 namespace Automattic\Fosse\Admin;
 
 /**
- * Mirrors the constant checks bundled ActivityPub uses in its
- * `pre_option_activitypub_actor_mode` filter (see
- * `bundled/activitypub/includes/class-options.php:501-515`). FOSSE's
- * own admin UI must honor the same locks, otherwise users see controls
- * they can interact with that have no effect on the saved option (the
- * pre_option filter overrides the read regardless).
+ * Mirrors the constant checks bundled ActivityPub uses in
+ * `Options::pre_option_activitypub_actor_mode()` (see
+ * `bundled/activitypub/includes/class-options.php`). FOSSE's own admin
+ * UI must honor the same locks, otherwise users see controls they can
+ * interact with that have no effect on the saved option (the pre_option
+ * filter overrides the read regardless).
  *
- * On wp.com, `ACTIVITYPUB_SINGLE_USER_MODE = true` is defined
- * unconditionally in `wpcom-activitypub-load.php`, so any FOSSE
- * deployment on wp.com Simple is permanently locked to blog mode.
+ * `register_hooks()` additionally enforces the lock at the save layer
+ * via `pre_update_option_activitypub_actor_mode`, which closes the
+ * write paths the UI alone cannot guard (tampered form POST, direct
+ * options.php submission, REST PUT to `/wp/v2/settings`).
+ *
+ * Hosts (including WordPress.com) may define `ACTIVITYPUB_SINGLE_USER_MODE`
+ * to permanently lock the actor mode at the platform level.
  */
-class Actor_Mode_Lock {
+final class Actor_Mode_Lock {
+
+	/**
+	 * Blog actor mode — site posts under a single site-wide profile.
+	 *
+	 * Matches `ACTIVITYPUB_BLOG_MODE` in
+	 * `bundled/activitypub/includes/constants.php`. Mirrored as a class
+	 * constant here to avoid a load-order dependency on bundled AP.
+	 *
+	 * @var string
+	 */
+	public const MODE_BLOG = 'blog';
+
+	/**
+	 * Author actor mode — each author posts under their own profile.
+	 *
+	 * Matches `ACTIVITYPUB_ACTOR_MODE` in
+	 * `bundled/activitypub/includes/constants.php`. Mirrored as a class
+	 * constant here to avoid a load-order dependency on bundled AP.
+	 *
+	 * @var string
+	 */
+	public const MODE_ACTOR = 'actor';
+
+	/**
+	 * Static-only utility; never instantiated.
+	 */
+	private function __construct() {}
 
 	/**
 	 * Returns the actor mode the host's constants force, or null if free.
 	 *
-	 * @return string|null One of 'blog', 'actor', or null when no constant lock is set.
+	 * @return string|null One of self::MODE_BLOG, self::MODE_ACTOR, or null when no constant lock is set.
 	 */
 	public static function forced_mode(): ?string {
 		if ( defined( 'ACTIVITYPUB_SINGLE_USER_MODE' ) && ACTIVITYPUB_SINGLE_USER_MODE ) {
-			return 'blog';
+			return self::MODE_BLOG;
 		}
 
 		if ( defined( 'ACTIVITYPUB_DISABLE_USER' ) && ACTIVITYPUB_DISABLE_USER ) {
-			return 'blog';
+			return self::MODE_BLOG;
 		}
 
 		if ( defined( 'ACTIVITYPUB_DISABLE_BLOG_USER' ) && ACTIVITYPUB_DISABLE_BLOG_USER ) {
-			return 'actor';
+			return self::MODE_ACTOR;
 		}
 
 		return null;
@@ -59,6 +90,49 @@ class Actor_Mode_Lock {
 	 * @return string
 	 */
 	public static function locked_notice(): string {
-		return __( '⚠ This setting is defined through server configuration by your blog\'s administrator.', 'fosse' );
+		return __(
+			/* translators: leading ⚠ (U+26A0) is a warning sign indicating the field is locked by a server-defined constant; preserve it verbatim. */
+			'⚠ This setting is defined through server configuration by your blog\'s administrator.',
+			'fosse'
+		);
+	}
+
+	/**
+	 * Wire save-layer enforcement so the stored option can't drift from
+	 * the constant-forced value.
+	 *
+	 * The UI `is_locked()` branches in the setup page and onboarding
+	 * wizard are advisory: they hide the controls and submit a hidden
+	 * input with the forced mode. They do not block the three other
+	 * write paths into `activitypub_actor_mode` — a tampered POST to
+	 * the FOSSE handlers, a direct submission to options.php (the
+	 * bundled AP page is reachable by URL), or a REST PUT to
+	 * `/wp/v2/settings` (bundled AP registers `activitypub_actor_mode`
+	 * as a REST-visible setting with no sanitize guard). All three
+	 * end up in `update_option()`, where this filter coerces the
+	 * incoming value back to the forced mode.
+	 *
+	 * Without this, the stored value can disagree with what bundled
+	 * AP serves on read, and removing the lock later would surface
+	 * the stale tampered value as the new active mode.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks(): void {
+		add_filter( 'pre_update_option_activitypub_actor_mode', array( self::class, 'coerce_to_forced_mode' ) );
+	}
+
+	/**
+	 * Coerce an incoming actor-mode write to the forced mode when locked.
+	 *
+	 * Callback for `pre_update_option_activitypub_actor_mode`. Pass-through
+	 * when no lock is set, so non-locked installs see no behavior change.
+	 *
+	 * @param mixed $value The incoming value being written.
+	 * @return mixed The forced mode when locked, otherwise the original value.
+	 */
+	public static function coerce_to_forced_mode( $value ) {
+		$forced = self::forced_mode();
+		return null === $forced ? $value : $forced;
 	}
 }

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -858,29 +858,45 @@ class Onboarding_Wizard {
 			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $nonce ); ?>" />
 
 			<div class="fosse-wizard__card">
-				<div class="fosse-mode-cards">
-					<?php foreach ( $modes as $value => $mode ) : ?>
-						<label class="fosse-mode-card">
-							<input
-								type="radio"
-								name="activitypub_actor_mode"
-								value="<?php echo esc_attr( $value ); ?>"
-								class="fosse-mode-card__input"
-								<?php checked( $value, $current_mode ); ?>
-							/>
-							<div class="fosse-mode-card__icon">
-								<span class="dashicons <?php echo esc_attr( $mode['icon'] ); ?>"></span>
-							</div>
-							<div class="fosse-mode-card__content">
-								<div class="fosse-mode-card__title"><?php echo esc_html( $mode['title'] ); ?></div>
-								<div class="fosse-mode-card__desc"><?php echo wp_kses( $mode['desc'], array( 'strong' => array() ) ); ?></div>
-							</div>
-							<div class="fosse-mode-card__check">
-								<span class="dashicons dashicons-yes-alt"></span>
-							</div>
-						</label>
-					<?php endforeach; ?>
-				</div>
+				<?php if ( Actor_Mode_Lock::is_locked() ) : ?>
+					<?php $forced_mode = Actor_Mode_Lock::forced_mode(); ?>
+					<div class="fosse-wizard__locked-mode">
+						<p>
+							<strong><?php echo esc_html( $modes[ $forced_mode ]['title'] ); ?></strong>
+						</p>
+						<p class="description">
+							<?php echo wp_kses( $modes[ $forced_mode ]['desc'], array( 'strong' => array() ) ); ?>
+						</p>
+						<p class="description">
+							<?php echo esc_html( Actor_Mode_Lock::locked_notice() ); ?>
+						</p>
+					</div>
+					<input type="hidden" name="activitypub_actor_mode" value="<?php echo esc_attr( $forced_mode ); ?>" />
+				<?php else : ?>
+					<div class="fosse-mode-cards">
+						<?php foreach ( $modes as $value => $mode ) : ?>
+							<label class="fosse-mode-card">
+								<input
+									type="radio"
+									name="activitypub_actor_mode"
+									value="<?php echo esc_attr( $value ); ?>"
+									class="fosse-mode-card__input"
+									<?php checked( $value, $current_mode ); ?>
+								/>
+								<div class="fosse-mode-card__icon">
+									<span class="dashicons <?php echo esc_attr( $mode['icon'] ); ?>"></span>
+								</div>
+								<div class="fosse-mode-card__content">
+									<div class="fosse-mode-card__title"><?php echo esc_html( $mode['title'] ); ?></div>
+									<div class="fosse-mode-card__desc"><?php echo wp_kses( $mode['desc'], array( 'strong' => array() ) ); ?></div>
+								</div>
+								<div class="fosse-mode-card__check">
+									<span class="dashicons dashicons-yes-alt"></span>
+								</div>
+							</label>
+						<?php endforeach; ?>
+					</div>
+				<?php endif; ?>
 
 				<?php
 				// Render preview containers for every mode that has content

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -787,8 +787,15 @@ class Onboarding_Wizard {
 		self::render_progress( 'appearance' );
 
 		$current_mode = get_option( 'activitypub_actor_mode', 'actor' );
-		$site_host    = wp_parse_url( home_url(), PHP_URL_HOST );
-		$nonce        = wp_create_nonce( 'fosse_wizard' );
+		// When constants force a mode, drive every downstream rendering
+		// decision (preview visibility, blog handle visibility) off the
+		// forced mode so the locked label can't disagree with the rest
+		// of the step if the stored option ever drifts.
+		if ( Actor_Mode_Lock::is_locked() ) {
+			$current_mode = Actor_Mode_Lock::forced_mode();
+		}
+		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
+		$nonce     = wp_create_nonce( 'fosse_wizard' );
 
 		$modes = array(
 			'blog'       => array(

--- a/src/Admin/templates/setup-page.php
+++ b/src/Admin/templates/setup-page.php
@@ -85,7 +85,7 @@ defined( 'ABSPATH' ) || exit;
 									<?php if ( \Automattic\Fosse\Admin\Actor_Mode_Lock::is_locked() ) : ?>
 										<?php
 										$forced_mode  = \Automattic\Fosse\Admin\Actor_Mode_Lock::forced_mode();
-										$forced_label = 'blog' === $forced_mode
+										$forced_label = \Automattic\Fosse\Admin\Actor_Mode_Lock::MODE_BLOG === $forced_mode
 											? __( 'Blog profile', 'fosse' )
 											: __( 'Author profiles', 'fosse' );
 										?>

--- a/src/Admin/templates/setup-page.php
+++ b/src/Admin/templates/setup-page.php
@@ -79,72 +79,88 @@ defined( 'ABSPATH' ) || exit;
 						<tr>
 							<th scope="row"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></th>
 							<td>
-								<fieldset>
-									<legend class="screen-reader-text"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></legend>
-									<label>
-										<input
-											type="radio"
-											id="fosse-activitypub-actor-mode-actor"
-											name="activitypub_actor_mode"
-											value="actor"
-											aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"
-											<?php checked( 'actor', $actor_mode ); ?>
-										/>
-										<?php esc_html_e( 'Author profiles', 'fosse' ); ?>
-									</label>
-									<p id="fosse-activitypub-actor-mode-actor-desc" class="description">
-										<?php esc_html_e( 'Each WordPress author publishes from their own fediverse profile. People follow individual authors, and posts appear under each author\'s name.', 'fosse' ); ?>
+								<?php if ( \Automattic\Fosse\Admin\Actor_Mode_Lock::is_locked() ) : ?>
+									<?php
+									$forced_mode  = \Automattic\Fosse\Admin\Actor_Mode_Lock::forced_mode();
+									$forced_label = 'blog' === $forced_mode
+										? __( 'Blog profile', 'fosse' )
+										: __( 'Author profiles', 'fosse' );
+									?>
+									<p>
+										<strong><?php echo esc_html( $forced_label ); ?></strong>
 									</p>
-									<label>
-										<input
-											type="radio"
-											id="fosse-activitypub-actor-mode-blog"
-											name="activitypub_actor_mode"
-											value="blog"
-											aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"
-											<?php checked( 'blog', $actor_mode ); ?>
-										/>
-										<?php esc_html_e( 'Blog profile', 'fosse' ); ?>
-									</label>
-									<p id="fosse-activitypub-actor-mode-blog-desc" class="description">
-										<?php esc_html_e( 'One site-wide profile publishes every post, regardless of author. Use this when people should follow the site as one account.', 'fosse' ); ?>
+									<p class="description">
+										<?php echo esc_html( \Automattic\Fosse\Admin\Actor_Mode_Lock::locked_notice() ); ?>
 									</p>
-									<label>
-										<input
-											type="radio"
-											id="fosse-activitypub-actor-mode-actor-blog"
-											name="activitypub_actor_mode"
-											value="actor_blog"
-											aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"
-											<?php checked( 'actor_blog', $actor_mode ); ?>
-										/>
-										<?php esc_html_e( 'Both', 'fosse' ); ?>
-									</label>
-									<p id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
-										<?php esc_html_e( 'Authors keep individual profiles, and the site also has its own blog profile. People can follow either.', 'fosse' ); ?>
-									</p>
-									<div class="fosse-activitypub-actor-mode-note">
-										<p id="fosse-activitypub-actor-mode-note" class="description">
-											<?php esc_html_e( 'Changing modes does not move followers between profiles. Future posts publish from the profiles enabled by the selected mode.', 'fosse' ); ?>
+									<input type="hidden" name="activitypub_actor_mode" value="<?php echo esc_attr( $forced_mode ); ?>" />
+								<?php else : ?>
+									<fieldset>
+										<legend class="screen-reader-text"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></legend>
+										<label>
+											<input
+												type="radio"
+												id="fosse-activitypub-actor-mode-actor"
+												name="activitypub_actor_mode"
+												value="actor"
+												aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"
+												<?php checked( 'actor', $actor_mode ); ?>
+											/>
+											<?php esc_html_e( 'Author profiles', 'fosse' ); ?>
+										</label>
+										<p id="fosse-activitypub-actor-mode-actor-desc" class="description">
+											<?php esc_html_e( 'Each WordPress author publishes from their own fediverse profile. People follow individual authors, and posts appear under each author\'s name.', 'fosse' ); ?>
 										</p>
-										<p class="description">
-											<?php
-											echo wp_kses(
-												sprintf(
-													/* translators: %s: anchor link reading "Blog profile settings" pointing to the ActivityPub blog profile tab. */
-													__( 'Configure the site-wide blog profile name, image, and description in %s.', 'fosse' ),
-													'<a href="' . esc_url( admin_url( 'options-general.php?page=activitypub&tab=blog-profile' ) ) . '">' . esc_html__( 'Blog profile settings', 'fosse' ) . '</a>'
-												),
-												array(
-													'a' => array(
-														'href' => array(),
+										<label>
+											<input
+												type="radio"
+												id="fosse-activitypub-actor-mode-blog"
+												name="activitypub_actor_mode"
+												value="blog"
+												aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"
+												<?php checked( 'blog', $actor_mode ); ?>
+											/>
+											<?php esc_html_e( 'Blog profile', 'fosse' ); ?>
+										</label>
+										<p id="fosse-activitypub-actor-mode-blog-desc" class="description">
+											<?php esc_html_e( 'One site-wide profile publishes every post, regardless of author. Use this when people should follow the site as one account.', 'fosse' ); ?>
+										</p>
+										<label>
+											<input
+												type="radio"
+												id="fosse-activitypub-actor-mode-actor-blog"
+												name="activitypub_actor_mode"
+												value="actor_blog"
+												aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"
+												<?php checked( 'actor_blog', $actor_mode ); ?>
+											/>
+											<?php esc_html_e( 'Both', 'fosse' ); ?>
+										</label>
+										<p id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
+											<?php esc_html_e( 'Authors keep individual profiles, and the site also has its own blog profile. People can follow either.', 'fosse' ); ?>
+										</p>
+										<div class="fosse-activitypub-actor-mode-note">
+											<p id="fosse-activitypub-actor-mode-note" class="description">
+												<?php esc_html_e( 'Changing modes does not move followers between profiles. Future posts publish from the profiles enabled by the selected mode.', 'fosse' ); ?>
+											</p>
+											<p class="description">
+												<?php
+												echo wp_kses(
+													sprintf(
+														/* translators: %s: anchor link reading "Blog profile settings" pointing to the ActivityPub blog profile tab. */
+														__( 'Configure the site-wide blog profile name, image, and description in %s.', 'fosse' ),
+														'<a href="' . esc_url( admin_url( 'options-general.php?page=activitypub&tab=blog-profile' ) ) . '">' . esc_html__( 'Blog profile settings', 'fosse' ) . '</a>'
 													),
-												)
-											);
-											?>
-										</p>
-									</div>
-								</fieldset>
+													array(
+														'a' => array(
+															'href' => array(),
+														),
+													)
+												);
+												?>
+											</p>
+										</div>
+									</fieldset>
+								<?php endif; ?>
 							</td>
 						</tr>
 					<?php endif; ?>

--- a/tests/php/Admin/Actor_Mode_LockTest.php
+++ b/tests/php/Admin/Actor_Mode_LockTest.php
@@ -156,59 +156,163 @@ class Actor_Mode_LockTest extends BaseTestCase {
 	}
 
 	/**
-	 * Wires the pre_update filter at default priority via register_hooks().
+	 * Wires both the pre_update filter and the admin_init repair action
+	 * via register_hooks().
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_register_hooks_wires_pre_update_filter(): void {
+	public function test_register_hooks_wires_filter_and_admin_init_action(): void {
 		Actor_Mode_Lock::register_hooks();
 
 		$this->assertNotFalse(
 			has_filter(
 				'pre_update_option_activitypub_actor_mode',
 				array( Actor_Mode_Lock::class, 'coerce_to_forced_mode' )
-			)
+			),
+			'pre_update filter should be wired'
+		);
+		$this->assertNotFalse(
+			has_action(
+				'admin_init',
+				array( Actor_Mode_Lock::class, 'repair_stored_value' )
+			),
+			'admin_init repair action should be wired'
 		);
 	}
 
 	/**
-	 * End-to-end: with the hook wired and a constant set, an
-	 * `update_option()` write of an arbitrary value is silently
-	 * coerced to the forced mode in the database. Closes the bypass
-	 * the UI hidden inputs alone could not.
+	 * Register-hooks is idempotent — repeated calls don't double-register.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_register_hooks_blocks_tampered_update_when_locked(): void {
-		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+	public function test_register_hooks_is_idempotent(): void {
+		Actor_Mode_Lock::register_hooks();
+		Actor_Mode_Lock::register_hooks();
 		Actor_Mode_Lock::register_hooks();
 
-		update_option( 'activitypub_actor_mode', 'actor_blog' );
+		$this->assertSame( 10, has_filter( 'pre_update_option_activitypub_actor_mode', array( Actor_Mode_Lock::class, 'coerce_to_forced_mode' ) ) );
+		$this->assertSame( 10, has_action( 'admin_init', array( Actor_Mode_Lock::class, 'repair_stored_value' ) ) );
+	}
+
+	/**
+	 * Repair writes the forced mode when no value exists yet.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_repair_writes_when_no_value_exists(): void {
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+
+		delete_option( 'activitypub_actor_mode' );
+
+		Actor_Mode_Lock::repair_stored_value();
 
 		$this->assertSame( Actor_Mode_Lock::MODE_BLOG, get_option( 'activitypub_actor_mode' ) );
 	}
 
 	/**
-	 * Pass-through end-to-end: with the hook wired but no lock, a
-	 * write proceeds untouched. Guards against a regression where
-	 * the filter accidentally coerces every install.
+	 * Repair rewrites a stored value that disagrees with the lock —
+	 * models the "value written before the lock activated" path.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_register_hooks_passes_through_when_unlocked(): void {
-		Actor_Mode_Lock::register_hooks();
-
+	public function test_repair_updates_when_value_disagrees_with_lock(): void {
+		// Seed a value as if it was written before the lock shipped.
 		update_option( 'activitypub_actor_mode', 'actor_blog' );
 
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+
+		Actor_Mode_Lock::repair_stored_value();
+
+		$this->assertSame( Actor_Mode_Lock::MODE_BLOG, get_option( 'activitypub_actor_mode' ) );
+	}
+
+	/**
+	 * Repair leaves a correctly-aligned value untouched.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_repair_no_ops_when_value_already_matches_lock(): void {
+		update_option( 'activitypub_actor_mode', 'blog' );
+
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+
+		Actor_Mode_Lock::repair_stored_value();
+
+		$this->assertSame( 'blog', get_option( 'activitypub_actor_mode' ) );
+	}
+
+	/**
+	 * Repair is a no-op on unlocked installs — a stored value disagreeing
+	 * with the default is left alone.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_repair_no_ops_when_unlocked(): void {
+		update_option( 'activitypub_actor_mode', 'actor_blog' );
+
+		Actor_Mode_Lock::repair_stored_value();
+
 		$this->assertSame( 'actor_blog', get_option( 'activitypub_actor_mode' ) );
+	}
+
+	/**
+	 * Production-faithful regression: with bundled AP's actual
+	 * `Activitypub\Options::pre_option_activitypub_actor_mode` mask
+	 * registered, the masked `get_option` call inside `update_option`
+	 * makes old-value-via-mask equal to new-value-via-coerce, so the
+	 * naive write path short-circuits. The repair pass unhooks AP's
+	 * mask, sees the actual stored value, writes the forced value
+	 * through, and restores the mask. After repair, removing the mask
+	 * exposes the corrected raw value. Reproduces (and fixes) the
+	 * failure mode codex called out on round-2 review.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_repair_fixes_value_under_active_pre_option_mask(): void {
+		// Seed a tampered value as if it landed before the lock shipped.
+		update_option( 'activitypub_actor_mode', 'actor_blog' );
+
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+
+		// Register bundled AP's actual pre_option mask so the test
+		// exercises the production code path (not an inline closure
+		// that the repair couldn't unhook).
+		$ap_mask = array( 'Activitypub\Options', 'pre_option_activitypub_actor_mode' );
+		add_filter( 'pre_option_activitypub_actor_mode', $ap_mask );
+
+		// With the mask active, get_option reports the forced mode
+		// regardless of what's stored — confirming the mask is in play.
+		$this->assertSame( 'blog', get_option( 'activitypub_actor_mode' ), 'mask should make get_option report blog' );
+
+		Actor_Mode_Lock::register_hooks();
+		Actor_Mode_Lock::repair_stored_value();
+
+		// Mask restored after repair — get_option still reports masked.
+		$this->assertSame( 'blog', get_option( 'activitypub_actor_mode' ) );
+
+		// Remove the mask to inspect the raw stored value.
+		remove_filter( 'pre_option_activitypub_actor_mode', $ap_mask );
+		$this->assertSame( Actor_Mode_Lock::MODE_BLOG, get_option( 'activitypub_actor_mode' ), 'repair should have rewritten the stored value to the forced mode' );
 	}
 }

--- a/tests/php/Admin/Actor_Mode_LockTest.php
+++ b/tests/php/Admin/Actor_Mode_LockTest.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Tests for Actor_Mode_Lock — the helper that mirrors bundled AP's
+ * `pre_option_activitypub_actor_mode` filter so FOSSE's own admin UI
+ * and save layer honor the same constant-based actor-mode locks.
+ *
+ * Constants are sticky for the PHP process lifetime, so each truth-table
+ * row runs in its own subprocess. Without isolation, the first test
+ * to define a constant would force every subsequent test into the
+ * same locked branch, masking the matrix entirely.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests\Admin;
+
+use Automattic\Fosse\Admin\Actor_Mode_Lock;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use WorDBless\BaseTestCase;
+
+/**
+ * Locks bundled AP's three actor-mode constants behind FOSSE's helper.
+ */
+class Actor_Mode_LockTest extends BaseTestCase {
+
+	/**
+	 * No constants defined: helper reports the option is freely settable.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_forced_mode_returns_null_when_no_constants_defined(): void {
+		$this->assertNull( Actor_Mode_Lock::forced_mode() );
+		$this->assertFalse( Actor_Mode_Lock::is_locked() );
+	}
+
+	/**
+	 * `ACTIVITYPUB_SINGLE_USER_MODE` is the wp.com-platform lock.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_single_user_mode_locks_to_blog(): void {
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+
+		$this->assertSame( Actor_Mode_Lock::MODE_BLOG, Actor_Mode_Lock::forced_mode() );
+		$this->assertTrue( Actor_Mode_Lock::is_locked() );
+	}
+
+	/**
+	 * `ACTIVITYPUB_DISABLE_USER` also locks to blog mode (mirrors AP).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_disable_user_locks_to_blog(): void {
+		define( 'ACTIVITYPUB_DISABLE_USER', true );
+
+		$this->assertSame( Actor_Mode_Lock::MODE_BLOG, Actor_Mode_Lock::forced_mode() );
+		$this->assertTrue( Actor_Mode_Lock::is_locked() );
+	}
+
+	/**
+	 * `ACTIVITYPUB_DISABLE_BLOG_USER` flips the lock to author mode.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_disable_blog_user_locks_to_actor(): void {
+		define( 'ACTIVITYPUB_DISABLE_BLOG_USER', true );
+
+		$this->assertSame( Actor_Mode_Lock::MODE_ACTOR, Actor_Mode_Lock::forced_mode() );
+		$this->assertTrue( Actor_Mode_Lock::is_locked() );
+	}
+
+	/**
+	 * Precedence regression canary: `SINGLE_USER_MODE` wins over
+	 * `DISABLE_BLOG_USER` (the two return different forced modes).
+	 * If a future refactor reorders the checks, this test fails.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_single_user_mode_takes_precedence_over_disable_blog_user(): void {
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+		define( 'ACTIVITYPUB_DISABLE_BLOG_USER', true );
+
+		$this->assertSame( Actor_Mode_Lock::MODE_BLOG, Actor_Mode_Lock::forced_mode() );
+	}
+
+	/**
+	 * Skip-on-falsy: a constant defined to false (or 0) does not lock,
+	 * so a lower-priority truthy constant still takes effect.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_falsy_single_user_mode_does_not_lock(): void {
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', false );
+		define( 'ACTIVITYPUB_DISABLE_BLOG_USER', true );
+
+		$this->assertSame( Actor_Mode_Lock::MODE_ACTOR, Actor_Mode_Lock::forced_mode() );
+	}
+
+	/**
+	 * The locked notice is non-empty and preserves the warning glyph
+	 * (translators are explicitly told to keep it). Pure string check;
+	 * runs in the main process.
+	 */
+	public function test_locked_notice_includes_warning_glyph(): void {
+		$notice = Actor_Mode_Lock::locked_notice();
+
+		$this->assertNotEmpty( $notice );
+		$this->assertStringContainsString( '⚠', $notice );
+	}
+
+	/**
+	 * Coerce passes the incoming value through when no lock is active.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_coerce_passes_through_when_unlocked(): void {
+		$this->assertSame( 'actor_blog', Actor_Mode_Lock::coerce_to_forced_mode( 'actor_blog' ) );
+		$this->assertSame( 'arbitrary', Actor_Mode_Lock::coerce_to_forced_mode( 'arbitrary' ) );
+	}
+
+	/**
+	 * Coerce overrides any incoming value with the forced mode when locked.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_coerce_overrides_when_locked(): void {
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+
+		$this->assertSame( Actor_Mode_Lock::MODE_BLOG, Actor_Mode_Lock::coerce_to_forced_mode( 'actor_blog' ) );
+		$this->assertSame( Actor_Mode_Lock::MODE_BLOG, Actor_Mode_Lock::coerce_to_forced_mode( 'tampered-value' ) );
+	}
+
+	/**
+	 * Wires the pre_update filter at default priority via register_hooks().
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_register_hooks_wires_pre_update_filter(): void {
+		Actor_Mode_Lock::register_hooks();
+
+		$this->assertNotFalse(
+			has_filter(
+				'pre_update_option_activitypub_actor_mode',
+				array( Actor_Mode_Lock::class, 'coerce_to_forced_mode' )
+			)
+		);
+	}
+
+	/**
+	 * End-to-end: with the hook wired and a constant set, an
+	 * `update_option()` write of an arbitrary value is silently
+	 * coerced to the forced mode in the database. Closes the bypass
+	 * the UI hidden inputs alone could not.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_register_hooks_blocks_tampered_update_when_locked(): void {
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+		Actor_Mode_Lock::register_hooks();
+
+		update_option( 'activitypub_actor_mode', 'actor_blog' );
+
+		$this->assertSame( Actor_Mode_Lock::MODE_BLOG, get_option( 'activitypub_actor_mode' ) );
+	}
+
+	/**
+	 * Pass-through end-to-end: with the hook wired but no lock, a
+	 * write proceeds untouched. Guards against a regression where
+	 * the filter accidentally coerces every install.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_register_hooks_passes_through_when_unlocked(): void {
+		Actor_Mode_Lock::register_hooks();
+
+		update_option( 'activitypub_actor_mode', 'actor_blog' );
+
+		$this->assertSame( 'actor_blog', get_option( 'activitypub_actor_mode' ) );
+	}
+}

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -8,6 +8,7 @@
 namespace Automattic\Fosse\Tests\Admin;
 
 use Atmosphere\OAuth\Encryption;
+use Automattic\Fosse\Admin\Actor_Mode_Lock;
 use Automattic\Fosse\Admin\AP_Provider;
 use Automattic\Fosse\Admin\Bluesky_Provider;
 use Automattic\Fosse\Admin\Connection_Provider;
@@ -16,6 +17,8 @@ use Automattic\Fosse\Admin\Onboarding_Wizard;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionMethod;
 use WorDBless\BaseTestCase;
 
@@ -640,6 +643,32 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'appearance' );
 
 		$this->assertStringContainsString( 'Pretend collision message.', $output );
+	}
+
+	/**
+	 * When the actor mode is constant-locked, the appearance step
+	 * replaces the mode-picker cards with a hidden input + locked
+	 * notice. Regression guard against the locked branch ever being
+	 * deleted by accident or the hidden input being dropped.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_render_appearance_locked_replaces_mode_cards_with_hidden_input(): void {
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+
+		$output = $this->render_wizard_step( 'appearance' );
+
+		$this->assertStringContainsString(
+			'<input type="hidden" name="activitypub_actor_mode" value="' . Actor_Mode_Lock::MODE_BLOG . '"',
+			$output
+		);
+		$this->assertStringNotContainsString( 'class="fosse-mode-cards"', $output );
+		$this->assertStringNotContainsString( 'class="fosse-mode-card__input"', $output );
+		$this->assertStringContainsString( 'defined through server configuration', $output );
+		$this->assertStringContainsString( 'fosse-wizard__locked-mode', $output );
 	}
 
 	// --- Bluesky step render ---

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -8,12 +8,15 @@
 namespace Automattic\Fosse\Tests\Admin;
 
 use Atmosphere\OAuth\Encryption;
+use Automattic\Fosse\Admin\Actor_Mode_Lock;
 use Automattic\Fosse\Admin\AP_Provider;
 use Automattic\Fosse\Admin\Bluesky_Provider;
 use Automattic\Fosse\Admin\Connection_Provider_Registry;
 use Automattic\Fosse\Admin\Setup_Page;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 
 /**
@@ -482,6 +485,40 @@ class Setup_PageTest extends BaseTestCase {
 		$this->assertStringContainsString( 'id="fosse-section-general"', $output );
 		$this->assertStringContainsString( 'name="activitypub_support_post_types[]"', $output );
 		$this->assertStringContainsString( 'name="activitypub_actor_mode"', $output );
+	}
+
+	/**
+	 * When the actor mode is constant-locked, the radios are replaced
+	 * by a hidden input + locked notice. Regression guard against the
+	 * locked branch ever being deleted by accident.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_render_actor_mode_locked_replaces_radios_with_hidden_input(): void {
+		define( 'ACTIVITYPUB_SINGLE_USER_MODE', true );
+
+		$this->become_admin();
+
+		$output = $this->capture_render();
+
+		// Hidden input still posts the forced mode so saves stay aligned.
+		$this->assertStringContainsString(
+			'<input type="hidden" name="activitypub_actor_mode" value="' . Actor_Mode_Lock::MODE_BLOG . '"',
+			$output
+		);
+		// No interactive radio for actor mode in the locked branch.
+		$this->assertStringNotContainsString(
+			'id="fosse-activitypub-actor-mode-actor"',
+			$output
+		);
+		// The locked-state notice is surfaced to the user.
+		$this->assertStringContainsString(
+			'defined through server configuration',
+			$output
+		);
 	}
 
 	// --- helpers ----------------------------------------------------------


### PR DESCRIPTION
## Summary

FOSSE's admin UI surfaces an actor-mode picker (Setup page + onboarding wizard step 2) for an option that bundled ActivityPub silently overrides via its `pre_option_activitypub_actor_mode` filter (`bundled/activitypub/includes/class-options.php:501-515`) when any of these constants are defined:

- `ACTIVITYPUB_SINGLE_USER_MODE` → forces blog mode
- `ACTIVITYPUB_DISABLE_USER` → forces blog mode
- `ACTIVITYPUB_DISABLE_BLOG_USER` → forces author mode

On wp.com, `wpcom-activitypub-load.php` defines `ACTIVITYPUB_SINGLE_USER_MODE = true` unconditionally on every request, so any FOSSE deployment on wp.com Simple is permanently locked to blog mode — but FOSSE was happily letting users select "Author profiles" or "Both" with no indication that the choice would have no effect.

This PR adds `Automattic\Fosse\Admin\Actor_Mode_Lock` (mirrors bundled AP's exact constant checks) and uses it to:

* **Setup page** (`src/Admin/templates/setup-page.php`): replace the actor-mode radio fieldset with a static block showing the forced mode + warning notice when locked. A hidden input keeps the saved option in sync.
* **Onboarding wizard, Appearance step** (`src/Admin/class-onboarding-wizard.php`): replace the mode-picker cards with a static block under the same conditions. The downstream preview rendering and blog-handle field already key off `$current_mode` (which `pre_option` makes correct), so no other wizard logic needed to change.

The warning copy mirrors the wording bundled AP uses on its own settings page (`bundled/activitypub/includes/wp-admin/class-settings-fields.php:197`) so users see a consistent message across both surfaces. wp.com's underlying constants are intentionally left unchanged — this PR only stops FOSSE from misrepresenting what's controllable.

Per the wpcom-Simple rollout SDD, the platform constants are part of the design contract (single-user mode supports primary-domain-aware actor resolution); changing that is a separate, bigger discussion.

## Test plan

- [x] `composer lint-php` clean.
- [ ] Manual on a wp.com Simple sandbox with `enable-fosse` sticker:
  - Setup page Actor Mode row shows "Blog profile" + the locked-notice; no radios; saved option is `blog`.
  - Wizard Appearance step shows the "As your site" card content as a static block + the locked-notice; no card-picker; submitting Continue saves `blog` and advances normally.
  - Preview pane on wizard step 2 shows only the blog handle preview.
  - Blog handle field stays editable (still meaningful in blog mode).
- [ ] Manual on a self-hosted install (no constants defined):
  - Setup page renders all three radios as before.
  - Wizard renders all three cards as before.
  - No regression in the existing JS preview-toggle behavior.

## Notes

* The blog identifier field (`activitypub_blog_identifier`) is intentionally left as-is — it's freely settable on wp.com and is the user's blog handle in blog mode, so it's exactly the field they'd want to customize.
* Post-types selection is not constant-locked, so it stays as-is.
* This is FOSSE-side only; no wpcom changes.