### PR TITLE
SDD: Data consistency and sync

### DIFF
--- a/sdd/data-consistency-sync/plan.md
+++ b/sdd/data-consistency-sync/plan.md
@@ -1,0 +1,196 @@
+# Implementation Plan: Data Consistency & Sync
+
+Based on: sdd/data-consistency-sync/spec.md
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## Progress
+
+- [ ] Task 1: Verify ActivityPub delete/update behavior and record upstream gaps
+- [ ] Task 2: Add FOSSE queue/backoff data model tests
+- [ ] Task 3: Implement FOSSE publish queue and send-status read model
+- [ ] Task 4: Add admin-visible persistent failure reporting
+- [ ] Task 5: Land upstream Atmosphere delete/update retry hooks
+- [ ] Task 6: Land upstream Atmosphere image sanitization and size selection
+- [ ] Task 7: Sync bundled upstream changes into FOSSE
+- [ ] Task 8: Add lifecycle e2e coverage and status feed checks
+- [ ] Task 9: Run verification and update SDD statuses
+
+## Tasks
+
+### Task 1: Verify ActivityPub delete/update behavior and record upstream gaps
+
+- **Status**: Not started
+- **Files**:
+  - Read: `bundled/activitypub/includes/scheduler/class-post.php`
+  - Read: `bundled/activitypub/includes/class-activitypub.php`
+  - Read: `bundled/activitypub/includes/collection/class-outbox.php`
+  - Create upstream tests in `Automattic/wordpress-activitypub` if a gap is found
+  - Do not modify `bundled/activitypub/` by hand
+- **Do**:
+  1. Inspect ActivityPub's post scheduler for publish to update to trash/private/draft to permanent delete transitions.
+  2. Confirm Delete supersedes pending Create/Update outbox items for the same object.
+  3. Confirm hard delete has access to object identity before WordPress deletes post meta.
+  4. If behavior is already correct, document the exact upstream files/methods in the implementation notes for this SDD.
+  5. If behavior is not correct, open an upstream ActivityPub PR with failing tests first, then implementation.
+- **Verify**:
+  - `composer run-script test-php` in FOSSE still passes after any bundled refresh.
+  - Upstream ActivityPub tests pass in the upstream repo if a PR is needed.
+- **Depends on**: none
+
+### Task 2: Add FOSSE queue/backoff data model tests
+
+- **Status**: Not started
+- **Files**:
+  - Create: `src/class-publish-queue.php`
+  - Create: `src/class-send-status.php`
+  - Create: `tests/php/Publish_QueueTest.php`
+  - Create: `tests/php/Send_StatusTest.php`
+- **Do**:
+  1. Write failing tests for `Publish_Queue` entry normalization: required keys, stable `id`, supported `network`/`operation`, compact `remote` data, autoload `false` option storage.
+  2. Write failing tests for backoff: attempt 0 schedules `+1s`, attempt 1 schedules `+5s`, attempt 2 schedules `+30s`, attempt 3 becomes `failed`.
+  3. Write failing tests for failure classification: retryable network/429/5xx; persistent auth/rate/schema/media errors.
+  4. Write failing tests for `Send_Status` update/read shape, including `atproto.remote_uri` from `_fosse_atproto_uri`, fallback to Atmosphere meta, `for_post()` UI normalization, and the `fosse_send_status_for_post` filter seam.
+  5. Run `composer dump-autoload && composer run-script test-php -- --filter 'Publish_Queue|Send_Status'` and confirm RED.
+- **Verify**:
+  - New tests fail because the classes do not exist yet.
+- **Depends on**: Task 1
+
+### Task 3: Implement FOSSE publish queue and send-status read model
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `src/class-publish-queue.php`
+  - Modify: `src/class-send-status.php`
+  - Modify: `fosse.php`
+  - Modify: `tests/php/Publish_QueueTest.php`
+  - Modify: `tests/php/Send_StatusTest.php`
+- **Do**:
+  1. Implement `Automattic\Fosse\Publish_Queue` with constants for `OPTION = 'fosse_publish_queue'` and `CRON_HOOK = 'fosse_process_publish_queue'`.
+  2. Store the option with autoload `false`; keep entries keyed by stable job ID.
+  3. Implement enqueue, mark retrying, mark sent, mark failed, supersede, due-entry selection, and pruning helpers.
+  4. Implement a cron registration method that processes due entries behind a short lock.
+  5. Implement `Automattic\Fosse\Send_Status` with `_fosse_send_status` post meta writes, reads, and `for_post()` normalization for UI consumers.
+  6. Register `fosse_retry_publication` handling so failed `activitypub` or `atproto` statuses can enqueue durable retry work.
+  7. Register queue cron hooks in `fosse.php` with the same `class_exists` guard pattern as existing projectors.
+  8. Run `composer dump-autoload && composer run-script test-php -- --filter 'Publish_Queue|Send_Status'` and confirm GREEN.
+  9. Run `composer run-script lint-php -- src/class-publish-queue.php src/class-send-status.php tests/php/Publish_QueueTest.php tests/php/Send_StatusTest.php fosse.php`.
+- **Verify**:
+  - Queue/status PHPUnit tests pass.
+  - PHPCS passes on touched files.
+- **Depends on**: Task 2
+
+### Task 4: Add admin-visible persistent failure reporting
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `src/Admin/class-status-page.php`
+  - Modify: `src/Admin/templates/status-page.php`
+  - Modify: `src/Admin/class-status-formatter.php`
+  - Modify: `tests/php/Admin/Status_FormatterTest.php`
+  - Modify or create focused Status_Page tests under `tests/php/Admin/`
+- **Do**:
+  1. Add tests for rendering persistent queue failures without exposing raw tokens or full request payloads.
+  2. Add formatter coverage for auth, rate-limit, schema, media, and permanent delete failure messages.
+  3. Surface a compact "needs attention" state on the FOSSE Status page using `Publish_Queue` / `Send_Status` read methods.
+  4. Keep composer-specific UI out of scope; only backend/admin status surfaces belong here.
+  5. Run `composer run-script test-php -- --filter 'Status_Formatter|Status_Page|Publish_Queue|Send_Status'`.
+  6. Run `composer run-script lint-php -- src/Admin/class-status-page.php src/Admin/templates/status-page.php src/Admin/class-status-formatter.php`.
+- **Verify**:
+  - Persistent failure messages are visible in admin status tests.
+  - No secrets or raw payloads appear in rendered output.
+- **Depends on**: Task 3
+
+### Task 5: Land upstream Atmosphere delete/update retry hooks
+
+- **Status**: Not started
+- **Files**:
+  - Upstream modify: `wordpress-atmosphere/includes/class-atmosphere.php`
+  - Upstream modify: `wordpress-atmosphere/includes/class-publisher.php`
+  - Upstream modify: `wordpress-atmosphere/includes/transformer/class-post.php`
+  - Upstream tests in `wordpress-atmosphere/tests/` or the upstream equivalent
+  - FOSSE does not modify `bundled/atmosphere/` until Task 7
+- **Do**:
+  1. Add upstream tests for `transition_post_status` / `wp_trash_post` scheduling delete, permanent delete capturing identifiers before meta removal, and delete failures leaving enough state for retry.
+  2. Add upstream tests for hybrid update behavior: in-place `putRecord` for stable shape, delete/republish when topology changes, thread cardinality changes handled deterministically.
+  3. Ensure delete accepts current Atmosphere meta and a fallback AT-URI parser compatible with `_fosse_atproto_uri` if FOSSE mirrors that state.
+  4. Add retry/error hooks or return values FOSSE can consume without duplicating PDS calls.
+  5. Open/land upstream PR(s), then record PR URLs in this plan when complete.
+- **Verify**:
+  - Upstream tests pass.
+  - FOSSE has a clear integration seam for queue/status updates.
+- **Depends on**: Task 3
+
+### Task 6: Land upstream Atmosphere image sanitization and size selection
+
+- **Status**: Not started
+- **Files**:
+  - Upstream modify: `wordpress-atmosphere/includes/transformer/class-post.php`
+  - Upstream modify if needed: `wordpress-atmosphere/includes/class-api.php`
+  - Upstream tests for image selection/sanitization
+  - FOSSE does not modify `bundled/atmosphere/` until Task 7
+- **Do**:
+  1. Add upstream tests proving images over 1 MB choose the largest available derivative under cap in order: `large`, `medium_large`, `medium`.
+  2. Add tests proving EXIF/GPS metadata is stripped by re-encoding before upload.
+  3. Add tests proving no more than 4 images are uploaded for a post.
+  4. Add tests proving cached blob refs are invalidated when source file mtime/checksum changes.
+  5. Implement with `WP_Image_Editor` and a sanitized temporary/cache file; do not upload the original binary.
+  6. Add filter hooks only if needed for site-specific image policy, keeping the secure default on.
+- **Verify**:
+  - Upstream image tests pass.
+  - Oversized or unprocessable media produces a classified warning/error FOSSE can surface.
+- **Depends on**: Task 3
+
+### Task 7: Sync bundled upstream changes into FOSSE
+
+- **Status**: Not started
+- **Files**:
+  - Modify via script only: `bundled/activitypub/` if Task 1 required upstream AP changes
+  - Modify via script only: `bundled/atmosphere/`
+  - Possibly modify: `composer.lock` only if the sync/build process changes root dependencies
+- **Do**:
+  1. Ensure upstream PRs needed by Tasks 5 and 6 are merged.
+  2. Run `./tools/sync-bundled.sh` with source checkouts pointing at the merged upstream branches/tags.
+  3. Do not hand-edit files under `bundled/`.
+  4. Run `composer dump-autoload`.
+  5. Run `composer run-script test-php`.
+- **Verify**:
+  - Bundled copies reflect upstream commits.
+  - FOSSE PHPUnit passes after sync.
+- **Depends on**: Task 5, Task 6
+
+### Task 8: Add lifecycle e2e coverage and status feed checks
+
+- **Status**: Not started
+- **Files**:
+  - Create: `tests/e2e/data-consistency-sync.spec.ts`
+  - Possibly modify: `tests/e2e/mu-plugins/fosse-bsky-capture.php`
+  - Possibly create: `tests/e2e/mu-plugins/fosse-sync-state.php`
+  - Possibly modify: `tests/e2e/blueprint.json`
+- **Do**:
+  1. Extend the e2e mu-plugin harness to capture intended Bluesky XRPC calls without a live network dependency.
+  2. Add a Playwright spec that publishes a post, edits it, trashes it, restores/republishes it, and permanently deletes it.
+  3. Assert the captured sequence matches the hybrid policy: create, put/update or republish based on shape, delete on trash/delete.
+  4. Assert `_fosse_send_status` or a REST/debug test endpoint exposes provider states the future composer can consume.
+  5. Assert persistent failures become visible on the FOSSE Status page.
+  6. Run `pnpm run test:e2e -- data-consistency-sync`.
+- **Verify**:
+  - New e2e spec passes locally.
+  - The spec does not require real Bluesky credentials.
+- **Depends on**: Task 7
+
+### Task 9: Run verification and update SDD statuses
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `sdd/data-consistency-sync/plan.md`
+  - Create later if allowed by the implementing worker: `sdd/data-consistency-sync/implementation.md`
+- **Do**:
+  1. Run required local checks: `composer run-script lint-php`, `composer run-script test-php`, `pnpm run format:check`, `pnpm run lint`.
+  2. Run focused e2e: `pnpm run test:e2e -- data-consistency-sync`.
+  3. Update the Progress checklist and each task's `**Status**` with the AGENTS.md Done status value and a commit or PR reference only after verification passes.
+  4. If an implementation notes file is permitted for the implementing worker, capture upstream PR links, verification output, and deviations from this SDD.
+- **Verify**:
+  - Progress checklist mirrors per-task statuses.
+  - All verification commands and upstream refs are recorded.
+- **Depends on**: Task 8

--- a/sdd/data-consistency-sync/requirements.md
+++ b/sdd/data-consistency-sync/requirements.md
@@ -1,0 +1,71 @@
+# Data Consistency & Sync - Requirements
+
+## Goal
+
+Define how FOSSE keeps WordPress canonical while synchronizing outward to ActivityPub and Bluesky. This covers [DOTCOM-16798](https://linear.app/a8c/issue/DOTCOM-16798) and child issues [DOTCOM-16821](https://linear.app/a8c/issue/DOTCOM-16821), [DOTCOM-16822](https://linear.app/a8c/issue/DOTCOM-16822), [DOTCOM-16823](https://linear.app/a8c/issue/DOTCOM-16823), and [DOTCOM-16824](https://linear.app/a8c/issue/DOTCOM-16824).
+
+WordPress is the source of truth. When a user publishes, edits, trashes, restores, permanently deletes, or changes media in WordPress, the federated copies should converge to the WordPress state. If a network-side copy diverges, v1 does not attempt multi-network conflict resolution; WordPress wins on the next outbound operation.
+
+## Requirements
+
+1. **WordPress-canonical model.** FOSSE treats WordPress post state as canonical and networks as projections. Backend status must describe each network projection without changing where canonical content lives.
+2. **Delete sync for Bluesky.** When a published WordPress post transitions to `trash`, is permanently deleted, or is deleted after already leaving `publish`, Bluesky records created for that post must be deleted from the PDS. The delete path must use stored record identity, including `_fosse_atproto_uri` when present and the current Atmosphere record meta (`_atmosphere_bsky_uri`, `_atmosphere_bsky_tid`, `_atmosphere_bsky_thread_records`) as compatibility/current-source data.
+3. **Permanent delete coverage.** Hard deletes must capture remote identifiers before WordPress removes post meta and child comments. `before_delete_post` is the likely hook; the SDD should also call out `post_delete`/`deleted_post` as too late for meta-dependent cleanup except as a defensive fallback.
+4. **ActivityPub behavior confirmed.** The implementation must verify that bundled ActivityPub already emits/schedules Delete activities for WordPress trash/unpublish/delete transitions. If ActivityPub has a real gap, the fix goes upstream to `wordpress-activitypub`, not into `bundled/`.
+5. **Edit-sync policy chosen.** The spec must pick a v1 policy among append-only, delete-and-republish, and hybrid. The policy must explain how short posts, long-form thread posts, media changes, object-type changes, and unsupported in-place mutations behave.
+6. **Failure handling and retry queue.** Failed outbound operations must be recorded with enough state to retry. Backoff is `1s`, `5s`, `30s`; after those attempts, failures remain visible and retryable. The queue may use `fosse_publish_queue`, but the shape must be justified.
+7. **Cron retry.** A WP-Cron worker retries due queue entries and updates per-network send state. It must avoid duplicate concurrent processing and must not publish/delete stale state that WordPress has since superseded.
+8. **Admin-visible persistent failures.** Persistent authentication, rate-limit, schema/validation, and permanent deletion failures must surface in wp-admin notices or provider status surfaces. Notices must be actionable without exposing tokens or raw payload secrets.
+9. **Image size handling for Bluesky.** Bluesky uploads are capped at 1 MB per image and 4 images per post. The implementation must choose an appropriate WordPress derivative under the cap (`large`, `medium_large`, then `medium`, falling back to a re-encoded derivative if needed) and skip extra images deterministically.
+10. **EXIF stripping.** Images uploaded to Bluesky must be stripped of EXIF/GPS metadata for privacy and to reduce file size. The sanitized file, not the original upload, is what gets uploaded/cached.
+11. **ActivityPub media coordination.** The SDD must confirm whether ActivityPub sends original media URLs, cached files, or transformed attachments. If EXIF/size behavior is post-type-agnostic and useful to standalone ActivityPub, coordinate upstream rather than adding a FOSSE-only workaround.
+12. **Composer send-status feed.** Backend state from publish/update/delete/retry must be queryable by the future composer send-status UI ([DOTCOM-16805](https://linear.app/a8c/issue/DOTCOM-16805)). This SDD does not implement that UI.
+13. **No edits to `bundled/`.** Upstream changes land in `wordpress-atmosphere` or `wordpress-activitypub`, then FOSSE consumes them through `tools/sync-bundled.sh`.
+
+## Constraints
+
+- FOSSE-specific policy belongs in FOSSE: canonical WordPress-wins status aggregation, queue presentation, and composer-facing status shape.
+- Post-type-agnostic correctness belongs upstream: Atmosphere delete/update/retry/image-upload behavior and ActivityPub delete/media behavior should be fixed in their upstream repositories.
+- Existing projector patterns should be followed for small FOSSE classes (`Object_Type`, `Post_Types`, `Long_Form_Strategy`, `Reactions_Label`).
+- PHP code follows the Jetpack/WPCS ruleset, tabs, Yoda conditions, PHPDoc on public/protected methods, and text domain `fosse`.
+- Tests should start in PHPUnit for pure queue/status policy, then use e2e/Playground only where WordPress lifecycle behavior needs a real boot.
+
+## Out of Scope
+
+- Multi-network conflict resolution beyond WordPress wins.
+- Pulling edits from Bluesky, Mastodon, or any other network back into WordPress.
+- A composer UI or block-editor UI for send status. This SDD only defines backend state the future UI can consume.
+- Manual conflict merge tools.
+- Rewriting bundled plugin code directly under `bundled/`.
+- Changing the long-form Bluesky composition strategy itself; this SDD consumes whatever thread/single-record shape exists.
+- Guaranteeing deletion of third-party replies, likes, or reposts on remote networks. FOSSE deletes records it created in the user's repository; remote reactions are controlled by their authors and networks.
+
+## Relevant Code / Patterns Found
+
+### FOSSE
+
+- `fosse.php` registers FOSSE projectors and provider bootstrap.
+- `src/class-object-type.php`, `src/class-post-types.php`, `src/class-long-form-strategy.php`, and `src/class-reactions-label.php` are the local pattern for small cross-network policy projectors.
+- `src/Admin/class-bluesky-provider.php` reads Atmosphere connection state and renders FOSSE-owned Bluesky setup/status surfaces.
+- `src/Admin/class-status-page.php` and `src/Admin/templates/status-page.php` are the likely home for persistent provider failure summaries until DOTCOM-16805 consumes the same data in the composer.
+
+### Atmosphere / Bluesky
+
+- `bundled/atmosphere/includes/class-atmosphere.php` wires `transition_post_status`, `before_delete_post`, async cron hooks such as `atmosphere_publish_post`, `atmosphere_update_post`, `atmosphere_delete_post`, and `atmosphere_delete_records`.
+- `bundled/atmosphere/includes/class-publisher.php` owns `publish_post()`, `update_post()`, `delete_post()`, `delete_post_by_tids()`, comment delete cascades, and record-meta cleanup.
+- `bundled/atmosphere/includes/transformer/class-post.php` defines `_atmosphere_bsky_uri`, `_atmosphere_bsky_tid`, `_atmosphere_bsky_cid`, `_atmosphere_bsky_thread_records`, and `upload_thumbnail()`.
+- Current `upload_thumbnail()` checks the original file and falls back to `large` when the original exceeds 1 MB; it does not by itself prove EXIF stripping or best-derivative selection across `large` / `medium_large` / `medium`.
+
+### ActivityPub
+
+- `bundled/activitypub/includes/scheduler/class-post.php` schedules ActivityPub Create/Update/Delete activities on post status transitions.
+- `bundled/activitypub/includes/class-activitypub.php` hooks `wp_trash_post` / `untrash_post` to preserve and clear canonical URL state around trash.
+- `bundled/activitypub/includes/collection/class-outbox.php` models Delete as superseding pending Create/Update activities for the same object.
+- Any confirmed gap in these behaviors should be patched upstream in `wordpress-activitypub` and pulled into FOSSE later.
+
+## Open Questions To Resolve In Spec
+
+- Should FOSSE introduce `_fosse_atproto_uri` as a canonical mirror, or treat it as compatibility/future composer state while Atmosphere remains the source of record identifiers?
+- Should retry queue state live in a single `fosse_publish_queue` option, per-post meta, or a custom post type/table?
+- Which failures are retryable vs immediately persistent: network timeout, 429, 5xx, expired token, invalid grant, schema validation, missing record, and oversized image?
+- How much image handling should be upstream Atmosphere now vs FOSSE-specific policy for the composer?

--- a/sdd/data-consistency-sync/spec.md
+++ b/sdd/data-consistency-sync/spec.md
@@ -1,0 +1,170 @@
+# Spec: Data Consistency & Sync
+
+## Goal
+
+Make WordPress the canonical state machine for outbound federation. A WordPress post's publish/edit/trash/delete/media state drives ActivityPub and Bluesky projections; backend status records what happened and what still needs retry. v1 explicitly does not resolve conflicts between networks. If WordPress and a remote copy disagree, the next outbound WordPress action overwrites or deletes the remote projection.
+
+## Requirements Summary
+
+- Delete Bluesky records on trash/unpublish/permanent delete using stored record identity.
+- Confirm ActivityPub already sends equivalent Delete activities; fix upstream if not.
+- Use a chosen edit policy, not a menu of options.
+- Persist failed operations into a retry queue with `1s`, `5s`, `30s` backoff and admin-visible persistent failures.
+- Strip EXIF and keep Bluesky image uploads under 1 MB, max 4 images per post.
+- Expose backend send state for the future DOTCOM-16805 composer send-status UI, without building that UI here.
+- Keep upstream-generic correctness upstream; keep FOSSE policy/status aggregation in FOSSE.
+
+## Chosen Edit Strategy
+
+**Recommendation: hybrid edit sync.**
+
+Append-only is rejected because it leaves stale copies in remote feeds and breaks the WordPress-canonical promise. Delete-and-republish for every edit is also rejected because it unnecessarily resets Bluesky recency, loses reply continuity, and creates noisy ActivityPub behavior for simple typo fixes.
+
+The v1 policy:
+
+- **Stable single-record Bluesky edits:** update in place with `com.atproto.repo.putRecord` when the record collection, rkey, and shape can remain stable.
+- **Stable thread edits:** update existing thread records in place when the thread cardinality and ordering remain compatible with the newly composed output. Extra old records are deleted if the new thread is shorter; missing new records are created as replies when the new thread is longer.
+- **Topology-changing edits:** delete and republish when the WordPress edit changes the outbound topology in a way that cannot be safely mapped in place. Examples: object type changes short-form to long-form, long-form strategy changes single-record to thread, media/embed shape changes beyond what a record can update safely, or the stored thread metadata is incomplete.
+- **ActivityPub edits:** rely on ActivityPub's normal Update/Delete outbox pipeline. If confirmation shows AP lacks a specific status transition, fix that upstream.
+- **User-facing semantics:** in wp-admin and the future composer status UI, call topology-changing edits "republish" rather than "edit" because they can orphan Bluesky reply chains and reset feed recency.
+
+This keeps common edits quiet while preserving a deterministic fallback when the remote record graph no longer matches WordPress.
+
+## Delete Sync
+
+### Bluesky
+
+Bluesky delete sync belongs primarily upstream in `wordpress-atmosphere` because standalone Atmosphere sites have the same correctness requirement. FOSSE should not implement a parallel PDS delete shim if Atmosphere can own it.
+
+The delete worker must support both current Atmosphere meta and FOSSE compatibility state:
+
+| State | Purpose |
+|-------|---------|
+| `_fosse_atproto_uri` | FOSSE/composer-facing canonical AT-URI mirror when present. Used to display and recover send state. |
+| `_atmosphere_bsky_uri` / `_atmosphere_bsky_tid` / `_atmosphere_bsky_cid` | Current Atmosphere root record identity. |
+| `_atmosphere_bsky_thread_records` | Ordered list of Bluesky records for thread strategies. |
+| `_atmosphere_doc_uri` / `_atmosphere_doc_tid` / `_atmosphere_doc_cid` | `site.standard.document` identity. |
+
+For a trashed post, `transition_post_status` from `publish` to `trash` and/or `wp_trash_post` should schedule a delete job that calls the same underlying delete path as permanent deletion. For a hard delete, `before_delete_post` captures TIDs/URIs before WordPress removes post meta and comments, then schedules a cron job that can delete after the row is gone. `post_delete` / `deleted_post` are too late for primary cleanup because meta may already be unavailable; they are acceptable only as defensive logging or to mark a previously captured queue entry as no longer resolvable.
+
+Implementation should prefer deleting by rkey/TID where available because `com.atproto.repo.deleteRecord` and `applyWrites#delete` require `collection` + `rkey`. If only `_fosse_atproto_uri` exists, parse the AT-URI to recover repository DID, collection, and rkey, then call `com.atproto.repo.deleteRecord` for that stored record; reject malformed URIs into a persistent schema failure rather than guessing.
+
+### ActivityPub
+
+The expected AP behavior is:
+
+- publish to Create/Announce-style outbound activity as configured by ActivityPub.
+- edit while publish remains publish to Update activity.
+- publish to trash/draft/private to Delete activity when the object was previously federated.
+- permanent delete to Delete activity or pre-delete outbox item while object identity is still available.
+- pending Create/Update items for the same object should be superseded by Delete.
+
+The plan includes a verification task against bundled ActivityPub. If ActivityPub misses one of these states, the fix is upstream in `wordpress-activitypub`; FOSSE only documents the required behavior and refreshes `bundled/` after upstream lands.
+
+## Retry Queue And Failure State
+
+### Queue Shape
+
+Use a FOSSE-owned option named `fosse_publish_queue`, stored with autoload `false`, for v1. A custom table is premature for the current plugin scale, and per-post meta alone cannot represent hard-delete work after the post is gone. The option is acceptable if entries are compact, keyed, and pruned. If queue volume becomes a problem, the same entry shape can move to a custom table later.
+
+Entry shape:
+
+| Field | Meaning |
+|-------|---------|
+| `id` | Stable hash of network + operation + object type + object ID or captured URI. |
+| `network` | `activitypub` or `atproto`. |
+| `operation` | `publish`, `update`, `republish`, or `delete`. |
+| `object_type` | `post`, `comment`, `document`, or provider-specific subtype. |
+| `object_id` | WordPress ID when the object still exists; `0` for captured hard-delete-only jobs. |
+| `remote` | Captured AT-URI/TID/outbox ID values needed when the object no longer exists. |
+| `attempts` | Number of attempts already made. |
+| `next_run_gmt` | UTC timestamp when cron may retry. |
+| `last_error` | Sanitized `code`, `message`, `classification`, and timestamp. |
+| `status` | `queued`, `retrying`, `failed`, `sent`, or `superseded`. |
+| `state_version` | Monotonic version/hash of the WordPress source state that created the job. |
+
+The queue stores post IDs as requested by DOTCOM-16823, but it does not store only post IDs. It also stores operation, network, remote identifiers, error classification, and source-state version so cron can avoid replaying stale work.
+
+### Backoff And Cron
+
+Backoff schedule is exactly `1s`, `5s`, `30s`. After the third failed attempt, the entry remains in `failed` status until a later WordPress action supersedes it or an admin/user triggers a manual retry. Transient network failures, 429 rate limits with no `Retry-After`, and 5xx failures are retryable. `Retry-After` may push `next_run_gmt` later than the fixed sequence, but the attempt labels still use the fixed schedule.
+
+Authentication failures, invalid grants, permission failures, malformed AT-URIs, schema validation errors, and persistent oversized media are not blindly retried after classification. They become persistent failures with an admin-visible notice because repeating them will not converge without user or code action.
+
+Cron hook: `fosse_process_publish_queue`.
+
+The worker:
+
+1. Acquires a short lock option/transient before processing.
+2. Loads due entries from `fosse_publish_queue`.
+3. Re-reads WordPress state when `object_id` still exists and skips/supersedes work if the source state has changed.
+4. Delegates network-specific work to upstream provider APIs where possible.
+5. Updates queue entries and per-post send state after each attempt.
+6. Prunes `sent` and `superseded` entries after a short retention window, while keeping failed entries visible.
+
+## Send State For DOTCOM-16805
+
+Add a read model separate from the queue: `_fosse_send_status` post meta for existing posts, plus captured queue entries for hard-deleted objects. The composer UI can later read this data without needing to understand Atmosphere internals.
+
+Suggested per-post shape:
+
+| Field | Meaning |
+|-------|---------|
+| `activitypub.status` | `not_configured`, `pending`, `sent`, `retrying`, `failed`, `deleted`, or `skipped`. |
+| `activitypub.message` | Sanitized human-readable summary. |
+| `activitypub.updated_gmt` | Last state change. |
+| `atproto.status` | Same status enum for Bluesky. |
+| `atproto.remote_uri` | Root AT-URI, usually mirrored from `_fosse_atproto_uri` / Atmosphere meta. |
+| `atproto.remote_url` | Optional bsky.app URL derived from AT-URI. |
+| `atproto.next_retry_gmt` | Present only while queued/retrying. |
+| `atproto.error_code` | Sanitized last error code when failed. |
+
+This SDD does not create the composer UI. It only ensures publish/update/delete/retry code writes a stable backend state that DOTCOM-16805 can consume.
+
+Add a UI-facing facade on top of the post meta shape:
+
+```php
+$statuses = Automattic\Fosse\Send_Status::for_post( $post_id );
+$statuses = apply_filters( 'fosse_send_status_for_post', $statuses, $post_id );
+```
+
+The facade returns a normalized array keyed by `activitypub` and `atproto`, using the status enum above. UI consumers should treat `atproto` as the Bluesky row label, but must not create a second status taxonomy for Bluesky. A retry request uses `do_action( 'fosse_retry_publication', $post_id, $network )`, where `$network` is `activitypub` or `atproto`; the queue layer decides whether the retry is allowed and schedules durable work.
+
+## Image Upload Policy
+
+Bluesky limits embedded images to 4 images per post and 1 MB per image. v1 behavior:
+
+- Select at most 4 images in deterministic WordPress order: featured image first for link-card/document cover contexts, then attached/embedded images if the upstream composition supports image embeds.
+- For each image, choose the largest available derivative under 1 MB in this order: `large`, `medium_large`, `medium`.
+- If no existing derivative is under 1 MB, create a temporary sanitized derivative with `WP_Image_Editor`, reducing dimensions/quality until under cap or until a lower bound is reached.
+- Always strip EXIF/GPS metadata by re-encoding through the image editor before upload, even if the selected derivative is already under 1 MB.
+- Cache blob references against a key that includes attachment ID, source file modification time, selected size, and sanitized-file checksum. A cached blob for an old source image must not be reused after media replacement.
+- If an image cannot be made valid under 1 MB, skip that image, record a send-status warning, and keep publishing the post without that image unless the schema requires it.
+
+This image behavior belongs upstream in `wordpress-atmosphere` because any Atmosphere site uploading images to Bluesky needs the privacy and size guarantee. FOSSE's role is to consume the upstream behavior, surface warnings in `_fosse_send_status`, and coordinate ActivityPub behavior.
+
+ActivityPub coordination requirement: inspect the ActivityPub media pipeline before implementation. If ActivityPub exposes original media URLs rather than uploading binaries, the EXIF risk is site-media-publication policy rather than AP transport. If ActivityPub transforms/uploads media and can leak EXIF, file an upstream ActivityPub issue/PR; do not add a FOSSE-only fork of AP media handling.
+
+## Ownership
+
+| Concern | Owner |
+|---------|-------|
+| Atmosphere delete/update correctness, thread delete, image upload sanitization, retryable PDS errors | Upstream `wordpress-atmosphere` |
+| ActivityPub Delete/Update scheduler gaps, AP media EXIF/size behavior | Upstream `wordpress-activitypub` |
+| FOSSE WordPress-wins policy, `_fosse_send_status`, `fosse_publish_queue`, admin notices/status aggregation | FOSSE |
+| Bundled refresh after upstream merges | FOSSE via `tools/sync-bundled.sh` |
+
+## Verification Strategy
+
+- PHPUnit for queue shape, backoff, failure classification, send-status updates, AT-URI parsing, and image-size selection helpers.
+- PHPUnit or upstream unit tests for Atmosphere delete/update/image behavior where the logic can be isolated.
+- FOSSE PHP tests for projector/status/queue classes under `tests/php/`.
+- Playwright e2e only for lifecycle smoke coverage that requires a real WordPress boot: publish, edit, trash, delete, and status visibility.
+- No network-dependent live Bluesky tests in CI. Use stubs/mu-plugins or upstream API seams to capture intended XRPC calls.
+
+## Known Limitations
+
+- v1 cannot delete third-party replies to a Bluesky thread; it only deletes records created in the connected repo.
+- Hybrid edit sync can still republish in topology-changing cases, which can orphan old Bluesky replies. The status UI must be honest about this.
+- `fosse_publish_queue` as an option is not an infinite queue. It is suitable for bounded v1 state and should be revisited if entries grow large.
+- Persistent auth/schema/media failures require user/admin action; cron will not make them converge by retrying forever.


### PR DESCRIPTION
Draft status: Early unreviewed SDD draft for planning discussion. This is not ready to merge.

Related Linear epic: [DOTCOM-16798](https://linear.app/a8c/issue/DOTCOM-16798)

## Summary
- Adds requirements, spec, and implementation plan for WordPress-canonical outbound sync.
- Covers edit/delete policy, retry queue, send-status state, and upstream ownership boundaries.

## Notes
- Docs-only planning PR.
- Opened as a draft intentionally for early review.
- No auto-close keyword is used.