### PR TITLE
SDD: Unified homepage display

### DIFF
--- a/sdd/unified-homepage-display/plan.md
+++ b/sdd/unified-homepage-display/plan.md
@@ -1,0 +1,290 @@
+# Implementation Plan: Unified Homepage / Display
+
+Based on: `sdd/unified-homepage-display/spec.md`
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## Progress
+
+- [ ] Task 1: Add `Homepage_Stream` query/classification helpers
+- [ ] Task 2: Add rendering helpers and PHP output coverage
+- [ ] Task 3: Register the `fosse/unified-homepage-stream` block and editor assets
+- [ ] Task 4: Add block CSS and visual consistency coverage
+- [ ] Task 5: Close the single-post reactions label fallback gap
+- [ ] Task 6: Add deterministic homepage/replies e2e seeding
+- [ ] Task 7: Add Playwright coverage for homepage stream and single-post reactions/replies
+- [ ] Task 8: Run verification and update SDD status
+
+## Tasks
+
+### Task 1: Add `Homepage_Stream` query/classification helpers
+
+- **Status**: Not started
+- **Linear**: [DOTCOM-16818](https://linear.app/a8c/issue/DOTCOM-16818), [DOTCOM-16820](https://linear.app/a8c/issue/DOTCOM-16820)
+- **Files**:
+  - Create: `src/class-homepage-stream.php`
+  - Create: `tests/php/Homepage_StreamTest.php`
+- **Do**:
+  - Create `Automattic\Fosse\Homepage_Stream` with constants:
+    - `BLOCK_NAME = 'fosse/unified-homepage-stream'`
+    - `DEFAULT_POSTS_PER_PAGE = 10`
+    - `MAX_POSTS_PER_PAGE = 50`
+    - `DEFAULT_MEDIA_LIMIT = 4`
+    - `MAX_MEDIA_LIMIT = 6`
+    - `PHOTO_CAPTION_MAX_CHARS = 280`
+  - Add `public static function build_query_args( array $attributes ): array`.
+    - Clamp `postsPerPage` to `1..50`.
+    - Return a `WP_Query` args array with `post_type => 'post'`, `post_status => 'publish'`, `orderby => 'date'`, `order => 'DESC'`, `ignore_sticky_posts => true`, and `no_found_rows => true`.
+  - Add `public static function get_post_images( int $post_id, int $limit ): array`.
+    - Include the featured image first when present.
+    - Include image attachments returned by `get_attached_media( 'image', $post_id )`.
+    - Deduplicate by attachment ID.
+    - Clamp `limit` to `0..6`.
+  - Add `public static function classify_post( \WP_Post $post ): string`.
+    - Return `'photo'` when `get_post_format( $post )` is `'image'`.
+    - Return `'photo'` when `get_post_images( $post->ID, 1 )` returns an image and the stripped, rendered post content is at most 280 characters.
+    - Return `'note'` when `get_post_format( $post )` is `'status'` or `get_the_title( $post )` is empty after trimming.
+    - Return `'article'` otherwise.
+  - Add focused PHPUnit tests:
+    - `test_build_query_args_queries_published_standard_posts_only`
+    - `test_build_query_args_clamps_posts_per_page`
+    - `test_status_format_classifies_as_note`
+    - `test_untitled_post_classifies_as_note`
+    - `test_image_format_classifies_as_photo`
+    - `test_short_caption_with_attached_image_classifies_as_photo`
+    - `test_long_article_with_attached_image_stays_article`
+    - `test_titled_default_post_classifies_as_article`
+    - `test_get_post_images_orders_featured_image_first_and_dedupes`
+  - Use WorDBless factories or `wp_insert_post()` plus `set_post_format()` in the test setup. For image tests, create attachment posts with `post_parent` set to the seeded post and set one attachment as `_thumbnail_id`. Reset inserted posts, attachments, thumbnail meta, and post formats after each test.
+- **Verify**:
+  - `composer dump-autoload`
+  - `composer run-script test-php -- --filter Homepage_Stream`
+  - `composer run-script lint-php -- src/class-homepage-stream.php tests/php/Homepage_StreamTest.php`
+- **Depends on**: none
+
+### Task 2: Add rendering helpers and PHP output coverage
+
+- **Status**: Not started
+- **Linear**: [DOTCOM-16818](https://linear.app/a8c/issue/DOTCOM-16818), [DOTCOM-16820](https://linear.app/a8c/issue/DOTCOM-16820)
+- **Files**:
+  - Modify: `src/class-homepage-stream.php`
+  - Modify: `tests/php/Homepage_StreamTest.php`
+- **Do**:
+  - Add `public static function render( array $attributes = array(), string $content = '', ?\WP_Block $block = null ): string`.
+    - Run `new \WP_Query( self::build_query_args( $attributes ) )`.
+    - Render an empty-state paragraph when there are no posts: "No posts found."
+    - Wrap output in `get_block_wrapper_attributes( array( 'class' => 'fosse-stream' ) )`.
+    - Render each item with `render_item( \WP_Post $post, array $attributes ): string`.
+    - Call `wp_reset_postdata()` after the query loop.
+  - Add private helpers inside the class:
+    - `render_item()`
+    - `render_media()`
+    - `render_article_content()`
+    - `render_note_content()`
+    - `render_photo_content()`
+  - Output expectations:
+    - Every item is `<article class="fosse-stream__item is-article|is-note|is-photo">`.
+    - Article items include `.fosse-stream__title` and `.fosse-stream__excerpt` when `showExcerpt` is true.
+    - Note items include `.fosse-stream__content` and do not invent `.fosse-stream__title`.
+    - Photo items include `.fosse-stream__media` before text.
+    - All titles/permalinks/dates are escaped with WordPress helpers.
+  - Add PHPUnit tests:
+    - `test_render_outputs_article_note_and_photo_classes`
+    - `test_render_note_does_not_invent_title`
+    - `test_render_outputs_empty_state_when_no_posts_exist`
+    - `test_render_respects_show_media_false`
+    - `test_render_respects_show_excerpt_false`
+- **Verify**:
+  - `composer run-script test-php -- --filter Homepage_Stream`
+  - `composer run-script lint-php -- src/class-homepage-stream.php tests/php/Homepage_StreamTest.php`
+- **Depends on**: Task 1
+
+### Task 3: Register the `fosse/unified-homepage-stream` block and editor assets
+
+- **Status**: Not started
+- **Linear**: [DOTCOM-16818](https://linear.app/a8c/issue/DOTCOM-16818)
+- **Files**:
+  - Modify: `src/class-homepage-stream.php`
+  - Create: `src/Blocks/unified-homepage-stream/block.json`
+  - Create: `src/Blocks/unified-homepage-stream/editor.js`
+  - Modify: `fosse.php`
+  - Modify: `tests/php/Homepage_StreamTest.php`
+- **Do**:
+  - Add `public static function register(): void` to `Homepage_Stream`.
+    - Register an editor script handle, `fosse-unified-homepage-stream-editor`, using `plugins_url( 'Blocks/unified-homepage-stream/editor.js', __FILE__ )` from `src/class-homepage-stream.php`.
+    - Script dependencies: `wp-blocks`, `wp-block-editor`, `wp-components`, `wp-element`, `wp-i18n`, `wp-server-side-render`.
+    - Call `register_block_type_from_metadata( __DIR__ . '/Blocks/unified-homepage-stream', array( 'render_callback' => array( self::class, 'render' ), 'editor_script' => 'fosse-unified-homepage-stream-editor' ) )`.
+  - Create `block.json` with:
+    - `apiVersion: 3`
+    - `name: "fosse/unified-homepage-stream"`
+    - `title: "Social Web Stream"`
+    - `category: "widgets"`
+    - `icon: "admin-post"`
+    - `description: "Display long-form posts, notes, and photos in one chronological stream."`
+    - attributes from `spec.md`
+    - `supports.html: false`
+    - `supports.align: [ "wide", "full" ]`
+    - `style: "file:./style.css"`
+  - Create `editor.js` as unbuilt JS using WordPress globals.
+    - Register the block type with the same attributes.
+    - Render inspector controls for `postsPerPage`, `showExcerpt`, `showMedia`, `mediaLimit`, and `showDates`.
+    - Render `wp.serverSideRender` for preview.
+    - Use `wp.i18n.__()` with text domain `fosse`.
+  - Wire registration into `fosse.php` using the existing `init` + `class_exists` guard pattern.
+  - Add PHPUnit coverage:
+    - `test_register_registers_block_type`
+    - `test_register_is_idempotent`
+- **Verify**:
+  - `composer dump-autoload`
+  - `composer run-script test-php -- --filter Homepage_Stream`
+  - `composer run-script lint-php -- src/class-homepage-stream.php tests/php/Homepage_StreamTest.php fosse.php`
+  - `pnpm run lint -- src/Blocks/unified-homepage-stream/editor.js`
+  - `pnpm run format:check -- src/Blocks/unified-homepage-stream/block.json src/Blocks/unified-homepage-stream/editor.js`
+- **Depends on**: Task 2
+
+### Task 4: Add block CSS and visual consistency coverage
+
+- **Status**: Not started
+- **Linear**: [DOTCOM-16820](https://linear.app/a8c/issue/DOTCOM-16820)
+- **Files**:
+  - Create: `src/Blocks/unified-homepage-stream/style.css`
+  - Modify: `tests/php/Homepage_StreamTest.php`
+- **Do**:
+  - Add scoped CSS for:
+    - `.wp-block-fosse-unified-homepage-stream`
+    - `.fosse-stream`
+    - `.fosse-stream__item`
+    - `.fosse-stream__item.is-article`
+    - `.fosse-stream__item.is-note`
+    - `.fosse-stream__item.is-photo`
+    - `.fosse-stream__media`
+    - `.fosse-stream__title`
+    - `.fosse-stream__content`
+    - `.fosse-stream__meta`
+  - Use theme-aware values:
+    - `max-width: var(--wp--style--global--content-size, 720px)`
+    - `color: inherit`
+    - `border-color: color-mix(...)` only with a fallback, or use `currentColor` opacity where safer.
+  - Use stable media dimensions:
+    - media grid images use `aspect-ratio`, `object-fit: cover`, and `max-width: 100%`.
+    - mobile layout avoids fixed widths.
+  - Add a PHPUnit assertion that `block.json` references `file:./style.css` so a future refactor does not drop frontend styles.
+- **Verify**:
+  - `pnpm run format:check -- src/Blocks/unified-homepage-stream/style.css`
+  - `pnpm run lint -- src/Blocks/unified-homepage-stream/editor.js`
+  - `composer run-script test-php -- --filter Homepage_Stream`
+- **Depends on**: Task 3
+
+### Task 5: Close the single-post reactions label fallback gap
+
+- **Status**: Not started
+- **Linear**: [DOTCOM-16819](https://linear.app/a8c/issue/DOTCOM-16819)
+- **Files**:
+  - Modify: `src/class-reactions-label.php`
+  - Modify: `tests/php/Reactions_LabelTest.php`
+- **Do**:
+  - Add a block-render-scoped fallback rewrite to `Reactions_Label::register()`:
+    - Hook `render_block_activitypub/reactions`.
+    - Callback signature accepts the rendered block content and parsed block array.
+    - Replace only the legacy visible fallback heading text `Fediverse Reactions` with `Social Reactions`.
+    - Do not use a broad `gettext` filter.
+  - Add `public static function rewrite_rendered_block( string $block_content, array $block ): string`.
+  - Add PHPUnit tests:
+    - `test_render_rewrite_relabels_legacy_fallback_heading`
+    - `test_render_rewrite_does_not_touch_unrelated_text_when_no_legacy_heading`
+    - `test_render_rewrite_uses_fosse_translation`
+    - extend the idempotency test so both `register_block_type_args` and `render_block_activitypub/reactions` have exactly one callback.
+  - Keep the existing metadata relabel tests intact.
+- **Verify**:
+  - `composer run-script test-php -- --filter Reactions_Label`
+  - `composer run-script lint-php -- src/class-reactions-label.php tests/php/Reactions_LabelTest.php`
+- **Depends on**: completed `sdd/unified-reactions-display/`
+
+### Task 6: Add deterministic homepage/replies e2e seeding
+
+- **Status**: Not started
+- **Linear**: [DOTCOM-16818](https://linear.app/a8c/issue/DOTCOM-16818), [DOTCOM-16819](https://linear.app/a8c/issue/DOTCOM-16819)
+- **Files**:
+  - Create: `tests/e2e/mu-plugins/fosse-homepage-stream-seed.php`
+  - Modify: `tests/e2e/blueprint.json`
+- **Do**:
+  - Create a test-only mu-plugin gated by `FOSSE_E2E`.
+  - Register REST route `POST /wp-json/fosse-e2e/v1/homepage-stream-seed` with `manage_options` permission.
+  - Seed exactly four published posts:
+    - Article: title `FOSSE E2E Article`, no post format, content long enough to produce an excerpt.
+    - Note: title empty, `post_format=status`, body `FOSSE E2E status note`.
+    - Photo-forward: title `FOSSE E2E Photo`, `post_format=image`, one attached image.
+    - Note with photo: title empty, `post_format=status`, body `FOSSE E2E photo note`, one attached image.
+  - Create image attachments using generated small PNG files written through WordPress upload APIs, with alt text:
+    - `FOSSE e2e photo`
+    - `FOSSE e2e note photo`
+  - Create or update a page titled `FOSSE E2E Stream Page` with content `<!-- wp:fosse/unified-homepage-stream {"postsPerPage":4} /-->`.
+  - On the article post, seed:
+    - one approved AP like comment (`comment_type='like'`, `protocol='activitypub'`)
+    - one approved AT like comment (`comment_type='like'`, `protocol='atproto'`)
+    - one approved AT repost comment (`comment_type='repost'`, `protocol='atproto'`)
+    - one approved AP reply (`comment_type='comment'`, `protocol='activitypub'`, author `Reply via Mastodon`)
+    - one approved AT reply (`comment_type='comment'`, `protocol='atproto'`, author `Reply via Bluesky`)
+  - Make seeding idempotent:
+    - Store seeded object IDs in option `fosse_e2e_homepage_stream_seed`.
+    - On re-run, delete prior seeded comments/attachments/posts from that option before recreating.
+  - Return JSON containing stream page URL, post IDs, post URLs, and comment IDs.
+  - Add a `cp` step to `tests/e2e/blueprint.json` copying the new mu-plugin into `wp-content/mu-plugins/`.
+- **Verify**:
+  - `composer run-script lint-php -- tests/e2e/mu-plugins/fosse-homepage-stream-seed.php` if the file is in PHPCS scope; otherwise note that e2e mu-plugins are outside `.phpcs.xml.dist` and rely on review plus Playwright.
+  - `pnpm run format:check -- tests/e2e/blueprint.json`
+- **Depends on**: Task 3
+
+### Task 7: Add Playwright coverage for homepage stream and single-post reactions/replies
+
+- **Status**: Not started
+- **Linear**: [DOTCOM-16818](https://linear.app/a8c/issue/DOTCOM-16818), [DOTCOM-16819](https://linear.app/a8c/issue/DOTCOM-16819), [DOTCOM-16820](https://linear.app/a8c/issue/DOTCOM-16820)
+- **Files**:
+  - Create: `tests/e2e/homepage-stream.spec.ts`
+- **Do**:
+  - In the spec, open `/wp-admin/post-new.php` and wait for `window.wpApiSettings.nonce`, matching existing e2e conventions.
+  - POST to `/wp-json/fosse-e2e/v1/homepage-stream-seed`.
+  - Visit the returned stream page URL.
+  - Assert:
+    - `.wp-block-fosse-unified-homepage-stream.fosse-stream` is visible.
+    - exactly four `.fosse-stream__item` elements render.
+    - items are in reverse chronological order using their seeded titles/body markers.
+    - one item has `.is-article`, two have `.is-note`, one has `.is-photo`.
+    - image alt text for both seeded images is present.
+    - visible homepage text does not include `ActivityPub`, `Fediverse`, or `Bluesky`.
+  - Set viewport to `390x844`; assert `document.documentElement.scrollWidth <= document.documentElement.clientWidth`.
+  - Visit the seeded article single-post URL.
+  - Assert:
+    - `Social Reactions` is visible.
+    - `Fediverse Reactions` is not visible.
+    - like count aggregates to `2`.
+    - repost count is `1`.
+    - `Reply via Mastodon` and `Reply via Bluesky` are visible in comments.
+  - Add a second test that posts to the seed endpoint twice and asserts the stream item count and reaction/reply counts do not duplicate.
+- **Verify**:
+  - `pnpm run test:e2e -- homepage-stream`
+  - `pnpm run lint -- tests/e2e/homepage-stream.spec.ts`
+  - `pnpm run format:check -- tests/e2e/homepage-stream.spec.ts`
+- **Depends on**: Tasks 4, 5, 6
+
+### Task 8: Run verification and update SDD status
+
+- **Status**: Not started
+- **Linear**: [DOTCOM-16797](https://linear.app/a8c/issue/DOTCOM-16797)
+- **Files**:
+  - Modify: `sdd/unified-homepage-display/plan.md`
+- **Do**:
+  - Run local verification:
+    - `composer run-script lint-php`
+    - `composer run-script test-php`
+    - `pnpm run lint`
+    - `pnpm run format:check`
+    - `pnpm run test:e2e -- homepage-stream reactions-display`
+  - Update this plan:
+    - Check each completed Progress item.
+    - Replace each completed task's status with the AGENTS.md Done status value and a commit or PR reference.
+  - Do not mark a task done until its Verify commands pass or the implementation notes document the exact skipped reason.
+- **Verify**:
+  - `rg -n "Status\\*\\*: Not started|\\[ \\]" sdd/unified-homepage-display/plan.md` only shows intentionally unfinished work.
+  - All SDD status fields and Progress checklist entries agree.
+- **Depends on**: Task 7

--- a/sdd/unified-homepage-display/requirements.md
+++ b/sdd/unified-homepage-display/requirements.md
@@ -1,0 +1,69 @@
+# Unified Homepage / Display - Requirements
+
+## Goal
+
+Build the public display layer for FOSSE's "your home on the web" promise: a homepage stream that looks like the person/site, not like a protocol plugin. The stream combines long-form posts, short-form notes, and photo-forward posts in one chronological surface, while single posts surface social reactions and replies from ActivityPub and Bluesky without exposing bundled-plugin branding.
+
+Linear:
+
+- [DOTCOM-16797](https://linear.app/a8c/issue/DOTCOM-16797) - 5. Unified homepage / display
+- [DOTCOM-16818](https://linear.app/a8c/issue/DOTCOM-16818) - Unified homepage stream
+- [DOTCOM-16819](https://linear.app/a8c/issue/DOTCOM-16819) - Single-post reactions display
+- [DOTCOM-16820](https://linear.app/a8c/issue/DOTCOM-16820) - Visual consistency
+
+## Requirements
+
+1. **One chronological homepage stream.** The display queries standard WordPress `post` posts in reverse chronological order and renders long-form posts, short-form notes, and photo-forward posts as siblings in the same list.
+2. **No new content type.** Do not introduce a CPT. FOSSE's content model remains standard WP posts. Short notes are standard posts with `post_format=status`; photos are standard image attachments associated with those same posts.
+3. **Long-form posts stay recognizable as articles.** Titled posts without `post_format=status` render with title, permalink, date, excerpt, and optional attached/featured media.
+4. **Short-form notes stay note-like.** Posts with `post_format=status` and untitled posts render body-first, without forcing an article-card treatment or title placeholder.
+5. **Photos belong to the post.** Featured images and attached image media render inside the stream item for any post shape. Photo-forward posts get a visual treatment that feels equal to notes and long-form posts, but still link to the canonical single post.
+6. **Single-post reactions are visible.** Like and repost counts from both ActivityPub and Bluesky show on single posts via the completed `sdd/unified-reactions-display/` work. The visible label must be "Social Reactions", not "Fediverse Reactions".
+7. **Single-post replies are visible.** ActivityPub and Bluesky replies stored as approved WordPress comments (`comment_type='comment'`, protocol metadata distinguishing source) appear in the site's normal single-post comments area. FOSSE verifies this path and avoids creating a parallel comments UI.
+8. **Coherent default styling.** Notes, photos, and long-form posts share one FOSSE visual system: spacing, borders, metadata, media treatment, and link treatment should feel related. The design must be restrained and theme-aware, using WordPress/theme CSS variables where available.
+9. **Plugin-appropriate placement.** FOSSE must not replace the active theme's homepage or single-post template. The homepage stream is an insertable block that site owners can place on a page or template. Single-post reactions use block hooks/standard comments rather than a theme override.
+10. **No leaky bundled-plugin UI.** Public labels must say FOSSE/social-web concepts, not ActivityPub/Bluesky implementation details. Internal DOM classes from bundled blocks are acceptable only where they are not user-facing.
+11. **Upstream-first for generic fixes.** Generic bugs in ActivityPub reaction blocks, reply rendering, comment registration, or block hook behavior go upstream to `wordpress-activitypub` or `wordpress-atmosphere`. FOSSE owns only the FOSSE-shaped display composition and wording.
+
+## Constraints
+
+- FOSSE is a WordPress plugin, not a theme. It cannot own full page chrome, typography, navigation, archive templates, or comment templates.
+- Do not edit `bundled/` by hand. Any generic block/reaction/comment fix needed in a bundled plugin lands upstream, then FOSSE consumes it via `tools/sync-bundled.sh`.
+- Preserve the existing PHP and JS toolchain. The repo currently has no `@wordpress/scripts` build step. Any editor script for the v1 block should be small, unbuilt JS using WordPress global packages, or the plan must explicitly justify build tooling.
+- PHP remains PHP 8.2+ / WP 6.9+. PHP follows Jetpack PHPCS, tabs, Yoda conditions, `fosse` text domain, and `Automattic\Fosse` namespace.
+- Tests must stay deterministic in Playground. E2E tests seed posts, attachments, comments, and reaction rows directly through test-only mu-plugin endpoints rather than relying on live ActivityPub or Bluesky network traffic.
+
+## Out of Scope
+
+- A FOSSE theme or full-site design replacement.
+- A composer/posting UI for creating notes/photos. This SDD renders existing standard posts; composer defaults belong to the posting epic.
+- A new CPT for notes, photos, replies, or reactions.
+- Infinite scroll, client-side hydration, live reaction polling, or personalized timelines.
+- Per-network badges such as "via Mastodon" or "via Bluesky" in v1.
+- A bespoke comments system. Replies should use WordPress comments unless a later upstream gap proves that impossible.
+- Replacing the bundled `activitypub/reactions` block with a FOSSE-owned reactions block. The completed unified reactions display SDD already chose the smaller path.
+- Displaying private, password-protected, draft, scheduled, or non-public posts in the public stream.
+- Attachment-heavy gallery management. V1 renders attached images; editing/reordering galleries remains WordPress media behavior.
+
+## Dependencies
+
+- `sdd/unified-reactions-display/` is a hard dependency for DOTCOM-16819. It verified that the bundled `activitypub/reactions` block aggregates `protocol='activitypub'` and `protocol='atproto'` rows and relabeled the block metadata to "Social Reactions".
+- The homepage stream depends on the existing post-shape work from the Bluesky native publishing SDD: standard posts plus `post_format=status` are the content model. This SDD does not revisit that decision.
+
+## Related Code / Patterns Found
+
+- `src/class-reactions-label.php` - FOSSE-side relabel for the bundled `activitypub/reactions` block. Current implementation rewrites registered block metadata and intentionally does not rewrite the legacy render fallback.
+- `tests/e2e/reactions-display.spec.ts` and `tests/e2e/mu-plugins/fosse-reactions-seed.php` - existing deterministic e2e pattern for seeding reaction comments and verifying unified Social Reactions behavior.
+- `bundled/activitypub/build/reactions/block.json` - bundled reactions block includes `blockHooks: { "core/post-content": "after" }`, so single-post reactions are already auto-injected after post content.
+- `bundled/activitypub/build/reactions/render.php` - protocol-agnostic reaction query; legacy fallback title still contains "Fediverse Reactions".
+- `bundled/activitypub/build/posts-and-replies/` - upstream AP block pattern for a small server-rendered block and scoped CSS.
+- `src/class-object-type.php`, `src/class-post-types.php`, `src/class-long-form-strategy.php` - FOSSE projector/registration pattern: small static class, `register()` method, `fosse.php` `init` hook with `class_exists` guard.
+- `tests/e2e/blueprint.json` - mounts test-only mu-plugins into Playground and sets `FOSSE_E2E`.
+- `.phpcs.xml.dist` - PHPCS checks `fosse.php`, `src/`, and `tests/php/`; bundled code is excluded.
+
+## Open Questions Resolved
+
+- **Block, shortcode, template part, or theme hook?** Resolved in `spec.md`: v1 ships a dynamic block, `fosse/unified-homepage-stream`. A block is the best plugin-shaped surface because it can be placed in the Site Editor or page editor without taking over the theme.
+- **Should the homepage query multiple post types?** No. Query standard `post` only. No CPT and no union query.
+- **Should reactions render in the homepage stream?** Not in v1. The stream links to canonical single posts. DOTCOM-16819 is single-post display.
+- **Should FOSSE create a comments UI for replies?** No. AP and Bluesky replies are normal approved comments and should display through the theme's comments area. FOSSE adds deterministic verification and only fixes gaps if the standard path fails.

--- a/sdd/unified-homepage-display/spec.md
+++ b/sdd/unified-homepage-display/spec.md
@@ -1,0 +1,224 @@
+# Spec: Unified Homepage / Display
+
+## Goal
+
+Ship a FOSSE-owned homepage stream block that displays standard WordPress posts as a unified social-web stream: long-form articles, short notes, and photo-forward posts in one chronological list. On single posts, rely on the completed unified reactions work and WordPress comments so AP + Bluesky likes, reposts, and replies are visible without replacing the theme.
+
+## Requirements Summary
+
+- Unified chronological stream of standard WP `post` posts.
+- Short notes use `post_format=status`; photos are attached/featured images on the same posts.
+- No CPT, no theme replacement, no bundled UI leaks.
+- Single posts show "Social Reactions" and approved AP/Bluesky replies.
+- Visual defaults make notes, photos, and long-form posts feel like siblings.
+- Deterministic PHPUnit and Playwright coverage.
+
+## Chosen Approach
+
+**Ship a dynamic block: `fosse/unified-homepage-stream`.**
+
+The block is server-rendered by PHP and registered by a small FOSSE class. Site owners can insert it on the front page, a block theme template, or any page. It queries standard posts, classifies each result for display, renders theme-aware markup, and ships scoped CSS. It does not replace the homepage template or inject itself globally.
+
+### Why This Is the Right v1 Surface
+
+- **Plugin-appropriate.** A block gives FOSSE a real public surface without becoming a theme. The active theme still owns layout chrome, navigation, comments, template hierarchy, and typography.
+- **Site-editor friendly.** Users can place the stream where they want. A shortcode is less discoverable in block themes, and a template hook/filter would either be invisible or too theme-dependent.
+- **No new content model.** The block can query ordinary posts and inspect `post_format` plus attachments at render time. No CPT or migration.
+- **Small build footprint.** The editor UI can be a tiny unbuilt script using WordPress globals (`wp.blocks`, `wp.element`, `wp.components`, `wp.serverSideRender`). No `@wordpress/scripts` build step is required for v1.
+
+### Alternatives Considered
+
+- **Shortcode.** Easy to implement, but it is a weaker Site Editor experience and pushes users toward manual syntax. Rejected as the primary v1 surface.
+- **Template-part helper.** Too theme-shaped for FOSSE. It would work only for themes that opt into the helper intentionally and gives users no inserter UX.
+- **Theme hook/filter.** Risks surprising users by changing their homepage automatically and depends on theme-specific hook surfaces. Rejected.
+- **FOSSE theme or bundled template override.** Violates the core constraint. FOSSE is a plugin.
+- **Core Query Loop variation only.** Attractive, but Query Loop does not give enough control over note/photo/article sibling rendering and image-attachment treatment without more theme/block complexity. A FOSSE dynamic block is clearer for v1.
+
+## Technical Details
+
+### Architecture
+
+```
+fosse.php
+  -> init
+     -> Automattic\Fosse\Homepage_Stream::register()
+        -> wp_register_script( editor handle )
+        -> register_block_type_from_metadata( src/Blocks/unified-homepage-stream )
+           -> render_callback: Homepage_Stream::render()
+
+Homepage_Stream::render()
+  -> build_query_args( $attributes )
+  -> WP_Query
+  -> for each WP_Post:
+       classify_post()
+       get_post_images()
+       render_item()
+```
+
+The block owns only its own markup. Single-post reactions remain separate:
+
+- `activitypub/reactions` is already block-hooked after `core/post-content`.
+- `Automattic\Fosse\Reactions_Label` relabels the block metadata to "Social Reactions".
+- This SDD adds a narrow rendered-output guard for the legacy fallback so the auto-hooked block cannot expose "Fediverse Reactions" on a real single post.
+- Replies remain approved WordPress comments rendered by the active theme's comments block/template.
+
+### Block Contract
+
+Block name: `fosse/unified-homepage-stream`
+
+Block title: `Social Web Stream`
+
+Attributes:
+
+| Attribute | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `postsPerPage` | number | `10` | Number of stream items to render. Clamped to `1..50`. |
+| `showExcerpt` | boolean | `true` | Show generated excerpt for article-shaped posts. |
+| `showMedia` | boolean | `true` | Show featured/attached images. |
+| `mediaLimit` | number | `4` | Maximum images per item. Clamped to `0..6`. |
+| `showDates` | boolean | `true` | Show published date/permalink metadata. |
+
+No per-network attributes in v1. The block is about the site's public stream, not protocol filtering.
+
+### Query Semantics
+
+The block uses `WP_Query` with:
+
+- `post_type => 'post'`
+- `post_status => 'publish'`
+- `orderby => 'date'`
+- `order => 'DESC'`
+- `posts_per_page => clamped postsPerPage`
+- `ignore_sticky_posts => true`
+- `no_found_rows => true`
+
+There is no tax query for post formats because the stream intentionally includes all published posts in one chronological list. Classification happens after query.
+
+### Display Classification
+
+Each item is one standard `WP_Post`. FOSSE classifies display shape without changing storage:
+
+1. **Photo-forward** when `post_format=image` or the post has one or more featured/attached image media and the rendered plain text is at most 280 characters, which is short enough to behave like a caption.
+2. **Note** when `post_format=status` or the post has no title.
+3. **Article** for the remaining titled posts.
+
+Attached images can appear on every shape. "Photo-forward" is a display treatment, not a post type.
+
+This intentionally keeps v1 narrow:
+
+- `status` is the note signal because DOTCOM-16818 names it explicitly and future composer work can set it consistently.
+- Other WordPress post formats can still render, but only `image` gets a special photo-forward treatment in v1.
+- If publishing logic treats additional post formats as short-form, that does not require the homepage display to visually specialize every format immediately.
+
+### Markup Shape
+
+The rendered wrapper uses the normal block wrapper attributes and FOSSE-scoped classes:
+
+```html
+<div class="wp-block-fosse-unified-homepage-stream fosse-stream">
+	<article class="fosse-stream__item is-note|is-article|is-photo">
+		<a class="fosse-stream__permalink" href="...">
+			<time class="fosse-stream__date" datetime="...">...</time>
+		</a>
+		<div class="fosse-stream__media">...</div>
+		<h2 class="fosse-stream__title">...</h2>
+		<div class="fosse-stream__content">...</div>
+	</article>
+</div>
+```
+
+Rules:
+
+- Article items render a linked title and excerpt/content preview.
+- Note items render body text first and never invent a title.
+- Photo-forward items render media first, then caption/body text when present.
+- Every item links to the canonical single post.
+- Image output uses WordPress attachment APIs (`wp_get_attachment_image`) so alt text, responsive sizes, and lazy loading stay native.
+- User-provided content is escaped through WordPress helpers and rendered with the same caution as excerpts. Do not echo raw post content.
+
+### Visual System
+
+The CSS is scoped to `.wp-block-fosse-unified-homepage-stream` / `.fosse-stream`.
+
+The default style should be theme-aware rather than brand-heavy:
+
+- Use `currentColor`, `--wp--preset--color--contrast`, `--wp--preset--color--base`, and `--wp--style--global--content-size` where available.
+- Use a single shared item container rhythm for all shapes.
+- Keep borders and separators quiet; no large marketing cards or full theme replacement.
+- Use consistent metadata placement across notes, photos, and articles.
+- Media grids use fixed aspect-ratio constraints so images do not shift layout.
+- Mobile layout must not overflow at 390px width.
+
+### Single-Post Reactions and Replies
+
+DOTCOM-16819 is implemented as composition and verification, not as a new FOSSE reactions block:
+
+- Likes/reposts: use `activitypub/reactions`, already verified as protocol-agnostic in `sdd/unified-reactions-display/`.
+- Labeling: visible UI must say "Social Reactions". Extend `Reactions_Label` with a block-specific `render_block_activitypub/reactions` filter to rewrite only the legacy fallback title inside that rendered block output.
+- Replies: AP and Bluesky replies are approved WordPress comments. They surface wherever the theme renders comments. FOSSE adds e2e coverage that seeds one AP reply and one Bluesky reply and verifies both appear on the single post under the default Playground theme.
+
+FOSSE does not add a parallel comments list in v1. If replies fail to render because a bundled plugin stores them with nonstandard `comment_type` or filters them out generically, the fix belongs upstream.
+
+### File Changes
+
+| File | Change Type | Description |
+| --- | --- | --- |
+| `src/class-homepage-stream.php` | new | Registers and renders `fosse/unified-homepage-stream`; contains query, classification, image lookup, and rendering helpers. |
+| `src/Blocks/unified-homepage-stream/block.json` | new | Block metadata. |
+| `src/Blocks/unified-homepage-stream/editor.js` | new | Small unbuilt editor UI using WordPress globals and `ServerSideRender`. |
+| `src/Blocks/unified-homepage-stream/style.css` | new | Frontend/editor block styles scoped to the stream block. |
+| `fosse.php` | modify | Register `Homepage_Stream::register()` on `init` with existing `class_exists` guard pattern. |
+| `src/class-reactions-label.php` | modify | Add a narrow rendered-output fallback rewrite for the auto-hooked reactions block's legacy fallback title. |
+| `tests/php/Homepage_StreamTest.php` | new | PHPUnit coverage for query args, attribute clamping, classification, image lookup, rendering branches, and registration idempotency. |
+| `tests/php/Reactions_LabelTest.php` | modify | Add coverage for the rendered-output fallback rewrite added for single posts. |
+| `tests/e2e/mu-plugins/fosse-homepage-stream-seed.php` | new | Test-only REST seed endpoint for homepage posts, attachments, replies, and reactions. |
+| `tests/e2e/homepage-stream.spec.ts` | new | Playwright coverage for homepage stream and single-post reactions/replies. |
+| `tests/e2e/blueprint.json` | modify | Copy the new homepage stream seed mu-plugin into `wp-content/mu-plugins/`. |
+
+## Verification Strategy
+
+PHPUnit:
+
+- Query args include only public standard posts and no CPT.
+- `postsPerPage` and `mediaLimit` are clamped.
+- `post_format=status` classifies as note.
+- Titled posts without status/image classify as article.
+- Image-format or short caption + attached image classifies as photo-forward.
+- Featured image and attached images are deduplicated and ordered predictably.
+- Render output uses escaped URLs/text and expected FOSSE classes.
+- Block registration is idempotent.
+- Reactions fallback rewrite affects only `activitypub/reactions`.
+
+Playwright:
+
+- Seed one article, one status note, one photo-forward post, and one status note with image attachment.
+- Insert/use a page containing `<!-- wp:fosse/unified-homepage-stream /-->`.
+- Assert the stream renders all seeded posts in reverse chronological order.
+- Assert note, article, and photo-forward items share the same base class and have distinct shape classes.
+- Assert no public homepage text says "ActivityPub", "Fediverse", or "Bluesky".
+- Visit a seeded single post and assert "Social Reactions" appears, "Fediverse Reactions" does not, AP + Bluesky like/repost counts aggregate, and AP + Bluesky replies appear as comments.
+- Check desktop and 390px mobile widths for no horizontal overflow and visible media.
+
+## Upstream Policy
+
+FOSSE owns:
+
+- the homepage stream block,
+- FOSSE-scoped display styling,
+- FOSSE wording such as "Social Web Stream" and "Social Reactions",
+- tests proving the bundled backends integrate cleanly in FOSSE.
+
+Upstream owns:
+
+- generic reaction query behavior,
+- generic comment/reply storage,
+- generic ActivityPub block bugs,
+- generic Atmosphere reaction/reply sync bugs,
+- bundled block APIs that would help any standalone AP/Atmosphere site.
+
+## Known Risks
+
+- The active theme can omit comments on single posts. FOSSE should document that replies appear through the theme's comments area; it should not inject a second comments UI to compensate.
+- The AP reactions block currently has a legacy fallback title in its render path. This SDD explicitly tests the single-post auto-hook path so a visible "Fediverse Reactions" leak is caught.
+- A no-build editor script is intentionally limited. If the block editor UI grows beyond simple controls and server preview, a separate build-tooling decision should be made rather than accreting complex unbuilt JS.
+- Photo-forward classification is heuristic. The storage model stays simple, and future composer UI can make the author's intent clearer without requiring a migration.


### PR DESCRIPTION
Draft status: Early unreviewed SDD draft for planning discussion. This is not ready to merge.

Related Linear epic: [DOTCOM-16797](https://linear.app/a8c/issue/DOTCOM-16797)

## Summary
- Adds requirements, spec, and implementation plan for unified homepage and single-post display work.
- Covers homepage stream classification, reaction label fallback, e2e seeding, and visual consistency checks.

## Notes
- Docs-only planning PR.
- Opened as a draft intentionally for early review.
- No auto-close keyword is used.