### PR TITLE
Wizard: set hidden page admin title

### DIFF
--- a/src/Admin/class-menu.php
+++ b/src/Admin/class-menu.php
@@ -80,7 +80,7 @@ class Menu {
 		// preserving a real admin URL. (PHP 8.2 deprecates passing null
 		// through plugin_basename() inside add_submenu_page(), so we keep
 		// the empty-string form rather than the documented null idiom.)
-		add_submenu_page(
+		$wizard_hook = add_submenu_page(
 			'',
 			__( 'Setup Wizard', 'fosse' ),
 			__( 'Setup Wizard', 'fosse' ),
@@ -88,6 +88,29 @@ class Menu {
 			'fosse-wizard',
 			array( Onboarding_Wizard::class, 'render' )
 		);
+
+		if ( false !== $wizard_hook ) {
+			add_action( "load-{$wizard_hook}", array( static::class, 'set_wizard_admin_title' ) );
+		}
+	}
+
+	/**
+	 * Provide a title for the hidden wizard screen before admin-header.php runs.
+	 *
+	 * WordPress core's admin header calls `strip_tags( $title )`. Hidden
+	 * submenu pages registered under an empty parent can leave `$title` null
+	 * on newer Playground builds, which emits a PHP 8.3 deprecation before
+	 * headers are sent. Setting the core global on the screen's `load-*` hook
+	 * keeps the page title intact and prevents the follow-on header warnings.
+	 *
+	 * @return void
+	 */
+	public static function set_wizard_admin_title(): void {
+		global $title;
+
+		if ( ! is_string( $title ) || '' === $title ) {
+			$title = __( 'Setup Wizard', 'fosse' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Core expects this global before admin-header.php renders.
+		}
 	}
 
 	/**

--- a/tests/php/Admin/MenuTest.php
+++ b/tests/php/Admin/MenuTest.php
@@ -238,6 +238,42 @@ class MenuTest extends BaseTestCase {
 		$this->assertNotFalse( get_option( Onboarding_Wizard::REDIRECT_OPTION ) );
 	}
 
+	// --- hidden wizard title ---
+
+	/**
+	 * Hidden wizard pages still need a core admin title before admin-header.php.
+	 */
+	public function test_sets_wizard_admin_title_when_missing(): void {
+		$old_title = $GLOBALS['title'] ?? null;
+
+		try {
+			$GLOBALS['title'] = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test setup for core title global.
+
+			Menu::set_wizard_admin_title();
+
+			$this->assertSame( 'Setup Wizard', $GLOBALS['title'] );
+		} finally {
+			$GLOBALS['title'] = $old_title; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore core title global after test.
+		}
+	}
+
+	/**
+	 * Existing non-empty admin titles are preserved.
+	 */
+	public function test_preserves_existing_wizard_admin_title(): void {
+		$old_title = $GLOBALS['title'] ?? null;
+
+		try {
+			$GLOBALS['title'] = 'Existing Title'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test setup for core title global.
+
+			Menu::set_wizard_admin_title();
+
+			$this->assertSame( 'Existing Title', $GLOBALS['title'] );
+		} finally {
+			$GLOBALS['title'] = $old_title; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore core title global after test.
+		}
+	}
+
 	// --- notice suppression (#56) ---
 
 	/**

--- a/tests/php/Admin/MenuTest.php
+++ b/tests/php/Admin/MenuTest.php
@@ -242,18 +242,46 @@ class MenuTest extends BaseTestCase {
 
 	/**
 	 * Hidden wizard pages still need a core admin title before admin-header.php.
+	 *
+	 * Hooks `gettext` to confirm the title goes through `__()` with the
+	 * `fosse` text domain — asserting the rendered string alone wouldn't
+	 * catch a regression that dropped the wrapper, since wrapped and
+	 * unwrapped paths produce identical output in a no-translation env.
 	 */
 	public function test_sets_wizard_admin_title_when_missing(): void {
+		$had_title = array_key_exists( 'title', $GLOBALS );
 		$old_title = $GLOBALS['title'] ?? null;
+
+		$captured = array();
+		$capture  = static function ( $translation, $text, $domain ) use ( &$captured ) {
+			$captured[ $text ] = $domain;
+			return $translation;
+		};
+		add_filter( 'gettext', $capture, 10, 3 );
 
 		try {
 			$GLOBALS['title'] = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test setup for core title global.
 
 			Menu::set_wizard_admin_title();
 
-			$this->assertSame( 'Setup Wizard', $GLOBALS['title'] );
+			$this->assertSame( __( 'Setup Wizard', 'fosse' ), $GLOBALS['title'] );
+			$this->assertSame(
+				'fosse',
+				$captured['Setup Wizard'] ?? null,
+				'Wizard title must call __() with the fosse text domain.'
+			);
 		} finally {
-			$GLOBALS['title'] = $old_title; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore core title global after test.
+			remove_filter( 'gettext', $capture, 10 );
+
+			// `?? null` can't distinguish an absent key from a null value, so
+			// only restore the original value when the key existed; otherwise
+			// drop the key we just introduced to avoid leaking state into
+			// later tests.
+			if ( $had_title ) {
+				$GLOBALS['title'] = $old_title; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore core title global after test.
+			} else {
+				unset( $GLOBALS['title'] );
+			}
 		}
 	}
 
@@ -261,6 +289,7 @@ class MenuTest extends BaseTestCase {
 	 * Existing non-empty admin titles are preserved.
 	 */
 	public function test_preserves_existing_wizard_admin_title(): void {
+		$had_title = array_key_exists( 'title', $GLOBALS );
 		$old_title = $GLOBALS['title'] ?? null;
 
 		try {
@@ -270,7 +299,11 @@ class MenuTest extends BaseTestCase {
 
 			$this->assertSame( 'Existing Title', $GLOBALS['title'] );
 		} finally {
-			$GLOBALS['title'] = $old_title; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore core title global after test.
+			if ( $had_title ) {
+				$GLOBALS['title'] = $old_title; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore core title global after test.
+			} else {
+				unset( $GLOBALS['title'] );
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- set the hidden setup wizard screen title on its load hook before admin-header.php runs
- prevent PHP 8.3 strip_tags(null) deprecation noise and follow-on header warnings
- add MenuTest coverage for missing and pre-existing title values

## Testing
- composer run-script lint-php
- composer run-script test-php -- --filter MenuTest