### PR TITLE
SDD: Usage metrics and adoption tracking

### DIFF
--- a/sdd/usage-metrics-adoption/plan.md
+++ b/sdd/usage-metrics-adoption/plan.md
@@ -1,0 +1,232 @@
+# Implementation Plan: Usage Metrics & Adoption Tracking
+
+Based on: [`requirements.md`](./requirements.md) and [`spec.md`](./spec.md)
+
+## Progress
+
+- [ ] Task 1: Add metrics recorder and normalization core
+- [ ] Task 2: Add privacy consent and disclosure surfaces
+- [ ] Task 3: Record site observation and onboarding funnel events
+- [ ] Task 4: Record Bluesky OAuth and connection-state events
+- [ ] Task 5: Coordinate upstream publish-result hooks
+- [ ] Task 6: Record publish attempts, results, and first-post milestones
+- [ ] Task 7: Record inbound interaction aggregate events
+- [ ] Task 8: Add sink adapters and test helpers
+- [ ] Task 9: Add dashboard/query documentation
+- [ ] Task 10: End-to-end verification and SDD closeout
+
+## Tasks
+
+### Task 1: Add metrics recorder and normalization core
+- **Status**: Not started
+- **Files**:
+  - Create: `src/Metrics/interface-sink.php`
+  - Create: `src/Metrics/class-null-sink.php`
+  - Create: `src/Metrics/class-recorder.php`
+  - Create: `src/Metrics/class-event-normalizer.php`
+  - Modify: `fosse.php`
+  - Test: `tests/php/Metrics/RecorderTest.php`
+  - Test: `tests/php/Metrics/Event_NormalizerTest.php`
+- **Do**:
+  1. Add `Automattic\Fosse\Metrics\Sink` with `record( string $event, array $properties ): void`.
+  2. Add `Null_Sink` as the default implementation.
+  3. Add `Recorder::record( string $event, array $properties = array() ): void`.
+  4. Add `Event_Normalizer` allowlists for v1 event names and properties from `spec.md`.
+  5. Strip forbidden keys: `post_id`, `comment_id`, `title`, `content`, `excerpt`, `permalink`, `url`, `did`, `handle`, `actor`, `author`, `raw_error`, `response`, `payload`.
+  6. Add duration buckets: `<1h`, `1-24h`, `1-7d`, `7-30d`, `>30d`, `unknown`.
+  7. Add error categories: `auth`, `configuration`, `validation`, `rate_limit`, `transport`, `remote_4xx`, `remote_5xx`, `partial_rollback`, `unknown`.
+  8. Register no global sink in `fosse.php`; only ensure classes load and later listeners can call `Recorder`.
+- **Verify**:
+  - `composer run-script test-php -- --filter 'Metrics\\\\(Recorder|Event_Normalizer)'` passes.
+  - `composer run-script lint-php` passes.
+- **Depends on**: none
+
+### Task 2: Add privacy consent and disclosure surfaces
+- **Status**: Not started
+- **Files**:
+  - Create: `src/Metrics/class-consent.php`
+  - Modify: `src/Admin/class-onboarding-wizard.php`
+  - Modify: `src/Admin/class-setup-page.php`
+  - Modify: `src/Admin/templates/setup-page.php`
+  - Modify: `src/Admin/assets/css/admin.css`
+  - Test: `tests/php/Metrics/ConsentTest.php`
+  - Test: `tests/php/Admin/Onboarding_WizardTest.php`
+  - Test: `tests/php/Admin/Setup_PageTest.php`
+  - Test: `tests/e2e/onboarding-wizard.spec.ts`
+- **Do**:
+  1. Add `Consent::is_enabled()` backed by `fosse_metrics_consent`, default `false`.
+  2. Add a FOSSE-core force-disable filter, such as `fosse_metrics_disabled`, so hosts can prevent telemetry even when the option is enabled. Do not add a force-enable path in FOSSE core; wp.com can register its own first-party sink outside this repository under platform privacy rules.
+  3. Add a standalone-only disclosure checkbox to the wizard completion step.
+  4. Add a persistent Setup page checkbox for aggregate usage metrics.
+  5. Hide or replace the standalone consent UI when a host filter marks the environment as `wpcom`.
+  6. Disclosure copy: "Send aggregate usage metrics to help improve FOSSE. FOSSE does not send post content, profile handles, DIDs, URLs, or raw federation payloads."
+- **Verify**:
+  - Unit tests cover default disabled, enabled option, and host-forced disabled states.
+  - Wizard and Setup tests cover saving the option.
+  - `pnpm exec playwright test tests/e2e/onboarding-wizard.spec.ts` verifies the checkbox is visible on standalone and can be saved.
+  - `composer run-script lint-php`, `composer run-script test-php`, `pnpm run format:check`, and `pnpm run lint` pass.
+- **Depends on**: Task 1
+
+### Task 3: Record site observation and onboarding funnel events
+- **Status**: Not started
+- **Files**:
+  - Create: `src/Metrics/class-lifecycle-listener.php`
+  - Modify: `fosse.php`
+  - Modify: `src/Admin/class-onboarding-wizard.php`
+  - Test: `tests/php/Metrics/Lifecycle_ListenerTest.php`
+  - Test: `tests/php/Admin/Onboarding_WizardTest.php`
+- **Do**:
+  1. Register `Lifecycle_Listener::register()` from `fosse.php`.
+  2. Emit `fosse_site_observed` at most once daily per site using `fosse_metrics_last_observed_at`.
+  3. Include `fosse_version`, `wp_version`, `php_version`, `environment`, `ap_backend_source`, `atmo_backend_source`, `ap_available`, and `bluesky_available`.
+  4. Derive backend source from FOSSE bootstrap booleans and standalone sentinel checks.
+  5. Emit `fosse_onboarding_completed` from wizard complete and skip handlers with `completion_type`.
+  6. Persist first-observed timestamp in `fosse_metrics_first_observed_at` with autoload `false`.
+- **Verify**:
+  - Tests assert daily sampling, first-observed persistence, bundled-vs-standalone source values, complete-vs-skip events, and no forbidden fields.
+  - `composer run-script test-php -- --filter 'Metrics\\\\Lifecycle_Listener|Onboarding_Wizard'` passes.
+  - `composer run-script lint-php` passes.
+- **Depends on**: Task 1
+
+### Task 4: Record Bluesky OAuth and connection-state events
+- **Status**: Not started
+- **Files**:
+  - Create: `src/Metrics/class-connection-listener.php`
+  - Modify: `fosse.php`
+  - Modify: `src/Admin/class-bluesky-provider.php`
+  - Test: `tests/php/Metrics/Connection_ListenerTest.php`
+  - Test: `tests/php/Admin/Bluesky_ProviderTest.php`
+- **Do**:
+  1. Emit `fosse_bluesky_oauth_started` after `Bluesky_Provider::handle_connect()` passes nonce/capability and before redirecting to the auth server.
+  2. Emit `fosse_bluesky_oauth_completed` from `handle_oauth_callback()` for success, warning, and failure branches.
+  3. Emit `fosse_connection_state_changed` when Bluesky connects or disconnects.
+  4. Treat ActivityPub as connected when `AP_Provider::is_available()` is true.
+  5. Include `origin` (`setup`, `wizard`, `unknown`) and `both_networks_ready`.
+  6. Do not send the submitted handle, stored DID, PDS endpoint, or token error text.
+- **Verify**:
+  - Tests assert event presence and sanitized properties for OAuth start, callback success, callback failure, disconnect, and both-networks-ready state.
+  - `composer run-script test-php -- --filter 'Metrics\\\\Connection_Listener|Bluesky_Provider'` passes.
+  - `composer run-script lint-php` passes.
+- **Depends on**: Task 1
+
+### Task 5: Coordinate upstream publish-result hooks
+- **Status**: Not started
+- **Files**:
+  - Upstream modify: `Automattic/wordpress-atmosphere/includes/class-publisher.php`
+  - Upstream test: `Automattic/wordpress-atmosphere/tests/phpunit/tests/class-test-publisher.php`
+  - Upstream modify if needed: `Automattic/wordpress-activitypub/includes/class-dispatcher.php`
+  - Upstream test if needed: `Automattic/wordpress-activitypub/tests/test-class-dispatcher.php`
+  - FOSSE refresh via sync after merge: `bundled/atmosphere/**`
+  - FOSSE refresh via sync after merge if needed: `bundled/activitypub/**`
+- **Do**:
+  1. Open an Atmosphere PR adding `atmosphere_publish_attempt` and `atmosphere_publish_result` around `Publisher::publish_post()`, `update_post()`, `delete_post()`, `publish_comment()`, `update_comment()`, and `delete_comment()`.
+  2. Include operation, object type (`post` or `comment`), short/long classification, long-form strategy, record count, result state, and `WP_Error` object for local categorization.
+  3. Confirm ActivityPub's existing `post_activitypub_add_to_outbox`, `activitypub_add_to_outbox_failed`, and `activitypub_sent_to_inbox` hooks are sufficient. If not, add one focused upstream hook in `includes/class-dispatcher.php`.
+  4. After upstream merges, refresh bundles with `./tools/sync-bundled.sh`.
+- **Verify**:
+  - Upstream unit tests prove hooks fire on success and failure without exposing payload content.
+  - FOSSE bundle refresh contains the merged hook changes.
+  - `composer run-script lint-php` passes after bundle refresh.
+- **Depends on**: Task 1
+
+### Task 6: Record publish attempts, results, and first-post milestones
+- **Status**: Not started
+- **Files**:
+  - Create: `src/Metrics/class-publish-listener.php`
+  - Modify: `fosse.php`
+  - Test: `tests/php/Metrics/Publish_ListenerTest.php`
+  - Test: `tests/e2e/short-form-facets.spec.ts`
+  - Test: `tests/e2e/long-form-link-card.spec.ts`
+  - Test: `tests/e2e/mu-plugins/fosse-bsky-capture.php`
+- **Do**:
+  1. Hook ActivityPub and Atmosphere publish attempt/result actions.
+  2. Emit `fosse_publish_attempt` and `fosse_publish_result`.
+  3. Classify `network` as `activitypub` or `bluesky`.
+  4. Classify `post_shape` as `short-form`, `long-form`, `reply`, or `unknown`.
+  5. Include `object_type_mode` from `fosse_object_type` and `long_form_strategy` from `fosse_long_form_strategy`.
+  6. Emit `fosse_first_post_funnel` for first eligible post, first publish attempt, and first success. Store milestone timestamps in a single `fosse_metrics_funnel` option with autoload `false`.
+  7. Map all `WP_Error` and HTTP failures to normalized `error_category` values.
+- **Verify**:
+  - Unit tests cover successful AP outbox, failed AP outbox, successful Atmosphere publish, Atmosphere `WP_Error`, short/long classification, and first-milestone idempotency.
+  - E2E fixtures can inject a test sink and assert short-form/long-form publish events without contacting real networks.
+  - `composer run-script test-php -- --filter 'Metrics\\\\Publish_Listener'` passes.
+  - `pnpm exec playwright test tests/e2e/short-form-facets.spec.ts tests/e2e/long-form-link-card.spec.ts` passes.
+- **Depends on**: Task 5
+
+### Task 7: Record inbound interaction aggregate events
+- **Status**: Not started
+- **Files**:
+  - Create: `src/Metrics/class-interaction-listener.php`
+  - Modify: `fosse.php`
+  - Test: `tests/php/Metrics/Interaction_ListenerTest.php`
+  - Test: `tests/e2e/reactions-display.spec.ts`
+- **Do**:
+  1. Hook ActivityPub handled interaction actions: `activitypub_handled_create`, `activitypub_handled_like`, and `activitypub_handled_announce`.
+  2. Hook ActivityPub follow handling separately through `activitypub_handled_follow`.
+  3. Hook Atmosphere's `atmosphere_reaction_synced`.
+  4. Emit `fosse_inbound_interaction_synced` for replies/comments, likes, and reposts with `source_network`, `interaction_type`, `post_shape`, and `local_comment_type`.
+  5. Emit `fosse_follow_synced` for follows with `source_network`, `result`, and `backend_source`.
+  6. Skip failed inbound handlers where the upstream hook reports failure.
+  7. Do not send comment IDs, author names, handles, URLs, DIDs, or content.
+- **Verify**:
+  - Unit tests cover ActivityPub reply/like/announce, ActivityPub follow, and Atmosphere comment/like/repost.
+  - Tests assert forbidden fields are stripped even if accidentally passed.
+  - `composer run-script test-php -- --filter 'Metrics\\\\Interaction_Listener'` passes.
+  - `pnpm exec playwright test tests/e2e/reactions-display.spec.ts` passes.
+- **Depends on**: Task 1
+
+### Task 8: Add sink adapters and test helpers
+- **Status**: Not started
+- **Files**:
+  - Create: `src/Metrics/class-memory-sink.php`
+  - Create: `src/Metrics/class-self-host-aggregate-sink.php`
+  - Test: `tests/php/Metrics/Memory_SinkTest.php`
+  - Test: `tests/php/Metrics/Self_Host_Aggregate_SinkTest.php`
+  - Modify: `tests/php/bootstrap.php`
+- **Do**:
+  1. Add `Memory_Sink` for unit/e2e injection.
+  2. Add `Self_Host_Aggregate_Sink`, gated by `Consent::is_enabled()`.
+  3. Send only aggregate event payloads to a filterable endpoint, defaulting to disabled unless an endpoint is explicitly configured by host code.
+  4. Add `fosse_metrics_endpoint` filter for hosts that want to operate a standalone aggregate endpoint.
+  5. In tests, expose helper methods to reset and inspect captured events.
+- **Verify**:
+  - Tests assert self-host sink sends nothing when consent is disabled or endpoint is empty.
+  - Tests assert payloads contain no forbidden keys.
+  - `composer run-script test-php -- --filter 'Metrics\\\\(Memory_Sink|Self_Host_Aggregate_Sink)'` passes.
+  - `composer run-script lint-php` passes.
+- **Depends on**: Task 2
+
+### Task 9: Add dashboard/query documentation
+- **Status**: Not started
+- **Files**:
+  - Create: `sdd/usage-metrics-adoption/dashboard.md`
+  - Modify: `sdd/usage-metrics-adoption/spec.md`
+  - Modify: `sdd/usage-metrics-adoption/requirements.md`
+- **Do**:
+  1. Document canonical funnel definitions.
+  2. Document required dashboard slices: version, environment, backend source, network, post shape, long-form strategy, object type mode, error category.
+  3. Add wp.com Tracks event mapping in a clearly marked wp.com-only section.
+  4. Add standalone self-host reporting caveats: WP.org active installs estimate distinct installs; opt-in aggregate events estimate behavior among participating installs only.
+- **Verify**:
+  - Docs define every event in `spec.md`.
+  - Docs do not require Automattic-only infrastructure for self-hosted installs.
+  - Markdown links resolve locally.
+- **Depends on**: Task 8
+
+### Task 10: End-to-end verification and SDD closeout
+- **Status**: Not started
+- **Files**:
+  - Modify: `sdd/usage-metrics-adoption/requirements.md`
+  - Modify: `sdd/usage-metrics-adoption/spec.md`
+  - Modify: `sdd/usage-metrics-adoption/plan.md`
+  - Create: `sdd/usage-metrics-adoption/implementation-notes.md`
+- **Do**:
+  1. Run the local verification suite: `composer run-script lint-php`, `composer run-script test-php`, `pnpm run format:check`, `pnpm run lint`, and the touched Playwright specs.
+  2. Update task statuses with PR refs after each implementation PR lands.
+  3. Capture deviations, privacy decisions, and upstream hook decisions in `implementation-notes.md`.
+  4. Confirm no event payload includes content, DIDs, handles, URLs, raw errors, or raw federation payloads.
+- **Verify**:
+  - Verification commands pass.
+  - SDD status fields match the top Progress checklist.
+  - Implementation notes include final self-host consent posture and upstream PR links.
+- **Depends on**: Tasks 1-9

--- a/sdd/usage-metrics-adoption/requirements.md
+++ b/sdd/usage-metrics-adoption/requirements.md
@@ -1,0 +1,69 @@
+# Requirements: Usage Metrics & Adoption Tracking
+
+Linear: [DOTCOM-16879](https://linear.app/a8c/issue/DOTCOM-16879)
+
+## Goal
+
+Know whether FOSSE is working with privacy-respecting adoption and success metrics. Without a shared measurement layer, every discussion about success is anecdotal: we can say a feature shipped, but not whether sites adopt it, publish through it, receive reactions, or get stuck at a specific setup step.
+
+## Existing Material
+
+A prior docs-only commit added `sdd/fosse-metrics-strategy/spec.md` under the title "FOSSE Metrics - measuring whether regular people use it". That file is not present in the current tree, but git history contains it in commit `d7d3a0a`. This SDD keeps the useful strategic framing from that document:
+
+- WordPress.com Simple is the strongest leading-indicator population for "regular people use it".
+- Self-hosted plugin metrics are important, but should not be treated as equivalent evidence to a managed wp.com rollout.
+- The early signal is a funnel; the durable signal is sustained publishing and inbound engagement over time.
+- Search-indexed/public wp.com sites may be a natural rollout gate, but that belongs to the wp.com integration plan, not the self-hosted plugin contract.
+
+This SDD narrows the implementation strategy so FOSSE core does not require Automattic-only infrastructure.
+
+## Functional Requirements
+
+1. **Adoption by environment and backend source.** Report onboarded sites by FOSSE version, WordPress environment, network availability, and whether ActivityPub / Atmosphere came from FOSSE's bundled copy or a standalone plugin.
+2. **Connection funnel.** Measure completion of key setup states: wizard completed, Bluesky OAuth started, Bluesky OAuth completed, first network connected, both networks available/connected, first publishable post created, first successful federated post, and time-to-first-post.
+3. **Publishing activity.** Count posts published per network, split by short-form vs long-form, ActivityPub object type mode, long-form strategy, and backend source.
+4. **Federation reliability.** Count publish attempts, successes, partial successes, retries, and failures by network and normalized error category.
+5. **Inbound interaction activity.** Count inbound replies/comments, likes, and reposts/announces by source network and local post shape. Count follows separately by source network because they are not tied to a local post shape. Do not store remote handles, DIDs, content, URLs, or raw activity payloads in metrics events.
+6. **Queryable dashboards.** Define event names, dimensions, and dashboard-ready derived metrics so product, engineering, and data teams can answer the same questions without ad hoc log spelunking.
+7. **Upstream coordination.** If instrumentation describes generic ActivityPub or Atmosphere publish/reaction behavior, add hooks upstream and consume them from FOSSE. FOSSE-specific funnel and cross-network classifications stay in FOSSE.
+
+## Privacy Requirements
+
+- Metrics events MUST NOT include post content, post titles, excerpts, remote actor DIDs, handles, profile URLs, raw inbox activities, raw PDS responses, or raw error messages.
+- Event properties should be low-cardinality enums, booleans, counts, durations, version strings, and coarse environment labels.
+- WordPress.com may use its existing first-party analytics pipeline and site identifiers under the wp.com privacy model. This must be documented as a wp.com adapter, not as a hard dependency for FOSSE core.
+- Self-hosted FOSSE must default to no external telemetry in v1. If standalone telemetry ships, it must be explicitly disclosed in onboarding/settings and require an opt-in before sending aggregate events.
+- Aggregate self-host events may include a generated install bucket only if product/legal approve the privacy tradeoff. The recommended v1 is no stable standalone site identifier; use WP.org active installs and GitHub download counts for distinct-install estimates.
+- Metrics collection must degrade to a no-op when no sink is registered.
+
+## Minimal V1 Questions
+
+The v1 event set must answer:
+
+- How many sites have FOSSE active, and on which FOSSE versions?
+- How many sites run bundled backends versus standalone ActivityPub / Atmosphere?
+- How many sites complete onboarding?
+- How many complete Bluesky OAuth?
+- How many have ActivityPub available and Bluesky connected at the same time?
+- How long does it take from activation/onboarding to first federated post?
+- How many publish attempts happen per network?
+- Which publish attempts succeed or fail, and why at a normalized category level?
+- Are posts being sent as short-form or long-form, and which FOSSE projector setting drove that shape?
+- Are inbound interactions arriving, and from which network?
+
+## Non-Goals
+
+- No content analytics, sentiment analysis, recommendation ranking, or per-post performance leaderboard.
+- No user-facing dashboard in v1 beyond disclosure/consent. Internal queryability is enough.
+- No hand edits inside `bundled/`. Upstream hook changes land in `wordpress-activitypub` or `wordpress-atmosphere`, then FOSSE refreshes bundles.
+- No attempt to prove causality for wp.com Simple adoption inside this plugin SDD. Cohort analysis belongs to the wp.com data/dashboard layer.
+
+## Open Questions
+
+- Should wp.com Simple use an opt-out disclosure tied to existing Tracks/privacy notices, or an explicit FOSSE-specific disclosure?
+- Does Automattic want standalone self-hosted telemetry to remain opt-in permanently, or move to opt-out once the payload is externally reviewed?
+- Should the self-hosted aggregate endpoint live in Automattic infrastructure, WordPress.org infrastructure, or remain unimplemented until there is a clear consumer?
+- Who owns the canonical dashboards and SQL/query definitions?
+- Should bundled-vs-standalone reporting be based only on FOSSE's bootstrap booleans, or also record detected standalone versions?
+- Which generic publish/reaction hooks should land upstream before FOSSE records reliability metrics?
+- What volume target makes the v1 funnel actionable for DOTCOM-16879?

--- a/sdd/usage-metrics-adoption/spec.md
+++ b/sdd/usage-metrics-adoption/spec.md
@@ -1,0 +1,162 @@
+# Spec: Usage Metrics & Adoption Tracking
+
+## Goal
+
+Give FOSSE a privacy-respecting measurement layer that can answer whether sites adopt the product, complete setup, publish successfully to ActivityPub and Bluesky, and receive inbound interactions. FOSSE core owns event taxonomy and instrumentation points; each host decides where compliant aggregate events are sent.
+
+Full requirements at [`requirements.md`](./requirements.md).
+
+## Recommendation
+
+Use a **sink-based metrics recorder** in FOSSE core:
+
+1. FOSSE emits normalized, low-cardinality events through a local recorder.
+2. The default sink is no-op.
+3. WordPress.com registers a Tracks sink in its integration layer.
+4. Self-hosted installs stay no-op unless the site owner opts into aggregate telemetry.
+
+This separates the product question from the infrastructure question. The event taxonomy is shared, but the transport differs:
+
+- **wp.com**: first-party Tracks adapter, governed by existing wp.com privacy/disclosure rules and queryable through internal dashboards.
+- **self-hosted**: no external telemetry by default; optional aggregate sink only after explicit disclosure and consent.
+- **tests/local**: in-memory sink for assertions; no network.
+
+## Privacy Posture
+
+Recommended v1 posture:
+
+- **Aggregate by default, no content identifiers.** Events may include `network`, `backend_source`, `result`, `error_category`, `post_shape`, `object_type_mode`, `long_form_strategy`, `fosse_version`, and coarse environment labels. They must not include post IDs in external sinks, titles, content, permalinks, DIDs, handles, raw URLs, raw errors, or raw remote payloads.
+- **Differentiate wp.com from standalone.** wp.com can use site/user identifiers already covered by wp.com analytics policy, but dashboard outputs for this SDD should be aggregate funnels and cohorts. FOSSE core must not require Tracks.
+- **Self-hosted opt-in.** The standalone plugin should not send external telemetry until the site owner enables it. The disclosure belongs in the first-run wizard and Setup page, with a FOSSE-core filter for hosts to force-disable telemetry. FOSSE core does not provide a force-enable path for standalone installs.
+- **Normalize before sending.** Error messages and remote responses are mapped locally into enums like `auth`, `configuration`, `validation`, `rate_limit`, `transport`, `remote_4xx`, `remote_5xx`, `partial_rollback`, and `unknown`.
+
+## Minimal V1 Event Set
+
+Event names use the `fosse_` prefix and intentionally avoid IDs:
+
+| Event | When | Required Properties |
+|---|---|---|
+| `fosse_site_observed` | FOSSE boots, sampled at most daily per site for enabled sinks | `fosse_version`, `wp_version`, `php_version`, `environment`, `ap_backend_source`, `atmo_backend_source`, `ap_available`, `bluesky_available` |
+| `fosse_onboarding_completed` | Wizard completion or skip | `completion_type`, `ap_available`, `bluesky_connected`, `both_networks_ready`, `elapsed_bucket` |
+| `fosse_bluesky_oauth_started` | Bluesky connect form passes nonce/capability and redirects to auth | `origin`, `handle_supplied`, `atmo_backend_source` |
+| `fosse_bluesky_oauth_completed` | OAuth callback returns to FOSSE | `result`, `error_category`, `origin`, `elapsed_bucket` |
+| `fosse_connection_state_changed` | Provider state changes materially | `network`, `connected`, `backend_source`, `both_networks_ready` |
+| `fosse_first_post_funnel` | First eligible post, first attempted federation, first success | `milestone`, `network`, `post_shape`, `elapsed_bucket` |
+| `fosse_publish_attempt` | Outbound publish/update/delete attempt starts | `network`, `operation`, `post_shape`, `post_type_public`, `object_type_mode`, `long_form_strategy`, `backend_source` |
+| `fosse_publish_result` | Outbound attempt ends | all attempt fields plus `result`, `error_category`, `record_count_bucket`, `retry_count_bucket` |
+| `fosse_inbound_interaction_synced` | Remote interaction is stored as a local comment/reaction | `source_network`, `interaction_type`, `post_shape`, `local_comment_type` |
+| `fosse_follow_synced` | Remote follow is accepted or stored by an inbound backend | `source_network`, `result`, `backend_source` |
+
+## Derived Metrics
+
+Dashboards should compute:
+
+- **Onboarded sites** by FOSSE version, environment, backend source, and network readiness.
+- **Adoption funnel**: observed site -> onboarding complete -> Bluesky OAuth complete -> both networks ready -> first publish attempt -> first publish success.
+- **Time-to-first-post** from activation or first observation to first successful federated post, bucketed to `<1h`, `1-24h`, `1-7d`, `7-30d`, `>30d`.
+- **Publishing volume** by network, short vs long, object type mode, and long-form strategy.
+- **Federation success rate** by network, operation, backend source, and error category.
+- **Inbound interaction volume** by network and interaction type.
+- **Bundled-vs-standalone health**: publish success and OAuth completion rates split by backend source.
+
+## Technical Design
+
+### FOSSE Core
+
+Add a metrics namespace under `src/Metrics/`:
+
+| File | Responsibility |
+|---|---|
+| `src/Metrics/interface-sink.php` | Defines `record( string $event, array $properties ): void`. |
+| `src/Metrics/class-null-sink.php` | Default sink; drops events. |
+| `src/Metrics/class-recorder.php` | Public facade. Normalizes event names/properties, strips forbidden fields, applies `fosse_metrics_sink`, and records. |
+| `src/Metrics/class-event-normalizer.php` | Low-cardinality allowlists, duration buckets, backend source detection, error categorization. |
+| `src/Metrics/class-lifecycle-listener.php` | Daily site observation and activation/onboarding milestones. |
+| `src/Metrics/class-connection-listener.php` | Bluesky OAuth and provider connection-state events. |
+| `src/Metrics/class-publish-listener.php` | Publish attempt/result classification and first-post milestones. |
+| `src/Metrics/class-interaction-listener.php` | Inbound interaction counters from ActivityPub and Atmosphere hooks. |
+| `src/Metrics/class-consent.php` | Self-host telemetry consent option, host override filter, disclosure state. |
+
+`fosse.php` registers the listeners when the classes exist, matching the existing degradation pattern for projectors and admin providers.
+
+### Sink Registration
+
+FOSSE core exposes:
+
+```php
+apply_filters( 'fosse_metrics_sink', new Null_Sink() );
+do_action( 'fosse_metric_recorded', $event, $properties );
+```
+
+wp.com can register a Tracks-backed sink outside this repo. A standalone aggregate sink can be added later behind `Consent::is_enabled()`. Tests can inject an in-memory sink.
+
+### Backend Source Detection
+
+FOSSE already computes `$fosse_loaded_bundled_ap` and `$fosse_loaded_bundled_atmo` in `fosse.php`. Persist those request-local facts into the site-observation event as:
+
+- `ap_backend_source`: `bundled`, `standalone`, or `unavailable`
+- `atmo_backend_source`: `bundled`, `standalone`, or `unavailable`
+
+Do not infer source from class names alone; standalone plugins can define the same classes and constants.
+
+### Publish Instrumentation
+
+FOSSE can classify post shape locally through existing projectors:
+
+- `src/class-object-type.php` for `object_type_mode`
+- `src/class-long-form-strategy.php` for `long_form_strategy`
+- Atmosphere's `is_short_form_post()` / `build_long_form_records()` result, once exposed through upstream hooks, for actual `post_shape`
+
+ActivityPub already has useful hooks:
+
+- `post_activitypub_add_to_outbox`
+- `activitypub_add_to_outbox_failed`
+- `activitypub_sent_to_inbox`
+
+Atmosphere needs upstream hooks in `Automattic/wordpress-atmosphere` because publish result and error category live inside `includes/class-publisher.php`. Add hooks there instead of parsing post meta from FOSSE.
+
+Recommended upstream Atmosphere hook:
+
+```php
+do_action(
+	'atmosphere_publish_result',
+	$object,
+	$operation,
+	$result,
+	array(
+		'record_count' => $record_count,
+		'strategy'     => $strategy,
+		'is_short'     => $is_short,
+	)
+);
+```
+
+### Inbound Interaction Instrumentation
+
+Use existing hooks where possible:
+
+- ActivityPub: `activitypub_handled_create`, `activitypub_handled_like`, `activitypub_handled_announce`, `activitypub_handled_follow`, and related `activitypub_handled_*` actions.
+- Atmosphere: `atmosphere_reaction_synced` in `bundled/atmosphere/includes/class-reaction-sync.php`.
+
+FOSSE records comment/reaction hooks as `fosse_inbound_interaction_synced` with only the network, interaction type, local comment type, and post-shape context. Follow hooks emit `fosse_follow_synced` instead because follows are not tied to a local post/comment shape. No inbound event may send comment content or remote author metadata.
+
+## Disclosure UX
+
+Self-hosted disclosure belongs in both setup surfaces:
+
+- `src/Admin/class-onboarding-wizard.php`: final/complete step includes a checkbox to enable aggregate usage metrics for standalone installs.
+- `src/Admin/templates/setup-page.php`: persistent setting under a "Privacy" or "Usage metrics" section.
+
+Copy must say that FOSSE sends aggregate counts only and does not send post content, profile handles, DIDs, or URLs. On wp.com, this UI can be hidden or replaced by wp.com's standard analytics disclosure.
+
+## Out of Scope
+
+- Implementing the wp.com Tracks adapter inside this repository.
+- Building a public analytics dashboard.
+- Backfilling historical metrics before instrumentation ships.
+- Measuring consumption/read-side experiences owned by other teams.
+- Recording post-level engagement details.
+
+## Review Notes
+
+The key product call is self-hosted telemetry consent. The prior metrics strategy floated opt-out aggregate pingback for standalone sites. This spec recommends opt-in for v1 because FOSSE is a new plugin handling social identities, and trust matters more than perfect self-hosted funnel math.


### PR DESCRIPTION
Draft status: Early unreviewed SDD draft for planning discussion. This is not ready to merge.

Related Linear epic: [DOTCOM-16879](https://linear.app/a8c/issue/DOTCOM-16879)

## Summary
- Adds requirements, spec, and implementation plan for privacy-respecting usage metrics and adoption tracking.
- Covers event taxonomy, consent posture, sinks, upstream hooks, and dashboard/query documentation.

## Notes
- Docs-only planning PR.
- Opened as a draft intentionally for early review.
- No auto-close keyword is used.