### PR TITLE
Ignore local agent config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,8 @@
 /.claude/scheduled_tasks.lock
 /.claude/worktrees/
 
+# Local agent config
+/.air/
+
 # Superpowers — local visual brainstorming sessions
 /.superpowers/


### PR DESCRIPTION
## Summary
- ignore the local `.air/` agent config directory
- keep local MCP config out of formatting checks and git status

## Testing
- not run; .gitignore-only change