### PR TITLE
Wizard: warm up onboarding visuals

### DIFF
--- a/sdd/destination-first-onboarding-wizard/plan.md
+++ b/sdd/destination-first-onboarding-wizard/plan.md
@@ -12,13 +12,13 @@
 
 ## Progress
 
-- [ ] Task 1: Add destination state and save routing
-- [ ] Task 2: Render the destination-card first step
-- [ ] Task 3: Update progress, identity copy, and content grouping
-- [ ] Task 4: Make the Bluesky step first-class in action hierarchy
-- [ ] Task 5: Update review summary and completion behavior
-- [ ] Task 6: Update Playwright coverage
-- [ ] Task 7: Final verification and SDD status cleanup
+- [x] Task 1: Add destination state and save routing
+- [x] Task 2: Render the destination-card first step
+- [x] Task 3: Update progress, identity copy, and content grouping
+- [x] Task 4: Make the Bluesky step first-class in action hierarchy
+- [x] Task 5: Update review summary and completion behavior
+- [x] Task 6: Update Playwright coverage
+- [x] Task 7: Final verification and SDD status cleanup
 
 ## File Structure
 
@@ -46,7 +46,7 @@
 
 ### Task 1: Add Destination State And Save Routing
 
-- **Status**: Not started
+- **Status**: ✅ Done (34bb461)
 
 **Files:**
 - Modify: `src/Admin/class-onboarding-wizard.php`
@@ -268,7 +268,7 @@ git commit -m "Wizard: add destination intent state"
 
 ### Task 2: Render The Destination-Card First Step
 
-- **Status**: Not started
+- **Status**: ✅ Done (a2a0957)
 
 **Files:**
 - Modify: `src/Admin/class-onboarding-wizard.php`
@@ -529,7 +529,7 @@ git commit -m "Wizard: add destination-card first step"
 
 ### Task 3: Update Progress, Identity Copy, And Content Grouping
 
-- **Status**: Not started
+- **Status**: ✅ Done (25b22f4)
 
 **Files:**
 - Modify: `src/Admin/class-onboarding-wizard.php`
@@ -803,7 +803,7 @@ git commit -m "Wizard: clarify progress identity and content steps"
 
 ### Task 4: Make The Bluesky Step First-Class In Action Hierarchy
 
-- **Status**: Not started
+- **Status**: ✅ Done (f52a7e3)
 
 **Files:**
 - Modify: `src/Admin/class-onboarding-wizard.php`
@@ -939,7 +939,7 @@ git commit -m "Wizard: make Bluesky connect the primary action"
 
 ### Task 5: Update Review Summary And Completion Behavior
 
-- **Status**: Not started
+- **Status**: ✅ Done (6af0508)
 
 **Files:**
 - Modify: `src/Admin/class-onboarding-wizard.php`
@@ -1132,7 +1132,7 @@ git commit -m "Wizard: summarize destination-first setup"
 
 ### Task 6: Update Playwright Coverage
 
-- **Status**: Not started
+- **Status**: ✅ Done (415bb17)
 
 **Files:**
 - Modify: `tests/e2e/onboarding-wizard.spec.ts`
@@ -1256,7 +1256,7 @@ git commit -m "Tests: update onboarding wizard e2e flow"
 
 ### Task 7: Final Verification And SDD Status Cleanup
 
-- **Status**: Not started
+- **Status**: ✅ Done (41e8e8e)
 
 **Files:**
 - Modify: `sdd/destination-first-onboarding-wizard/plan.md`

--- a/sdd/destination-first-onboarding-wizard/plan.md
+++ b/sdd/destination-first-onboarding-wizard/plan.md
@@ -1,0 +1,1317 @@
+# Destination-First Onboarding Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the first-run wizard from a welcome-first flow into a destination-first flow where Bluesky is a first-class setup choice.
+
+**Architecture:** Keep the wizard PHP-rendered and option-backed. Add a wizard-owned destination-intent option that controls flow and summary copy only; publishing behavior still uses ActivityPub's existing post-type option and the current Atmosphere projection. Use the existing per-step save pattern, provider-backed Bluesky status, and PHPUnit/Playwright coverage.
+
+**Tech Stack:** PHP 8.2+, WordPress admin pages, WorDBless PHPUnit, Playwright E2E, native WordPress admin CSS, small existing vanilla JS for Appearance preview only.
+
+---
+
+## Progress
+
+- [ ] Task 1: Add destination state and save routing
+- [ ] Task 2: Render the destination-card first step
+- [ ] Task 3: Update progress, identity copy, and content grouping
+- [ ] Task 4: Make the Bluesky step first-class in action hierarchy
+- [ ] Task 5: Update review summary and completion behavior
+- [ ] Task 6: Update Playwright coverage
+- [ ] Task 7: Final verification and SDD status cleanup
+
+## File Structure
+
+- Modify `src/Admin/class-onboarding-wizard.php`
+  - Add destination constants and helpers.
+  - Replace the Welcome step with a Destinations step.
+  - Render dynamic progress with Review included.
+  - Route Content directly to Review when Bluesky was not selected.
+  - Rework Bluesky disconnected actions so Connect is primary and Skip is secondary.
+  - Add destination and Bluesky-skipped states to the Review summary.
+- Modify `src/Admin/assets/css/admin.css`
+  - Add destination-card styles.
+  - Add responsive rules for destination cards, progress, action rows, and the Bluesky form.
+  - Keep the visual treatment restrained and consistent with WordPress admin.
+- Modify `tests/php/Admin/Onboarding_WizardTest.php`
+  - Cover destination state, invalid fallback, routing, rendering, reset cleanup, Review summary, and Bluesky action hierarchy.
+- Modify `tests/e2e/onboarding-wizard.spec.ts`
+  - Update first-step expectations.
+  - Cover the two destination-card paths.
+  - Cover the new Bluesky action hierarchy.
+- Modify `sdd/destination-first-onboarding-wizard/plan.md`
+  - Keep task statuses in sync as implementation progresses.
+
+## Implementation Tasks
+
+### Task 1: Add Destination State And Save Routing
+
+- **Status**: Not started
+
+**Files:**
+- Modify: `src/Admin/class-onboarding-wizard.php`
+- Modify: `tests/php/Admin/Onboarding_WizardTest.php`
+
+- [ ] **Step 1: Add failing PHPUnit tests for destination persistence**
+
+Add these tests near the existing `handle_save` tests in `tests/php/Admin/Onboarding_WizardTest.php`:
+
+```php
+	// --- handle_save: destinations step ---
+
+	/**
+	 * Saving the destinations step stores the wizard destination intent.
+	 */
+	public function test_handle_save_destinations_stores_destination(): void {
+		$this->simulate_save_request(
+			'destinations',
+			array( 'fosse_onboarding_destination' => 'fediverse_only' )
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'fediverse_only', get_option( 'fosse_onboarding_destination' ) );
+	}
+
+	/**
+	 * Invalid destination submissions fall back to the recommended path.
+	 */
+	public function test_handle_save_destinations_invalid_falls_back_to_default(): void {
+		$this->simulate_save_request(
+			'destinations',
+			array( 'fosse_onboarding_destination' => 'not-a-destination' )
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'fediverse_bluesky', get_option( 'fosse_onboarding_destination' ) );
+	}
+```
+
+Also update `set_up_state()` to clear the new option:
+
+```php
+		delete_option( Onboarding_Wizard::DESTINATION_OPTION );
+```
+
+- [ ] **Step 2: Run the focused PHPUnit tests and verify they fail**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter Onboarding_WizardTest
+```
+
+Expected: fail because `Onboarding_Wizard::DESTINATION_OPTION` and `destinations` handling do not exist.
+
+- [ ] **Step 3: Add destination constants and helpers**
+
+In `src/Admin/class-onboarding-wizard.php`, update the class-level step list docblock so Step 1 is `Destinations` rather than `Welcome`, and add this public option constant after `COMPLETED_OPTION`:
+
+```php
+	/**
+	 * Option key storing the wizard's destination intent.
+	 *
+	 * This controls onboarding flow and Review-summary wording only. It does
+	 * not enable or disable publishing destinations.
+	 *
+	 * @var string
+	 */
+	public const DESTINATION_OPTION = 'fosse_onboarding_destination';
+```
+
+Add these private constants near `STEPS`:
+
+```php
+	/**
+	 * Destination intent that includes the Bluesky connection step.
+	 *
+	 * @var string
+	 */
+	private const DESTINATION_FEDIVERSE_BLUESKY = 'fediverse_bluesky';
+
+	/**
+	 * Destination intent that skips the Bluesky connection step.
+	 *
+	 * @var string
+	 */
+	private const DESTINATION_FEDIVERSE_ONLY = 'fediverse_only';
+
+	/**
+	 * Valid destination values.
+	 *
+	 * @var string[]
+	 */
+	private const DESTINATIONS = array(
+		self::DESTINATION_FEDIVERSE_BLUESKY,
+		self::DESTINATION_FEDIVERSE_ONLY,
+	);
+```
+
+Replace the current `STEPS` constant with:
+
+```php
+	private const STEPS = array( 'destinations', 'appearance', 'content', 'bluesky', 'complete' );
+```
+
+Add these helpers after `get_current_step()` or near the other step helpers:
+
+```php
+	/**
+	 * Get the saved destination intent, falling back to the recommended path.
+	 *
+	 * @return string
+	 */
+	private static function get_destination(): string {
+		$destination = (string) get_option( self::DESTINATION_OPTION, self::DESTINATION_FEDIVERSE_BLUESKY );
+
+		return in_array( $destination, self::DESTINATIONS, true )
+			? $destination
+			: self::DESTINATION_FEDIVERSE_BLUESKY;
+	}
+
+	/**
+	 * Whether the saved destination intent includes Bluesky setup.
+	 *
+	 * @return bool
+	 */
+	private static function destination_includes_bluesky(): bool {
+		return self::DESTINATION_FEDIVERSE_BLUESKY === self::get_destination();
+	}
+
+	/**
+	 * Human label for the saved destination intent.
+	 *
+	 * @param string $destination Destination value.
+	 * @return string
+	 */
+	private static function get_destination_label( string $destination ): string {
+		return self::DESTINATION_FEDIVERSE_ONLY === $destination
+			? __( 'Fediverse only', 'fosse' )
+			: __( 'Fediverse + Bluesky', 'fosse' );
+	}
+```
+
+Update `get_current_step()` so the default and legacy welcome slug both resolve to `destinations`:
+
+```php
+	private static function get_current_step(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only navigation, no state change.
+		$step = sanitize_text_field( wp_unslash( $_GET['step'] ?? 'destinations' ) );
+
+		if ( 'welcome' === $step ) {
+			return 'destinations';
+		}
+
+		if ( in_array( $step, self::STEPS, true ) ) {
+			return $step;
+		}
+
+		return 'destinations';
+	}
+```
+
+- [ ] **Step 4: Save the destination step**
+
+In `handle_save()`, add this block before the existing `appearance` block:
+
+```php
+			if ( 'destinations' === $step ) {
+				$destination = sanitize_text_field( wp_unslash( $_POST['fosse_onboarding_destination'] ?? '' ) );
+				if ( ! in_array( $destination, self::DESTINATIONS, true ) ) {
+					$destination = self::DESTINATION_FEDIVERSE_BLUESKY;
+				}
+
+				update_option( self::DESTINATION_OPTION, $destination, false );
+				self::redirect_to_step( 'appearance' );
+			}
+```
+
+In `handle_reset()`, delete the destination option before redirecting:
+
+```php
+		delete_option( self::DESTINATION_OPTION );
+```
+
+Update the final fallback redirect in `handle_save()` from `welcome` to `destinations` so malformed saves land on the real first step:
+
+```php
+		self::redirect_to_step( 'destinations' );
+```
+
+- [ ] **Step 5: Run focused PHPUnit tests and verify they pass**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter Onboarding_WizardTest
+```
+
+Expected: pass for the new destination persistence tests and no regressions in the focused class.
+
+- [ ] **Step 6: Commit Task 1**
+
+Run:
+
+```bash
+git add src/Admin/class-onboarding-wizard.php tests/php/Admin/Onboarding_WizardTest.php
+git commit -m "Wizard: add destination intent state"
+```
+
+### Task 2: Render The Destination-Card First Step
+
+- **Status**: Not started
+
+**Files:**
+- Modify: `src/Admin/class-onboarding-wizard.php`
+- Modify: `src/Admin/assets/css/admin.css`
+- Modify: `tests/php/Admin/Onboarding_WizardTest.php`
+
+- [ ] **Step 1: Add failing render tests for the new first step**
+
+Add these tests near the existing render tests:
+
+```php
+	/**
+	 * The default wizard screen is the destination-selection step.
+	 */
+	public function test_render_default_step_shows_destination_cards(): void {
+		$output = $this->render_wizard_step( '' );
+
+		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
+		$this->assertStringContainsString( 'Fediverse + Bluesky', $output );
+		$this->assertStringContainsString( 'Fediverse only', $output );
+		$this->assertStringContainsString( 'name="fosse_onboarding_destination"', $output );
+		$this->assertStringNotContainsString( 'Welcome to FOSSE', $output );
+	}
+
+	/**
+	 * The legacy welcome slug resolves to the destination-selection step.
+	 */
+	public function test_render_legacy_welcome_step_shows_destination_cards(): void {
+		$output = $this->render_wizard_step( 'welcome' );
+
+		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
+		$this->assertStringContainsString( 'Fediverse + Bluesky', $output );
+	}
+```
+
+Update `render_wizard_step()` so an empty step omits the `step` query arg:
+
+```php
+	private function render_wizard_step( string $step ): string {
+		$this->become_admin();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- test setup.
+		$_GET = array( 'page' => 'fosse-wizard' );
+		if ( '' !== $step ) {
+			$_GET['step'] = $step;
+		}
+
+		ob_start();
+		try {
+			Onboarding_Wizard::render();
+		} finally {
+			$output = ob_get_clean();
+		}
+
+		return (string) $output;
+	}
+```
+
+- [ ] **Step 2: Run the focused render tests and verify they fail**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter "test_render_default_step_shows_destination_cards|test_render_legacy_welcome_step_shows_destination_cards"
+```
+
+Expected: fail because the wizard still renders the old Welcome step.
+
+- [ ] **Step 3: Switch render dispatch from welcome to destinations**
+
+In `render()`, replace the default branch with a destination branch:
+
+```php
+				case 'destinations':
+					self::render_step_destinations();
+					break;
+```
+
+Keep the final `default` branch but point it to destinations:
+
+```php
+				default:
+					self::render_step_destinations();
+					break;
+```
+
+- [ ] **Step 4: Replace `render_step_welcome()` with `render_step_destinations()`**
+
+Rename `render_step_welcome()` to `render_step_destinations()` and replace its body with:
+
+```php
+	private static function render_step_destinations(): void {
+		self::render_progress( 'destinations' );
+
+		$current_destination = self::get_destination();
+		$nonce               = wp_create_nonce( 'fosse_wizard' );
+
+		$destinations = array(
+			self::DESTINATION_FEDIVERSE_BLUESKY => array(
+				'badge' => __( 'Recommended', 'fosse' ),
+				'title' => __( 'Fediverse + Bluesky', 'fosse' ),
+				'desc'  => __( 'Let people follow your site from Mastodon-compatible apps and publish eligible posts to Bluesky.', 'fosse' ),
+			),
+			self::DESTINATION_FEDIVERSE_ONLY => array(
+				'badge' => __( 'Later', 'fosse' ),
+				'title' => __( 'Fediverse only', 'fosse' ),
+				'desc'  => __( 'Set up social web following now. Connect Bluesky later from FOSSE Settings.', 'fosse' ),
+			),
+		);
+		?>
+		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Where should your WordPress posts appear?', 'fosse' ); ?></h1>
+		<p class="fosse-wizard__description">
+			<?php esc_html_e( 'Choose the destinations FOSSE should help you set up. You can change this later from FOSSE Settings.', 'fosse' ); ?>
+		</p>
+
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<input type="hidden" name="action" value="fosse_wizard_save" />
+			<input type="hidden" name="fosse_wizard_step" value="destinations" />
+			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $nonce ); ?>" />
+
+			<div class="fosse-wizard__card">
+				<div class="fosse-destination-cards">
+					<?php foreach ( $destinations as $value => $destination ) : ?>
+						<label class="fosse-destination-card">
+							<input
+								type="radio"
+								name="fosse_onboarding_destination"
+								value="<?php echo esc_attr( $value ); ?>"
+								class="fosse-destination-card__input"
+								<?php checked( $value, $current_destination ); ?>
+							/>
+							<span class="fosse-destination-card__badge"><?php echo esc_html( $destination['badge'] ); ?></span>
+							<span class="fosse-destination-card__title"><?php echo esc_html( $destination['title'] ); ?></span>
+							<span class="fosse-destination-card__desc"><?php echo esc_html( $destination['desc'] ); ?></span>
+							<span class="fosse-destination-card__check">
+								<span class="dashicons dashicons-yes-alt"></span>
+							</span>
+						</label>
+					<?php endforeach; ?>
+				</div>
+			</div>
+
+			<div class="fosse-wizard__actions fosse-wizard__actions--center">
+				<div class="fosse-wizard__actions-column">
+					<?php submit_button( __( 'Continue', 'fosse' ), 'primary large', 'submit', false ); ?>
+					<a href="<?php echo esc_url( self::get_skip_url() ); ?>" class="fosse-wizard__skip">
+						<?php esc_html_e( 'Skip setup', 'fosse' ); ?>
+					</a>
+				</div>
+			</div>
+		</form>
+		<?php
+	}
+```
+
+- [ ] **Step 5: Add destination-card CSS**
+
+Append near the wizard card styles in `src/Admin/assets/css/admin.css`, and remove obsolete `.fosse-welcome-features` rules once no markup references them:
+
+```css
+/* Destination cards */
+.fosse-destination-cards {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 16px;
+}
+
+.fosse-destination-card {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	min-height: 140px;
+	padding: 18px 20px;
+	border: 2px solid #dcdcde;
+	border-radius: 8px;
+	background: #fff;
+	cursor: pointer;
+	transition:
+		border-color 0.15s ease,
+		background-color 0.15s ease;
+}
+
+.fosse-destination-card:hover {
+	border-color: #a7aaad;
+}
+
+.fosse-destination-card__input {
+	position: absolute;
+	opacity: 0;
+	pointer-events: none;
+}
+
+.fosse-destination-card:has(.fosse-destination-card__input:checked) {
+	border-color: #3858e9;
+	background: #f7f9ff;
+}
+
+.fosse-destination-card:has(.fosse-destination-card__input:focus-visible),
+.fosse-destination-card:focus-within {
+	border-color: #3858e9;
+	outline: 2px solid #3858e9;
+	outline-offset: 2px;
+}
+
+.fosse-destination-card__badge {
+	align-self: flex-start;
+	margin-bottom: 10px;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	color: #3858e9;
+}
+
+.fosse-destination-card__title {
+	margin-bottom: 6px;
+	font-size: 17px;
+	font-weight: 600;
+	color: #1e1e1e;
+}
+
+.fosse-destination-card__desc {
+	font-size: 13px;
+	line-height: 1.5;
+	color: #646970;
+}
+
+.fosse-destination-card__check {
+	position: absolute;
+	right: 14px;
+	top: 14px;
+	color: #dcdcde;
+}
+
+.fosse-destination-card:has(.fosse-destination-card__input:checked)
+	.fosse-destination-card__check {
+	color: #3858e9;
+}
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter "test_render_default_step_shows_destination_cards|test_render_legacy_welcome_step_shows_destination_cards"
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit Task 2**
+
+Run:
+
+```bash
+git add src/Admin/class-onboarding-wizard.php src/Admin/assets/css/admin.css tests/php/Admin/Onboarding_WizardTest.php
+git commit -m "Wizard: add destination-card first step"
+```
+
+### Task 3: Update Progress, Identity Copy, And Content Grouping
+
+- **Status**: Not started
+
+**Files:**
+- Modify: `src/Admin/class-onboarding-wizard.php`
+- Modify: `src/Admin/assets/css/admin.css`
+- Modify: `tests/php/Admin/Onboarding_WizardTest.php`
+
+- [ ] **Step 1: Add failing tests for progress and identity copy**
+
+Add these tests near the progress and appearance render tests:
+
+```php
+	/**
+	 * Progress reflects the destination-first flow and labels the final step Review.
+	 */
+	public function test_progress_uses_destination_first_labels(): void {
+		$output = $this->render_wizard_step( 'destinations' );
+
+		$this->assertStringContainsString( 'Destinations', $output );
+		$this->assertStringContainsString( 'Identity', $output );
+		$this->assertStringContainsString( 'Content', $output );
+		$this->assertStringContainsString( 'Bluesky', $output );
+		$this->assertStringContainsString( 'Review', $output );
+		$this->assertStringNotContainsString( '>Welcome<', $output );
+	}
+
+	/**
+	 * The identity step leads with the follow decision and default card first.
+	 */
+	public function test_identity_step_uses_follow_question_and_actor_first(): void {
+		$output = $this->render_wizard_step( 'appearance' );
+
+		$this->assertStringContainsString( 'Who should people follow?', $output );
+		$this->assertMatchesRegularExpression(
+			'/fosse-mode-card__title">As you<.*fosse-mode-card__title">As your site</s',
+			$output,
+			'The default author-profile option should render before the site-profile option.'
+		);
+	}
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter "test_progress_uses_destination_first_labels|test_identity_step_uses_follow_question_and_actor_first"
+```
+
+Expected: fail because progress still uses the old labels and the Appearance heading/order is unchanged.
+
+- [ ] **Step 3: Make progress dynamic and include Review**
+
+Replace `render_progress()` with:
+
+```php
+	private static function render_progress( string $current_step ): void {
+		$labels = array(
+			'destinations' => __( 'Destinations', 'fosse' ),
+			'appearance'   => __( 'Identity', 'fosse' ),
+			'content'      => __( 'Content', 'fosse' ),
+			'bluesky'      => __( 'Bluesky', 'fosse' ),
+			'complete'     => __( 'Review', 'fosse' ),
+		);
+
+		$step_keys = array_keys( $labels );
+		if ( ! self::destination_includes_bluesky() ) {
+			$step_keys = array_values(
+				array_filter(
+					$step_keys,
+					static function ( string $step ): bool {
+						return 'bluesky' !== $step;
+					}
+				)
+			);
+		}
+
+		$current_i = array_search( $current_step, $step_keys, true );
+
+		if ( false === $current_i ) {
+			return;
+		}
+
+		?>
+		<ol class="fosse-wizard__progress" aria-label="<?php esc_attr_e( 'Setup progress', 'fosse' ); ?>">
+			<?php foreach ( $step_keys as $i => $key ) : ?>
+				<?php
+				$is_complete = $i < $current_i;
+				$is_active   = $i === $current_i;
+				$classes     = 'fosse-wizard__progress-step';
+				if ( $is_complete ) {
+					$classes .= ' is-complete';
+				}
+				if ( $is_active ) {
+					$classes .= ' is-active';
+				}
+				?>
+				<?php if ( $i > 0 ) : ?>
+					<li class="fosse-wizard__progress-line<?php echo $is_complete ? ' is-complete' : ''; ?>" aria-hidden="true"></li>
+				<?php endif; ?>
+				<li class="<?php echo esc_attr( $classes ); ?>"<?php echo $is_active ? ' aria-current="step"' : ''; ?>>
+					<span class="fosse-wizard__progress-dot" aria-hidden="true"></span>
+					<?php echo esc_html( $labels[ $key ] ); ?>
+				</li>
+			<?php endforeach; ?>
+		</ol>
+		<?php
+	}
+```
+
+- [ ] **Step 4: Update progress CSS for `ol` and responsive behavior**
+
+Modify the progress CSS:
+
+```css
+.fosse-wizard__progress {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin: 0 0 32px;
+	padding: 0;
+	list-style: none;
+}
+```
+
+Add this responsive block near the end of the wizard CSS:
+
+```css
+@media (max-width: 782px) {
+	.fosse-wizard {
+		max-width: none;
+		margin: 0;
+	}
+
+	.fosse-wizard__progress {
+		flex-wrap: wrap;
+		row-gap: 10px;
+	}
+
+	.fosse-wizard__progress-line {
+		display: none;
+	}
+
+	.fosse-wizard__card {
+		padding: 24px;
+	}
+
+	.fosse-destination-cards {
+		grid-template-columns: 1fr;
+	}
+
+	.fosse-wizard__actions,
+	.fosse-wizard__actions-primary,
+	.fosse-bluesky-form__controls {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.fosse-wizard__actions {
+		gap: 12px;
+	}
+
+	.fosse-wizard__actions .button,
+	.fosse-wizard__actions input[type="submit"] {
+		text-align: center;
+	}
+}
+```
+
+- [ ] **Step 5: Reframe Appearance as Identity and reorder cards**
+
+In `render_step_appearance()`, change the heading and description:
+
+```php
+		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Who should people follow?', 'fosse' ); ?></h1>
+		<p class="fosse-wizard__description">
+			<?php esc_html_e( 'Choose the identity people follow from social apps. This affects who appears as the publisher when your selected content is shared.', 'fosse' ); ?>
+		</p>
+```
+
+Reorder the `$modes` array so `actor` appears first, then `blog`, then `actor_blog`. Use the existing descriptions, moved into this order.
+
+- [ ] **Step 6: Group common and other post types**
+
+In `render_step_content()`, replace the single `foreach ( $all_post_types as $pt )` block with:
+
+```php
+					<?php
+					$primary_order = array( 'post', 'page' );
+					$primary_types = array();
+					$other_types   = $all_post_types;
+					foreach ( $primary_order as $type_name ) {
+						if ( isset( $all_post_types[ $type_name ] ) ) {
+							$primary_types[ $type_name ] = $all_post_types[ $type_name ];
+							unset( $other_types[ $type_name ] );
+						}
+					}
+
+					$groups = array(
+						'primary' => array(
+							'label' => __( 'Common content types', 'fosse' ),
+							'types' => $primary_types,
+						),
+						'other'   => array(
+							'label' => __( 'Other content types', 'fosse' ),
+							'types' => $other_types,
+						),
+					);
+					foreach ( $groups as $group ) :
+						if ( empty( $group['types'] ) ) {
+							continue;
+						}
+						?>
+						<div class="fosse-post-types__group">
+							<div class="fosse-post-types__group-label"><?php echo esc_html( $group['label'] ); ?></div>
+							<?php foreach ( $group['types'] as $pt ) : ?>
+								<label class="fosse-post-type-item">
+									<input
+										type="checkbox"
+										name="activitypub_support_post_types[]"
+										value="<?php echo esc_attr( $pt->name ); ?>"
+										<?php checked( in_array( $pt->name, $post_types, true ) ); ?>
+									/>
+									<span class="fosse-post-type-item__label">
+										<?php echo esc_html( $pt->label ); ?>
+									</span>
+								</label>
+							<?php endforeach; ?>
+						</div>
+					<?php endforeach; ?>
+```
+
+Add CSS:
+
+```css
+.fosse-post-types__group {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.fosse-post-types__group + .fosse-post-types__group {
+	margin-top: 20px;
+}
+
+.fosse-post-types__group-label {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	color: #646970;
+}
+```
+
+- [ ] **Step 7: Run focused PHPUnit tests**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter Onboarding_WizardTest
+```
+
+Expected: pass.
+
+- [ ] **Step 8: Commit Task 3**
+
+Run:
+
+```bash
+git add src/Admin/class-onboarding-wizard.php src/Admin/assets/css/admin.css tests/php/Admin/Onboarding_WizardTest.php
+git commit -m "Wizard: clarify progress identity and content steps"
+```
+
+### Task 4: Make The Bluesky Step First-Class In Action Hierarchy
+
+- **Status**: Not started
+
+**Files:**
+- Modify: `src/Admin/class-onboarding-wizard.php`
+- Modify: `tests/php/Admin/Onboarding_WizardTest.php`
+- Modify: `tests/e2e/onboarding-wizard.spec.ts`
+
+- [ ] **Step 1: Add failing PHPUnit tests for Bluesky routing and actions**
+
+Add these tests near the Bluesky render tests:
+
+```php
+	/**
+	 * The disconnected Bluesky step makes Connect the primary footer action.
+	 */
+	public function test_render_bluesky_step_disconnected_connect_is_primary_footer_action(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_bluesky' );
+
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertMatchesRegularExpression(
+			'/<button[^>]*form="fosse-wizard-bluesky-connect-form"[^>]*class="[^"]*button-primary[^"]*"[^>]*>\s*Connect Bluesky\s*<\/button>/i',
+			$output,
+			'Connect Bluesky should be the primary footer action.'
+		);
+		$this->assertStringContainsString( 'Skip Bluesky for now', $output );
+	}
+
+	/**
+	 * A fediverse-only destination does not render the Bluesky connect form.
+	 */
+	public function test_render_bluesky_step_fediverse_only_redirects_away(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+
+		$captured = null;
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new RedirectFired( 'redirect' );
+			},
+			9
+		);
+
+		try {
+			$this->render_wizard_step( 'bluesky' );
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull( $captured );
+		$this->assertStringContainsString( 'step=content', $captured );
+	}
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter "test_render_bluesky_step_disconnected_connect_is_primary_footer_action|test_render_bluesky_step_fediverse_only_redirects_away"
+```
+
+Expected: fail because the current disconnected form keeps Connect inside the card and the Bluesky step renders for every destination.
+
+- [ ] **Step 3: Redirect away from Bluesky when not selected**
+
+At the start of `render_step_bluesky()`, before `self::render_progress( 'bluesky' )` or any status reads, add:
+
+```php
+		if ( ! self::destination_includes_bluesky() ) {
+			self::redirect_to_step( 'content' );
+		}
+```
+
+- [ ] **Step 4: Move Connect Bluesky into the footer action row**
+
+In the disconnected branch of `render_step_bluesky()`, add a form id:
+
+```php
+					<form id="fosse-wizard-bluesky-connect-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+```
+
+Remove the inline `submit_button( __( 'Connect Bluesky', 'fosse' ), ... )` from `.fosse-bluesky-form__controls`. Leave the input in the form.
+
+Before the final action row, create a reusable complete URL:
+
+```php
+			$complete_url = wp_nonce_url( admin_url( 'admin-post.php?action=fosse_wizard_complete' ), 'fosse_wizard_complete' );
+```
+
+Replace the footer action block with this shape:
+
+```php
+			<div class="fosse-wizard__actions">
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=content' ) ); ?>" class="button">
+					&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
+				</a>
+				<div class="fosse-wizard__actions-primary">
+					<?php if ( $status['available'] && ! $is_connected ) : ?>
+						<a href="<?php echo esc_url( $complete_url ); ?>" class="button">
+							<?php esc_html_e( 'Skip Bluesky for now', 'fosse' ); ?>
+						</a>
+						<button type="submit" form="fosse-wizard-bluesky-connect-form" class="button button-primary">
+							<?php esc_html_e( 'Connect Bluesky', 'fosse' ); ?>
+						</button>
+					<?php else : ?>
+						<a href="<?php echo esc_url( $complete_url ); ?>" class="button button-primary">
+							<?php echo esc_html( $is_connected ? __( 'Finish setup', 'fosse' ) : __( 'Skip for now', 'fosse' ) ); ?>
+						</a>
+					<?php endif; ?>
+				</div>
+			</div>
+```
+
+- [ ] **Step 5: Run focused PHPUnit tests**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter Onboarding_WizardTest
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add src/Admin/class-onboarding-wizard.php tests/php/Admin/Onboarding_WizardTest.php
+git commit -m "Wizard: make Bluesky connect the primary action"
+```
+
+### Task 5: Update Review Summary And Completion Behavior
+
+- **Status**: Not started
+
+**Files:**
+- Modify: `src/Admin/class-onboarding-wizard.php`
+- Modify: `tests/php/Admin/Onboarding_WizardTest.php`
+
+- [ ] **Step 1: Add failing tests for content routing and Review summary**
+
+Add these tests near the completion tests:
+
+```php
+	/**
+	 * Saving content on the fediverse-only path completes the wizard and skips Bluesky.
+	 */
+	public function test_handle_save_content_fediverse_only_redirects_to_complete(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+
+		$captured = null;
+		$this->simulate_save_request( 'content', array( 'activitypub_support_post_types' => array( 'post' ) ) );
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new RedirectFired( 'redirect' );
+			},
+			9
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertTrue( Onboarding_Wizard::is_complete() );
+		$this->assertStringContainsString( 'step=complete', (string) $captured );
+		$this->assertStringNotContainsString( 'step=bluesky', (string) $captured );
+	}
+
+	/**
+	 * The Review summary includes the selected destination and skipped Bluesky state.
+	 */
+	public function test_complete_summary_shows_fediverse_only_destination_and_skipped_bluesky(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'Destinations', $output );
+		$this->assertStringContainsString( 'Fediverse only', $output );
+		$this->assertStringContainsString( 'Skipped', $output );
+	}
+
+	/**
+	 * Reset clears destination intent along with completion state.
+	 */
+	public function test_handle_reset_clears_destination_intent(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+		$this->simulate_reset_request();
+
+		try {
+			Onboarding_Wizard::handle_reset();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( get_option( Onboarding_Wizard::DESTINATION_OPTION ) );
+	}
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter "test_handle_save_content_fediverse_only_redirects_to_complete|test_complete_summary_shows_fediverse_only_destination_and_skipped_bluesky|test_handle_reset_clears_destination_intent"
+```
+
+Expected: fail because content always redirects to Bluesky and the completion summary has no destination row.
+
+- [ ] **Step 3: Route content save based on destination**
+
+In the `content` block inside `handle_save()`, replace:
+
+```php
+				update_option( 'activitypub_support_post_types', $post_types );
+				self::redirect_to_step( 'bluesky' );
+```
+
+with:
+
+```php
+				update_option( 'activitypub_support_post_types', $post_types );
+
+				if ( self::destination_includes_bluesky() ) {
+					self::redirect_to_step( 'bluesky' );
+				}
+
+				self::mark_complete();
+				self::redirect_to_step( 'complete' );
+```
+
+- [ ] **Step 4: Add Review progress and destination summary**
+
+In `render_step_complete()`, after the `is_complete()` guard, call:
+
+```php
+			self::render_progress( 'complete' );
+```
+
+Also update the incomplete direct-visit guard to redirect to `destinations` instead of the legacy `welcome` step:
+
+```php
+			self::redirect_to_step( 'destinations' );
+```
+
+Add destination data near the existing `$actor_mode` line:
+
+```php
+			$destination       = self::get_destination();
+			$includes_bluesky  = self::DESTINATION_FEDIVERSE_BLUESKY === $destination;
+			$destination_label = self::get_destination_label( $destination );
+```
+
+Replace the Bluesky summary initialization with:
+
+```php
+			$bluesky_summary = $includes_bluesky ? __( 'Not connected', 'fosse' ) : __( 'Skipped', 'fosse' );
+			if ( ! $bluesky['available'] && $includes_bluesky ) {
+				$bluesky_summary = __( 'Unavailable', 'fosse' );
+			}
+			if ( $includes_bluesky && $bluesky['connected'] ) {
+				$bluesky_summary = $bluesky['handle']
+					? sprintf(
+						/* translators: %s: Bluesky handle. */
+						__( 'Connected as %s', 'fosse' ),
+						$bluesky['handle']
+					)
+					: __( 'Connected', 'fosse' );
+			}
+```
+
+Add a destination row at the top of the summary table:
+
+```php
+					<tr>
+						<td class="fosse-summary__label"><?php esc_html_e( 'Destinations', 'fosse' ); ?></td>
+						<td class="fosse-summary__value"><?php echo esc_html( $destination_label ); ?></td>
+					</tr>
+```
+
+Update the completion description:
+
+```php
+					<?php esc_html_e( 'Review your setup, then publish from WordPress when you are ready.', 'fosse' ); ?>
+```
+
+Update CTA help to depend on destination:
+
+```php
+			<p class="fosse-wizard__cta-help">
+				<?php
+				echo esc_html(
+					$includes_bluesky
+						? __( 'Your post will reach followers across Mastodon-compatible apps and Bluesky if connected.', 'fosse' )
+						: __( 'Your post will reach followers across Mastodon-compatible apps.', 'fosse' )
+				);
+				?>
+			</p>
+```
+
+- [ ] **Step 5: Run focused PHPUnit tests**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter Onboarding_WizardTest
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit Task 5**
+
+Run:
+
+```bash
+git add src/Admin/class-onboarding-wizard.php tests/php/Admin/Onboarding_WizardTest.php
+git commit -m "Wizard: summarize destination-first setup"
+```
+
+### Task 6: Update Playwright Coverage
+
+- **Status**: Not started
+
+**Files:**
+- Modify: `tests/e2e/onboarding-wizard.spec.ts`
+
+- [ ] **Step 1: Update first-step E2E expectations**
+
+Replace the initial welcome expectations with destination expectations:
+
+```ts
+test( 'Wizard page loads without errors', async ( { page } ) => {
+	const response = await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+	expect( response?.status() ).toBeLessThan( 400 );
+
+	await expect(
+		page.locator( 'text=/Fatal error|Parse error|Uncaught .*Error/i' )
+	).toHaveCount( 0 );
+	await expect( page.locator( '#error-page' ) ).toHaveCount( 0 );
+
+	await expect(
+		page.locator( '.fosse-wizard__title', {
+			hasText: 'Where should your WordPress posts appear?',
+		} )
+	).toBeVisible();
+} );
+
+test( 'Destination step shows two destination cards', async ( { page } ) => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+
+	await expect( page.locator( '.fosse-destination-card' ) ).toHaveCount( 2 );
+	await expect( page.locator( '.fosse-destination-card', { hasText: 'Fediverse + Bluesky' } ) ).toBeVisible();
+	await expect( page.locator( '.fosse-destination-card', { hasText: 'Fediverse only' } ) ).toBeVisible();
+} );
+```
+
+- [ ] **Step 2: Update navigation E2E test**
+
+Replace `Get Started navigates to appearance step` with:
+
+```ts
+test( 'Destination selection navigates to identity step', async ( { page } ) => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
+	await expect( page ).toHaveURL( /step=appearance/ );
+	await expect(
+		page.locator( '.fosse-wizard__title', {
+			hasText: 'Who should people follow?',
+		} )
+	).toBeVisible();
+} );
+```
+
+- [ ] **Step 3: Add Fediverse-only skip path E2E test**
+
+Add this test before the existing Bluesky step tests:
+
+```ts
+test( 'Fediverse-only path skips the Bluesky connect step', async ( { page } ) => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+
+	await page
+		.locator( '.fosse-destination-card', { hasText: 'Fediverse only' } )
+		.click();
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
+
+	await expect( page ).toHaveURL( /step=appearance/ );
+	await page
+		.locator( '.fosse-mode-card', {
+			has: page.locator( '.fosse-mode-card__title', {
+				hasText: /^As you$/,
+			} ),
+		} )
+		.click();
+	await page.click( 'input[type="submit"]' );
+
+	await expect( page ).toHaveURL( /step=content/ );
+	await page.click( 'input[type="submit"]' );
+
+	await expect( page ).toHaveURL( /step=complete/ );
+	await expect(
+		page.locator( '.fosse-summary__label', { hasText: 'Destinations' } )
+	).toBeVisible();
+	await expect( page.locator( '.fosse-summary' ) ).toContainText(
+		'Fediverse only'
+	);
+	await expect( page.locator( '.fosse-summary' ) ).toContainText( 'Skipped' );
+} );
+```
+
+- [ ] **Step 4: Update Bluesky action hierarchy E2E test**
+
+In `Bluesky step shows connect form`, add:
+
+```ts
+	await expect(
+		page.getByRole( 'button', { name: 'Connect Bluesky' } )
+	).toHaveClass( /button-primary/ );
+	await expect(
+		page.getByRole( 'link', { name: 'Skip Bluesky for now' } )
+	).toBeVisible();
+```
+
+- [ ] **Step 5: Run Playwright wizard spec**
+
+Run:
+
+```bash
+pnpm exec playwright test tests/e2e/onboarding-wizard.spec.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit Task 6**
+
+Run:
+
+```bash
+git add tests/e2e/onboarding-wizard.spec.ts
+git commit -m "Tests: update onboarding wizard e2e flow"
+```
+
+### Task 7: Final Verification And SDD Status Cleanup
+
+- **Status**: Not started
+
+**Files:**
+- Modify: `sdd/destination-first-onboarding-wizard/plan.md`
+
+- [ ] **Step 1: Run full focused verification**
+
+Run:
+
+```bash
+composer run-script test-php -- --filter Onboarding_WizardTest
+pnpm exec playwright test tests/e2e/onboarding-wizard.spec.ts
+git diff --check
+```
+
+Expected: PHPUnit passes, Playwright wizard spec passes, and `git diff --check` produces no output.
+
+- [ ] **Step 2: Run cheap pre-push checks**
+
+Run:
+
+```bash
+composer run-script lint-php
+pnpm run format:check
+pnpm run lint
+```
+
+Expected: all three commands pass.
+
+- [ ] **Step 3: Update SDD statuses**
+
+In `sdd/destination-first-onboarding-wizard/plan.md`, set each completed task status to:
+
+```markdown
+- **Status**: ✅ Done (<commit-or-pr-ref>)
+```
+
+Update the `## Progress` checklist so each completed task is checked.
+
+- [ ] **Step 4: Commit SDD status update**
+
+Run:
+
+```bash
+git add sdd/destination-first-onboarding-wizard/plan.md
+git commit -m "SDD: mark destination-first wizard plan progress"
+```
+
+- [ ] **Step 5: Final branch review**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline origin/trunk..HEAD
+git diff --stat origin/trunk..HEAD
+```
+
+Expected: clean worktree, commits only for the destination-first wizard work, and changed files limited to the wizard implementation, wizard tests, CSS, and SDD plan.

--- a/sdd/destination-first-onboarding-wizard/spec.md
+++ b/sdd/destination-first-onboarding-wizard/spec.md
@@ -1,0 +1,178 @@
+# Spec: Destination-First Onboarding Wizard
+
+## Goal
+
+Revise the first-run onboarding wizard so Bluesky is a first-class setup
+destination instead of a final optional add-on. The wizard should start from the
+user-facing question "Where should your posts appear?" while preserving the
+current implementation constraint that ActivityPub/fediverse support remains the
+baseline backend for this iteration.
+
+This is an iteration on `sdd/onboarding-setup-ux/`, not a replacement for the
+overall onboarding architecture.
+
+## Current Constraints
+
+- FOSSE bundles and loads ActivityPub and Atmosphere automatically.
+- The current wizard requires a registered ActivityPub provider before it can
+  render.
+- The shared post-type setting is ActivityPub's
+  `activitypub_support_post_types` option.
+- FOSSE projects that ActivityPub option into Atmosphere via
+  `atmosphere_syncable_post_types`.
+- Because of that projection, clearing or bypassing ActivityPub post types would
+  also affect Bluesky publishing today.
+
+True Bluesky-only setup, or making fediverse publishing an opt-in backend, needs
+a separate architecture decision where FOSSE owns destination enablement and
+projects into ActivityPub and Atmosphere independently.
+
+## Proposed Flow
+
+### Step 1: Destinations
+
+Question: "Where should your WordPress posts appear?"
+
+Use a clean destination-card layout: two large selectable cards in a centered
+wizard column. The card UI should stay simple and readable, with a restrained
+accent on the selected/recommended card. Avoid decorative hero treatment,
+marketing-style imagery, and dense protocol explanation.
+
+Choices:
+
+1. **Fediverse + Bluesky**
+   - Recommended/default option.
+   - Copy: "Let people follow your site from Mastodon-compatible apps and also
+     publish eligible posts to Bluesky."
+   - Sets a wizard-local intention to show the Bluesky connect step.
+
+2. **Fediverse only**
+   - Copy: "Let people follow your site from Mastodon-compatible apps. You can
+     connect Bluesky later from FOSSE Settings."
+   - Skips the Bluesky connect step.
+
+ActivityPub remains enabled in all choices for this iteration. Do not offer a
+"Bluesky only" option until FOSSE owns independent destination settings.
+
+### Step 2: Identity
+
+Question: "Who should people follow?"
+
+Choices map to the existing `activitypub_actor_mode` values:
+
+- **Me** -> `actor`
+- **My site** -> `blog`
+- **Both** -> `actor_blog`
+
+This is the current Appearance step, reframed after the destination decision.
+Keep the live fediverse preview and inline Site Handle field from the current
+wizard. Reorder cards so the current default/recommended option appears first,
+or add an explicit "Recommended" cue.
+
+### Step 3: Content
+
+Question: "What should publish?"
+
+Continue saving to `activitypub_support_post_types`, with the existing empty
+selection guard. Prefer a clearer visual grouping:
+
+- Primary/common types first, usually Posts and Pages.
+- Custom or unusual public post types under a secondary "Other content types"
+  grouping when present.
+
+The copy should state that the selection applies to the destinations chosen in
+step 1. Since ActivityPub remains required, avoid implying Bluesky can publish
+when fediverse publishing is disabled.
+
+### Step 4: Bluesky
+
+Render this step only when step 1 selected **Fediverse + Bluesky**.
+
+States stay provider-backed:
+
+- Unavailable: render skip-only notice.
+- Disconnected: show handle form and sign-up/domain-handle help.
+- Connected: show confirmation summary and finish action.
+
+Action hierarchy should make Bluesky first-class:
+
+- "Connect Bluesky" is the primary action in the main footer/action area.
+- "Skip Bluesky for now" is secondary.
+- Avoid a layout where the connect button is inside the card while the footer
+  primary action skips the step.
+
+When step 1 did not select Bluesky, the wizard should route directly from
+Content to Review.
+
+### Step 5: Review
+
+Replace the current Complete-only framing with a review/confirmation screen that
+summarizes:
+
+- Destinations: "Fediverse + Bluesky" or "Fediverse only".
+- Identity: selected actor mode plus resolved handle(s).
+- Content: selected post types.
+- Bluesky: connected account, not connected, or skipped.
+
+Primary CTA remains the publish CTA resolved from selected post types.
+Secondary actions remain Status Dashboard and Settings. The "Run wizard again"
+link can stay subtle.
+
+## State Model
+
+Persist the destination intent in a wizard-owned option:
+`fosse_onboarding_destination`.
+
+Store it with autoload disabled. The value needs to survive normal wizard
+navigation, refreshes, back/forward flows, and the final Review summary, but it
+must not be treated as a publishing enablement setting.
+
+Allowed values:
+
+- `fediverse_bluesky`
+- `fediverse_only`
+
+This is not a publishing enablement setting in this iteration. It is wizard flow
+state and completion-summary state only. Publishing behavior continues to be
+driven by existing ActivityPub and Atmosphere settings.
+
+Saving should follow the current per-step pattern: validate the submitted value,
+write the option, and redirect to the next step. If the option is missing or
+invalid on a later step, fall back to `fediverse_bluesky`.
+
+## Non-Goals
+
+- No Bluesky-only setup.
+- No fediverse disable switch.
+- No replacement of the `activitypub_support_post_types` source-of-truth
+  decision.
+- No new destination routing engine.
+- No React/admin SPA rewrite.
+
+## Test Coverage
+
+Expected tests:
+
+- PHPUnit: destination step saves and validates the destination choice.
+- PHPUnit: destination choice controls whether the Bluesky step is next after
+  Content.
+- PHPUnit: completion summary reflects the selected destination and Bluesky
+  status.
+- PHPUnit: invalid or missing destination falls back to the recommended
+  `fediverse_bluesky` path.
+- Playwright: first step renders destination cards and defaults/recommends
+  Fediverse + Bluesky.
+- Playwright: Fediverse + Bluesky path reaches the Bluesky connect step.
+- Playwright: Fediverse-only path skips the Bluesky connect step and lands on
+  Review/Complete.
+- Playwright: disconnected Bluesky path presents Connect as the primary action
+  and Skip as secondary.
+
+## Open Decisions
+
+1. Exact label for the default path: "Fediverse + Bluesky" is clear but
+   protocol-heavy. "Mastodon-compatible apps + Bluesky" is more concrete but
+   longer.
+2. Whether the stored destination intent should be surfaced after completion
+   for analytics or future settings hints. It should not affect publishing
+   behavior until a separate destination-enable architecture exists.

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -290,43 +290,82 @@
 	margin: 0 0 24px;
 }
 
-/* Welcome features grid */
-.fosse-welcome-features {
+/* Destination cards */
+.fosse-destination-cards {
 	display: grid;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
 	gap: 16px;
 }
 
-.fosse-welcome-feature {
+.fosse-destination-card {
+	position: relative;
 	display: flex;
-	align-items: flex-start;
-	gap: 12px;
+	flex-direction: column;
+	min-height: 140px;
+	padding: 18px 20px;
+	border: 2px solid #dcdcde;
+	border-radius: 8px;
+	background: #fff;
+	cursor: pointer;
+	transition:
+		border-color 0.15s ease,
+		background-color 0.15s ease;
 }
 
-.fosse-welcome-feature__icon {
-	width: 32px;
-	height: 32px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	flex-shrink: 0;
+.fosse-destination-card:hover {
+	border-color: #a7aaad;
 }
 
-.fosse-welcome-feature__icon .dashicons {
+.fosse-destination-card__input {
+	position: absolute;
+	opacity: 0;
+	pointer-events: none;
+}
+
+.fosse-destination-card:has(.fosse-destination-card__input:checked) {
+	border-color: #3858e9;
+	background: #f7f9ff;
+}
+
+.fosse-destination-card:has(.fosse-destination-card__input:focus-visible),
+.fosse-destination-card:focus-within {
+	border-color: #3858e9;
+	outline: 2px solid #3858e9;
+	outline-offset: 2px;
+}
+
+.fosse-destination-card__badge {
+	align-self: flex-start;
+	margin-bottom: 10px;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
 	color: #3858e9;
-	font-size: 20px;
-	width: 20px;
-	height: 20px;
 }
 
-.fosse-welcome-feature__text {
-	font-size: 13px;
-	color: #757575;
-	line-height: 1.5;
-}
-
-.fosse-welcome-feature__text strong {
+.fosse-destination-card__title {
+	margin-bottom: 6px;
+	font-size: 17px;
+	font-weight: 600;
 	color: #1e1e1e;
+}
+
+.fosse-destination-card__desc {
+	font-size: 13px;
+	line-height: 1.5;
+	color: #646970;
+}
+
+.fosse-destination-card__check {
+	position: absolute;
+	right: 14px;
+	top: 14px;
+	color: #dcdcde;
+}
+
+.fosse-destination-card:has(.fosse-destination-card__input:checked)
+	.fosse-destination-card__check {
+	color: #3858e9;
 }
 
 /* Actor mode cards */

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -152,8 +152,47 @@
    ============================================= */
 
 .fosse-wizard {
-	max-width: 700px;
+	--fosse-wizard-accent: #3858e9;
+	--fosse-wizard-success: #39a95c;
+	--fosse-wizard-ink: #1f2933;
+	--fosse-wizard-muted: #5f6b76;
+	--fosse-wizard-border: #e1d8c8;
+	--fosse-wizard-panel: #fffaf2;
+	--fosse-wizard-surface: rgba(255, 255, 255, 0.88);
+
+	box-sizing: border-box;
+	isolation: isolate;
+	max-width: 760px;
 	margin: 0 auto;
+	padding: 34px 20px 56px;
+	position: relative;
+}
+
+.fosse-wizard::before {
+	background: radial-gradient(
+			circle at 15% 25%,
+			rgba(57, 169, 92, 0.18),
+			transparent 34%
+		),
+		radial-gradient(
+			circle at 88% 6%,
+			rgba(56, 88, 233, 0.15),
+			transparent 30%
+		),
+		linear-gradient(
+			135deg,
+			rgba(255, 250, 242, 0.95),
+			rgba(238, 246, 255, 0.56)
+		);
+	border-radius: 32px;
+	content: "";
+	height: 260px;
+	left: -56px;
+	pointer-events: none;
+	position: absolute;
+	right: -56px;
+	top: 14px;
+	z-index: -1;
 }
 
 /* Progress indicator */
@@ -161,8 +200,12 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	margin: 0 0 32px;
-	padding: 0;
+	margin: 0 0 46px;
+	padding: 13px 18px;
+	background: var(--fosse-wizard-surface);
+	border: 1px solid rgba(225, 216, 200, 0.9);
+	border-radius: 999px;
+	box-shadow: 0 18px 40px rgba(31, 41, 51, 0.08);
 	list-style: none;
 }
 
@@ -171,68 +214,72 @@
 	align-items: center;
 	gap: 4px;
 	font-size: 12px;
-	color: #949494;
+	color: #8a8f94;
 }
 
 .fosse-wizard__progress-step.is-active {
-	color: #3858e9;
-	font-weight: 500;
+	color: var(--fosse-wizard-accent);
+	font-weight: 600;
 }
 
 .fosse-wizard__progress-step.is-complete {
-	color: #4ab866;
+	color: var(--fosse-wizard-success);
+	font-weight: 600;
 }
 
 .fosse-wizard__progress-dot {
 	width: 8px;
 	height: 8px;
 	border-radius: 50%;
-	background: #ddd;
+	background: #d7d7d7;
 	flex-shrink: 0;
 }
 
 .fosse-wizard__progress-step.is-active .fosse-wizard__progress-dot {
-	background: #3858e9;
+	background: var(--fosse-wizard-accent);
+	box-shadow: 0 0 0 4px rgba(56, 88, 233, 0.12);
 	width: 10px;
 	height: 10px;
 }
 
 .fosse-wizard__progress-step.is-complete .fosse-wizard__progress-dot {
-	background: #4ab866;
+	background: var(--fosse-wizard-success);
 }
 
 .fosse-wizard__progress-line {
 	flex: 1;
 	height: 2px;
-	background: #ddd;
+	background: #dedede;
 }
 
 .fosse-wizard__progress-line.is-complete {
-	background: #4ab866;
+	background: var(--fosse-wizard-success);
 }
 
 /* Title and description */
 .fosse-wizard__title {
 	font-size: 32px;
-	font-weight: 500;
+	font-weight: 600;
 	line-height: 1.2;
+	color: var(--fosse-wizard-ink);
 	margin-bottom: 12px;
 }
 
 .fosse-wizard__description {
 	font-size: 15px;
-	color: #757575;
+	color: var(--fosse-wizard-muted);
 	line-height: 1.6;
-	margin-bottom: 32px;
+	margin-bottom: 34px;
 	max-width: 560px;
 }
 
 /* Main content card */
 .fosse-wizard__card {
 	background: #fff;
-	border: 1px solid #c3c4c7;
-	border-radius: 8px;
-	padding: 32px;
+	border: 1px solid var(--fosse-wizard-border);
+	border-radius: 18px;
+	box-shadow: 0 24px 55px rgba(31, 41, 51, 0.1);
+	padding: 34px;
 	margin-bottom: 24px;
 }
 
@@ -303,19 +350,24 @@
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	min-height: 140px;
-	padding: 18px 20px;
-	border: 2px solid #dcdcde;
-	border-radius: 8px;
-	background: #fff;
+	min-height: 180px;
+	padding: 22px;
+	border: 2px solid #ddd5c7;
+	border-radius: 16px;
+	background: linear-gradient(180deg, #fff, var(--fosse-wizard-panel));
+	box-shadow: 0 12px 30px rgba(31, 41, 51, 0.06);
 	cursor: pointer;
 	transition:
 		border-color 0.15s ease,
-		background-color 0.15s ease;
+		background-color 0.15s ease,
+		box-shadow 0.15s ease,
+		transform 0.15s ease;
 }
 
 .fosse-destination-card:hover {
-	border-color: #a7aaad;
+	border-color: #b9ad99;
+	box-shadow: 0 16px 36px rgba(31, 41, 51, 0.09);
+	transform: translateY(-2px);
 }
 
 .fosse-destination-card__input {
@@ -325,15 +377,33 @@
 }
 
 .fosse-destination-card:has(.fosse-destination-card__input:checked) {
-	border-color: #3858e9;
-	background: #f7f9ff;
+	border-color: var(--fosse-wizard-accent);
+	background: linear-gradient(180deg, #fff, #f4f7ff);
 }
 
 .fosse-destination-card:has(.fosse-destination-card__input:focus-visible),
 .fosse-destination-card:focus-within {
-	border-color: #3858e9;
-	outline: 2px solid #3858e9;
+	border-color: var(--fosse-wizard-accent);
+	outline: 2px solid var(--fosse-wizard-accent);
 	outline-offset: 2px;
+}
+
+.fosse-destination-card__icon {
+	width: 44px;
+	height: 44px;
+	border-radius: 14px;
+	background: rgba(56, 88, 233, 0.08);
+	color: var(--fosse-wizard-accent);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-bottom: 18px;
+}
+
+.fosse-destination-card__icon .dashicons {
+	font-size: 22px;
+	width: 22px;
+	height: 22px;
 }
 
 .fosse-destination-card__badge {
@@ -342,20 +412,21 @@
 	font-size: 11px;
 	font-weight: 600;
 	text-transform: uppercase;
-	color: #3858e9;
+	color: var(--fosse-wizard-accent);
+	letter-spacing: 0.02em;
 }
 
 .fosse-destination-card__title {
 	margin-bottom: 6px;
 	font-size: 17px;
 	font-weight: 600;
-	color: #1e1e1e;
+	color: var(--fosse-wizard-ink);
 }
 
 .fosse-destination-card__desc {
 	font-size: 13px;
 	line-height: 1.5;
-	color: #646970;
+	color: var(--fosse-wizard-muted);
 }
 
 .fosse-destination-card__check {
@@ -367,7 +438,7 @@
 
 .fosse-destination-card:has(.fosse-destination-card__input:checked)
 	.fosse-destination-card__check {
-	color: #3858e9;
+	color: var(--fosse-wizard-accent);
 }
 
 /* Actor mode cards */
@@ -382,16 +453,21 @@
 	display: flex;
 	align-items: flex-start;
 	gap: 16px;
-	padding: 16px 24px;
-	border: 2px solid #e0e0e0;
-	border-radius: 8px;
+	padding: 18px 24px;
+	border: 2px solid #e6e0d6;
+	border-radius: 14px;
 	cursor: pointer;
-	transition: border-color 0.15s ease;
+	transition:
+		border-color 0.15s ease,
+		box-shadow 0.15s ease,
+		transform 0.15s ease;
 	background: #fff;
 }
 
 .fosse-mode-card:hover {
-	border-color: #ccc;
+	border-color: #c7bdac;
+	box-shadow: 0 12px 26px rgba(31, 41, 51, 0.06);
+	transform: translateY(-1px);
 }
 
 /* Hide the real radio input */
@@ -403,14 +479,14 @@
 
 /* Selected state via :has(:checked) */
 .fosse-mode-card:has(.fosse-mode-card__input:checked) {
-	border-color: #3858e9;
-	background: rgba(56, 88, 233, 0.02);
+	border-color: var(--fosse-wizard-accent);
+	background: rgba(56, 88, 233, 0.03);
 }
 
 /* Keyboard focus state — radio is visually hidden, so surface focus on the card. */
 .fosse-mode-card:has(.fosse-mode-card__input:focus-visible) {
-	border-color: #3858e9;
-	outline: 2px solid #3858e9;
+	border-color: var(--fosse-wizard-accent);
+	outline: 2px solid var(--fosse-wizard-accent);
 	outline-offset: 2px;
 }
 
@@ -418,16 +494,16 @@
    Same outline treatment so keyboard navigation surfaces a focus ring on the
    card even when :focus-visible isn't honored on the visually-hidden radio. */
 .fosse-mode-card:focus-within {
-	border-color: #3858e9;
-	outline: 2px solid #3858e9;
+	border-color: var(--fosse-wizard-accent);
+	outline: 2px solid var(--fosse-wizard-accent);
 	outline-offset: 2px;
 }
 
 .fosse-mode-card__icon {
 	width: 40px;
 	height: 40px;
-	border-radius: 8px;
-	background: #f0f0f0;
+	border-radius: 12px;
+	background: #f5f2ec;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -443,13 +519,13 @@
 	font-size: 20px;
 	width: 20px;
 	height: 20px;
-	color: #757575;
+	color: var(--fosse-wizard-muted);
 }
 
 .fosse-mode-card:has(.fosse-mode-card__input:checked)
 	.fosse-mode-card__icon
 	.dashicons {
-	color: #3858e9;
+	color: var(--fosse-wizard-accent);
 }
 
 .fosse-mode-card__content {
@@ -458,13 +534,14 @@
 
 .fosse-mode-card__title {
 	font-size: 15px;
-	font-weight: 500;
+	font-weight: 600;
+	color: var(--fosse-wizard-ink);
 	margin-bottom: 4px;
 }
 
 .fosse-mode-card__desc {
 	font-size: 13px;
-	color: #757575;
+	color: var(--fosse-wizard-muted);
 	line-height: 1.5;
 }
 
@@ -482,13 +559,13 @@
 	font-size: 24px;
 	width: 24px;
 	height: 24px;
-	color: #ddd;
+	color: #d7d7d7;
 }
 
 .fosse-mode-card:has(.fosse-mode-card__input:checked)
 	.fosse-mode-card__check
 	.dashicons {
-	color: #3858e9;
+	color: var(--fosse-wizard-accent);
 }
 
 /* Fediverse address preview */
@@ -496,22 +573,23 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	background: #f0f0f0;
-	border-radius: 4px;
-	padding: 12px 16px;
+	background: #f6f2eb;
+	border: 1px solid #ebe2d3;
+	border-radius: 10px;
+	padding: 13px 16px;
 	font-size: 13px;
 }
 
 .fosse-address-preview__label {
-	color: #757575;
+	color: var(--fosse-wizard-muted);
 }
 
 .fosse-address-preview__address {
 	font-size: 12px;
 	background: #fff;
 	padding: 4px 8px;
-	border-radius: 2px;
-	border: 1px solid #e0e0e0;
+	border-radius: 6px;
+	border: 1px solid #e2d8c8;
 }
 
 /* Wizard Appearance step swaps which fediverse-address preview is visible
@@ -740,11 +818,26 @@
 	.fosse-wizard {
 		max-width: none;
 		margin: 0;
+		padding: 24px 12px 40px;
+	}
+
+	.fosse-wizard::before {
+		border-radius: 24px;
+		left: -12px;
+		right: -12px;
+		top: 8px;
 	}
 
 	.fosse-wizard__progress {
 		flex-wrap: wrap;
+		margin-bottom: 30px;
+		padding: 12px;
+		border-radius: 22px;
 		row-gap: 10px;
+	}
+
+	.fosse-wizard__progress-step {
+		flex: 1 1 auto;
 	}
 
 	.fosse-wizard__progress-line {
@@ -753,6 +846,10 @@
 
 	.fosse-wizard__card {
 		padding: 24px;
+	}
+
+	.fosse-destination-card {
+		min-height: 0;
 	}
 
 	.fosse-destination-cards {

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -161,7 +161,9 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	margin-bottom: 32px;
+	margin: 0 0 32px;
+	padding: 0;
+	list-style: none;
 }
 
 .fosse-wizard__progress-step {
@@ -551,6 +553,23 @@
 	gap: 12px;
 }
 
+.fosse-post-types__group {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.fosse-post-types__group + .fosse-post-types__group {
+	margin-top: 20px;
+}
+
+.fosse-post-types__group-label {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	color: #646970;
+}
+
 .fosse-post-type-item {
 	display: flex;
 	align-items: center;
@@ -715,4 +734,44 @@
 /* Bluesky signup affordance */
 .fosse-bluesky-signup__link {
 	font-weight: 500;
+}
+
+@media (max-width: 782px) {
+	.fosse-wizard {
+		max-width: none;
+		margin: 0;
+	}
+
+	.fosse-wizard__progress {
+		flex-wrap: wrap;
+		row-gap: 10px;
+	}
+
+	.fosse-wizard__progress-line {
+		display: none;
+	}
+
+	.fosse-wizard__card {
+		padding: 24px;
+	}
+
+	.fosse-destination-cards {
+		grid-template-columns: 1fr;
+	}
+
+	.fosse-wizard__actions,
+	.fosse-wizard__actions-primary,
+	.fosse-bluesky-form__controls {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.fosse-wizard__actions {
+		gap: 12px;
+	}
+
+	.fosse-wizard__actions .button,
+	.fosse-wizard__actions input[type="submit"] {
+		text-align: center;
+	}
 }

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -559,7 +559,7 @@ class Bluesky_Provider implements Connection_Provider {
 		// upstream error like "PDS lookup failed: dns_get_record returned false".
 		if ( ! preg_match( '/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/', $handle ) ) {
 			$this->redirect_with_notice(
-				__( 'That doesn\'t look like a Bluesky handle. Try something like alice.bsky.social.', 'fosse' ),
+				__( 'That doesn\'t look like a valid handle. Try something like alice.bsky.social or example.com.', 'fosse' ),
 				'error',
 				$return_context
 			);

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -1179,6 +1179,10 @@ class Onboarding_Wizard {
 	 * @return void
 	 */
 	private static function render_step_bluesky(): void {
+		if ( ! self::destination_includes_bluesky() ) {
+			self::redirect_to_step( 'content' );
+		}
+
 		self::render_progress( 'bluesky' );
 		$status = self::get_bluesky_status();
 
@@ -1269,7 +1273,7 @@ class Onboarding_Wizard {
 					<?php endif; ?>
 				</table>
 			<?php else : ?>
-				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<form id="fosse-wizard-bluesky-connect-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 					<input type="hidden" name="action" value="fosse_connect_bluesky" />
 					<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_connect_bluesky' ) ); ?>" />
 					<input type="hidden" name="<?php echo esc_attr( Bluesky_Provider::RETURN_CONTEXT_FIELD ); ?>" value="<?php echo esc_attr( Bluesky_Provider::RETURN_CONTEXT_WIZARD ); ?>" />
@@ -1286,7 +1290,6 @@ class Onboarding_Wizard {
 								class="regular-text"
 								placeholder="<?php esc_attr_e( 'yourname.bsky.social', 'fosse' ); ?>"
 							/>
-							<?php submit_button( __( 'Connect Bluesky', 'fosse' ), 'primary', 'submit', false ); ?>
 						</div>
 					</div>
 				</form>
@@ -1323,14 +1326,24 @@ class Onboarding_Wizard {
 			<?php endif; ?>
 		</div>
 
+		<?php $complete_url = wp_nonce_url( admin_url( 'admin-post.php?action=fosse_wizard_complete' ), 'fosse_wizard_complete' ); ?>
 		<div class="fosse-wizard__actions">
 			<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=content' ) ); ?>" class="button">
 				&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
 			</a>
 			<div class="fosse-wizard__actions-primary">
-				<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=fosse_wizard_complete' ), 'fosse_wizard_complete' ) ); ?>" class="button button-primary">
-					<?php echo esc_html( $is_connected ? __( 'Finish setup', 'fosse' ) : __( 'Skip for now', 'fosse' ) ); ?>
-				</a>
+				<?php if ( $status['available'] && ! $is_connected ) : ?>
+					<a href="<?php echo esc_url( $complete_url ); ?>" class="button">
+						<?php esc_html_e( 'Skip Bluesky for now', 'fosse' ); ?>
+					</a>
+					<button type="submit" form="fosse-wizard-bluesky-connect-form" class="button button-primary">
+						<?php esc_html_e( 'Connect Bluesky', 'fosse' ); ?>
+					</button>
+				<?php else : ?>
+					<a href="<?php echo esc_url( $complete_url ); ?>" class="button button-primary">
+						<?php echo esc_html( $is_connected ? __( 'Finish setup', 'fosse' ) : __( 'Skip for now', 'fosse' ) ); ?>
+					</a>
+				<?php endif; ?>
 			</div>
 		</div>
 		<?php

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -758,13 +758,25 @@ class Onboarding_Wizard {
 	 * @return void
 	 */
 	private static function render_progress( string $current_step ): void {
-		$labels    = array(
-			'welcome'    => __( 'Welcome', 'fosse' ),
-			'appearance' => __( 'Appearance', 'fosse' ),
-			'content'    => __( 'Content', 'fosse' ),
-			'bluesky'    => __( 'Bluesky', 'fosse' ),
+		$labels = array(
+			'destinations' => __( 'Destinations', 'fosse' ),
+			'appearance'   => __( 'Identity', 'fosse' ),
+			'content'      => __( 'Content', 'fosse' ),
+			'bluesky'      => __( 'Bluesky', 'fosse' ),
+			'complete'     => __( 'Review', 'fosse' ),
 		);
 		$step_keys = array_keys( $labels );
+		if ( ! self::destination_includes_bluesky() ) {
+			$step_keys = array_values(
+				array_filter(
+					$step_keys,
+					static function ( string $step ): bool {
+						return 'bluesky' !== $step;
+					}
+				)
+			);
+		}
+
 		$current_i = array_search( $current_step, $step_keys, true );
 
 		if ( false === $current_i ) {
@@ -772,7 +784,7 @@ class Onboarding_Wizard {
 		}
 
 		?>
-		<div class="fosse-wizard__progress">
+		<ol class="fosse-wizard__progress" aria-label="<?php esc_attr_e( 'Setup progress', 'fosse' ); ?>">
 			<?php foreach ( $step_keys as $i => $key ) : ?>
 				<?php
 				$is_complete = $i < $current_i;
@@ -786,14 +798,14 @@ class Onboarding_Wizard {
 				}
 				?>
 				<?php if ( $i > 0 ) : ?>
-					<div class="fosse-wizard__progress-line<?php echo $is_complete ? ' is-complete' : ''; ?>"></div>
+					<li class="fosse-wizard__progress-line<?php echo $is_complete ? ' is-complete' : ''; ?>" aria-hidden="true"></li>
 				<?php endif; ?>
-				<div class="<?php echo esc_attr( $classes ); ?>">
-					<span class="fosse-wizard__progress-dot"></span>
+				<li class="<?php echo esc_attr( $classes ); ?>"<?php echo $is_active ? ' aria-current="step"' : ''; ?>>
+					<span class="fosse-wizard__progress-dot" aria-hidden="true"></span>
 					<?php echo esc_html( $labels[ $key ] ); ?>
-				</div>
+				</li>
 			<?php endforeach; ?>
-		</div>
+		</ol>
 		<?php
 	}
 
@@ -878,6 +890,16 @@ class Onboarding_Wizard {
 		$nonce        = wp_create_nonce( 'fosse_wizard' );
 
 		$modes = array(
+			'actor'      => array(
+				'icon'  => 'dashicons-admin-users',
+				'title' => __( 'As you', 'fosse' ),
+				'desc'  => sprintf(
+					/* translators: 1: opening <strong> tag, 2: closing </strong> tag */
+					__( 'People follow %1$syou%2$s personally. Posts appear under your author name. Best for personal sites.', 'fosse' ),
+					'<strong>',
+					'</strong>'
+				),
+			),
 			'blog'       => array(
 				'icon'  => 'dashicons-admin-site',
 				'title' => __( 'As your site', 'fosse' ),
@@ -890,16 +912,6 @@ class Onboarding_Wizard {
 						esc_html( $site_host )
 					)
 					: __( 'People follow your site. All posts appear from your site\'s name. Best for blogs and publications.', 'fosse' ),
-			),
-			'actor'      => array(
-				'icon'  => 'dashicons-admin-users',
-				'title' => __( 'As you', 'fosse' ),
-				'desc'  => sprintf(
-					/* translators: 1: opening <strong> tag, 2: closing </strong> tag */
-					__( 'People follow %1$syou%2$s personally. Posts appear under your author name. Best for personal sites.', 'fosse' ),
-					'<strong>',
-					'</strong>'
-				),
 			),
 			'actor_blog' => array(
 				'icon'  => 'dashicons-groups',
@@ -932,9 +944,9 @@ class Onboarding_Wizard {
 		}
 
 		?>
-		<h1 class="fosse-wizard__title"><?php esc_html_e( 'How should your site appear?', 'fosse' ); ?></h1>
+		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Who should people follow?', 'fosse' ); ?></h1>
 		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Choose how people on the social web will see your site. This affects who they follow and how your posts appear in their feeds.', 'fosse' ); ?>
+			<?php esc_html_e( 'Choose the identity people follow from social apps. This affects who appears as the publisher when your selected content is shared.', 'fosse' ); ?>
 		</p>
 
 		<?php settings_errors( 'fosse' ); ?>
@@ -1043,7 +1055,7 @@ class Onboarding_Wizard {
 			</div>
 
 			<div class="fosse-wizard__actions">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=welcome' ) ); ?>" class="button">
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=destinations' ) ); ?>" class="button">
 					&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
 				</a>
 				<div class="fosse-wizard__actions-primary">
@@ -1091,18 +1103,48 @@ class Onboarding_Wizard {
 
 			<div class="fosse-wizard__card">
 				<div class="fosse-post-types">
-					<?php foreach ( $all_post_types as $pt ) : ?>
-						<label class="fosse-post-type-item">
-							<input
-								type="checkbox"
-								name="activitypub_support_post_types[]"
-								value="<?php echo esc_attr( $pt->name ); ?>"
-								<?php checked( in_array( $pt->name, $post_types, true ) ); ?>
-							/>
-							<span class="fosse-post-type-item__label">
-								<?php echo esc_html( $pt->label ); ?>
-							</span>
-						</label>
+					<?php
+					$primary_order = array( 'post', 'page' );
+					$primary_types = array();
+					$other_types   = $all_post_types;
+					foreach ( $primary_order as $type_name ) {
+						if ( isset( $all_post_types[ $type_name ] ) ) {
+							$primary_types[ $type_name ] = $all_post_types[ $type_name ];
+							unset( $other_types[ $type_name ] );
+						}
+					}
+
+					$groups = array(
+						'primary' => array(
+							'label' => __( 'Common content types', 'fosse' ),
+							'types' => $primary_types,
+						),
+						'other'   => array(
+							'label' => __( 'Other content types', 'fosse' ),
+							'types' => $other_types,
+						),
+					);
+					foreach ( $groups as $group ) :
+						if ( empty( $group['types'] ) ) {
+							continue;
+						}
+						?>
+						<div class="fosse-post-types__group">
+							<div class="fosse-post-types__group-label"><?php echo esc_html( $group['label'] ); ?></div>
+							<?php foreach ( $group['types'] as $pt ) : ?>
+								<label class="fosse-post-type-item">
+									<input
+										type="checkbox"
+										name="activitypub_support_post_types[]"
+										value="<?php echo esc_attr( $pt->name ); ?>"
+										<?php checked( in_array( $pt->name, $post_types, true ) ); ?>
+									/>
+									<span class="fosse-post-type-item__label">
+										<?php echo esc_html( $pt->label ); ?>
+									</span>
+								</label>
+							<?php endforeach; ?>
+						</div>
 					<?php endforeach; ?>
 				</div>
 

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -763,7 +763,7 @@ class Onboarding_Wizard {
 	 * @return void
 	 */
 	private static function render_progress( string $current_step ): void {
-		$labels = array(
+		$labels    = array(
 			'destinations' => __( 'Destinations', 'fosse' ),
 			'appearance'   => __( 'Identity', 'fosse' ),
 			'content'      => __( 'Content', 'fosse' ),
@@ -831,7 +831,7 @@ class Onboarding_Wizard {
 				'title' => __( 'Fediverse + Bluesky', 'fosse' ),
 				'desc'  => __( 'Let people follow your site from Mastodon-compatible apps and publish eligible posts to Bluesky.', 'fosse' ),
 			),
-			self::DESTINATION_FEDIVERSE_ONLY => array(
+			self::DESTINATION_FEDIVERSE_ONLY    => array(
 				'badge' => __( 'Later', 'fosse' ),
 				'title' => __( 'Fediverse only', 'fosse' ),
 				'desc'  => __( 'Set up social web following now. Connect Bluesky later from FOSSE Settings.', 'fosse' ),

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -11,7 +11,7 @@ namespace Automattic\Fosse\Admin;
  * Renders and handles the multi-step onboarding wizard shown on first activation.
  *
  * Steps:
- *  1. Welcome - value prop overview
+ *  1. Destinations - destination intent selection
  *  2. Appearance - actor mode selection (blog / actor / actor_blog)
  *  3. Content - post type selection
  *  4. Bluesky - optional OAuth connection
@@ -25,6 +25,16 @@ class Onboarding_Wizard {
 	 * @var string
 	 */
 	public const COMPLETED_OPTION = 'fosse_onboarding_completed';
+
+	/**
+	 * Option key storing the wizard's destination intent.
+	 *
+	 * This controls onboarding flow and Review-summary wording only. It does
+	 * not enable or disable publishing destinations.
+	 *
+	 * @var string
+	 */
+	public const DESTINATION_OPTION = 'fosse_onboarding_destination';
 
 	/**
 	 * Option key for the one-shot activation redirect signal.
@@ -54,7 +64,31 @@ class Onboarding_Wizard {
 	 *
 	 * @var string[]
 	 */
-	private const STEPS = array( 'welcome', 'appearance', 'content', 'bluesky', 'complete' );
+	private const STEPS = array( 'destinations', 'appearance', 'content', 'bluesky', 'complete' );
+
+	/**
+	 * Destination intent that includes the Bluesky connection step.
+	 *
+	 * @var string
+	 */
+	private const DESTINATION_FEDIVERSE_BLUESKY = 'fediverse_bluesky';
+
+	/**
+	 * Destination intent that skips the Bluesky connection step.
+	 *
+	 * @var string
+	 */
+	private const DESTINATION_FEDIVERSE_ONLY = 'fediverse_only';
+
+	/**
+	 * Valid destination values.
+	 *
+	 * @var string[]
+	 */
+	private const DESTINATIONS = array(
+		self::DESTINATION_FEDIVERSE_BLUESKY,
+		self::DESTINATION_FEDIVERSE_ONLY,
+	);
 
 	/**
 	 * Allowed actor mode values.
@@ -195,6 +229,16 @@ class Onboarding_Wizard {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- nonce verified by self::require_nonce() above.
 		$step = sanitize_text_field( wp_unslash( $_POST['fosse_wizard_step'] ?? '' ) );
 
+		if ( 'destinations' === $step ) {
+			$destination = sanitize_text_field( wp_unslash( $_POST['fosse_onboarding_destination'] ?? '' ) );
+			if ( ! in_array( $destination, self::DESTINATIONS, true ) ) {
+				$destination = self::DESTINATION_FEDIVERSE_BLUESKY;
+			}
+
+			update_option( self::DESTINATION_OPTION, $destination, false );
+			self::redirect_to_step( 'appearance' );
+		}
+
 		if ( 'appearance' === $step ) {
 			$mode = sanitize_text_field( wp_unslash( $_POST['activitypub_actor_mode'] ?? '' ) );
 			if ( in_array( $mode, self::ACTOR_MODES, true ) ) {
@@ -270,7 +314,7 @@ class Onboarding_Wizard {
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		// Fallback: redirect to next logical step.
-		self::redirect_to_step( 'welcome' );
+		self::redirect_to_step( 'destinations' );
 	}
 
 	/**
@@ -327,6 +371,7 @@ class Onboarding_Wizard {
 		self::require_nonce( 'fosse_wizard_reset', 'fosse_wizard_reset' );
 
 		delete_option( self::COMPLETED_OPTION );
+		delete_option( self::DESTINATION_OPTION );
 
 		wp_safe_redirect( admin_url( 'admin.php?page=fosse-wizard' ) );
 		exit;
@@ -398,13 +443,51 @@ class Onboarding_Wizard {
 	 */
 	private static function get_current_step(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only navigation, no state change.
-		$step = sanitize_text_field( wp_unslash( $_GET['step'] ?? 'welcome' ) );
+		$step = sanitize_text_field( wp_unslash( $_GET['step'] ?? 'destinations' ) );
+
+		if ( 'welcome' === $step ) {
+			return 'destinations';
+		}
 
 		if ( in_array( $step, self::STEPS, true ) ) {
 			return $step;
 		}
 
-		return 'welcome';
+		return 'destinations';
+	}
+
+	/**
+	 * Get the saved destination intent, falling back to the recommended path.
+	 *
+	 * @return string
+	 */
+	private static function get_destination(): string {
+		$destination = (string) get_option( self::DESTINATION_OPTION, self::DESTINATION_FEDIVERSE_BLUESKY );
+
+		return in_array( $destination, self::DESTINATIONS, true )
+			? $destination
+			: self::DESTINATION_FEDIVERSE_BLUESKY;
+	}
+
+	/**
+	 * Whether the saved destination intent includes Bluesky setup.
+	 *
+	 * @return bool
+	 */
+	private static function destination_includes_bluesky(): bool {
+		return self::DESTINATION_FEDIVERSE_BLUESKY === self::get_destination();
+	}
+
+	/**
+	 * Human label for the saved destination intent.
+	 *
+	 * @param string $destination Destination value.
+	 * @return string
+	 */
+	private static function get_destination_label( string $destination ): string {
+		return self::DESTINATION_FEDIVERSE_ONLY === $destination
+			? __( 'Fediverse only', 'fosse' )
+			: __( 'Fediverse + Bluesky', 'fosse' );
 	}
 
 	/**

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -828,11 +828,13 @@ class Onboarding_Wizard {
 		$destinations = array(
 			self::DESTINATION_FEDIVERSE_BLUESKY => array(
 				'badge' => __( 'Recommended', 'fosse' ),
+				'icon'  => 'dashicons-share-alt2',
 				'title' => __( 'Fediverse + Bluesky', 'fosse' ),
 				'desc'  => __( 'Let people follow your site from Mastodon-compatible apps and publish eligible posts to Bluesky.', 'fosse' ),
 			),
 			self::DESTINATION_FEDIVERSE_ONLY    => array(
 				'badge' => __( 'Simple setup', 'fosse' ),
+				'icon'  => 'dashicons-admin-site-alt3',
 				'title' => __( 'Fediverse only', 'fosse' ),
 				'desc'  => __( 'Let people follow your site from Mastodon-compatible apps without setting up Bluesky in this wizard.', 'fosse' ),
 			),
@@ -859,6 +861,9 @@ class Onboarding_Wizard {
 								class="fosse-destination-card__input"
 								<?php checked( $value, $current_destination ); ?>
 							/>
+							<span class="fosse-destination-card__icon">
+								<span class="dashicons <?php echo esc_attr( $destination['icon'] ); ?>"></span>
+							</span>
 							<span class="fosse-destination-card__badge"><?php echo esc_html( $destination['badge'] ); ?></span>
 							<span class="fosse-destination-card__title"><?php echo esc_html( $destination['title'] ); ?></span>
 							<span class="fosse-destination-card__desc"><?php echo esc_html( $destination['desc'] ); ?></span>

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -312,7 +312,12 @@ class Onboarding_Wizard {
 			}
 
 			update_option( 'activitypub_support_post_types', $post_types );
-			self::redirect_to_step( 'bluesky' );
+			if ( self::destination_includes_bluesky() ) {
+				self::redirect_to_step( 'bluesky' );
+			}
+
+			self::mark_complete();
+			self::redirect_to_step( 'complete' );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
@@ -1359,12 +1364,17 @@ class Onboarding_Wizard {
 		// otherwise render the success screen without ever marking the wizard
 		// complete via handle_complete(), leaving the Setup notice nagging.
 		if ( ! self::is_complete() ) {
-			self::redirect_to_step( 'welcome' );
+			self::redirect_to_step( 'destinations' );
 		}
 
-		$actor_mode = get_option( 'activitypub_actor_mode', 'actor' );
-		$post_types = get_option( 'activitypub_support_post_types', array( 'post' ) );
-		$bluesky    = self::get_bluesky_status();
+		self::render_progress( 'complete' );
+
+		$actor_mode        = get_option( 'activitypub_actor_mode', 'actor' );
+		$post_types        = get_option( 'activitypub_support_post_types', array( 'post' ) );
+		$bluesky           = self::get_bluesky_status();
+		$destination       = self::get_destination();
+		$includes_bluesky  = self::DESTINATION_FEDIVERSE_BLUESKY === $destination;
+		$destination_label = self::get_destination_label( $destination );
 
 		$handles     = self::get_handle_previews( $actor_mode );
 		$user_handle = $handles['user'] ?? '';
@@ -1379,8 +1389,11 @@ class Onboarding_Wizard {
 			$post_types
 		);
 
-		$bluesky_summary = $bluesky['available'] ? __( 'Not connected', 'fosse' ) : __( 'Unavailable', 'fosse' );
-		if ( $bluesky['connected'] ) {
+		$bluesky_summary = $includes_bluesky ? __( 'Not connected', 'fosse' ) : __( 'Skipped', 'fosse' );
+		if ( ! $bluesky['available'] && $includes_bluesky ) {
+			$bluesky_summary = __( 'Unavailable', 'fosse' );
+		}
+		if ( $includes_bluesky && $bluesky['connected'] ) {
 			$bluesky_summary = $bluesky['handle']
 				? sprintf(
 					/* translators: %s: Bluesky handle. */
@@ -1397,12 +1410,16 @@ class Onboarding_Wizard {
 			</div>
 			<h1 class="fosse-wizard__title"><?php esc_html_e( 'You\'re all set!', 'fosse' ); ?></h1>
 			<p class="fosse-wizard__description">
-				<?php esc_html_e( 'Your site is now part of the social web. People can find and follow you from Mastodon and other compatible apps.', 'fosse' ); ?>
+				<?php esc_html_e( 'Review your setup, then publish from WordPress when you are ready.', 'fosse' ); ?>
 			</p>
 		</div>
 
 		<div class="fosse-wizard__card">
 			<table class="fosse-summary">
+				<tr>
+					<td class="fosse-summary__label"><?php esc_html_e( 'Destinations', 'fosse' ); ?></td>
+					<td class="fosse-summary__value"><?php echo esc_html( $destination_label ); ?></td>
+				</tr>
 				<tr>
 					<td class="fosse-summary__label"><?php esc_html_e( 'Site appears as', 'fosse' ); ?></td>
 					<td class="fosse-summary__value">
@@ -1423,7 +1440,7 @@ class Onboarding_Wizard {
 				</tr>
 				<tr>
 					<td class="fosse-summary__label"><?php esc_html_e( 'Bluesky', 'fosse' ); ?></td>
-					<td class="fosse-summary__value<?php echo $bluesky['connected'] ? '' : ' fosse-summary__value--muted'; ?>"><?php echo esc_html( $bluesky_summary ); ?></td>
+					<td class="fosse-summary__value<?php echo $includes_bluesky && $bluesky['connected'] ? '' : ' fosse-summary__value--muted'; ?>"><?php echo esc_html( $bluesky_summary ); ?></td>
 				</tr>
 			</table>
 
@@ -1442,7 +1459,13 @@ class Onboarding_Wizard {
 		</div>
 
 		<p class="fosse-wizard__cta-help">
-			<?php esc_html_e( 'Your post will reach followers across the social web — Mastodon, other ActivityPub apps, and Bluesky if connected.', 'fosse' ); ?>
+			<?php
+			echo esc_html(
+				$includes_bluesky
+					? __( 'Your post will reach followers across Mastodon-compatible apps and Bluesky if connected.', 'fosse' )
+					: __( 'Your post will reach followers across Mastodon-compatible apps.', 'fosse' )
+			);
+			?>
 		</p>
 
 		<div class="fosse-wizard__actions fosse-wizard__actions--center fosse-wizard__actions--secondary">

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -832,15 +832,15 @@ class Onboarding_Wizard {
 				'desc'  => __( 'Let people follow your site from Mastodon-compatible apps and publish eligible posts to Bluesky.', 'fosse' ),
 			),
 			self::DESTINATION_FEDIVERSE_ONLY    => array(
-				'badge' => __( 'Later', 'fosse' ),
+				'badge' => __( 'Simple setup', 'fosse' ),
 				'title' => __( 'Fediverse only', 'fosse' ),
-				'desc'  => __( 'Set up social web following now. Connect Bluesky later from FOSSE Settings.', 'fosse' ),
+				'desc'  => __( 'Let people follow your site from Mastodon-compatible apps without setting up Bluesky in this wizard.', 'fosse' ),
 			),
 		);
 		?>
 		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Where should your WordPress posts appear?', 'fosse' ); ?></h1>
 		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Choose the destinations FOSSE should help you set up. You can change this later from FOSSE Settings.', 'fosse' ); ?>
+			<?php esc_html_e( 'Choose where FOSSE should share your posts. You can change this later in FOSSE Settings.', 'fosse' ); ?>
 		</p>
 
 		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
@@ -1285,7 +1285,7 @@ class Onboarding_Wizard {
 
 					<div class="fosse-bluesky-form">
 						<label for="fosse-bsky-handle" class="fosse-bluesky-form__label">
-							<?php esc_html_e( 'Bluesky Handle', 'fosse' ); ?>
+							<?php esc_html_e( 'Bluesky or AT Protocol handle', 'fosse' ); ?>
 						</label>
 						<div class="fosse-bluesky-form__controls">
 							<input
@@ -1294,8 +1294,12 @@ class Onboarding_Wizard {
 								name="bluesky_handle"
 								class="regular-text"
 								placeholder="<?php esc_attr_e( 'yourname.bsky.social', 'fosse' ); ?>"
+								aria-describedby="fosse-bsky-handle-description"
 							/>
 						</div>
+						<p id="fosse-bsky-handle-description" class="description">
+							<?php esc_html_e( 'Use your Bluesky handle, or a custom domain handle if you have one.', 'fosse' ); ?>
+						</p>
 					</div>
 				</form>
 
@@ -1304,23 +1308,10 @@ class Onboarding_Wizard {
 						<?php
 						echo wp_kses_post(
 							sprintf(
-								/* translators: 1: opening anchor tag, 2: closing anchor tag */
-								__( 'Need a Bluesky account? %1$sCreate one at bsky.app%2$s, then come back to finish connecting.', 'fosse' ),
+								/* translators: 1: opening Bluesky signup anchor tag, 2: closing anchor tag, 3: opening domain-handle help anchor tag, 4: closing anchor tag. */
+								__( 'Need help getting started? %1$sCreate a Bluesky account%2$s, or %3$slearn how to use your domain as your handle%4$s.', 'fosse' ),
 								'<a href="' . esc_url( 'https://bsky.app/' ) . '" target="_blank" rel="noopener noreferrer" class="fosse-bluesky-signup__link">',
-								'</a>'
-							)
-						);
-						?>
-					</p>
-				</div>
-
-				<div class="fosse-wizard__hint">
-					<p>
-						<?php
-						echo wp_kses_post(
-							sprintf(
-								/* translators: 1: opening anchor tag, 2: closing anchor tag */
-								__( 'Want your domain as your handle? %1$sLearn how%2$s.', 'fosse' ),
+								'</a>',
 								'<a href="' . esc_url( 'https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial' ) . '" target="_blank" rel="noopener noreferrer">',
 								'</a>'
 							)

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -15,7 +15,7 @@ namespace Automattic\Fosse\Admin;
  *  2. Appearance - actor mode selection (blog / actor / actor_blog)
  *  3. Content - post type selection
  *  4. Bluesky - optional OAuth connection
- *  5. Complete - summary and handoff to Setup/Status pages
+ *  5. Review - summary and handoff to Setup/Status pages
  */
 class Onboarding_Wizard {
 
@@ -1186,6 +1186,7 @@ class Onboarding_Wizard {
 	private static function render_step_bluesky(): void {
 		if ( ! self::destination_includes_bluesky() ) {
 			self::redirect_to_step( 'content' );
+			return;
 		}
 
 		self::render_progress( 'bluesky' );
@@ -1346,7 +1347,7 @@ class Onboarding_Wizard {
 	}
 
 	/**
-	 * Render Step 5: Complete.
+	 * Render Step 5: Review.
 	 *
 	 * @return void
 	 */
@@ -1356,6 +1357,7 @@ class Onboarding_Wizard {
 		// complete via handle_complete(), leaving the Setup notice nagging.
 		if ( ! self::is_complete() ) {
 			self::redirect_to_step( 'destinations' );
+			return;
 		}
 
 		self::render_progress( 'complete' );

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -167,6 +167,9 @@ class Onboarding_Wizard {
 		$step = self::get_current_step();
 
 		switch ( $step ) {
+			case 'destinations':
+				self::render_step_destinations();
+				break;
 			case 'appearance':
 				self::render_step_appearance();
 				break;
@@ -180,7 +183,7 @@ class Onboarding_Wizard {
 				self::render_step_complete();
 				break;
 			default:
-				self::render_step_welcome();
+				self::render_step_destinations();
 				break;
 		}
 
@@ -795,69 +798,70 @@ class Onboarding_Wizard {
 	}
 
 	/**
-	 * Render Step 1: Welcome.
+	 * Render Step 1: Destinations.
 	 *
 	 * @return void
 	 */
-	private static function render_step_welcome(): void {
-		self::render_progress( 'welcome' );
+	private static function render_step_destinations(): void {
+		self::render_progress( 'destinations' );
+
+		$current_destination = self::get_destination();
+		$nonce               = wp_create_nonce( 'fosse_wizard' );
+
+		$destinations = array(
+			self::DESTINATION_FEDIVERSE_BLUESKY => array(
+				'badge' => __( 'Recommended', 'fosse' ),
+				'title' => __( 'Fediverse + Bluesky', 'fosse' ),
+				'desc'  => __( 'Let people follow your site from Mastodon-compatible apps and publish eligible posts to Bluesky.', 'fosse' ),
+			),
+			self::DESTINATION_FEDIVERSE_ONLY => array(
+				'badge' => __( 'Later', 'fosse' ),
+				'title' => __( 'Fediverse only', 'fosse' ),
+				'desc'  => __( 'Set up social web following now. Connect Bluesky later from FOSSE Settings.', 'fosse' ),
+			),
+		);
 		?>
-		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Welcome to FOSSE 🦎', 'fosse' ); ?></h1>
+		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Where should your WordPress posts appear?', 'fosse' ); ?></h1>
 		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'FOSSE helps people follow your WordPress site from social apps that speak the open social web. Publish here, keep ownership here, and let followers read from their feeds.', 'fosse' ); ?>
+			<?php esc_html_e( 'Choose the destinations FOSSE should help you set up. You can change this later from FOSSE Settings.', 'fosse' ); ?>
 		</p>
 
-		<div class="fosse-wizard__card">
-			<div class="fosse-welcome-features">
-				<div class="fosse-welcome-feature">
-					<div class="fosse-welcome-feature__icon">
-						<span class="dashicons dashicons-admin-site-alt3"></span>
-					</div>
-					<div class="fosse-welcome-feature__text">
-						<strong><?php esc_html_e( 'Reach new audiences', 'fosse' ); ?></strong><br>
-						<?php esc_html_e( 'Followers can see your new posts from compatible social apps, while WordPress stays the source of truth.', 'fosse' ); ?>
-					</div>
-				</div>
-				<div class="fosse-welcome-feature">
-					<div class="fosse-welcome-feature__icon">
-						<span class="dashicons dashicons-admin-home"></span>
-					</div>
-					<div class="fosse-welcome-feature__text">
-						<strong><?php esc_html_e( 'Your site, your home', 'fosse' ); ?></strong><br>
-						<?php esc_html_e( 'Everything lives on your WordPress site. You own your content.', 'fosse' ); ?>
-					</div>
-				</div>
-				<div class="fosse-welcome-feature">
-					<div class="fosse-welcome-feature__icon">
-						<span class="dashicons dashicons-groups"></span>
-					</div>
-					<div class="fosse-welcome-feature__text">
-						<strong><?php esc_html_e( 'Get followers', 'fosse' ); ?></strong><br>
-						<?php esc_html_e( 'People follow you from their favorite app. No account needed on your site.', 'fosse' ); ?>
-					</div>
-				</div>
-				<div class="fosse-welcome-feature">
-					<div class="fosse-welcome-feature__icon">
-						<span class="dashicons dashicons-share"></span>
-					</div>
-					<div class="fosse-welcome-feature__text">
-						<strong><?php esc_html_e( 'Publish once', 'fosse' ); ?></strong><br>
-						<?php esc_html_e( 'Write in WordPress, reach everywhere. No copy-pasting between platforms.', 'fosse' ); ?>
-					</div>
-				</div>
-			</div>
-		</div>
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<input type="hidden" name="action" value="fosse_wizard_save" />
+			<input type="hidden" name="fosse_wizard_step" value="destinations" />
+			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $nonce ); ?>" />
 
-		<div class="fosse-wizard__actions fosse-wizard__actions--center">
-			<div class="fosse-wizard__actions-column">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=appearance' ) ); ?>" class="button button-primary button-hero">
-					<?php esc_html_e( 'Get Started', 'fosse' ); ?>
-				</a>
-				<a href="<?php echo esc_url( self::get_skip_url() ); ?>" class="fosse-wizard__skip">
-					<?php esc_html_e( 'Skip setup', 'fosse' ); ?>
-				</a>
+			<div class="fosse-wizard__card">
+				<div class="fosse-destination-cards">
+					<?php foreach ( $destinations as $value => $destination ) : ?>
+						<label class="fosse-destination-card">
+							<input
+								type="radio"
+								name="fosse_onboarding_destination"
+								value="<?php echo esc_attr( $value ); ?>"
+								class="fosse-destination-card__input"
+								<?php checked( $value, $current_destination ); ?>
+							/>
+							<span class="fosse-destination-card__badge"><?php echo esc_html( $destination['badge'] ); ?></span>
+							<span class="fosse-destination-card__title"><?php echo esc_html( $destination['title'] ); ?></span>
+							<span class="fosse-destination-card__desc"><?php echo esc_html( $destination['desc'] ); ?></span>
+							<span class="fosse-destination-card__check">
+								<span class="dashicons dashicons-yes-alt"></span>
+							</span>
+						</label>
+					<?php endforeach; ?>
+				</div>
 			</div>
-		</div>
+
+			<div class="fosse-wizard__actions fosse-wizard__actions--center">
+				<div class="fosse-wizard__actions-column">
+					<?php submit_button( __( 'Continue', 'fosse' ), 'primary large', 'submit', false ); ?>
+					<a href="<?php echo esc_url( self::get_skip_url() ); ?>" class="fosse-wizard__skip">
+						<?php esc_html_e( 'Skip setup', 'fosse' ); ?>
+					</a>
+				</div>
+			</div>
+		</form>
 		<?php
 	}
 

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -1,5 +1,25 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { resetBlueskyState, setBlueskyState } from './test-helpers';
+
+const selectDestination = async ( page: Page, destination: string ) => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+	await page
+		.locator( '.fosse-destination-card', { hasText: destination } )
+		.click();
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
+	await expect( page ).toHaveURL( /step=appearance/ );
+};
+
+const openBlueskyStep = async ( page: Page ) => {
+	await selectDestination( page, 'Fediverse + Bluesky' );
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
+};
+
+const completeThroughBlueskySkip = async ( page: Page ) => {
+	await openBlueskyStep( page );
+	await page.getByRole( 'link', { name: 'Skip Bluesky for now' } ).click();
+	await expect( page ).toHaveURL( /step=complete/ );
+};
 
 test( 'Wizard page loads without errors', async ( { page } ) => {
 	const response = await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
@@ -11,29 +31,51 @@ test( 'Wizard page loads without errors', async ( { page } ) => {
 	await expect( page.locator( '#error-page' ) ).toHaveCount( 0 );
 
 	await expect(
-		page.locator( '.fosse-wizard__title', { hasText: 'Welcome to FOSSE' } )
+		page.locator( '.fosse-wizard__title', {
+			hasText: 'Where should your WordPress posts appear?',
+		} )
 	).toBeVisible();
 } );
 
-test( 'Wizard shows progress indicator on welcome step', async ( { page } ) => {
+test( 'Wizard shows progress indicator on destination step', async ( {
+	page,
+} ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 
 	await expect( page.locator( '.fosse-wizard__progress' ) ).toBeVisible();
 	await expect(
 		page.locator( '.fosse-wizard__progress-step.is-active', {
-			hasText: 'Welcome',
+			hasText: 'Destinations',
 		} )
 	).toBeVisible();
 } );
 
-test( 'Get Started navigates to appearance step', async ( { page } ) => {
+test( 'Destination step shows two destination cards', async ( { page } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 
-	await page.click( 'text=Get Started' );
+	await expect( page.locator( '.fosse-destination-card' ) ).toHaveCount( 2 );
+	await expect(
+		page.locator( '.fosse-destination-card', {
+			hasText: 'Fediverse + Bluesky',
+		} )
+	).toBeVisible();
+	await expect(
+		page.locator( '.fosse-destination-card', {
+			hasText: 'Fediverse only',
+		} )
+	).toBeVisible();
+} );
+
+test( 'Destination selection navigates to identity step', async ( {
+	page,
+} ) => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
 	await expect( page ).toHaveURL( /step=appearance/ );
 	await expect(
 		page.locator( '.fosse-wizard__title', {
-			hasText: 'How should your site appear',
+			hasText: 'Who should people follow?',
 		} )
 	).toBeVisible();
 } );
@@ -161,7 +203,7 @@ test( 'Content step saves post types and advances to Bluesky', async ( {
 } );
 
 test( 'Bluesky step shows connect form', async ( { page } ) => {
-	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
+	await openBlueskyStep( page );
 
 	await expect(
 		page.locator( '.fosse-wizard__title', {
@@ -171,6 +213,9 @@ test( 'Bluesky step shows connect form', async ( { page } ) => {
 	await expect( page.locator( '#fosse-bsky-handle' ) ).toBeVisible();
 	await expect(
 		page.getByRole( 'button', { name: 'Connect Bluesky' } )
+	).toHaveClass( /button-primary/ );
+	await expect(
+		page.getByRole( 'link', { name: 'Skip Bluesky for now' } )
 	).toBeVisible();
 	await expect( page.locator( 'text=Coming Soon' ) ).toHaveCount( 0 );
 } );
@@ -178,7 +223,7 @@ test( 'Bluesky step shows connect form', async ( { page } ) => {
 test( 'Bluesky step (disconnected) shows sign-up help linking to bsky.app', async ( {
 	page,
 } ) => {
-	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
+	await openBlueskyStep( page );
 
 	const signupLink = page.locator(
 		'.fosse-bluesky-signup a[href="https://bsky.app/"]'
@@ -240,10 +285,43 @@ test.describe( 'Bluesky step — connected (post-OAuth completion)', () => {
 	} );
 } );
 
-test( 'Skip for now on Bluesky step goes to completion', async ( { page } ) => {
-	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
+test( 'Fediverse-only path skips the Bluesky connect step', async ( {
+	page,
+} ) => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 
-	await page.click( 'text=Skip for now' );
+	await page
+		.locator( '.fosse-destination-card', { hasText: 'Fediverse only' } )
+		.click();
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
+
+	await expect( page ).toHaveURL( /step=appearance/ );
+	await page
+		.locator( '.fosse-mode-card', {
+			has: page.locator( '.fosse-mode-card__title', {
+				hasText: /^As you$/,
+			} ),
+		} )
+		.click();
+	await page.click( 'input[type="submit"]' );
+
+	await expect( page ).toHaveURL( /step=content/ );
+	await page.click( 'input[type="submit"]' );
+
+	await expect( page ).toHaveURL( /step=complete/ );
+	await expect(
+		page.locator( '.fosse-summary__label', { hasText: 'Destinations' } )
+	).toBeVisible();
+	await expect( page.locator( '.fosse-summary' ) ).toContainText(
+		'Fediverse only'
+	);
+	await expect( page.locator( '.fosse-summary' ) ).toContainText( 'Skipped' );
+} );
+
+test( 'Skip Bluesky for now goes to completion', async ( { page } ) => {
+	await openBlueskyStep( page );
+
+	await page.getByRole( 'link', { name: 'Skip Bluesky for now' } ).click();
 	await expect( page ).toHaveURL( /step=complete/ );
 	await expect(
 		page.locator( '.fosse-wizard__title', {
@@ -253,9 +331,12 @@ test( 'Skip for now on Bluesky step goes to completion', async ( { page } ) => {
 } );
 
 test( 'Completion step shows summary', async ( { page } ) => {
-	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=complete' );
+	await completeThroughBlueskySkip( page );
 
 	await expect( page.locator( '.fosse-summary' ) ).toBeVisible();
+	await expect(
+		page.locator( '.fosse-summary__label', { hasText: 'Destinations' } )
+	).toBeVisible();
 	await expect( page.locator( 'text=Site appears as' ) ).toBeVisible();
 	await expect( page.locator( 'text=Sharing' ) ).toBeVisible();
 	await expect(
@@ -266,7 +347,7 @@ test( 'Completion step shows summary', async ( { page } ) => {
 test( 'Completion step exposes "Publish your first Post" CTA to post-new.php', async ( {
 	page,
 } ) => {
-	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=complete' );
+	await completeThroughBlueskySkip( page );
 
 	const publishCta = page.locator( '.fosse-wizard__cta-publish' );
 	await expect( publishCta ).toBeVisible();

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -1040,7 +1040,8 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$messages = array_column( $errors, 'message' );
 
 		$this->assertNotEmpty( $messages );
-		$this->assertStringContainsString( 'handle', strtolower( implode( ' ', $messages ) ) );
+		$this->assertStringContainsString( 'valid handle', strtolower( implode( ' ', $messages ) ) );
+		$this->assertStringContainsString( 'example.com', strtolower( implode( ' ', $messages ) ) );
 	}
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -412,6 +412,34 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Fediverse + Bluesky', $output );
 	}
 
+	/**
+	 * Progress reflects the destination-first flow and labels the final step Review.
+	 */
+	public function test_progress_uses_destination_first_labels(): void {
+		$output = $this->render_wizard_step( 'destinations' );
+
+		$this->assertStringContainsString( 'Destinations', $output );
+		$this->assertStringContainsString( 'Identity', $output );
+		$this->assertStringContainsString( 'Content', $output );
+		$this->assertStringContainsString( 'Bluesky', $output );
+		$this->assertStringContainsString( 'Review', $output );
+		$this->assertStringNotContainsString( '>Welcome<', $output );
+	}
+
+	/**
+	 * The identity step leads with the follow decision and default card first.
+	 */
+	public function test_identity_step_uses_follow_question_and_actor_first(): void {
+		$output = $this->render_wizard_step( 'appearance' );
+
+		$this->assertStringContainsString( 'Who should people follow?', $output );
+		$this->assertMatchesRegularExpression(
+			'/fosse-mode-card__title">As you<.*fosse-mode-card__title">As your site</s',
+			$output,
+			'The default author-profile option should render before the site-profile option.'
+		);
+	}
+
 	// --- Appearance step render ---
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -747,12 +747,54 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'fosse_bluesky_return', $output );
 		$this->assertStringContainsString( 'value="wizard"', $output );
 		$this->assertStringContainsString( 'Connect Bluesky', $output );
-		$this->assertStringContainsString( 'Skip for now', $output );
+		$this->assertStringContainsString( 'Skip Bluesky for now', $output );
 		$this->assertStringContainsString( 'fosse-bluesky-form', $output );
 		$this->assertStringNotContainsString( 'fosse-bluesky-placeholder', $output );
 		$this->assertStringNotContainsString( 'Coming Soon', $output );
 		$this->assertMatchesRegularExpression( '/<input\b(?=[^>]*\bid="fosse-bsky-handle")(?=[^>]*\bname="bluesky_handle")[^>]*>/i', $output );
 		$this->assertDoesNotMatchRegularExpression( '/<input\b(?=[^>]*\bid="fosse-bsky-handle")[^>]*\bdisabled\b/i', $output );
+	}
+
+	/**
+	 * The disconnected Bluesky step makes Connect the primary footer action.
+	 */
+	public function test_render_bluesky_step_disconnected_connect_is_primary_footer_action(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_bluesky' );
+
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		$this->assertMatchesRegularExpression(
+			'/<button[^>]*form="fosse-wizard-bluesky-connect-form"[^>]*class="[^"]*button-primary[^"]*"[^>]*>\s*Connect Bluesky\s*<\/button>/i',
+			$output,
+			'Connect Bluesky should be the primary footer action.'
+		);
+		$this->assertStringContainsString( 'Skip Bluesky for now', $output );
+	}
+
+	/**
+	 * A fediverse-only destination does not render the Bluesky connect form.
+	 */
+	public function test_render_bluesky_step_fediverse_only_redirects_away(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+
+		$captured = null;
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new RedirectFired( 'redirect' );
+			},
+			9
+		);
+
+		try {
+			$this->render_wizard_step( 'bluesky' );
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull( $captured );
+		$this->assertStringContainsString( 'step=content', $captured );
 	}
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -441,10 +441,14 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( '' );
 
 		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
+		$this->assertStringContainsString( 'Choose where FOSSE should share your posts. You can change this later in FOSSE Settings.', $output );
 		$this->assertStringContainsString( 'Fediverse + Bluesky', $output );
 		$this->assertStringContainsString( 'Fediverse only', $output );
+		$this->assertStringContainsString( 'Simple setup', $output );
+		$this->assertStringContainsString( 'Let people follow your site from Mastodon-compatible apps without setting up Bluesky in this wizard.', $output );
 		$this->assertStringContainsString( 'name="fosse_onboarding_destination"', $output );
 		$this->assertStringNotContainsString( 'Welcome to FOSSE', $output );
+		$this->assertStringNotContainsString( '>Later<', $output );
 	}
 
 	/**
@@ -794,8 +798,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Connect Bluesky', $output );
 		$this->assertStringContainsString( 'Skip Bluesky for now', $output );
 		$this->assertStringContainsString( 'fosse-bluesky-form', $output );
+		$this->assertStringContainsString( 'Bluesky or AT Protocol handle', $output );
+		$this->assertStringContainsString( 'Use your Bluesky handle, or a custom domain handle if you have one.', $output );
 		$this->assertStringNotContainsString( 'fosse-bluesky-placeholder', $output );
 		$this->assertStringNotContainsString( 'Coming Soon', $output );
+		$this->assertStringNotContainsString( 'Bluesky Handle', $output );
 		$this->assertMatchesRegularExpression( '/<input\b(?=[^>]*\bid="fosse-bsky-handle")(?=[^>]*\bname="bluesky_handle")[^>]*>/i', $output );
 		$this->assertDoesNotMatchRegularExpression( '/<input\b(?=[^>]*\bid="fosse-bsky-handle")[^>]*\bdisabled\b/i', $output );
 	}
@@ -1087,15 +1094,19 @@ class Onboarding_WizardTest extends BaseTestCase {
 	// --- Bluesky signup help (#58) ---
 
 	/**
-	 * The disconnected Bluesky step links out to bsky.app so users without
-	 * an account can sign up before connecting.
+	 * The disconnected Bluesky step combines secondary Bluesky help into one callout.
 	 */
 	public function test_render_bluesky_step_disconnected_shows_signup_link(): void {
 		$output = $this->render_wizard_step( 'bluesky' );
 
 		$this->assertStringContainsString( 'fosse-bluesky-signup', $output );
+		$this->assertSame( 1, substr_count( $output, 'fosse-wizard__hint fosse-bluesky-signup' ) );
 		$this->assertStringContainsString( 'https://bsky.app/', $output );
-		$this->assertStringContainsString( 'Need a Bluesky account', $output );
+		$this->assertStringContainsString( 'https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial', $output );
+		$this->assertStringContainsString( 'Need help getting started?', $output );
+		$this->assertStringContainsString( 'Create a Bluesky account', $output );
+		$this->assertStringContainsString( 'learn how to use your domain as your handle', $output );
+		$this->assertStringNotContainsString( 'Want your domain as your handle?', $output );
 	}
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -295,6 +295,34 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertTrue( Onboarding_Wizard::is_complete() );
 	}
 
+	/**
+	 * Saving content on the fediverse-only path completes the wizard and skips Bluesky.
+	 */
+	public function test_handle_save_content_fediverse_only_redirects_to_complete(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+
+		$captured = null;
+		$this->simulate_save_request( 'content', array( 'activitypub_support_post_types' => array( 'post' ) ) );
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new RedirectFired( 'redirect' );
+			},
+			9
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertTrue( Onboarding_Wizard::is_complete() );
+		$this->assertStringContainsString( 'step=complete', (string) $captured );
+		$this->assertStringNotContainsString( 'step=bluesky', (string) $captured );
+	}
+
 	// --- handle_reset ---
 
 	/**
@@ -311,6 +339,23 @@ class Onboarding_WizardTest extends BaseTestCase {
 		}
 
 		$this->assertFalse( Onboarding_Wizard::is_complete() );
+	}
+
+	/**
+	 * Reset clears destination intent along with completion state.
+	 */
+	public function test_handle_reset_clears_destination_intent(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+		$this->simulate_reset_request();
+
+		try {
+			Onboarding_Wizard::handle_reset();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( get_option( Onboarding_Wizard::DESTINATION_OPTION ) );
 	}
 
 	// --- empty post types redirect ---
@@ -961,6 +1006,20 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
+	 * The Review summary includes the selected destination and skipped Bluesky state.
+	 */
+	public function test_complete_summary_shows_fediverse_only_destination_and_skipped_bluesky(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'Destinations', $output );
+		$this->assertStringContainsString( 'Fediverse only', $output );
+		$this->assertStringContainsString( 'Skipped', $output );
+	}
+
+	/**
 	 * In `actor_blog` mode, the completion screen shows both the user and
 	 * site fediverse handles instead of dropping them in favor of a bare
 	 * mode label. Stub `activitypub_user_can_activitypub` because WorDBless
@@ -1179,21 +1238,17 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
-	 * The publish CTA's helper paragraph talks about "the social web" — the
-	 * project's settled language for the destination network. Asserts against
-	 * the dedicated `fosse-wizard__cta-help` block so the test fails if the
-	 * helper copy is removed (the welcome-step body uses "social web" too,
-	 * which would otherwise mask a regression).
+	 * The publish CTA's helper paragraph reflects the selected destinations.
 	 */
-	public function test_render_complete_step_cta_uses_social_web_language(): void {
+	public function test_render_complete_step_cta_uses_destination_specific_language(): void {
 		Onboarding_Wizard::mark_complete();
 
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertMatchesRegularExpression(
-			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*social web~i',
+			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Mastodon-compatible apps and Bluesky~i',
 			$output,
-			'The publish CTA helper copy must reference "the social web".'
+			'The publish CTA helper copy must describe the selected destinations.'
 		);
 	}
 

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -387,6 +387,31 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'ActivityPub', $output );
 	}
 
+	// --- Destinations step render ---
+
+	/**
+	 * The default wizard screen is the destination-selection step.
+	 */
+	public function test_render_default_step_shows_destination_cards(): void {
+		$output = $this->render_wizard_step( '' );
+
+		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
+		$this->assertStringContainsString( 'Fediverse + Bluesky', $output );
+		$this->assertStringContainsString( 'Fediverse only', $output );
+		$this->assertStringContainsString( 'name="fosse_onboarding_destination"', $output );
+		$this->assertStringNotContainsString( 'Welcome to FOSSE', $output );
+	}
+
+	/**
+	 * The legacy welcome slug resolves to the destination-selection step.
+	 */
+	public function test_render_legacy_welcome_step_shows_destination_cards(): void {
+		$output = $this->render_wizard_step( 'welcome' );
+
+		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
+		$this->assertStringContainsString( 'Fediverse + Bluesky', $output );
+	}
+
 	// --- Appearance step render ---
 
 	/**
@@ -1450,10 +1475,10 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->become_admin();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- test setup.
-		$_GET = array(
-			'page' => 'fosse-wizard',
-			'step' => $step,
-		);
+		$_GET = array( 'page' => 'fosse-wizard' );
+		if ( '' !== $step ) {
+			$_GET['step'] = $step;
+		}
 
 		ob_start();
 		try {

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -40,6 +40,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		}
 
 		delete_option( Onboarding_Wizard::COMPLETED_OPTION );
+		delete_option( Onboarding_Wizard::DESTINATION_OPTION );
 		delete_option( 'activitypub_actor_mode' );
 		delete_option( 'activitypub_blog_identifier' );
 		delete_option( 'activitypub_support_post_types' );
@@ -156,6 +157,44 @@ class Onboarding_WizardTest extends BaseTestCase {
 		}
 
 		$this->assertSame( 'actor', get_option( 'activitypub_actor_mode' ) );
+	}
+
+	// --- handle_save: destinations step ---
+
+	/**
+	 * Saving the destinations step stores the wizard destination intent.
+	 */
+	public function test_handle_save_destinations_stores_destination(): void {
+		$this->simulate_save_request(
+			'destinations',
+			array( 'fosse_onboarding_destination' => 'fediverse_only' )
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'fediverse_only', get_option( 'fosse_onboarding_destination' ) );
+	}
+
+	/**
+	 * Invalid destination submissions fall back to the recommended path.
+	 */
+	public function test_handle_save_destinations_invalid_falls_back_to_default(): void {
+		$this->simulate_save_request(
+			'destinations',
+			array( 'fosse_onboarding_destination' => 'not-a-destination' )
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( 'fediverse_bluesky', get_option( 'fosse_onboarding_destination' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- give the onboarding wizard a warmer shell with a soft background wash, wider content column, and more breathing room around the progress rail
- restyle the destination and identity cards with rounded panels, subtle elevation, hover states, and stronger selected/focus states
- add icons to the destination cards so the first step feels less sparse without changing wizard behavior

## Testing
- composer run-script lint-php
- composer run-script test-php -- --filter Onboarding_WizardTest
- pnpm exec prettier --check src/Admin/assets/css/admin.css
- pnpm run lint
- git diff --check

## Notes
- This is stacked on #88 / `onboarding-wizard-ux-review`; retarget to `trunk` after #88 merges if needed.
- Full `pnpm run format:check` is noisy locally because `.air/mcp.json` is untracked on the stacked base branch; the touched CSS file passes Prettier directly.