### PR TITLE
SDD: Bundled backends migration

### DIFF
--- a/sdd/bundled-backends-migration/plan.md
+++ b/sdd/bundled-backends-migration/plan.md
@@ -1,0 +1,196 @@
+# Bundled Backends Migration Implementation Plan
+
+Based on: [sdd/bundled-backends-migration/spec.md](./spec.md)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## Progress
+
+- [ ] Task 1: Publish migration decision record
+- [ ] Task 2: Add bridge policy and provenance for checked-in bundles
+- [ ] Task 3: Prove package-based artifact assembly
+- [ ] Task 4: Add CI checks for bundle and package artifacts
+- [ ] Task 5: Design and implement external-backend dependency UX
+- [ ] Task 6: Define wp.com Simple artifact ownership
+- [ ] Task 7: Choose migration cutover and update release docs
+- [ ] Task 8: Open checked-in bundle removal follow-up after replacement ships
+
+## Tasks
+
+### Task 1: Publish migration decision record
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `sdd/bundled-backends-migration/spec.md`
+  - Create or modify: release/project tracking surface for DOTCOM-16826
+- **Do**:
+  1. Confirm the recommendation with project owners:
+     - Near-term: keep artifact vendoring as a bridge.
+     - Long-term: split FOSSE UI/orchestration from backend plugin distribution.
+     - Transition proof: package-based artifact assembly.
+  2. Record the accepted decision in the project tracking surface for DOTCOM-16826.
+  3. If the accepted decision differs from this SDD, update `spec.md` before implementation begins.
+- **Verify**:
+  - DOTCOM-16826 links to the accepted decision.
+  - `spec.md` has one clear chosen direction, not competing unranked options.
+- **Depends on**: none
+
+### Task 2: Add bridge policy and provenance for checked-in bundles
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `AGENTS.md`
+  - Modify: `.gitattributes`
+  - Modify: `tools/sync-bundled.sh`
+  - Create: `bundled/manifest.json`
+- **Do**:
+  1. Add a `bundled/manifest.json` file recording:
+     - backend slug (`activitypub`, `atmosphere`)
+     - upstream repository
+     - upstream commit SHA
+     - upstream version constant or release tag
+     - sync timestamp or release date
+     - sync command inputs
+  2. Update `tools/sync-bundled.sh` so every sync rewrites the manifest after copying both backends.
+  3. Update `AGENTS.md` to state that checked-in `bundled/` is bridge-only and must not receive feature patches.
+  4. Keep `.gitattributes` marking `bundled/**` as vendored/generated so reviews continue to focus on FOSSE-owned code.
+- **Verify**:
+  - Running `./tools/sync-bundled.sh` updates `bundled/manifest.json`.
+  - Manifest SHAs match `git -C "$FOSSE_AP_SOURCE" rev-parse HEAD` and `git -C "$FOSSE_ATMO_SOURCE" rev-parse HEAD`.
+  - No files under `bundled/` are changed by hand outside a sync.
+- **Depends on**: Task 1
+
+### Task 3: Prove package-based artifact assembly
+
+- **Status**: Not started
+- **Files**:
+  - Create: `tools/build-backend-artifacts.sh` or equivalent packaging script
+  - Create: backend package manifest or Composer package configuration
+  - Modify: `bin/build-zip.sh` only if the proof becomes part of the official build
+  - Modify: `composer.json` and `composer.lock` only if Composer is selected as the proof mechanism
+- **Do**:
+  1. Pick the proof input source:
+     - Preferred: Automattic package registry with release artifacts.
+     - Acceptable bridge: Composer VCS dependencies pinned by lockfile.
+     - Fallback: GitHub release zips with checksums.
+  2. Build an artifact from a clean checkout without reading checked-in `bundled/activitypub/` or `bundled/atmosphere/`.
+  3. Assemble backend files into a temporary staging directory that mirrors the current runtime paths.
+  4. Run the same zip sanity checks currently enforced by `bin/build-zip.sh`.
+  5. Document whether the proof still embeds backend files in the final zip or moves to external plugin dependencies.
+- **Verify**:
+  - A clean checkout can produce an installable zip without relying on checked-in backend source.
+  - The generated artifact contains `activitypub.php` and `atmosphere.php` when running in transitional embedded-backend mode.
+  - The generated artifact boots in WordPress Playground.
+- **Depends on**: Task 1
+
+### Task 4: Add CI checks for bundle and package artifacts
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `.github/workflows/build-zip.yml`
+  - Modify: `.github/workflows/e2e.yml`
+  - Create or modify: artifact verification script under `tools/`
+- **Do**:
+  1. Keep the existing build-zip job green for the checked-in bundle.
+  2. Add a non-release proof job that builds the package-based artifact from Task 3.
+  3. Add smoke checks for both artifact shapes:
+     - zip includes required FOSSE files
+     - backend entrypoints are present when expected
+     - `vendor/autoload_packages.php` is present
+     - Playground boots wp-admin without fatal errors
+  4. Fail CI if package pins drift from the recorded manifest or lockfile.
+- **Verify**:
+  - CI publishes or stores both artifacts for inspection.
+  - CI clearly distinguishes "current release artifact" from "migration proof artifact".
+  - Failed backend resolution blocks the proof job without blocking emergency releases until the migration is accepted.
+- **Depends on**: Task 3
+
+### Task 5: Design and implement external-backend dependency UX
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `src/Admin/*Provider*.php`
+  - Modify: `src/Admin/templates/*.php`
+  - Modify: `fosse.php`
+  - Modify or create: PHPUnit tests under `tests/php/Admin/`
+  - Modify or create: Playwright specs under `tests/e2e/`
+- **Do**:
+  1. Reuse `Automattic\Fosse\Bundled\Standalone_Backend_Status` from `sdd/deactivation-lifecycle/` if that SDD has shipped; otherwise keep any local state helper compatible with that planned contract.
+  2. Define provider states for:
+     - bundled backend loaded
+     - standalone backend active
+     - standalone backend installed but inactive
+     - backend missing
+  3. Render clear setup/status UI for missing or inactive dependencies.
+  4. Ensure FOSSE does not fatal when either backend is absent.
+  5. Preserve current one-click behavior while bundled bridge mode remains active.
+  6. Add tests covering each provider state.
+- **Verify**:
+  - PHPUnit covers provider status/state mapping.
+  - Playwright covers admin setup/status rendering when one backend is missing.
+  - Manual Playground smoke confirms no class collisions with standalone ActivityPub or Atmosphere installed.
+- **Depends on**: Task 1
+
+### Task 6: Define wp.com Simple artifact ownership
+
+- **Status**: Not started
+- **Files**:
+  - Modify: deployment or release documentation surface selected by the project
+  - Modify: `fosse.php` only if the load contract changes
+  - Modify: wp.com-specific artifact build configuration, if owned in this repo
+- **Do**:
+  1. Decide whether wp.com Simple consumes:
+     - the public FOSSE zip,
+     - a platform-specific FOSSE-plus-backends artifact, or
+     - separately deployed FOSSE, ActivityPub, and Atmosphere plugins.
+  2. Record who owns backend version pins for wp.com Simple.
+  3. Preserve the load-order contract documented in `fosse.php`, or replace it with a new documented contract.
+  4. Define rollback steps for a bad backend version.
+- **Verify**:
+  - wp.com Simple has a named artifact owner and version source of truth.
+  - Rollout and rollback do not depend on editing checked-in `bundled/` by hand.
+  - FOSSE's public build path and wp.com artifact path are both documented.
+- **Depends on**: Task 3
+
+### Task 7: Choose migration cutover and update release docs
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `AGENTS.md`
+  - Modify: release checklist or changelog surface
+  - Modify: `sdd/bundled-backends-migration/plan.md`
+- **Do**:
+  1. Choose the release where checked-in `bundled/` stops being the source of truth.
+  2. Update release docs with the selected model:
+     - build-time embedded backends, or
+     - external backend dependencies.
+  3. Record the final cutover criteria in this plan.
+  4. Mark bridge-only tasks done with PR references.
+- **Verify**:
+  - Release docs explain how backend versions are selected.
+  - The plan has no ambiguous "temporary" state without an owner or date.
+  - Project owners agree the replacement is ready.
+- **Depends on**: Task 4, Task 5, Task 6
+
+### Task 8: Open checked-in bundle removal follow-up after replacement ships
+
+- **Status**: Not started
+- **Files**:
+  - Create or modify: follow-up Linear issue or SDD for checked-in bundle removal
+  - Modify: `sdd/bundled-backends-migration/plan.md`
+  - Modify: release/project tracking surface for DOTCOM-16826
+- **Do**:
+  1. Confirm Tasks 3-7 are accepted and the replacement path is green in CI.
+  2. Open a focused removal follow-up that lists the deletion scope:
+     - `bundled/activitypub/**`
+     - `bundled/atmosphere/**`
+     - `tools/sync-bundled.sh`
+     - `tools/bundled-excludes.txt`
+     - bundle-specific loader, build, lint, test, and export-ignore rules
+  3. Record the selected final artifact model and migration notes for sites moving from bundled bridge mode to external/plugin-artifact mode.
+  4. Mark this SDD complete only after the follow-up has an owner, acceptance criteria, and rollback notes.
+- **Verify**:
+  - Follow-up tracking exists and links back to DOTCOM-16826.
+  - This SDD still states that it does not remove `bundled/`.
+  - The follow-up has explicit verification for lint, tests, e2e, and installable artifact checks.
+- **Depends on**: Task 7

--- a/sdd/bundled-backends-migration/plan.md
+++ b/sdd/bundled-backends-migration/plan.md
@@ -1,45 +1,75 @@
-# Bundled Backends Migration — Implementation Plan
+# Bundled Backends Migration - Implementation Plan
 
 Based on: [sdd/bundled-backends-migration/spec.md](./spec.md)
 
-## Status: DEFERRED
+## Status: PLANNING
 
-**No implementation tasks are scheduled.** The spec captures the future migration design; this plan tracks the trigger conditions that would unblock implementation, plus a sketch of what the plan would expand into when those triggers fire.
+**No implementation tasks are scheduled in this PR.** The plan tracks the review work needed now that ATmosphere is available on WordPress.org and FOSSE can use WordPress-native plugin dependencies across its supported WordPress range.
 
-## Trigger checklist
+## Progress
 
-Activate this plan (move tasks from "Sketch" below into a numbered checklist, set status to "In Progress") when ANY trigger fires:
+- [x] Refresh SDD assumptions.
+- [ ] Approve the public distribution strategy.
+- [ ] Choose the bundled-only install upgrade path.
+- [ ] Define backend compatibility gates.
+- [ ] Define wp.com Simple artifact ownership.
+- [ ] Choose dependency fixtures for CI and e2e.
 
-- [ ] **Atmosphere ships a stable public release** — versioned tag, published on a reachable distribution channel (wordpress.org, an Automattic Composer registry, or a stable GitHub release artifact).
-- [ ] **Bundling actively breaks** — `tools/sync-bundled.sh` produces unrecoverable conflicts, an upstream security advisory requires faster turnaround than sync allows, or the bundled zip exceeds a distribution channel's size limit.
-- [ ] **WordPress.org plugin dependency tooling matures** to the point where declarative cross-plugin dependencies work for the standalone install case (currently in-development in WP core).
-- [ ] **wp.com platform asks for separated artifacts** as part of its own deployment evolution.
-- [ ] **Three or more sync conflicts in a single quarter** that require manual resolution beyond the standard `sync-bundled.sh` flow.
+## Review tasks
 
-## Standing constraints (apply continuously while deferred)
+1. **Refresh SDD assumptions.**
+   - **Status**: ✅ Done (#93)
+   - **Verify**: The requirements, spec, and plan acknowledge <https://wordpress.org/plugins/atmosphere/> and cite `Requires Plugins: activitypub, atmosphere` as the preferred public dependency direction.
 
-These are not tasks; they're rules contributors should respect today so deferring this work doesn't grow the eventual migration delta. Verified by reviewers, not by this plan's task list.
+2. **Approve the public distribution strategy.**
+   - **Status**: Not started
+   - **Decision needed**: Confirm whether the public FOSSE plugin should declare `Requires Plugins: activitypub, atmosphere`, or whether one-zip distribution remains a hard public requirement.
+   - **Verify**: Review comments explicitly accept or reject the native dependency-header direction.
+
+3. **Choose the bundled-only install upgrade path.**
+   - **Status**: Not started
+   - **Decision needed**: Choose one migration PR versus a transitional warning release before removing checked-in backend source.
+   - **Verify**: The implementation plan names the release sequence and the user-visible behavior for sites that rely on the current bundled copies.
+
+4. **Define backend compatibility gates.**
+   - **Status**: Not started
+   - **Decision needed**: Pick the ActivityPub minimum version and the ATmosphere minimum version or symbol set FOSSE requires.
+   - **Verify**: Runtime checks and tests can assert the chosen versions/symbols without relying on `bundled/` internals.
+
+5. **Define wp.com Simple artifact ownership.**
+   - **Status**: Not started
+   - **Decision needed**: Choose plugin dependencies, a platform-assembled bundle, or temporary continuation of vendoring for wp.com Simple.
+   - **Verify**: The chosen owner, artifact shape, load-order contract, and rollback behavior are documented before code changes start.
+
+6. **Choose dependency fixtures for CI and e2e.**
+   - **Status**: Not started
+   - **Decision needed**: Decide whether CI fetches dependencies from WordPress.org zips, SVN tags, GitHub release artifacts, or local source overrides.
+   - **Verify**: The future implementation tasks can install ActivityPub and ATmosphere standalone in PHPUnit/e2e without reading from `bundled/`.
+
+## Standing constraints (apply continuously while planning)
+
+These are not implementation tasks; they're rules contributors should respect today so planning this work doesn't grow the eventual migration delta. Verified by reviewers, not by this plan's task list.
 
 - [ ] Don't add new `require_once bundled/...` calls outside `fosse.php`'s existing bootstrap.
 - [ ] Don't add filters/hooks whose contracts depend on bundled code being at a specific filesystem path.
-- [ ] Don't add tests that reach into `bundled/` directly (use the public API of the bundled plugins, or stub them).
-- [ ] Treat `bundled/` as read-only; `tools/sync-bundled.sh` is the only writer.
+- [ ] Don't add tests that reach into `bundled/` directly (use the public API of the backend plugins, or stub them).
+- [ ] Treat `bundled/` as read-only; `tools/sync-bundled.sh` is the only writer until removal is approved.
 - [ ] Land protocol-agnostic functionality in the upstream repos first (existing upstream-first policy).
-- [ ] Document the load contract at every coupling point — match the pattern set by `fosse.php:25-38` (the wp.com Simple load contract comment).
+- [ ] Document the load contract at every coupling point - match the pattern set by the wp.com Simple load-order contract comment near the top of `fosse.php`.
 
-## Sketch of the implementation plan, when activated
+## Sketch of the implementation plan, after review approval
 
-When a trigger fires, expand each of the following into a real task with files / dependencies / verification steps. Until then, this is a sketch.
+When reviewers approve the migration direction, expand each of the following into a real task with files, dependencies, and verification steps. Until then, this is a sketch.
 
-1. **Publish migration decision record.** Confirm with project owners (likely kraft + RCowles + whoever owns wp.com Simple deployment at the time) that the spec's chosen direction (two-phase bridge → migration) still reflects the right call given the trigger context.
-2. **Add bridge policy and provenance for checked-in bundles.** Backend-version manifest or package-lock equivalent so vendored source has traceable provenance during the bridge phase.
-3. **Prove package-based artifact assembly.** CI job that resolves AP and Atmosphere from versioned package inputs (Composer VCS, GitHub release zips, or registry — pick at activation time) and assembles an installable FOSSE zip without `bundled/` source.
-4. **Add CI checks for bundle and package artifacts.** Compare the generated artifact byte-for-byte (or structurally) with the current bundled output. Both pipelines run until cutover.
-5. **Design and implement external-backend dependency UX.** Missing AP shows clear action; missing Atmosphere shows clear action; installed-but-inactive distinguished from absent; FOSSE setup/status pages remain useful when one backend is unavailable.
-6. **Define wp.com Simple artifact ownership.** Coordinate with wp.com platform team on whether the platform assembles FOSSE + AP + Atmosphere from package inputs or continues vendoring. Document the decision and the new load contract.
-7. **Choose migration cutover and update release docs.** Pick the release where checked-in `bundled/` stops being the source of truth. Update AGENTS.md, CONTRIBUTING.md, and any release engineering docs.
-8. **Open checked-in bundle removal follow-up after replacement ships.** Separate PR; not part of cutover. Removes `bundled/`, `tools/sync-bundled.sh`, and bundle-specific export/linguist/tooling rules after the replacement has shipped and run in production for at least one release cycle.
+1. **Add runtime dependency readiness checks.** FOSSE detects missing, inactive, too-old, or API-incompatible ActivityPub and ATmosphere installs and reports provider availability without fatals.
+2. **Add dependency UX.** Missing ActivityPub shows clear action; missing ATmosphere shows clear action; installed-but-inactive and incompatible versions are distinguished from absent plugins; setup/status pages remain useful when one backend is unavailable.
+3. **Add standalone dependency fixtures.** PHPUnit and e2e install ActivityPub and ATmosphere as explicit standalone plugins from the approved source, and tests stop reading from `bundled/`.
+4. **Ship the approved upgrade sequence.** Either ship a warning release first or implement the one-step migration path reviewers approve.
+5. **Add the public dependency header.** Update `fosse.php` with `Requires Plugins: activitypub, atmosphere` only after dependency UX and upgrade sequencing are ready.
+6. **Define and implement wp.com Simple artifact path.** Coordinate with the platform owner on plugin dependencies, platform assembly, or temporary vendoring; document the load contract and rollback.
+7. **Remove checked-in backend source in a follow-up.** Separate PR after replacement behavior ships and has run for the approved release window; remove `bundled/`, `tools/sync-bundled.sh`, and bundle-specific export/linguist/tooling rules.
+8. **Keep package-based assembly only if selected.** If reviewers require a one-zip bridge, add a CI job that resolves AP and ATmosphere from versioned package inputs and assembles an installable FOSSE artifact without relying on checked-in `bundled/`.
 
 ## What to do right now
 
-Nothing in this plan. If a trigger fires, the right next step is to re-read `spec.md`, expand this sketch into real tasks, and push a new commit that flips the status from DEFERRED to IN PROGRESS. Until then, leave the SDD alone — it's reference material, not implementation guidance.
+Review the updated SDD. Do not remove `bundled/`, add dependency headers, or change loaders until reviewers approve the public dependency strategy, upgrade sequence, backend compatibility gates, and wp.com Simple artifact owner.

--- a/sdd/bundled-backends-migration/plan.md
+++ b/sdd/bundled-backends-migration/plan.md
@@ -1,196 +1,45 @@
-# Bundled Backends Migration Implementation Plan
+# Bundled Backends Migration — Implementation Plan
 
 Based on: [sdd/bundled-backends-migration/spec.md](./spec.md)
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+## Status: DEFERRED
 
-## Progress
+**No implementation tasks are scheduled.** The spec captures the future migration design; this plan tracks the trigger conditions that would unblock implementation, plus a sketch of what the plan would expand into when those triggers fire.
 
-- [ ] Task 1: Publish migration decision record
-- [ ] Task 2: Add bridge policy and provenance for checked-in bundles
-- [ ] Task 3: Prove package-based artifact assembly
-- [ ] Task 4: Add CI checks for bundle and package artifacts
-- [ ] Task 5: Design and implement external-backend dependency UX
-- [ ] Task 6: Define wp.com Simple artifact ownership
-- [ ] Task 7: Choose migration cutover and update release docs
-- [ ] Task 8: Open checked-in bundle removal follow-up after replacement ships
+## Trigger checklist
 
-## Tasks
+Activate this plan (move tasks from "Sketch" below into a numbered checklist, set status to "In Progress") when ANY trigger fires:
 
-### Task 1: Publish migration decision record
+- [ ] **Atmosphere ships a stable public release** — versioned tag, published on a reachable distribution channel (wordpress.org, an Automattic Composer registry, or a stable GitHub release artifact).
+- [ ] **Bundling actively breaks** — `tools/sync-bundled.sh` produces unrecoverable conflicts, an upstream security advisory requires faster turnaround than sync allows, or the bundled zip exceeds a distribution channel's size limit.
+- [ ] **WordPress.org plugin dependency tooling matures** to the point where declarative cross-plugin dependencies work for the standalone install case (currently in-development in WP core).
+- [ ] **wp.com platform asks for separated artifacts** as part of its own deployment evolution.
+- [ ] **Three or more sync conflicts in a single quarter** that require manual resolution beyond the standard `sync-bundled.sh` flow.
 
-- **Status**: Not started
-- **Files**:
-  - Modify: `sdd/bundled-backends-migration/spec.md`
-  - Create or modify: release/project tracking surface for DOTCOM-16826
-- **Do**:
-  1. Confirm the recommendation with project owners:
-     - Near-term: keep artifact vendoring as a bridge.
-     - Long-term: split FOSSE UI/orchestration from backend plugin distribution.
-     - Transition proof: package-based artifact assembly.
-  2. Record the accepted decision in the project tracking surface for DOTCOM-16826.
-  3. If the accepted decision differs from this SDD, update `spec.md` before implementation begins.
-- **Verify**:
-  - DOTCOM-16826 links to the accepted decision.
-  - `spec.md` has one clear chosen direction, not competing unranked options.
-- **Depends on**: none
+## Standing constraints (apply continuously while deferred)
 
-### Task 2: Add bridge policy and provenance for checked-in bundles
+These are not tasks; they're rules contributors should respect today so deferring this work doesn't grow the eventual migration delta. Verified by reviewers, not by this plan's task list.
 
-- **Status**: Not started
-- **Files**:
-  - Modify: `AGENTS.md`
-  - Modify: `.gitattributes`
-  - Modify: `tools/sync-bundled.sh`
-  - Create: `bundled/manifest.json`
-- **Do**:
-  1. Add a `bundled/manifest.json` file recording:
-     - backend slug (`activitypub`, `atmosphere`)
-     - upstream repository
-     - upstream commit SHA
-     - upstream version constant or release tag
-     - sync timestamp or release date
-     - sync command inputs
-  2. Update `tools/sync-bundled.sh` so every sync rewrites the manifest after copying both backends.
-  3. Update `AGENTS.md` to state that checked-in `bundled/` is bridge-only and must not receive feature patches.
-  4. Keep `.gitattributes` marking `bundled/**` as vendored/generated so reviews continue to focus on FOSSE-owned code.
-- **Verify**:
-  - Running `./tools/sync-bundled.sh` updates `bundled/manifest.json`.
-  - Manifest SHAs match `git -C "$FOSSE_AP_SOURCE" rev-parse HEAD` and `git -C "$FOSSE_ATMO_SOURCE" rev-parse HEAD`.
-  - No files under `bundled/` are changed by hand outside a sync.
-- **Depends on**: Task 1
+- [ ] Don't add new `require_once bundled/...` calls outside `fosse.php`'s existing bootstrap.
+- [ ] Don't add filters/hooks whose contracts depend on bundled code being at a specific filesystem path.
+- [ ] Don't add tests that reach into `bundled/` directly (use the public API of the bundled plugins, or stub them).
+- [ ] Treat `bundled/` as read-only; `tools/sync-bundled.sh` is the only writer.
+- [ ] Land protocol-agnostic functionality in the upstream repos first (existing upstream-first policy).
+- [ ] Document the load contract at every coupling point — match the pattern set by `fosse.php:25-38` (the wp.com Simple load contract comment).
 
-### Task 3: Prove package-based artifact assembly
+## Sketch of the implementation plan, when activated
 
-- **Status**: Not started
-- **Files**:
-  - Create: `tools/build-backend-artifacts.sh` or equivalent packaging script
-  - Create: backend package manifest or Composer package configuration
-  - Modify: `bin/build-zip.sh` only if the proof becomes part of the official build
-  - Modify: `composer.json` and `composer.lock` only if Composer is selected as the proof mechanism
-- **Do**:
-  1. Pick the proof input source:
-     - Preferred: Automattic package registry with release artifacts.
-     - Acceptable bridge: Composer VCS dependencies pinned by lockfile.
-     - Fallback: GitHub release zips with checksums.
-  2. Build an artifact from a clean checkout without reading checked-in `bundled/activitypub/` or `bundled/atmosphere/`.
-  3. Assemble backend files into a temporary staging directory that mirrors the current runtime paths.
-  4. Run the same zip sanity checks currently enforced by `bin/build-zip.sh`.
-  5. Document whether the proof still embeds backend files in the final zip or moves to external plugin dependencies.
-- **Verify**:
-  - A clean checkout can produce an installable zip without relying on checked-in backend source.
-  - The generated artifact contains `activitypub.php` and `atmosphere.php` when running in transitional embedded-backend mode.
-  - The generated artifact boots in WordPress Playground.
-- **Depends on**: Task 1
+When a trigger fires, expand each of the following into a real task with files / dependencies / verification steps. Until then, this is a sketch.
 
-### Task 4: Add CI checks for bundle and package artifacts
+1. **Publish migration decision record.** Confirm with project owners (likely kraft + RCowles + whoever owns wp.com Simple deployment at the time) that the spec's chosen direction (two-phase bridge → migration) still reflects the right call given the trigger context.
+2. **Add bridge policy and provenance for checked-in bundles.** Backend-version manifest or package-lock equivalent so vendored source has traceable provenance during the bridge phase.
+3. **Prove package-based artifact assembly.** CI job that resolves AP and Atmosphere from versioned package inputs (Composer VCS, GitHub release zips, or registry — pick at activation time) and assembles an installable FOSSE zip without `bundled/` source.
+4. **Add CI checks for bundle and package artifacts.** Compare the generated artifact byte-for-byte (or structurally) with the current bundled output. Both pipelines run until cutover.
+5. **Design and implement external-backend dependency UX.** Missing AP shows clear action; missing Atmosphere shows clear action; installed-but-inactive distinguished from absent; FOSSE setup/status pages remain useful when one backend is unavailable.
+6. **Define wp.com Simple artifact ownership.** Coordinate with wp.com platform team on whether the platform assembles FOSSE + AP + Atmosphere from package inputs or continues vendoring. Document the decision and the new load contract.
+7. **Choose migration cutover and update release docs.** Pick the release where checked-in `bundled/` stops being the source of truth. Update AGENTS.md, CONTRIBUTING.md, and any release engineering docs.
+8. **Open checked-in bundle removal follow-up after replacement ships.** Separate PR; not part of cutover. Removes `bundled/`, `tools/sync-bundled.sh`, and bundle-specific export/linguist/tooling rules after the replacement has shipped and run in production for at least one release cycle.
 
-- **Status**: Not started
-- **Files**:
-  - Modify: `.github/workflows/build-zip.yml`
-  - Modify: `.github/workflows/e2e.yml`
-  - Create or modify: artifact verification script under `tools/`
-- **Do**:
-  1. Keep the existing build-zip job green for the checked-in bundle.
-  2. Add a non-release proof job that builds the package-based artifact from Task 3.
-  3. Add smoke checks for both artifact shapes:
-     - zip includes required FOSSE files
-     - backend entrypoints are present when expected
-     - `vendor/autoload_packages.php` is present
-     - Playground boots wp-admin without fatal errors
-  4. Fail CI if package pins drift from the recorded manifest or lockfile.
-- **Verify**:
-  - CI publishes or stores both artifacts for inspection.
-  - CI clearly distinguishes "current release artifact" from "migration proof artifact".
-  - Failed backend resolution blocks the proof job without blocking emergency releases until the migration is accepted.
-- **Depends on**: Task 3
+## What to do right now
 
-### Task 5: Design and implement external-backend dependency UX
-
-- **Status**: Not started
-- **Files**:
-  - Modify: `src/Admin/*Provider*.php`
-  - Modify: `src/Admin/templates/*.php`
-  - Modify: `fosse.php`
-  - Modify or create: PHPUnit tests under `tests/php/Admin/`
-  - Modify or create: Playwright specs under `tests/e2e/`
-- **Do**:
-  1. Reuse `Automattic\Fosse\Bundled\Standalone_Backend_Status` from `sdd/deactivation-lifecycle/` if that SDD has shipped; otherwise keep any local state helper compatible with that planned contract.
-  2. Define provider states for:
-     - bundled backend loaded
-     - standalone backend active
-     - standalone backend installed but inactive
-     - backend missing
-  3. Render clear setup/status UI for missing or inactive dependencies.
-  4. Ensure FOSSE does not fatal when either backend is absent.
-  5. Preserve current one-click behavior while bundled bridge mode remains active.
-  6. Add tests covering each provider state.
-- **Verify**:
-  - PHPUnit covers provider status/state mapping.
-  - Playwright covers admin setup/status rendering when one backend is missing.
-  - Manual Playground smoke confirms no class collisions with standalone ActivityPub or Atmosphere installed.
-- **Depends on**: Task 1
-
-### Task 6: Define wp.com Simple artifact ownership
-
-- **Status**: Not started
-- **Files**:
-  - Modify: deployment or release documentation surface selected by the project
-  - Modify: `fosse.php` only if the load contract changes
-  - Modify: wp.com-specific artifact build configuration, if owned in this repo
-- **Do**:
-  1. Decide whether wp.com Simple consumes:
-     - the public FOSSE zip,
-     - a platform-specific FOSSE-plus-backends artifact, or
-     - separately deployed FOSSE, ActivityPub, and Atmosphere plugins.
-  2. Record who owns backend version pins for wp.com Simple.
-  3. Preserve the load-order contract documented in `fosse.php`, or replace it with a new documented contract.
-  4. Define rollback steps for a bad backend version.
-- **Verify**:
-  - wp.com Simple has a named artifact owner and version source of truth.
-  - Rollout and rollback do not depend on editing checked-in `bundled/` by hand.
-  - FOSSE's public build path and wp.com artifact path are both documented.
-- **Depends on**: Task 3
-
-### Task 7: Choose migration cutover and update release docs
-
-- **Status**: Not started
-- **Files**:
-  - Modify: `AGENTS.md`
-  - Modify: release checklist or changelog surface
-  - Modify: `sdd/bundled-backends-migration/plan.md`
-- **Do**:
-  1. Choose the release where checked-in `bundled/` stops being the source of truth.
-  2. Update release docs with the selected model:
-     - build-time embedded backends, or
-     - external backend dependencies.
-  3. Record the final cutover criteria in this plan.
-  4. Mark bridge-only tasks done with PR references.
-- **Verify**:
-  - Release docs explain how backend versions are selected.
-  - The plan has no ambiguous "temporary" state without an owner or date.
-  - Project owners agree the replacement is ready.
-- **Depends on**: Task 4, Task 5, Task 6
-
-### Task 8: Open checked-in bundle removal follow-up after replacement ships
-
-- **Status**: Not started
-- **Files**:
-  - Create or modify: follow-up Linear issue or SDD for checked-in bundle removal
-  - Modify: `sdd/bundled-backends-migration/plan.md`
-  - Modify: release/project tracking surface for DOTCOM-16826
-- **Do**:
-  1. Confirm Tasks 3-7 are accepted and the replacement path is green in CI.
-  2. Open a focused removal follow-up that lists the deletion scope:
-     - `bundled/activitypub/**`
-     - `bundled/atmosphere/**`
-     - `tools/sync-bundled.sh`
-     - `tools/bundled-excludes.txt`
-     - bundle-specific loader, build, lint, test, and export-ignore rules
-  3. Record the selected final artifact model and migration notes for sites moving from bundled bridge mode to external/plugin-artifact mode.
-  4. Mark this SDD complete only after the follow-up has an owner, acceptance criteria, and rollback notes.
-- **Verify**:
-  - Follow-up tracking exists and links back to DOTCOM-16826.
-  - This SDD still states that it does not remove `bundled/`.
-  - The follow-up has explicit verification for lint, tests, e2e, and installable artifact checks.
-- **Depends on**: Task 7
+Nothing in this plan. If a trigger fires, the right next step is to re-read `spec.md`, expand this sketch into real tasks, and push a new commit that flips the status from DEFERRED to IN PROGRESS. Until then, leave the SDD alone — it's reference material, not implementation guidance.

--- a/sdd/bundled-backends-migration/requirements.md
+++ b/sdd/bundled-backends-migration/requirements.md
@@ -1,92 +1,52 @@
-# Bundled Backends Migration - Requirements
+# Bundled Backends Migration — Requirements
 
 Tracked under: [DOTCOM-16826](https://linear.app/a8c/issue/DOTCOM-16826) "Plan migration off bundled-backends bootstrap".
 
+## Status: DEFERRED
+
+This SDD is **not active for implementation**. See `spec.md` for the deferral rationale, trigger conditions, and the design captured for the eventual migration.
+
 ## Goal
 
-Define the strategy for moving FOSSE off the current bundled-backends bootstrap without breaking the standalone plugin zip or wp.com Simple rollout that currently depend on artifact vendoring.
+Capture the design for moving FOSSE off the current bundled-backends bootstrap so that, when migration becomes worth doing, there's a starting point — the analysis, the chosen direction, the principles, the proofs needed before removing `bundled/`. While deferred, the doc also serves as a list of constraints that should shape today's architectural decisions ("don't grow the bundled-coupling surface area").
 
-The outcome should make the current `bundled/` approach explicitly temporary, identify the next packaging proof needed to replace it, and choose a long-term distribution model for the federation backends.
+## What this deferred design must capture
 
-## Current State
+1. **The four candidate distribution models**: Composer VCS dependencies / package registry, splitting FOSSE UI from backend plugins, wp.com-specific artifact strategy, continued vendoring with stricter policy. Each evaluated for pros, cons, and fit at the time of activation.
 
-FOSSE currently vendors release-build source for `wordpress-activitypub` and `wordpress-atmosphere` under `bundled/`:
+2. **A chosen direction** for the migration team to start from: two-phase (bridge then migration), with package-based artifact assembly as the bridge proof.
 
-- `bundled/activitypub/`
-- `bundled/atmosphere/`
+3. **Migration principles** that respect the upstream-first policy and the read-only treatment of `bundled/`.
 
-The vendored copies are refreshed from local upstream checkouts by `tools/sync-bundled.sh`, which:
+4. **The proofs required before removing `bundled/`**: packaging, runtime, dependency UX, wp.com Simple platform path.
 
-- Reads `FOSSE_AP_SOURCE` and `FOSSE_ATMO_SOURCE` environment variables.
-- Runs `composer update --no-dev --optimize-autoloader` inside the Atmosphere source before syncing.
-- Uses `rsync --delete` and `tools/bundled-excludes.txt`.
-- Treats the vendored copies as release-build artifacts, not editable source.
+5. **Trigger conditions** that, when met, make the migration worth activating.
 
-The distribution zip is built by `bin/build-zip.sh` from `git archive HEAD` plus a production Composer install. Anything not marked `export-ignore` in `.gitattributes` ships. `bundled/` is not export-ignored, so the standalone zip currently includes:
+6. **Constraints on today's architecture** so deferring this work doesn't create more migration debt over time.
 
-- `fosse.php`
-- `src/`
-- `bundled/`
-- production `vendor/`
-
-This was created by the earlier `sdd/bundled-backends/` work and landed as the short-term bootstrap for PR #11. Both that SDD and `AGENTS.md` say bundling is temporary and expected to be replaced by a cleaner distribution approach.
-
-## Requirements
-
-1. **Keep current rollout unblocked while planning the migration.**
-   The plan must not require an immediate removal of `bundled/`, because the standalone zip and wp.com Simple rollout currently rely on artifact vendoring.
-
-2. **Recommend both a near-term and long-term direction.**
-   The SDD must evaluate the known options and make a recommendation, not just list tradeoffs.
-
-3. **Evaluate these options explicitly:**
-   - Composer VCS dependencies or package registry.
-   - Splitting FOSSE UI/orchestration from backend plugin distribution.
-   - wp.com-specific artifact strategy.
-   - Continued vendoring with stricter policy.
-
-4. **Respect the upstream-first policy.**
-   General ActivityPub or Atmosphere fixes belong upstream. FOSSE should not accumulate backend-specific shims or patches in `bundled/` except as unavoidable release-artifact consumption.
-
-5. **Do not hand-edit vendored backend source.**
-   Any plan that keeps a vendored artifact for any period must keep `bundled/` read-only and refreshed through automation, not manual edits.
-
-6. **Avoid making bundled backends permanent load-bearing infrastructure by accident.**
-   The migration plan must add decision gates, ownership rules, and removal criteria so the temporary bootstrap does not become the default architecture.
-
-7. **Preserve install ergonomics.**
-   A user installing the standalone FOSSE zip should still get a working Social Web experience. If the long-term model requires separate backend plugins, FOSSE must provide clear dependency detection, activation guidance, and failure states.
-
-8. **Account for wp.com Simple separately from general plugin distribution.**
-   wp.com Simple can use platform-specific artifact assembly or deployment controls that should not necessarily define the open-source repository shape.
-
-9. **Keep packaging reproducible.**
-   Replacing checked-in `bundled/` must include a proof that the same backend versions can be resolved, built, assembled into an installable artifact, and verified in CI.
-
-10. **Keep migration reversible until the replacement is proven.**
-    The first implementation phase should produce a packaging proof and policy hardening before deleting the existing bundle.
-
-## Constraints
+## Constraints (apply now, even though implementation is deferred)
 
 - WordPress plugin installs do not automatically install arbitrary Composer dependencies at runtime.
 - The current standalone zip is a drop-in plugin bundle and cannot assume a site runs Composer.
-- FOSSE's root `composer.json` currently excludes `bundled/` from classmap autoload; bundled plugins own their own bootstrap/autoload paths.
-- `bin/build-zip.sh` validates `composer.lock` drift and installs production `vendor/`; any Composer-based backend strategy must fit that build model or replace it deliberately.
+- FOSSE's root `composer.json` excludes `bundled/` from classmap autoload; bundled plugins own their own bootstrap/autoload paths.
+- `bin/build-zip.sh` validates `composer.lock` drift and installs production `vendor/`; any future Composer-based backend strategy must fit that build model or replace it deliberately.
 - wp.com Simple rollout currently relies on artifact vendoring and load ordering documented in `fosse.php`.
 - Backend plugins may continue to need separate release cadence, review, and ownership from FOSSE UI work.
+- `bundled/` is treated as read-only. `tools/sync-bundled.sh` is the only legitimate writer.
+- New FOSSE code MUST NOT add load-bearing assumptions about `bundled/` beyond the existing surface area (`fosse.php` bootstrap + the documented class/constant references). See the spec's "What to be aware of in the meantime" section.
 
-## Out of Scope
+## Out of Scope (now)
 
-- Removing `bundled/` in this SDD.
-- Changing the current backend loader, activation bootstrap, or wp.com Simple load contract.
+- Removing `bundled/`.
 - Implementing Composer/package-registry publishing.
-- Changing ActivityPub or Atmosphere upstream code.
-- Replacing FOSSE admin UI.
+- Building the dependency UX for missing/inactive external backends.
+- Changing the current backend loader, activation bootstrap, or wp.com Simple load contract.
+- Changing ActivityPub or Atmosphere upstream code (other than the existing upstream-first policy that already governs all such decisions).
 - Designing a full updater for third-party plugin dependencies.
 
-## Success Criteria
+## Success Criteria (for the deferred design)
 
-- The repository has a clear migration strategy with near-term and long-term recommendations.
-- The plan defines concrete follow-up tasks for decision record, packaging proof, build/CI changes, migration checks, and deprecation/removal.
-- The plan preserves the existing rollout path until a replacement artifact strategy is proven.
-- The plan makes `bundled/` visibly temporary and governed by stricter policy while it remains.
+- The repository has a documented migration strategy that captures the analysis without requiring it to ship now.
+- The trigger conditions are explicit enough that the next person looking at this doc can answer "should we start now?" by checking against them.
+- The "what to be aware of in the meantime" section gives current contributors clear constraints to respect.
+- When implementation does activate, `plan.md` can be expanded from a trigger checklist into real tasks without re-doing the analysis.

--- a/sdd/bundled-backends-migration/requirements.md
+++ b/sdd/bundled-backends-migration/requirements.md
@@ -1,0 +1,92 @@
+# Bundled Backends Migration - Requirements
+
+Tracked under: [DOTCOM-16826](https://linear.app/a8c/issue/DOTCOM-16826) "Plan migration off bundled-backends bootstrap".
+
+## Goal
+
+Define the strategy for moving FOSSE off the current bundled-backends bootstrap without breaking the standalone plugin zip or wp.com Simple rollout that currently depend on artifact vendoring.
+
+The outcome should make the current `bundled/` approach explicitly temporary, identify the next packaging proof needed to replace it, and choose a long-term distribution model for the federation backends.
+
+## Current State
+
+FOSSE currently vendors release-build source for `wordpress-activitypub` and `wordpress-atmosphere` under `bundled/`:
+
+- `bundled/activitypub/`
+- `bundled/atmosphere/`
+
+The vendored copies are refreshed from local upstream checkouts by `tools/sync-bundled.sh`, which:
+
+- Reads `FOSSE_AP_SOURCE` and `FOSSE_ATMO_SOURCE` environment variables.
+- Runs `composer update --no-dev --optimize-autoloader` inside the Atmosphere source before syncing.
+- Uses `rsync --delete` and `tools/bundled-excludes.txt`.
+- Treats the vendored copies as release-build artifacts, not editable source.
+
+The distribution zip is built by `bin/build-zip.sh` from `git archive HEAD` plus a production Composer install. Anything not marked `export-ignore` in `.gitattributes` ships. `bundled/` is not export-ignored, so the standalone zip currently includes:
+
+- `fosse.php`
+- `src/`
+- `bundled/`
+- production `vendor/`
+
+This was created by the earlier `sdd/bundled-backends/` work and landed as the short-term bootstrap for PR #11. Both that SDD and `AGENTS.md` say bundling is temporary and expected to be replaced by a cleaner distribution approach.
+
+## Requirements
+
+1. **Keep current rollout unblocked while planning the migration.**
+   The plan must not require an immediate removal of `bundled/`, because the standalone zip and wp.com Simple rollout currently rely on artifact vendoring.
+
+2. **Recommend both a near-term and long-term direction.**
+   The SDD must evaluate the known options and make a recommendation, not just list tradeoffs.
+
+3. **Evaluate these options explicitly:**
+   - Composer VCS dependencies or package registry.
+   - Splitting FOSSE UI/orchestration from backend plugin distribution.
+   - wp.com-specific artifact strategy.
+   - Continued vendoring with stricter policy.
+
+4. **Respect the upstream-first policy.**
+   General ActivityPub or Atmosphere fixes belong upstream. FOSSE should not accumulate backend-specific shims or patches in `bundled/` except as unavoidable release-artifact consumption.
+
+5. **Do not hand-edit vendored backend source.**
+   Any plan that keeps a vendored artifact for any period must keep `bundled/` read-only and refreshed through automation, not manual edits.
+
+6. **Avoid making bundled backends permanent load-bearing infrastructure by accident.**
+   The migration plan must add decision gates, ownership rules, and removal criteria so the temporary bootstrap does not become the default architecture.
+
+7. **Preserve install ergonomics.**
+   A user installing the standalone FOSSE zip should still get a working Social Web experience. If the long-term model requires separate backend plugins, FOSSE must provide clear dependency detection, activation guidance, and failure states.
+
+8. **Account for wp.com Simple separately from general plugin distribution.**
+   wp.com Simple can use platform-specific artifact assembly or deployment controls that should not necessarily define the open-source repository shape.
+
+9. **Keep packaging reproducible.**
+   Replacing checked-in `bundled/` must include a proof that the same backend versions can be resolved, built, assembled into an installable artifact, and verified in CI.
+
+10. **Keep migration reversible until the replacement is proven.**
+    The first implementation phase should produce a packaging proof and policy hardening before deleting the existing bundle.
+
+## Constraints
+
+- WordPress plugin installs do not automatically install arbitrary Composer dependencies at runtime.
+- The current standalone zip is a drop-in plugin bundle and cannot assume a site runs Composer.
+- FOSSE's root `composer.json` currently excludes `bundled/` from classmap autoload; bundled plugins own their own bootstrap/autoload paths.
+- `bin/build-zip.sh` validates `composer.lock` drift and installs production `vendor/`; any Composer-based backend strategy must fit that build model or replace it deliberately.
+- wp.com Simple rollout currently relies on artifact vendoring and load ordering documented in `fosse.php`.
+- Backend plugins may continue to need separate release cadence, review, and ownership from FOSSE UI work.
+
+## Out of Scope
+
+- Removing `bundled/` in this SDD.
+- Changing the current backend loader, activation bootstrap, or wp.com Simple load contract.
+- Implementing Composer/package-registry publishing.
+- Changing ActivityPub or Atmosphere upstream code.
+- Replacing FOSSE admin UI.
+- Designing a full updater for third-party plugin dependencies.
+
+## Success Criteria
+
+- The repository has a clear migration strategy with near-term and long-term recommendations.
+- The plan defines concrete follow-up tasks for decision record, packaging proof, build/CI changes, migration checks, and deprecation/removal.
+- The plan preserves the existing rollout path until a replacement artifact strategy is proven.
+- The plan makes `bundled/` visibly temporary and governed by stricter policy while it remains.

--- a/sdd/bundled-backends-migration/requirements.md
+++ b/sdd/bundled-backends-migration/requirements.md
@@ -1,52 +1,65 @@
-# Bundled Backends Migration — Requirements
+# Bundled Backends Migration - Requirements
 
 Tracked under: [DOTCOM-16826](https://linear.app/a8c/issue/DOTCOM-16826) "Plan migration off bundled-backends bootstrap".
 
-## Status: DEFERRED
+## Status: PLANNING
 
-This SDD is **not active for implementation**. See `spec.md` for the deferral rationale, trigger conditions, and the design captured for the eventual migration.
+This SDD is **open for review, not active for implementation**. The original deferred design captured useful caution, but two assumptions have materially changed: ATmosphere is now published on WordPress.org, and FOSSE's WordPress >=6.9 floor means WordPress' native dependency header is available across the whole supported range.
+
+This refresh remains docs-only until reviewers approve the migration approach.
+
+## 2026-05 Refresh
+
+- ATmosphere is now available from WordPress.org at <https://wordpress.org/plugins/atmosphere/>.
+- ActivityPub is available from WordPress.org at <https://wordpress.org/plugins/activitypub/>.
+- WordPress supports a `Requires Plugins` header, documented as a comma-separated list of WordPress.org plugin slugs.
+- FOSSE's public plugin direction should therefore prefer `Requires Plugins: activitypub, atmosphere` over keeping checked-in backend source indefinitely.
+- The wp.com Simple artifact strategy remains a separate coordination item. It should not, by itself, decide the public repository source layout.
 
 ## Goal
 
-Capture the design for moving FOSSE off the current bundled-backends bootstrap so that, when migration becomes worth doing, there's a starting point — the analysis, the chosen direction, the principles, the proofs needed before removing `bundled/`. While deferred, the doc also serves as a list of constraints that should shape today's architectural decisions ("don't grow the bundled-coupling surface area").
+Plan a safe migration from checked-in bundled backend source to explicit upstream plugin dependencies, while preserving the original migration caution for existing bundled-only installs and wp.com Simple rollout constraints.
 
-## What this deferred design must capture
+The updated SDD should give reviewers a clear public distribution proposal, preserve the package-artifact bridge analysis as a fallback or platform-specific option, and identify the decisions needed before implementation begins.
 
-1. **The four candidate distribution models**: Composer VCS dependencies / package registry, splitting FOSSE UI from backend plugins, wp.com-specific artifact strategy, continued vendoring with stricter policy. Each evaluated for pros, cons, and fit at the time of activation.
+## What this planning design must capture
 
-2. **A chosen direction** for the migration team to start from: two-phase (bridge then migration), with package-based artifact assembly as the bridge proof.
+1. **The preferred public distribution model**: FOSSE declares native WordPress plugin dependencies with `Requires Plugins: activitypub, atmosphere`.
 
-3. **Migration principles** that respect the upstream-first policy and the read-only treatment of `bundled/`.
+2. **Runtime readiness requirements**: FOSSE still checks for the required backend versions, symbols, and APIs because WordPress dependency headers do not encode minimum versions or symbol-level capability.
 
-4. **The proofs required before removing `bundled/`**: packaging, runtime, dependency UX, wp.com Simple platform path.
+3. **Upgrade strategy for bundled-only installs**: removing `bundled/` changes behavior for sites that currently rely on FOSSE's nested copies of ActivityPub and ATmosphere.
 
-5. **Trigger conditions** that, when met, make the migration worth activating.
+4. **wp.com Simple separation**: public WordPress.org distribution and wp.com Simple artifact ownership are related but separate decisions.
 
-6. **Constraints on today's architecture** so deferring this work doesn't create more migration debt over time.
+5. **Alternative bridge options**: package-based artifact assembly remains available if reviewers decide wp.com Simple, release engineering, or one-zip distribution needs a transitional bundle.
 
-## Constraints (apply now, even though implementation is deferred)
+6. **Constraints on today's architecture** so planning this work does not create new migration debt before implementation starts.
 
-- WordPress plugin installs do not automatically install arbitrary Composer dependencies at runtime.
-- The current standalone zip is a drop-in plugin bundle and cannot assume a site runs Composer.
-- FOSSE's root `composer.json` excludes `bundled/` from classmap autoload; bundled plugins own their own bootstrap/autoload paths.
-- `bin/build-zip.sh` validates `composer.lock` drift and installs production `vendor/`; any future Composer-based backend strategy must fit that build model or replace it deliberately.
+## Constraints (apply now, even while implementation is pending review)
+
+- WordPress plugin installs do not automatically enforce minimum versions for dependencies declared in `Requires Plugins`.
+- The current standalone zip is a drop-in plugin bundle; existing bundled-only installs need an explicit upgrade story before `bundled/` is removed.
+- FOSSE's root `composer.json` excludes `bundled/` from classmap autoload; bundled plugins own their own bootstrap/autoload paths until migration happens.
+- `bin/build-zip.sh` validates `composer.lock` drift and installs production `vendor/`; any transitional package-based backend strategy must fit that build model or replace it deliberately.
 - wp.com Simple rollout currently relies on artifact vendoring and load ordering documented in `fosse.php`.
 - Backend plugins may continue to need separate release cadence, review, and ownership from FOSSE UI work.
-- `bundled/` is treated as read-only. `tools/sync-bundled.sh` is the only legitimate writer.
-- New FOSSE code MUST NOT add load-bearing assumptions about `bundled/` beyond the existing surface area (`fosse.php` bootstrap + the documented class/constant references). See the spec's "What to be aware of in the meantime" section.
+- `bundled/` is treated as read-only. `tools/sync-bundled.sh` is the only legitimate writer until reviewers approve removal.
+- New FOSSE code MUST NOT add load-bearing assumptions about `bundled/` beyond the existing surface area (`fosse.php` bootstrap + the documented class/constant references). See the spec's "What to be aware of during planning" section.
 
-## Out of Scope (now)
+## Out of Scope (until reviewers approve implementation)
 
 - Removing `bundled/`.
-- Implementing Composer/package-registry publishing.
-- Building the dependency UX for missing/inactive external backends.
+- Adding the `Requires Plugins` header to `fosse.php`.
 - Changing the current backend loader, activation bootstrap, or wp.com Simple load contract.
-- Changing ActivityPub or Atmosphere upstream code (other than the existing upstream-first policy that already governs all such decisions).
+- Building the dependency UX for missing, inactive, or too-old external backends.
+- Changing ActivityPub or ATmosphere upstream code beyond the existing upstream-first policy that already governs all such decisions.
 - Designing a full updater for third-party plugin dependencies.
 
-## Success Criteria (for the deferred design)
+## Success Criteria (for the updated SDD)
 
-- The repository has a documented migration strategy that captures the analysis without requiring it to ship now.
-- The trigger conditions are explicit enough that the next person looking at this doc can answer "should we start now?" by checking against them.
-- The "what to be aware of in the meantime" section gives current contributors clear constraints to respect.
-- When implementation does activate, `plan.md` can be expanded from a trigger checklist into real tasks without re-doing the analysis.
+- The SDD acknowledges the WordPress.org ATmosphere release.
+- The SDD cites `Requires Plugins: activitypub, atmosphere` as the preferred public plugin dependency mechanism.
+- The SDD treats WordPress native dependency support as available for FOSSE's supported WordPress range.
+- The SDD separates public WordPress.org distribution from wp.com Simple artifact ownership.
+- The SDD keeps a clear upgrade discussion for existing bundled-only installs.

--- a/sdd/bundled-backends-migration/spec.md
+++ b/sdd/bundled-backends-migration/spec.md
@@ -1,141 +1,97 @@
 # Spec: Bundled Backends Migration
 
-## Goal
+## Status: DEFERRED
 
-Move FOSSE from "checked-in bundled backend plugins are the product architecture" to "FOSSE is the UI/orchestration plugin, and backend plugins are independently distributed dependencies", without interrupting current standalone zip installs or wp.com Simple rollout.
+This SDD captures a future migration. **No implementation is planned at this time.** The bundled-backends approach (`bundled/activitypub/` and `bundled/atmosphere/` checked into the FOSSE repo, included in the standalone zip and the wp.com Simple artifact) is the production architecture for now and the foreseeable future. The "short-term bootstrap" framing from `sdd/bundled-backends/` is correct in spirit but, in practice, the bootstrap is now a load-bearing wall.
 
-## Recommendation
+This doc exists so the eventual migration has a starting design rather than a fresh blank page, and so today's architectural decisions are made with the future migration in mind.
 
-### Near-Term Recommendation
+## Why deferred
 
-Keep artifact vendoring as the near-term bridge, but tighten policy and prove a replacement packaging path immediately.
+Concrete blockers — each of these would need to clear before migration becomes worth the cost:
 
-Near-term means:
+1. **Atmosphere has no stable public release.** `ATMOSPHERE_VERSION` is `'unreleased'` in the bundled copy. Composer-based deps, package registries, and external-plugin distribution all assume a stable release artifact to depend on. There isn't one yet.
 
-- Continue shipping the existing standalone zip with backend artifacts included while FOSSE needs one-click install behavior.
-- Keep `bundled/` read-only and refreshed only through `tools/sync-bundled.sh`.
-- Add explicit policy and verification around vendored source so no one treats it as FOSSE-owned code.
-- Build a packaging proof that assembles ActivityPub and Atmosphere from versioned package inputs instead of checked-in `bundled/` source.
-- Keep wp.com Simple on artifact vendoring until the platform has an equivalent deployment bundle or dependency-management story.
+2. **wp.com Simple just shipped on bundled.** DOTCOM-16983 (artifact vendoring) and DOTCOM-16984 (mu-plugin loader) landed within the past week. The platform deployment workflow is built around a single vendored artifact at `wp-content/plugins/fosse/<version>/`. Migrating now would force a redesign of the wp.com Simple deployment story before its first round of production-incident-driven feedback has even arrived.
 
-This avoids breaking rollout while making the migration measurable.
+3. **WordPress.org plugin directory does not allow Composer-managed dependencies.** Plugins must include their vendored code in the zip. So "FOSSE depends on AP/Atmosphere via Composer" only works for self-hosted-via-GitHub or platform-built artifacts — it doesn't help the WP.org distribution case at all.
 
-### Long-Term Recommendation
+4. **Bundling is working in production.** Coexistence with standalone AP/Atmosphere is handled cleanly by the skip-when-standalone checks at `fosse.php:42-58`. There are no open bug reports or operational incidents traceable to the bundling architecture. The maintenance burden (`tools/sync-bundled.sh`) is real but small — a few syncs a month.
 
-Split FOSSE UI/orchestration from backend plugin distribution.
+5. **Migration is high-risk, low-immediate-value.** The benefits (smaller plugin zip, cleaner upstream sync) don't outweigh the costs (wp.com platform redesign, dependency UX work, WP.org policy navigation, regression risk on a production-critical path) until at least one of items 1-4 changes.
 
-Long-term, FOSSE should not contain hidden copies of ActivityPub or Atmosphere in its repository. The preferred model is:
+## Trigger conditions for revisiting
 
-- `wordpress-activitypub` and `wordpress-atmosphere` ship as independent plugins with their own releases.
-- FOSSE declares and detects those backend plugins as dependencies.
-- FOSSE owns shared UI, onboarding, settings projection, provider state, and FOSSE-specific policy.
-- Backend-agnostic correctness and protocol implementation continue upstream.
-- Platform builds, including wp.com Simple, may assemble FOSSE plus required backend plugins as a deployment artifact, but that should be a platform packaging concern rather than FOSSE's source tree shape.
+Revisit this SDD and consider activating implementation when ANY of the following becomes true:
 
-Composer VCS dependencies or an Automattic package registry are the best transition mechanism for reproducible artifact assembly. They are not the final user-facing architecture by themselves, because a WordPress site installing a plugin zip cannot be expected to run Composer.
+- **Atmosphere ships a stable public release** (versioned tag, published on a reachable distribution channel — wordpress.org, an Automattic Composer registry, or a stable GitHub release artifact).
+- **The bundling approach actively breaks.** Specifically: a `tools/sync-bundled.sh` run produces unrecoverable conflicts, a security advisory in upstream AP or Atmosphere requires faster-than-sync turnaround, or the bundled zip exceeds a size limit imposed by a distribution channel.
+- **WordPress.org's plugin dependency tooling matures** to allow declarative cross-plugin dependencies that work for the standalone install case (currently in development as part of WP core; not yet a usable surface).
+- **wp.com platform asks for separated artifacts** as part of its own deployment evolution.
+- **Three or more sync conflicts in a single quarter** that require manual resolution beyond the standard `sync-bundled.sh` flow.
 
-## Options Evaluated
+When a trigger fires, the next step is: re-evaluate this spec, confirm the chosen direction below still holds, expand `plan.md` with implementation tasks, and only then begin work.
 
-### Option A: Composer VCS Dependencies or Package Registry
+## What to be aware of in the meantime
 
-FOSSE could depend on versioned package inputs for ActivityPub and Atmosphere, either through VCS repositories or a package registry. The build step would resolve those inputs and assemble the distribution artifact.
+These are constraints today's architectural decisions should respect even though we're not migrating:
 
-**Pros**
+1. **Don't add NEW load-bearing assumptions about `bundled/`.** Existing FOSSE code reads bundled AP/Atmosphere class names and constants (e.g. `ACTIVITYPUB_PLUGIN_DIR`, `\Activitypub\Activitypub`, `\Atmosphere\Publisher`). That's existing surface area. Don't grow it. Specifically:
+   - Don't add `require_once bundled/...` calls outside `fosse.php`'s existing bootstrap.
+   - Don't add filters/hooks whose contracts depend on bundled code being at a specific filesystem path.
+   - Don't add tests that reach into `bundled/` directly.
 
-- Reproducible version pinning through `composer.lock` or an equivalent lockfile.
-- Removes local manual sync as the source of truth.
-- Creates a clean audit trail for which upstream versions ship.
-- Fits CI proofs and artifact builds well.
-- Can support private/pre-release Atmosphere builds before public plugin-directory availability.
+2. **Treat `bundled/` as read-only.** Already enforced by policy. `tools/sync-bundled.sh` is the only legitimate writer.
 
-**Cons**
+3. **Land protocol-agnostic functionality upstream first.** This is the existing "upstream-first" policy; migration just makes it more important. Anything that's a candidate for "should be in AP / Atmosphere" should land there before the bundled copy gets it via sync. Reduces the migration delta when the time comes.
 
-- WordPress plugin users do not run Composer during plugin install.
-- Composer packages for full WordPress plugins need careful install paths, artifact pruning, and autoload boundaries.
-- If the resulting zip still embeds backend plugin source, this replaces checked-in vendoring with build-time vendoring but does not by itself solve hidden dependency ownership.
-- VCS dependencies are slower and less stable than a package registry for routine CI.
+4. **Document the load contract at every coupling point.** The wp.com Simple load-order contract (`fosse.php:25-38`) is a model. When FOSSE adds a new touchpoint with bundled code, document the contract in-line so the migration team (probably future-us) can find the contracts to redesign.
 
-**Assessment**
+5. **Keep `bin/build-zip.sh` validation strict.** The existing "fail if `bundled/vendor/autoload.php` missing" check (`bin/build-zip.sh:73-83`) is exactly the kind of guard that protects the bundled artifact from silent breakage. Add similar guards for any new bundled file that load-bearing code depends on.
+
+## Chosen direction (when implementation begins)
+
+Two-phase migration:
+
+1. **Bridge phase**: keep checked-in `bundled/` artifacts, but harden policy and add a packaging proof. Build a CI job that assembles an equivalent FOSSE zip from versioned package inputs (Composer VCS, GitHub release zips, or Automattic package registry — whichever is most stable at the time) without relying on `bundled/` source. Compare the assembled artifact byte-for-byte (or structurally) with the current bundled output.
+
+2. **Migration phase**: once the packaging proof + dependency UX + wp.com Simple platform path are all proven, move backend source out of the FOSSE repo. FOSSE becomes UI/orchestration; ActivityPub and Atmosphere become external dependencies. The standalone artifact (if still desired) is built from package inputs at release time, not from checked-in source.
+
+The bridge phase has an explicit expiration gate: once package-based artifact assembly is green in CI, new feature work must not extend `bundled/` except through upstream syncs needed to reach migration cutover.
+
+## Options analysis (for future reference)
+
+The four candidate distribution models, evaluated when this SDD was originally drafted. Preserved here so the migration team has the prior reasoning when they pick this up.
+
+### Option A: Composer VCS dependencies or package registry
 
 Recommended as the near-term packaging proof and transition path. Prefer a package registry once upstream release automation exists; use VCS only while releases are still moving quickly.
 
-### Option B: Split FOSSE UI from Backend Plugins
+**Pros**: reproducible version pinning via lockfile; removes manual sync as source of truth; clean audit trail; CI-friendly; supports private/pre-release Atmosphere builds.
+**Cons**: WP plugin users don't run Composer; resulting zip may still embed backend source (build-time vendoring instead of checked-in vendoring); VCS deps slower than registry.
 
-FOSSE becomes an orchestration/UI plugin that requires ActivityPub and Atmosphere to be installed separately. It detects backend availability, guides activation, and degrades clearly when dependencies are missing.
-
-**Pros**
-
-- Clean ownership boundary.
-- Backend plugins update independently and remain visible to site owners.
-- FOSSE stops shipping hidden copies of other plugins.
-- Aligns with upstream-first policy.
-- Makes dependency state explicit in wp-admin instead of implicit in `bundled/`.
-- Removes class-collision and activation-hook gaps caused by programmatic nested plugin loading.
-
-**Cons**
-
-- Standalone install is no longer a single zip unless the artifact includes all plugins or the user installs dependencies separately.
-- Requires dependency UX, activation checks, and failure states.
-- WordPress plugin dependency tooling helps, but the user experience still needs design and testing.
-- wp.com Simple needs a platform deployment answer so rollout remains one coordinated install.
-
-**Assessment**
+### Option B: Split FOSSE UI from backend plugins
 
 Recommended long-term architecture. Do not switch until dependency UX and platform artifact assembly are proven.
 
-### Option C: wp.com-Specific Artifact Strategy
+**Pros**: clean ownership boundary; backend plugins update independently; no hidden copies; aligns with upstream-first; explicit dependency state in wp-admin; removes class-collision and activation-hook gaps from programmatic nested loading.
+**Cons**: standalone install no longer one zip unless all plugins assembled; requires dependency UX work; WP plugin dependency tooling helps but UX still needs design; wp.com Simple needs platform deployment answer.
 
-Keep FOSSE source clean, but let wp.com Simple build/deploy an artifact containing FOSSE plus the required backend plugins.
-
-**Pros**
-
-- Matches wp.com's platform control over plugin deployment and load ordering.
-- Avoids forcing wp.com constraints into the open-source repository.
-- Can preserve one-step rollout while FOSSE's public source moves toward explicit dependencies.
-- Allows platform-specific pinning, staged rollout, and rollback.
-
-**Cons**
-
-- Creates two distribution paths that must be tested separately.
-- Risk of wp.com artifact behavior diverging from the public plugin zip.
-- Requires clear ownership of artifact assembly and backend version pins outside the FOSSE source tree.
-
-**Assessment**
+### Option C: wp.com-specific artifact strategy
 
 Recommended as part of the transition. wp.com Simple can keep artifact vendoring longer than the public repo if needed, but it should become platform packaging, not checked-in FOSSE source.
 
-### Option D: Continued Vendoring With Stricter Policy
+**Pros**: matches wp.com's platform control over plugin deployment; avoids forcing wp.com constraints into open-source repo; preserves one-step rollout while public source moves; allows platform-specific pinning, staged rollout, rollback.
+**Cons**: two distribution paths to test separately; wp.com artifact behavior could diverge from public zip; requires clear ownership of artifact assembly outside FOSSE source tree.
 
-Keep `bundled/` checked in, but add stronger rules: no hand edits, source SHA manifest, automated drift checks, build checks, and periodic removal review.
+### Option D: Continued vendoring with stricter policy
 
-**Pros**
+**This is the current production choice.** Accept as a long bridge while migration triggers haven't fired. Not recommended as the eventual long-term architecture, but the right choice today given the deferral rationale above.
 
-- Lowest immediate risk.
-- Preserves current standalone zip and wp.com Simple behavior.
-- Easy to understand with current code.
-- Adds guardrails quickly.
+**Pros**: lowest immediate risk; preserves current standalone zip + wp.com Simple behavior; easy to understand; current guardrails (no hand edits, sync-only refresh) work.
+**Cons**: still makes FOSSE carry other plugins' source; risks the temporary approach becoming permanent (already happened); creates large vendored diffs; doesn't solve dependency ownership.
 
-**Cons**
-
-- Still makes FOSSE carry other plugins' source.
-- Still risks the temporary approach becoming permanent.
-- Still creates large generated/vendored diffs.
-- Does not solve dependency ownership or independent backend updates.
-
-**Assessment**
-
-Accept only as a short bridge while Option A's packaging proof and Option B's dependency model are built. Not recommended as the long-term architecture.
-
-## Chosen Direction
-
-Use a two-phase migration:
-
-1. **Bridge phase:** Keep the current checked-in `bundled/` artifacts, but harden the policy and add migration checks. In parallel, prove that CI can assemble an equivalent FOSSE zip from versioned backend package inputs.
-2. **Migration phase:** Move backend source out of the FOSSE repository once the packaging proof, dependency UX, and wp.com artifact path are accepted. FOSSE then treats ActivityPub and Atmosphere as external backend plugins.
-
-The bridge phase should have an explicit expiration gate: once package-based artifact assembly and dependency UX are green in CI, new backend feature work must not extend `bundled/` except through upstream syncs required to reach the migration cutover.
-
-## Target Architecture
+## Target architecture (when implementation begins)
 
 ```
 Development source:
@@ -153,17 +109,10 @@ Automattic/wordpress-atmosphere
   `-- independent plugin release
 ```
 
-Distribution artifacts may differ:
+Distribution artifacts at the migration target:
 
 ```
-Public standalone artifact, transitional:
-  fosse/
-    fosse.php
-    src/
-    vendor/
-    bundled/ or assembled backend artifacts
-
-Public standalone artifact, final:
+Public standalone artifact (final):
   fosse/
     fosse.php
     src/
@@ -175,7 +124,7 @@ wp.com Simple artifact:
   with pinned backend versions and rollout/rollback controls
 ```
 
-## Migration Principles
+## Migration principles (when implementation begins)
 
 - **Source ownership stays upstream.** If a change is useful outside FOSSE, land it in ActivityPub or Atmosphere first.
 - **FOSSE owns projection and product policy.** FOSSE-specific option defaults, unified UI, and cross-network coordination stay in FOSSE.
@@ -183,68 +132,21 @@ wp.com Simple artifact:
 - **Dependency state must be visible.** Users and operators should be able to tell whether ActivityPub and Atmosphere are installed, active, bundled, or missing.
 - **Rollout should be reversible.** Do not delete `bundled/` until package-based artifact assembly and dependency UX both have tests.
 
-## Required Proofs Before Removing `bundled/`
+## Required proofs before removing `bundled/` (when implementation begins)
 
-1. **Packaging proof**
-   - Resolve ActivityPub and Atmosphere from versioned inputs.
-   - Assemble an installable FOSSE artifact without relying on checked-in `bundled/`.
-   - Verify the artifact includes whatever backend files the selected transition path requires.
-   - Run `composer run-script build-zip` or successor build command in CI.
+1. **Packaging proof**: resolve AP and Atmosphere from versioned inputs; assemble an installable FOSSE artifact without relying on checked-in `bundled/`; verify the artifact includes whatever backend files the selected transition path requires; CI build job green.
+2. **Runtime proof**: install generated artifact in Playground; FOSSE admin loads without fatals; AP and Atmosphere provider availability reported correctly; standalone backend plugins don't class-collide with FOSSE.
+3. **Dependency UX proof**: missing AP shows clear action/state; missing Atmosphere shows clear action/state; installed-but-inactive distinguished from absent; FOSSE setup/status pages remain useful when one backend is unavailable.
+4. **wp.com Simple proof**: platform artifact or deployment path installs FOSSE plus required backend versions; load ordering still suppresses duplicate platform AP loads where required; rollback returns to previous known-good artifact.
 
-2. **Runtime proof**
-   - Install the generated artifact in Playground.
-   - Confirm FOSSE admin loads without fatals.
-   - Confirm ActivityPub and Atmosphere provider availability is reported correctly.
-   - Confirm standalone backend plugins do not class-collide with FOSSE.
-
-3. **Dependency UX proof**
-   - Missing ActivityPub shows a clear action/state.
-   - Missing Atmosphere shows a clear action/state.
-   - Installed-but-inactive backends are distinguished from absent backends.
-   - FOSSE setup/status pages remain useful when one backend is unavailable.
-
-4. **wp.com Simple proof**
-   - Platform artifact or deployment path installs FOSSE plus the required backend versions.
-   - Load ordering still suppresses duplicate platform ActivityPub loads where required.
-   - Rollback can return to the previous known-good artifact.
-
-## Build and CI Implications
-
-The existing `bin/build-zip.sh` assumes tracked source plus production `vendor/`. The migration should either:
-
-- Extend the build to assemble backend artifacts from package inputs before zipping, or
-- Remove backend artifacts from the FOSSE zip and rely on explicit plugin dependencies.
-
-During the bridge phase, CI should keep verifying the current checked-in bundle. Once the packaging proof exists, CI should add a second artifact job that builds from package inputs and compares key files/behavior against the current bundle.
-
-Minimum checks:
-
-- Backend entrypoints are present in transitional artifacts when expected.
-- FOSSE root `vendor/autoload_packages.php` is present.
-- Bundled or external backend activation path does not fatal.
-- `bundled/` is not included in FOSSE Composer classmap.
-- No files under `bundled/` are modified except by a sync task.
-
-## Deprecation Plan
-
-1. Mark checked-in `bundled/` as bridge-only in SDD, AGENTS.md, and release engineering notes.
-2. Add a backend-version manifest or package-lock equivalent so vendored source has traceable provenance while it remains.
-3. Prove package-based artifact assembly in CI.
-4. Build dependency UX for missing/inactive external backends.
-5. Decide whether the public standalone artifact should:
-   - Continue including backend artifacts assembled at build time for one-click install, or
-   - Stop including backend artifacts and rely on explicit plugin dependencies.
-6. Move wp.com Simple to a platform-owned artifact/dependency strategy.
-7. Remove checked-in `bundled/`, `tools/sync-bundled.sh`, and bundle-specific export/linguist/tooling rules after the selected replacement ships.
-
-## Non-Goals
+## Non-goals (now AND when implementation begins)
 
 - This SDD does not remove `bundled/`.
 - This SDD does not pick exact package names or registry infrastructure.
 - This SDD does not redesign FOSSE onboarding or provider UI.
 - This SDD does not change upstream release policy for ActivityPub or Atmosphere.
 
-## Open Questions
+## Open questions (for the future migration team)
 
 - Should the first packaging proof use Composer VCS repositories, GitHub release zips, or an internal Automattic package registry?
 - Does the public FOSSE zip need to remain one-click with backend artifacts included after v1, or can it rely on WordPress plugin dependency installation UX?

--- a/sdd/bundled-backends-migration/spec.md
+++ b/sdd/bundled-backends-migration/spec.md
@@ -1,0 +1,253 @@
+# Spec: Bundled Backends Migration
+
+## Goal
+
+Move FOSSE from "checked-in bundled backend plugins are the product architecture" to "FOSSE is the UI/orchestration plugin, and backend plugins are independently distributed dependencies", without interrupting current standalone zip installs or wp.com Simple rollout.
+
+## Recommendation
+
+### Near-Term Recommendation
+
+Keep artifact vendoring as the near-term bridge, but tighten policy and prove a replacement packaging path immediately.
+
+Near-term means:
+
+- Continue shipping the existing standalone zip with backend artifacts included while FOSSE needs one-click install behavior.
+- Keep `bundled/` read-only and refreshed only through `tools/sync-bundled.sh`.
+- Add explicit policy and verification around vendored source so no one treats it as FOSSE-owned code.
+- Build a packaging proof that assembles ActivityPub and Atmosphere from versioned package inputs instead of checked-in `bundled/` source.
+- Keep wp.com Simple on artifact vendoring until the platform has an equivalent deployment bundle or dependency-management story.
+
+This avoids breaking rollout while making the migration measurable.
+
+### Long-Term Recommendation
+
+Split FOSSE UI/orchestration from backend plugin distribution.
+
+Long-term, FOSSE should not contain hidden copies of ActivityPub or Atmosphere in its repository. The preferred model is:
+
+- `wordpress-activitypub` and `wordpress-atmosphere` ship as independent plugins with their own releases.
+- FOSSE declares and detects those backend plugins as dependencies.
+- FOSSE owns shared UI, onboarding, settings projection, provider state, and FOSSE-specific policy.
+- Backend-agnostic correctness and protocol implementation continue upstream.
+- Platform builds, including wp.com Simple, may assemble FOSSE plus required backend plugins as a deployment artifact, but that should be a platform packaging concern rather than FOSSE's source tree shape.
+
+Composer VCS dependencies or an Automattic package registry are the best transition mechanism for reproducible artifact assembly. They are not the final user-facing architecture by themselves, because a WordPress site installing a plugin zip cannot be expected to run Composer.
+
+## Options Evaluated
+
+### Option A: Composer VCS Dependencies or Package Registry
+
+FOSSE could depend on versioned package inputs for ActivityPub and Atmosphere, either through VCS repositories or a package registry. The build step would resolve those inputs and assemble the distribution artifact.
+
+**Pros**
+
+- Reproducible version pinning through `composer.lock` or an equivalent lockfile.
+- Removes local manual sync as the source of truth.
+- Creates a clean audit trail for which upstream versions ship.
+- Fits CI proofs and artifact builds well.
+- Can support private/pre-release Atmosphere builds before public plugin-directory availability.
+
+**Cons**
+
+- WordPress plugin users do not run Composer during plugin install.
+- Composer packages for full WordPress plugins need careful install paths, artifact pruning, and autoload boundaries.
+- If the resulting zip still embeds backend plugin source, this replaces checked-in vendoring with build-time vendoring but does not by itself solve hidden dependency ownership.
+- VCS dependencies are slower and less stable than a package registry for routine CI.
+
+**Assessment**
+
+Recommended as the near-term packaging proof and transition path. Prefer a package registry once upstream release automation exists; use VCS only while releases are still moving quickly.
+
+### Option B: Split FOSSE UI from Backend Plugins
+
+FOSSE becomes an orchestration/UI plugin that requires ActivityPub and Atmosphere to be installed separately. It detects backend availability, guides activation, and degrades clearly when dependencies are missing.
+
+**Pros**
+
+- Clean ownership boundary.
+- Backend plugins update independently and remain visible to site owners.
+- FOSSE stops shipping hidden copies of other plugins.
+- Aligns with upstream-first policy.
+- Makes dependency state explicit in wp-admin instead of implicit in `bundled/`.
+- Removes class-collision and activation-hook gaps caused by programmatic nested plugin loading.
+
+**Cons**
+
+- Standalone install is no longer a single zip unless the artifact includes all plugins or the user installs dependencies separately.
+- Requires dependency UX, activation checks, and failure states.
+- WordPress plugin dependency tooling helps, but the user experience still needs design and testing.
+- wp.com Simple needs a platform deployment answer so rollout remains one coordinated install.
+
+**Assessment**
+
+Recommended long-term architecture. Do not switch until dependency UX and platform artifact assembly are proven.
+
+### Option C: wp.com-Specific Artifact Strategy
+
+Keep FOSSE source clean, but let wp.com Simple build/deploy an artifact containing FOSSE plus the required backend plugins.
+
+**Pros**
+
+- Matches wp.com's platform control over plugin deployment and load ordering.
+- Avoids forcing wp.com constraints into the open-source repository.
+- Can preserve one-step rollout while FOSSE's public source moves toward explicit dependencies.
+- Allows platform-specific pinning, staged rollout, and rollback.
+
+**Cons**
+
+- Creates two distribution paths that must be tested separately.
+- Risk of wp.com artifact behavior diverging from the public plugin zip.
+- Requires clear ownership of artifact assembly and backend version pins outside the FOSSE source tree.
+
+**Assessment**
+
+Recommended as part of the transition. wp.com Simple can keep artifact vendoring longer than the public repo if needed, but it should become platform packaging, not checked-in FOSSE source.
+
+### Option D: Continued Vendoring With Stricter Policy
+
+Keep `bundled/` checked in, but add stronger rules: no hand edits, source SHA manifest, automated drift checks, build checks, and periodic removal review.
+
+**Pros**
+
+- Lowest immediate risk.
+- Preserves current standalone zip and wp.com Simple behavior.
+- Easy to understand with current code.
+- Adds guardrails quickly.
+
+**Cons**
+
+- Still makes FOSSE carry other plugins' source.
+- Still risks the temporary approach becoming permanent.
+- Still creates large generated/vendored diffs.
+- Does not solve dependency ownership or independent backend updates.
+
+**Assessment**
+
+Accept only as a short bridge while Option A's packaging proof and Option B's dependency model are built. Not recommended as the long-term architecture.
+
+## Chosen Direction
+
+Use a two-phase migration:
+
+1. **Bridge phase:** Keep the current checked-in `bundled/` artifacts, but harden the policy and add migration checks. In parallel, prove that CI can assemble an equivalent FOSSE zip from versioned backend package inputs.
+2. **Migration phase:** Move backend source out of the FOSSE repository once the packaging proof, dependency UX, and wp.com artifact path are accepted. FOSSE then treats ActivityPub and Atmosphere as external backend plugins.
+
+The bridge phase should have an explicit expiration gate: once package-based artifact assembly and dependency UX are green in CI, new backend feature work must not extend `bundled/` except through upstream syncs required to reach the migration cutover.
+
+## Target Architecture
+
+```
+Development source:
+
+Automattic/fosse
+  |-- fosse.php
+  |-- src/                       # FOSSE UI/orchestration
+  |-- composer.json              # FOSSE runtime deps
+  `-- packaging config           # backend version pins, not backend source
+
+Automattic/wordpress-activitypub
+  `-- independent plugin release
+
+Automattic/wordpress-atmosphere
+  `-- independent plugin release
+```
+
+Distribution artifacts may differ:
+
+```
+Public standalone artifact, transitional:
+  fosse/
+    fosse.php
+    src/
+    vendor/
+    bundled/ or assembled backend artifacts
+
+Public standalone artifact, final:
+  fosse/
+    fosse.php
+    src/
+    vendor/
+  plus explicit dependency UX for ActivityPub + Atmosphere
+
+wp.com Simple artifact:
+  platform-controlled bundle of FOSSE + backend plugins
+  with pinned backend versions and rollout/rollback controls
+```
+
+## Migration Principles
+
+- **Source ownership stays upstream.** If a change is useful outside FOSSE, land it in ActivityPub or Atmosphere first.
+- **FOSSE owns projection and product policy.** FOSSE-specific option defaults, unified UI, and cross-network coordination stay in FOSSE.
+- **Build artifacts may contain dependencies; source should not.** Temporary artifact vendoring is acceptable. Long-term checked-in backend source is not.
+- **Dependency state must be visible.** Users and operators should be able to tell whether ActivityPub and Atmosphere are installed, active, bundled, or missing.
+- **Rollout should be reversible.** Do not delete `bundled/` until package-based artifact assembly and dependency UX both have tests.
+
+## Required Proofs Before Removing `bundled/`
+
+1. **Packaging proof**
+   - Resolve ActivityPub and Atmosphere from versioned inputs.
+   - Assemble an installable FOSSE artifact without relying on checked-in `bundled/`.
+   - Verify the artifact includes whatever backend files the selected transition path requires.
+   - Run `composer run-script build-zip` or successor build command in CI.
+
+2. **Runtime proof**
+   - Install the generated artifact in Playground.
+   - Confirm FOSSE admin loads without fatals.
+   - Confirm ActivityPub and Atmosphere provider availability is reported correctly.
+   - Confirm standalone backend plugins do not class-collide with FOSSE.
+
+3. **Dependency UX proof**
+   - Missing ActivityPub shows a clear action/state.
+   - Missing Atmosphere shows a clear action/state.
+   - Installed-but-inactive backends are distinguished from absent backends.
+   - FOSSE setup/status pages remain useful when one backend is unavailable.
+
+4. **wp.com Simple proof**
+   - Platform artifact or deployment path installs FOSSE plus the required backend versions.
+   - Load ordering still suppresses duplicate platform ActivityPub loads where required.
+   - Rollback can return to the previous known-good artifact.
+
+## Build and CI Implications
+
+The existing `bin/build-zip.sh` assumes tracked source plus production `vendor/`. The migration should either:
+
+- Extend the build to assemble backend artifacts from package inputs before zipping, or
+- Remove backend artifacts from the FOSSE zip and rely on explicit plugin dependencies.
+
+During the bridge phase, CI should keep verifying the current checked-in bundle. Once the packaging proof exists, CI should add a second artifact job that builds from package inputs and compares key files/behavior against the current bundle.
+
+Minimum checks:
+
+- Backend entrypoints are present in transitional artifacts when expected.
+- FOSSE root `vendor/autoload_packages.php` is present.
+- Bundled or external backend activation path does not fatal.
+- `bundled/` is not included in FOSSE Composer classmap.
+- No files under `bundled/` are modified except by a sync task.
+
+## Deprecation Plan
+
+1. Mark checked-in `bundled/` as bridge-only in SDD, AGENTS.md, and release engineering notes.
+2. Add a backend-version manifest or package-lock equivalent so vendored source has traceable provenance while it remains.
+3. Prove package-based artifact assembly in CI.
+4. Build dependency UX for missing/inactive external backends.
+5. Decide whether the public standalone artifact should:
+   - Continue including backend artifacts assembled at build time for one-click install, or
+   - Stop including backend artifacts and rely on explicit plugin dependencies.
+6. Move wp.com Simple to a platform-owned artifact/dependency strategy.
+7. Remove checked-in `bundled/`, `tools/sync-bundled.sh`, and bundle-specific export/linguist/tooling rules after the selected replacement ships.
+
+## Non-Goals
+
+- This SDD does not remove `bundled/`.
+- This SDD does not pick exact package names or registry infrastructure.
+- This SDD does not redesign FOSSE onboarding or provider UI.
+- This SDD does not change upstream release policy for ActivityPub or Atmosphere.
+
+## Open Questions
+
+- Should the first packaging proof use Composer VCS repositories, GitHub release zips, or an internal Automattic package registry?
+- Does the public FOSSE zip need to remain one-click with backend artifacts included after v1, or can it rely on WordPress plugin dependency installation UX?
+- Who owns wp.com Simple artifact assembly once it diverges from the public plugin zip?
+- What version pin format should be the source of truth during the bridge phase: Composer lock, package manifest, or a dedicated backend manifest?
+- What is the earliest release milestone where checked-in `bundled/` can be deleted without harming current rollout?

--- a/sdd/bundled-backends-migration/spec.md
+++ b/sdd/bundled-backends-migration/spec.md
@@ -1,155 +1,198 @@
+---
+status: planning
+---
+
 # Spec: Bundled Backends Migration
 
-## Status: DEFERRED
+## Status: PLANNING
 
-This SDD captures a future migration. **No implementation is planned at this time.** The bundled-backends approach (`bundled/activitypub/` and `bundled/atmosphere/` checked into the FOSSE repo, included in the standalone zip and the wp.com Simple artifact) is the production architecture for now and the foreseeable future. The "short-term bootstrap" framing from `sdd/bundled-backends/` is correct in spirit but, in practice, the bootstrap is now a load-bearing wall.
+This SDD is open for review after the 2026-05 dependency refresh. **No code implementation is planned in this PR.** The bundled-backends approach (`bundled/activitypub/` and `bundled/atmosphere/` checked into the FOSSE repo, included in the standalone zip and the wp.com Simple artifact) remains the production architecture until reviewers approve a migration path.
 
-This doc exists so the eventual migration has a starting design rather than a fresh blank page, and so today's architectural decisions are made with the future migration in mind.
+The original design captured why removing `bundled/` was too risky before ATmosphere had a public release and before FOSSE could rely on native WordPress plugin dependencies. That caution still matters, but the public dependency facts have changed enough that this SDD should be reviewed instead of left on the shelf.
 
-## Why deferred
+## 2026-05 Refresh
 
-Concrete blockers — each of these would need to clear before migration becomes worth the cost:
+Two original trigger conditions have fired or materially changed:
 
-1. **Atmosphere has no stable public release.** `ATMOSPHERE_VERSION` is `'unreleased'` in the bundled copy. Composer-based deps, package registries, and external-plugin distribution all assume a stable release artifact to depend on. There isn't one yet.
+1. **ATmosphere is now published on WordPress.org.** It has a WordPress.org plugin page at <https://wordpress.org/plugins/atmosphere/> and the slug `atmosphere`.
 
-2. **wp.com Simple just shipped on bundled.** DOTCOM-16983 (artifact vendoring) and DOTCOM-16984 (mu-plugin loader) landed within the past week. The platform deployment workflow is built around a single vendored artifact at `wp-content/plugins/fosse/<version>/`. Migrating now would force a redesign of the wp.com Simple deployment story before its first round of production-incident-driven feedback has even arrived.
+2. **FOSSE can rely on native WordPress plugin dependencies.** WordPress 6.5 introduced plugin dependencies, and FOSSE requires WordPress >=6.9. The Plugin Handbook documents the `Requires Plugins` header as a comma-separated list of WordPress.org slugs.
 
-3. **WordPress.org plugin directory does not allow Composer-managed dependencies.** Plugins must include their vendored code in the zip. So "FOSSE depends on AP/Atmosphere via Composer" only works for self-hosted-via-GitHub or platform-built artifacts — it doesn't help the WP.org distribution case at all.
+ActivityPub is also available from WordPress.org at <https://wordpress.org/plugins/activitypub/>, so the preferred public dependency declaration is:
 
-4. **Bundling is working in production.** Coexistence with standalone AP/Atmosphere is handled cleanly by the skip-when-standalone checks at `fosse.php:42-58`. There are no open bug reports or operational incidents traceable to the bundling architecture. The maintenance burden (`tools/sync-bundled.sh`) is real but small — a few syncs a month.
+```text
+Requires Plugins: activitypub, atmosphere
+```
 
-5. **Migration is high-risk, low-immediate-value.** The benefits (smaller plugin zip, cleaner upstream sync) don't outweigh the costs (wp.com platform redesign, dependency UX work, WP.org policy navigation, regression risk on a production-critical path) until at least one of items 1-4 changes.
+This header should be the default public WordPress.org distribution strategy unless reviewers explicitly decide one-zip distribution remains a hard requirement.
 
-## Trigger conditions for revisiting
+## Current Recommendation
 
-Revisit this SDD and consider activating implementation when ANY of the following becomes true:
+The migration direction should pivot from "prove package-based artifact assembly first" to "prefer native WordPress plugin dependencies for public distribution."
 
-- **Atmosphere ships a stable public release** (versioned tag, published on a reachable distribution channel — wordpress.org, an Automattic Composer registry, or a stable GitHub release artifact).
-- **The bundling approach actively breaks.** Specifically: a `tools/sync-bundled.sh` run produces unrecoverable conflicts, a security advisory in upstream AP or Atmosphere requires faster-than-sync turnaround, or the bundled zip exceeds a size limit imposed by a distribution channel.
-- **WordPress.org's plugin dependency tooling matures** to allow declarative cross-plugin dependencies that work for the standalone install case (currently in development as part of WP core; not yet a usable surface).
-- **wp.com platform asks for separated artifacts** as part of its own deployment evolution.
-- **Three or more sync conflicts in a single quarter** that require manual resolution beyond the standard `sync-bundled.sh` flow.
+1. **Public FOSSE distribution declares plugin dependencies.** FOSSE should eventually add `Requires Plugins: activitypub, atmosphere` and stop treating checked-in backend source as the public plugin source of truth.
 
-When a trigger fires, the next step is: re-evaluate this spec, confirm the chosen direction below still holds, expand `plan.md` with implementation tasks, and only then begin work.
+2. **FOSSE keeps defensive runtime checks.** WordPress dependency headers identify required slugs; they do not express minimum versions, required classes, constants, filters, or behavior. FOSSE still needs runtime readiness checks for ActivityPub and ATmosphere before enabling provider-specific features.
 
-## What to be aware of in the meantime
+3. **Tests run against standalone dependency fixtures.** PHPUnit, Jest where relevant, and e2e should exercise explicit standalone ActivityPub and ATmosphere installs rather than reaching into `bundled/` internals.
 
-These are constraints today's architectural decisions should respect even though we're not migrating:
+4. **wp.com Simple artifact ownership is a separate decision.** wp.com Simple can use native dependencies, a platform-assembled bundle, or a temporary continuation of vendoring. That decision should not force the public repository to carry checked-in backend source forever.
 
-1. **Don't add NEW load-bearing assumptions about `bundled/`.** Existing FOSSE code reads bundled AP/Atmosphere class names and constants (e.g. `ACTIVITYPUB_PLUGIN_DIR`, `\Activitypub\Activitypub`, `\Atmosphere\Publisher`). That's existing surface area. Don't grow it. Specifically:
+5. **Package-based assembly remains an alternative bridge.** The original bridge analysis is still valuable if reviewers decide a generated one-zip artifact is required for wp.com Simple, release engineering, or a transitional warning release.
+
+## Remaining Cautions
+
+The changed dependency facts make migration more plausible; they do not make it automatic.
+
+1. **Existing bundled-only installs need an upgrade path.** Sites currently relying on FOSSE's nested copies of ActivityPub and ATmosphere could lose backend functionality if `bundled/` disappears before the standalone plugins are installed and active.
+
+2. **One-step cutover versus warning release needs review.** Reviewers should decide whether to ship a transitional release that warns about upcoming required plugins before removing checked-in backend source.
+
+3. **Minimum compatible versions need to be chosen.** ActivityPub and ATmosphere may publish stable zips, but FOSSE must still define the minimum version or symbol set required for current integration points.
+
+4. **Dependency UX still matters.** WordPress core can show dependency relationships, but FOSSE's setup/status surfaces should remain clear when a dependency is absent, inactive, too old, or missing a required API.
+
+5. **wp.com Simple rollout needs an owner.** The current platform deployment workflow is built around a single vendored artifact at `wp-content/plugins/fosse/<version>/`. Any divergence from the public plugin zip needs explicit platform ownership, test coverage, and rollback behavior.
+
+## What to be aware of during planning
+
+These are constraints today's architectural decisions should respect until implementation starts:
+
+1. **Don't add NEW load-bearing assumptions about `bundled/`.** Existing FOSSE code reads bundled AP/ATmosphere class names and constants (e.g. `ACTIVITYPUB_PLUGIN_DIR`, `\Activitypub\Activitypub`, `\Atmosphere\Publisher`). That's existing surface area. Don't grow it. Specifically:
    - Don't add `require_once bundled/...` calls outside `fosse.php`'s existing bootstrap.
    - Don't add filters/hooks whose contracts depend on bundled code being at a specific filesystem path.
    - Don't add tests that reach into `bundled/` directly.
 
-2. **Treat `bundled/` as read-only.** Already enforced by policy. `tools/sync-bundled.sh` is the only legitimate writer.
+2. **Treat `bundled/` as read-only.** Already enforced by policy. `tools/sync-bundled.sh` is the only legitimate writer until removal is approved.
 
-3. **Land protocol-agnostic functionality upstream first.** This is the existing "upstream-first" policy; migration just makes it more important. Anything that's a candidate for "should be in AP / Atmosphere" should land there before the bundled copy gets it via sync. Reduces the migration delta when the time comes.
+3. **Land protocol-agnostic functionality upstream first.** This is the existing upstream-first policy; migration just makes it more important. Anything that's a candidate for "should be in AP / ATmosphere" should land there before the bundled copy gets it via sync.
 
-4. **Document the load contract at every coupling point.** The wp.com Simple load-order contract (`fosse.php:25-38`) is a model. When FOSSE adds a new touchpoint with bundled code, document the contract in-line so the migration team (probably future-us) can find the contracts to redesign.
+4. **Document the load contract at every coupling point.** The wp.com Simple load-order contract comment near the top of `fosse.php` is a model. When FOSSE adds a new touchpoint with bundled code, document the contract in-line so the migration team can find the contracts to redesign.
 
-5. **Keep `bin/build-zip.sh` validation strict.** The existing "fail if `bundled/vendor/autoload.php` missing" check (`bin/build-zip.sh:73-83`) is exactly the kind of guard that protects the bundled artifact from silent breakage. Add similar guards for any new bundled file that load-bearing code depends on.
+5. **Keep `bin/build-zip.sh` validation strict.** The bundled `vendor/autoload.php` existence check in `bin/build-zip.sh` protects the bundled artifact from silent breakage. Add similar guards for any new bundled file that load-bearing code depends on.
 
-## Chosen direction (when implementation begins)
+## Proposed direction (pending review)
 
-Two-phase migration:
+The proposed public distribution path is Option A in the analysis below: WordPress-native dependency declarations.
 
-1. **Bridge phase**: keep checked-in `bundled/` artifacts, but harden policy and add a packaging proof. Build a CI job that assembles an equivalent FOSSE zip from versioned package inputs (Composer VCS, GitHub release zips, or Automattic package registry — whichever is most stable at the time) without relying on `bundled/` source. Compare the assembled artifact byte-for-byte (or structurally) with the current bundled output.
+```text
+Requires Plugins: activitypub, atmosphere
+```
 
-2. **Migration phase**: once the packaging proof + dependency UX + wp.com Simple platform path are all proven, move backend source out of the FOSSE repo. FOSSE becomes UI/orchestration; ActivityPub and Atmosphere become external dependencies. The standalone artifact (if still desired) is built from package inputs at release time, not from checked-in source.
+The implementation path should be:
 
-The bridge phase has an explicit expiration gate: once package-based artifact assembly is green in CI, new feature work must not extend `bundled/` except through upstream syncs needed to reach migration cutover.
+1. **Review and decision phase**: confirm the public dependency strategy, the minimum backend compatibility requirements, the existing-install upgrade path, and the wp.com Simple artifact owner.
 
-## Options analysis (for future reference)
+2. **Transitional readiness phase**: add runtime checks and admin/status UX for missing, inactive, or incompatible standalone backends while `bundled/` is still present.
 
-The four candidate distribution models, evaluated when this SDD was originally drafted. Preserved here so the migration team has the prior reasoning when they pick this up.
+3. **Migration phase**: add the dependency header, update tests and e2e fixtures to use standalone plugins, and remove checked-in backend source only after the upgrade path is proven.
 
-### Option A: Composer VCS dependencies or package registry
+The original package-artifact bridge should remain available as a wp.com-specific or release-engineering alternative, not the default public plugin strategy.
 
-Recommended as the near-term packaging proof and transition path. Prefer a package registry once upstream release automation exists; use VCS only while releases are still moving quickly.
+## Options analysis
 
-**Pros**: reproducible version pinning via lockfile; removes manual sync as source of truth; clean audit trail; CI-friendly; supports private/pre-release Atmosphere builds.
-**Cons**: WP plugin users don't run Composer; resulting zip may still embed backend source (build-time vendoring instead of checked-in vendoring); VCS deps slower than registry.
+The candidate distribution models, updated after the 2026-05 refresh. The original package-based reasoning is preserved here so reviewers can still choose it deliberately if needed.
 
-### Option B: Split FOSSE UI from backend plugins
+### Option A: Native WordPress plugin dependencies
 
-Recommended long-term architecture. Do not switch until dependency UX and platform artifact assembly are proven.
+Recommended as the public distribution target.
+
+**Pros**: uses WordPress core's dependency mechanism; makes ActivityPub and ATmosphere visible as standalone plugins; avoids hidden copies; aligns with upstream-first; keeps public source ownership clean; works across FOSSE's WordPress >=6.9 support range.
+**Cons**: dependency headers do not encode minimum versions or symbol requirements; existing bundled-only installs need an upgrade path; one-click install behavior depends on WordPress dependency UX; wp.com Simple still needs a platform answer.
+
+### Option B: Composer VCS dependencies or package registry
+
+Useful as a packaging proof or wp.com bridge, not the preferred public plugin strategy.
+
+**Pros**: reproducible version pinning via lockfile; removes manual sync as source of truth; clean audit trail; CI-friendly; supports private/pre-release ATmosphere builds.
+**Cons**: WP plugin users don't run Composer; resulting zip may still embed backend source at build time; VCS deps are slower than registry; does not use the public WordPress.org dependency relationship users already understand.
+
+### Option C: Split FOSSE UI from backend plugins
+
+Recommended long-term architecture. Native plugin dependencies are the practical public path to this split.
 
 **Pros**: clean ownership boundary; backend plugins update independently; no hidden copies; aligns with upstream-first; explicit dependency state in wp-admin; removes class-collision and activation-hook gaps from programmatic nested loading.
-**Cons**: standalone install no longer one zip unless all plugins assembled; requires dependency UX work; WP plugin dependency tooling helps but UX still needs design; wp.com Simple needs platform deployment answer.
+**Cons**: standalone install no longer behaves as a single self-contained zip; dependency UX still needs design; wp.com Simple needs a platform deployment answer.
 
-### Option C: wp.com-specific artifact strategy
+### Option D: wp.com-specific artifact strategy
 
-Recommended as part of the transition. wp.com Simple can keep artifact vendoring longer than the public repo if needed, but it should become platform packaging, not checked-in FOSSE source.
+Recommended as a separate coordination item. wp.com Simple can keep artifact vendoring longer than the public repo if needed, but it should become platform packaging, not checked-in FOSSE source.
 
 **Pros**: matches wp.com's platform control over plugin deployment; avoids forcing wp.com constraints into open-source repo; preserves one-step rollout while public source moves; allows platform-specific pinning, staged rollout, rollback.
 **Cons**: two distribution paths to test separately; wp.com artifact behavior could diverge from public zip; requires clear ownership of artifact assembly outside FOSSE source tree.
 
-### Option D: Continued vendoring with stricter policy
+### Option E: Continued checked-in vendoring
 
-**This is the current production choice.** Accept as a long bridge while migration triggers haven't fired. Not recommended as the eventual long-term architecture, but the right choice today given the deferral rationale above.
+Accept only as the current production state while the reviewed migration path is not approved.
 
 **Pros**: lowest immediate risk; preserves current standalone zip + wp.com Simple behavior; easy to understand; current guardrails (no hand edits, sync-only refresh) work.
-**Cons**: still makes FOSSE carry other plugins' source; risks the temporary approach becoming permanent (already happened); creates large vendored diffs; doesn't solve dependency ownership.
+**Cons**: makes FOSSE carry other plugins' source; creates large vendored diffs; hides dependency ownership; keeps accumulating migration debt now that public dependency channels exist.
 
-## Target architecture (when implementation begins)
+## Target architecture (after migration)
 
 ```
 Development source:
 
 Automattic/fosse
-  |-- fosse.php
+  |-- fosse.php                  # Declares Requires Plugins once migration ships
   |-- src/                       # FOSSE UI/orchestration
   |-- composer.json              # FOSSE runtime deps
-  `-- packaging config           # backend version pins, not backend source
+  `-- dependency checks/tests    # Version/API readiness, not backend source
 
 Automattic/wordpress-activitypub
-  `-- independent plugin release
+  `-- independent WordPress.org plugin release
 
 Automattic/wordpress-atmosphere
-  `-- independent plugin release
+  `-- independent WordPress.org plugin release
 ```
 
 Distribution artifacts at the migration target:
 
 ```
-Public standalone artifact (final):
+Public WordPress.org plugin:
   fosse/
-    fosse.php
+    fosse.php                    # Requires Plugins: activitypub, atmosphere
     src/
     vendor/
-  plus explicit dependency UX for ActivityPub + Atmosphere
+  plus FOSSE runtime checks and setup/status UX for dependency readiness
 
 wp.com Simple artifact:
-  platform-controlled bundle of FOSSE + backend plugins
-  with pinned backend versions and rollout/rollback controls
+  one of:
+    - platform-installed plugin dependencies
+    - platform-controlled bundle of FOSSE + backend plugins
+    - temporary continuation of vendoring with an explicit removal date
 ```
 
-## Migration principles (when implementation begins)
+## Migration principles
 
-- **Source ownership stays upstream.** If a change is useful outside FOSSE, land it in ActivityPub or Atmosphere first.
+- **Source ownership stays upstream.** If a change is useful outside FOSSE, land it in ActivityPub or ATmosphere first.
 - **FOSSE owns projection and product policy.** FOSSE-specific option defaults, unified UI, and cross-network coordination stay in FOSSE.
-- **Build artifacts may contain dependencies; source should not.** Temporary artifact vendoring is acceptable. Long-term checked-in backend source is not.
-- **Dependency state must be visible.** Users and operators should be able to tell whether ActivityPub and Atmosphere are installed, active, bundled, or missing.
-- **Rollout should be reversible.** Do not delete `bundled/` until package-based artifact assembly and dependency UX both have tests.
+- **Public source should not carry backend source indefinitely.** Build or platform artifacts may temporarily contain dependencies, but checked-in backend source should have an approved removal path.
+- **Dependency state must be visible.** Users and operators should be able to tell whether ActivityPub and ATmosphere are installed, active, compatible, or missing.
+- **Rollout should be reversible.** Do not delete `bundled/` until dependency readiness, upgrade sequencing, and wp.com Simple behavior are all verified.
 
-## Required proofs before removing `bundled/` (when implementation begins)
+## Required proofs before removing `bundled/`
 
-1. **Packaging proof**: resolve AP and Atmosphere from versioned inputs; assemble an installable FOSSE artifact without relying on checked-in `bundled/`; verify the artifact includes whatever backend files the selected transition path requires; CI build job green.
-2. **Runtime proof**: install generated artifact in Playground; FOSSE admin loads without fatals; AP and Atmosphere provider availability reported correctly; standalone backend plugins don't class-collide with FOSSE.
-3. **Dependency UX proof**: missing AP shows clear action/state; missing Atmosphere shows clear action/state; installed-but-inactive distinguished from absent; FOSSE setup/status pages remain useful when one backend is unavailable.
-4. **wp.com Simple proof**: platform artifact or deployment path installs FOSSE plus required backend versions; load ordering still suppresses duplicate platform AP loads where required; rollback returns to previous known-good artifact.
+1. **Dependency declaration proof**: add `Requires Plugins: activitypub, atmosphere`; verify WordPress recognizes both slugs and surfaces the dependency relationship in supported versions.
+2. **Runtime proof**: install FOSSE with standalone ActivityPub and ATmosphere; FOSSE admin loads without fatals; provider availability is reported correctly; missing, inactive, and incompatible backends degrade cleanly.
+3. **Upgrade proof**: existing bundled-only installs receive either a transitional warning release or a one-step migration path that avoids silent loss of federation behavior.
+4. **Test fixture proof**: PHPUnit and e2e fixtures run against explicit standalone dependency installs and no tests reach into `bundled/` directly.
+5. **wp.com Simple proof**: platform artifact or deployment path installs FOSSE plus required backend versions; load ordering remains correct; rollback returns to the previous known-good artifact.
+6. **Bridge proof, if chosen**: resolve AP and ATmosphere from versioned inputs; assemble an installable artifact without relying on checked-in `bundled/`; verify the artifact includes whatever backend files the selected transition path requires.
 
-## Non-goals (now AND when implementation begins)
+## Non-goals (for this docs PR)
 
 - This SDD does not remove `bundled/`.
-- This SDD does not pick exact package names or registry infrastructure.
+- This SDD does not add the dependency header to `fosse.php`.
+- This SDD does not pick exact minimum backend versions.
 - This SDD does not redesign FOSSE onboarding or provider UI.
-- This SDD does not change upstream release policy for ActivityPub or Atmosphere.
+- This SDD does not change upstream release policy for ActivityPub or ATmosphere.
 
-## Open questions (for the future migration team)
+## Review questions
 
-- Should the first packaging proof use Composer VCS repositories, GitHub release zips, or an internal Automattic package registry?
-- Does the public FOSSE zip need to remain one-click with backend artifacts included after v1, or can it rely on WordPress plugin dependency installation UX?
-- Who owns wp.com Simple artifact assembly once it diverges from the public plugin zip?
-- What version pin format should be the source of truth during the bridge phase: Composer lock, package manifest, or a dedicated backend manifest?
-- What is the earliest release milestone where checked-in `bundled/` can be deleted without harming current rollout?
+- Do we ship one migration PR or a warning release first?
+- What ActivityPub minimum version should FOSSE require?
+- What ATmosphere minimum version or symbol set should FOSSE require?
+- Should wp.com Simple use plugin dependencies, a platform-assembled bundle, or a temporary continuation of vendoring?
+- Should CI fetch dependencies from WordPress.org zips, SVN tags, GitHub release artifacts, or local source overrides?
+- Does the public FOSSE zip need to remain one-click with backend artifacts included, or can it rely on WordPress dependency installation UX?


### PR DESCRIPTION
Draft status: Early unreviewed SDD draft for planning discussion. This is not ready to merge.

Related Linear epic: [DOTCOM-16826](https://linear.app/a8c/issue/DOTCOM-16826)

## Summary
- Adds requirements, spec, and implementation plan for migrating away from checked-in bundled backend source.
- Covers bridge policy, package-based artifact proof, dependency UX, wp.com Simple ownership, and removal follow-up gates.

## Notes
- Docs-only planning PR.
- Opened as a draft intentionally for early review.
- No auto-close keyword is used.