### PR TITLE
Ignore Superpowers brainstorming artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 /.claude/settings.local.json
 /.claude/scheduled_tasks.lock
 /.claude/worktrees/
+
+# Superpowers — local visual brainstorming sessions
+/.superpowers/


### PR DESCRIPTION
## Summary
- Add .superpowers/ to .gitignore so local visual brainstorming sessions do not show up in git status.

## Testing
- git diff --check origin/trunk..HEAD