### PR TITLE
fix: remove Bluesky auto-publish toggle from Settings UI

### DIFF
--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -103,10 +103,9 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return array<string, mixed>
 	 */
 	public function get_status(): array {
-		$connection   = \Atmosphere\get_connection();
-		$connected    = \Atmosphere\is_connected();
-		$auto_publish = '1' === get_option( 'atmosphere_auto_publish', '1' );
-		$token_error  = null;
+		$connection  = \Atmosphere\get_connection();
+		$connected   = \Atmosphere\is_connected();
+		$token_error = null;
 
 		if ( $connected && method_exists( '\Atmosphere\OAuth\Client', 'access_token' ) ) {
 			$token = \Atmosphere\OAuth\Client::access_token();
@@ -120,7 +119,6 @@ class Bluesky_Provider implements Connection_Provider {
 			'handle'       => $connection['handle'] ?? '',
 			'did'          => $connection['did'] ?? '',
 			'pds_endpoint' => $connection['pds_endpoint'] ?? '',
-			'auto_publish' => $auto_publish,
 			'token_error'  => $token_error,
 		);
 	}
@@ -128,52 +126,19 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Render Bluesky-specific settings inside the unified Settings form.
 	 *
-	 * Only renders the auto-publish toggle when Atmosphere is connected —
-	 * there is nothing protocol-specific to save while disconnected. The
-	 * connect/disconnect forms render outside the main Settings form via
-	 * {@see self::render_connection_actions()}.
+	 * Currently a no-op. The auto-publish toggle that used to render here
+	 * was removed because Atmosphere has no per-post manual publish
+	 * surface — disabling auto-publish today leaves the connection
+	 * functionally inert (only inbound reaction sync keeps working).
+	 * The `atmosphere_auto_publish` option is preserved in the database
+	 * with default `'1'` (on) so behavior is unchanged. When the
+	 * pre-publish federation panel for Bluesky lands (DOTCOM-17007 /
+	 * upstream wordpress-atmosphere#50), this method can re-introduce
+	 * a meaningful Bluesky-side fieldset.
 	 *
 	 * @return void
 	 */
 	public function render_setup_section(): void {
-		$status = $this->get_status();
-
-		if ( ! $status['connected'] ) {
-			return;
-		}
-
-		?>
-		<div class="fosse-settings-section" id="fosse-provider-bluesky-settings">
-			<h3><?php esc_html_e( 'Bluesky publishing', 'fosse' ); ?></h3>
-
-			<table class="form-table">
-				<tr>
-					<th scope="row">
-						<?php esc_html_e( 'Auto-publish', 'fosse' ); ?>
-					</th>
-					<td>
-						<fieldset>
-							<legend class="screen-reader-text"><?php esc_html_e( 'Auto-publish', 'fosse' ); ?></legend>
-							<label for="fosse-bluesky-auto-publish">
-								<input
-									type="checkbox"
-									id="fosse-bluesky-auto-publish"
-									name="atmosphere_auto_publish"
-									value="1"
-									aria-describedby="fosse-bluesky-auto-publish-desc"
-									<?php checked( $status['auto_publish'] ); ?>
-								/>
-								<?php esc_html_e( 'Automatically publish new posts to Bluesky.', 'fosse' ); ?>
-							</label>
-							<p id="fosse-bluesky-auto-publish-desc" class="description">
-								<?php esc_html_e( 'When enabled, posts in your selected post types are sent to Bluesky as soon as they are published. Disable to keep Bluesky publishing manual.', 'fosse' ); ?>
-							</p>
-						</fieldset>
-					</td>
-				</tr>
-			</table>
-		</div>
-		<?php
 	}
 
 	/**
@@ -324,10 +289,6 @@ class Bluesky_Provider implements Connection_Provider {
 						</tr>
 					<?php endif; ?>
 					<tr>
-						<td class="fosse-status-card__label"><?php esc_html_e( 'Auto Publish', 'fosse' ); ?></td>
-						<td class="fosse-status-card__value"><?php echo esc_html( $status['auto_publish'] ? __( 'Enabled', 'fosse' ) : __( 'Disabled', 'fosse' ) ); ?></td>
-					</tr>
-					<tr>
 						<td class="fosse-status-card__label"><?php esc_html_e( 'Token Health', 'fosse' ); ?></td>
 						<td class="fosse-status-card__value">
 							<?php if ( $status['token_error'] ) : ?>
@@ -373,28 +334,19 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Persist Bluesky-side settings from the unified save submission.
 	 *
-	 * The auto-publish field is the only Bluesky-side setting that surfaces
-	 * on the FOSSE Settings page; connection state is managed via the
-	 * separate connect/disconnect flows. The toggle is stored as `'1'` /
-	 * `'0'` to match Atmosphere's own setting registration, where an unset
-	 * checkbox simply omits the field and reads as "disabled".
+	 * Currently a no-op. The auto-publish toggle was the only Bluesky-side
+	 * setting that surfaced on the FOSSE Settings page, and it was removed
+	 * because Atmosphere has no per-post manual publish surface to back it
+	 * up — see {@see self::render_setup_section()} for the full rationale.
+	 * Connection state is managed via the separate connect/disconnect
+	 * flows. Returning true keeps the unified save's all-or-nothing
+	 * semantics: this provider never rejects a submission.
 	 *
-	 * Bails when disconnected so a Settings save can't silently flip
-	 * `atmosphere_auto_publish` to `'0'`: the toggle isn't rendered in that
-	 * state, so the omitted checkbox would otherwise be misread as an
-	 * intentional "uncheck".
-	 *
-	 * @param array<string, mixed> $post_data POST payload to read.
-	 * @return bool Always true — auto-publish input cannot be "rejected"; an
-	 *              omitted checkbox is the legitimate "disabled" submission.
+	 * @param array<string, mixed> $post_data POST payload to read (unused).
+	 * @return bool Always true.
 	 */
 	public function save_settings( array $post_data ): bool {
-		if ( ! $this->get_status()['connected'] ) {
-			return true;
-		}
-
-		$auto_publish = ! empty( $post_data['atmosphere_auto_publish'] ) ? '1' : '0';
-		update_option( 'atmosphere_auto_publish', $auto_publish );
+		unset( $post_data );
 
 		return true;
 	}

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -643,7 +643,7 @@ class Bluesky_Provider implements Connection_Provider {
 				<strong><?php esc_html_e( 'Bluesky auto-publishing is off.', 'fosse' ); ?></strong>
 				<?php
 				esc_html_e(
-					'New posts are not being sent to Bluesky. The toggle that controlled this was removed because FOSSE doesn\'t yet offer per-post manual publishing — until it does, leaving auto-publish off means your Bluesky connection is effectively idle.',
+					'New posts aren\'t being sent to Bluesky. The Settings toggle that controlled this was removed, so this notice is the only place to turn it back on. If leaving it off was intentional, no action is needed.',
 					'fosse'
 				);
 				?>

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -124,6 +124,29 @@ class Bluesky_Provider implements Connection_Provider {
 	}
 
 	/**
+	 * Whether Bluesky auto-publishing is enabled for this site.
+	 *
+	 * Centralizes the "absent option reads as enabled" rule that
+	 * `Atmosphere` itself follows: with the FOSSE Settings toggle
+	 * removed, brand-new sites never materialize the option, so the
+	 * default has to be on — anything else would silently break
+	 * publishing for the silent majority.
+	 *
+	 * Static so callers (wizard CTA copy, future per-post UI) can read
+	 * the state without resolving a provider instance through the
+	 * registry — the option is global to the site, not provider-instance
+	 * state. Do NOT use this to gate the recovery notice: that path needs
+	 * to distinguish "explicit `'0'`" from "absent" and reads the option
+	 * raw via `get_option( ..., null )`. Conflating absent with the
+	 * default would surface the recovery banner on every fresh install.
+	 *
+	 * @return bool True when the option is absent or `'1'`; false when explicitly `'0'`.
+	 */
+	public static function is_auto_publish_enabled(): bool {
+		return '1' === get_option( 'atmosphere_auto_publish', '1' );
+	}
+
+	/**
 	 * Render Bluesky-specific settings inside the unified Settings form.
 	 *
 	 * Currently a no-op. The auto-publish toggle that used to render here

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -370,9 +370,7 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @param array<string, mixed> $post_data POST payload to read (unused).
 	 * @return bool Always true.
 	 */
-	public function save_settings( array $post_data ): bool {
-		unset( $post_data );
-
+	public function save_settings( array $post_data ): bool { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Connection_Provider interface contract; no Bluesky-side fields to persist after the auto-publish toggle removal.
 		return true;
 	}
 

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -319,7 +319,9 @@ class Bluesky_Provider implements Connection_Provider {
 	public function register_hooks(): void {
 		add_action( 'admin_post_fosse_connect_bluesky', array( $this, 'handle_connect' ) );
 		add_action( 'admin_post_fosse_disconnect_bluesky', array( $this, 'handle_disconnect' ) );
+		add_action( 'admin_post_fosse_enable_bluesky_auto_publish', array( $this, 'handle_enable_auto_publish' ) );
 		add_action( 'admin_init', array( $this, 'handle_oauth_callback' ) );
+		add_action( 'admin_notices', array( $this, 'maybe_render_auto_publish_disabled_notice' ) );
 		add_action( 'init', array( $this, 'serve_atproto_did_well_known' ), 1 );
 		add_action( 'template_redirect', array( $this, 'maybe_suppress_atmosphere_well_known' ), 1 );
 
@@ -561,6 +563,98 @@ class Bluesky_Provider implements Connection_Provider {
 		}
 
 		$this->redirect_with_notice( __( 'Disconnected from Bluesky.', 'fosse' ), 'info' );
+	}
+
+	/**
+	 * Re-enable Bluesky auto-publishing for sites whose option is stuck at `'0'`.
+	 *
+	 * Backstop for the only state where the now-removed auto-publish toggle
+	 * left a user without a way to recover: a site that explicitly set
+	 * `atmosphere_auto_publish` to `'0'` before the toggle was removed has
+	 * no UI to flip it back on, and the connection silently drops new
+	 * posts. The notice rendered by
+	 * {@see self::maybe_render_auto_publish_disabled_notice()} surfaces a
+	 * one-click re-enable form that posts here.
+	 *
+	 * @return void
+	 */
+	public function handle_enable_auto_publish(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'fosse' ) );
+		}
+
+		check_admin_referer( 'fosse_enable_bluesky_auto_publish' );
+
+		update_option( 'atmosphere_auto_publish', '1' );
+
+		$this->redirect_with_notice(
+			__( 'Bluesky auto-publishing is back on. New posts will be sent to Bluesky.', 'fosse' ),
+			'success'
+		);
+	}
+
+	/**
+	 * Render an admin notice on FOSSE pages when Bluesky auto-publishing
+	 * is explicitly disabled in the database.
+	 *
+	 * The auto-publish toggle was removed from the FOSSE Settings UI
+	 * (Atmosphere has no per-post manual publish surface to back it up;
+	 * see {@see self::render_setup_section()} for the full rationale).
+	 * For every site at the default (`'1'` on, or option absent) this
+	 * removal is invisible. For the narrow population that explicitly
+	 * set the option to `'0'` BEFORE the toggle went away, the connection
+	 * silently drops every new post — and they have no UI to recover.
+	 * This notice is the recovery path: one-click re-enable form rendered
+	 * only when the option is explicitly `'0'`.
+	 *
+	 * Scoped to FOSSE admin pages so it doesn't leak across wp-admin.
+	 *
+	 * @return void
+	 */
+	public function maybe_render_auto_publish_disabled_notice(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( null === $screen || ! is_string( $screen->id ) || false === strpos( $screen->id, 'fosse' ) ) {
+			return;
+		}
+
+		// Only fire when the option is EXPLICITLY '0' — distinguish from
+		// "absent" (default-on) by reading without a default and checking
+		// the raw value. `get_option(..., '1')` would mask the explicit-off
+		// state behind the default.
+		$stored = get_option( 'atmosphere_auto_publish', null );
+		if ( '0' !== $stored ) {
+			return;
+		}
+
+		// Only show for connected sites — a disconnected site has nothing
+		// to publish to anyway, so the notice would be noise.
+		if ( ! $this->get_status()['connected'] ) {
+			return;
+		}
+
+		$action_url = admin_url( 'admin-post.php' );
+		?>
+		<div class="notice notice-warning">
+			<p>
+				<strong><?php esc_html_e( 'Bluesky auto-publishing is off.', 'fosse' ); ?></strong>
+				<?php
+				esc_html_e(
+					'New posts are not being sent to Bluesky. The toggle that controlled this was removed because FOSSE doesn\'t yet offer per-post manual publishing — until it does, leaving auto-publish off means your Bluesky connection is effectively idle.',
+					'fosse'
+				);
+				?>
+			</p>
+			<form method="post" action="<?php echo esc_url( $action_url ); ?>" style="margin-bottom: 6px;">
+				<input type="hidden" name="action" value="fosse_enable_bluesky_auto_publish" />
+				<?php wp_nonce_field( 'fosse_enable_bluesky_auto_publish' ); ?>
+				<?php submit_button( __( 'Turn auto-publishing back on', 'fosse' ), 'primary', 'submit', false ); ?>
+			</form>
+		</div>
+		<?php
 	}
 
 	/**

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -617,7 +617,7 @@ class Bluesky_Provider implements Connection_Provider {
 		}
 
 		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		if ( null === $screen || ! is_string( $screen->id ) || false === strpos( $screen->id, 'fosse' ) ) {
+		if ( ! $screen instanceof \WP_Screen || ! Menu::is_fosse_admin_screen( $screen ) ) {
 			return;
 		}
 

--- a/src/Admin/class-menu.php
+++ b/src/Admin/class-menu.php
@@ -265,24 +265,30 @@ class Menu {
 	}
 
 	/**
-	 * Suppress foreign admin notices on FOSSE Settings and Wizard screens.
+	 * Suppress foreign admin notices on the FOSSE Setup Wizard screen.
 	 *
-	 * The wizard and Settings page are focused flows; third-party notices
-	 * (host banners, plugin upsells, "rate this plugin" prompts) inject
+	 * The wizard is a focused first-run flow; third-party notices (host
+	 * banners, plugin upsells, "rate this plugin" prompts) inject
 	 * themselves into the wizard surface and break the orientation.
-	 * Strip the four core notice hooks on those screens only — the Status
-	 * page is exempt because it's a long-lived dashboard where foreign
-	 * notices are more legitimate.
+	 * Strip the four core notice hooks on that screen only.
 	 *
-	 * FOSSE's own messaging is unaffected: `settings_errors()` is rendered
-	 * by direct calls in our templates, not via the `admin_notices` hook,
-	 * so removing every callback here doesn't drop FOSSE notices.
+	 * The Settings page is NOT suppressed: long-lived admin pages benefit
+	 * from FOSSE's own `admin_notices`-hooked banners (e.g. the recovery
+	 * notice rendered by
+	 * {@see Bluesky_Provider::maybe_render_auto_publish_disabled_notice()})
+	 * and from legitimate cross-plugin notices that the user expects to
+	 * see in their normal admin flow. The Status page was already exempt
+	 * for the same reason.
+	 *
+	 * FOSSE's own template-driven messaging is unaffected either way:
+	 * `settings_errors()` is rendered by direct calls in our templates,
+	 * not via the `admin_notices` hook.
 	 *
 	 * @param \WP_Screen $screen Current admin screen.
 	 * @return void
 	 */
 	public static function maybe_suppress_admin_notices( \WP_Screen $screen ): void {
-		if ( ! self::is_fosse_setup_or_wizard_screen( $screen ) ) {
+		if ( ! self::is_fosse_wizard_screen( $screen ) ) {
 			return;
 		}
 
@@ -317,20 +323,17 @@ class Menu {
 	}
 
 	/**
-	 * Whether the given screen is the FOSSE Settings page or Setup Wizard.
+	 * Whether the given screen is the FOSSE Setup Wizard.
 	 *
-	 * Centralized so the suppression list and any future callers (e.g.
-	 * conditional asset enqueues) stay in sync. Status is excluded by
-	 * design — see {@see self::maybe_suppress_admin_notices()}.
+	 * Centralized so the suppression list and any future wizard-only
+	 * callers (e.g. conditional asset enqueues) stay in sync. Settings
+	 * and Status pages are excluded by design — see
+	 * {@see self::maybe_suppress_admin_notices()}.
 	 *
 	 * @param \WP_Screen $screen Current admin screen.
 	 * @return bool
 	 */
-	private static function is_fosse_setup_or_wizard_screen( \WP_Screen $screen ): bool {
-		return in_array(
-			$screen->id,
-			array( 'toplevel_page_fosse', 'admin_page_fosse-wizard' ),
-			true
-		);
+	private static function is_fosse_wizard_screen( \WP_Screen $screen ): bool {
+		return 'admin_page_fosse-wizard' === $screen->id;
 	}
 }

--- a/src/Admin/class-menu.php
+++ b/src/Admin/class-menu.php
@@ -336,4 +336,34 @@ class Menu {
 	private static function is_fosse_wizard_screen( \WP_Screen $screen ): bool {
 		return 'admin_page_fosse-wizard' === $screen->id;
 	}
+
+	/**
+	 * Whether the given screen is any FOSSE-owned admin screen.
+	 *
+	 * Public so providers and other admin-side code can scope notices,
+	 * banners, or asset enqueues to FOSSE pages without each caller
+	 * re-implementing screen-id matching. Strict whitelist by design — a
+	 * substring check (e.g. `strpos( $id, 'fosse' )`) would accidentally
+	 * match third-party plugins whose admin pages happen to contain
+	 * "fosse" in their slug.
+	 *
+	 * Covers Settings (`toplevel_page_fosse`), Status
+	 * (`fosse_page_fosse-status`), and the hidden Setup Wizard
+	 * (`admin_page_fosse-wizard`). Add new FOSSE screen IDs here when
+	 * registering new admin pages in {@see self::add_menu()}.
+	 *
+	 * @param \WP_Screen $screen Current admin screen.
+	 * @return bool
+	 */
+	public static function is_fosse_admin_screen( \WP_Screen $screen ): bool {
+		return in_array(
+			$screen->id,
+			array(
+				'toplevel_page_fosse',
+				'fosse_page_fosse-status',
+				'admin_page_fosse-wizard',
+			),
+			true
+		);
+	}
 }

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -650,7 +650,6 @@ class Onboarding_Wizard {
 			'handle'       => '',
 			'did'          => '',
 			'pds_endpoint' => '',
-			'auto_publish' => false,
 			'token_error'  => null,
 		);
 
@@ -1145,10 +1144,6 @@ class Onboarding_Wizard {
 							<td class="fosse-summary__value"><code><?php echo esc_html( $status['did'] ); ?></code></td>
 						</tr>
 					<?php endif; ?>
-					<tr>
-						<td class="fosse-summary__label"><?php esc_html_e( 'Auto Publish', 'fosse' ); ?></td>
-						<td class="fosse-summary__value"><?php echo esc_html( $status['auto_publish'] ? __( 'Enabled', 'fosse' ) : __( 'Disabled', 'fosse' ) ); ?></td>
-					</tr>
 					<?php if ( ! empty( $handle_previews['user'] ) ) : ?>
 						<tr>
 							<td class="fosse-summary__label"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></td>

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -735,12 +735,24 @@ class Onboarding_Wizard {
 	private static function get_bluesky_status(): array {
 		$provider = Connection_Provider_Registry::get_provider( 'bluesky' );
 
+		// `auto_publish` is read directly from the Atmosphere option
+		// rather than `Bluesky_Provider::get_status()` because the
+		// provider intentionally no longer exposes it: the toggle was
+		// removed from FOSSE's UI (Atmosphere has no per-post manual
+		// publish surface to back it up). The wizard's complete-step
+		// CTA still needs the value to phrase its messaging accurately
+		// — "your post will reach Bluesky" vs. "Bluesky is connected
+		// but auto-publish is off" — so the read happens here, against
+		// the same `'1'` default Atmosphere itself uses.
+		$auto_publish = '1' === get_option( 'atmosphere_auto_publish', '1' );
+
 		$defaults = array(
 			'available'    => false,
 			'connected'    => false,
 			'handle'       => '',
 			'did'          => '',
 			'pds_endpoint' => '',
+			'auto_publish' => $auto_publish,
 			'token_error'  => null,
 		);
 

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -735,16 +735,16 @@ class Onboarding_Wizard {
 	private static function get_bluesky_status(): array {
 		$provider = Connection_Provider_Registry::get_provider( 'bluesky' );
 
-		// `auto_publish` is read directly from the Atmosphere option
-		// rather than `Bluesky_Provider::get_status()` because the
-		// provider intentionally no longer exposes it: the toggle was
-		// removed from FOSSE's UI (Atmosphere has no per-post manual
-		// publish surface to back it up). The wizard's complete-step
-		// CTA still needs the value to phrase its messaging accurately
-		// — "your post will reach Bluesky" vs. "Bluesky is connected
-		// but auto-publish is off" — so the read happens here, against
-		// the same `'1'` default Atmosphere itself uses.
-		$auto_publish = '1' === get_option( 'atmosphere_auto_publish', '1' );
+		// `auto_publish` no longer rides along with `get_status()` (the
+		// Settings toggle that read it was removed). The wizard's
+		// complete-step CTA still needs the value to phrase its
+		// messaging accurately — "your post will reach Bluesky" vs.
+		// "Bluesky is connected but auto-publish is off" — so we read
+		// it through the provider's centralized helper, which encodes
+		// the absent-defaults-to-enabled rule alongside the recovery
+		// handler's `update_option` writes that depend on the same
+		// default.
+		$auto_publish = Bluesky_Provider::is_auto_publish_enabled();
 
 		$defaults = array(
 			'available'    => false,

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -81,18 +81,13 @@ test.describe( 'Bluesky provider UI', () => {
 			handle: 'alice.bsky.social',
 			did: 'did:plc:alice123',
 			pds_endpoint: 'https://bsky.social',
-			auto_publish: false,
 		} );
 
 		await page.goto( '/wp-admin/admin.php?page=fosse' );
 
-		const federationSettings = page.locator( '#fosse-federation-settings' );
 		const connections = page.locator( '#fosse-connections' );
 		const blueskyConnection = connections.locator(
 			'#fosse-provider-bluesky'
-		);
-		const blueskySettings = federationSettings.locator(
-			'#fosse-provider-bluesky-settings'
 		);
 
 		await expect(
@@ -102,9 +97,14 @@ test.describe( 'Bluesky provider UI', () => {
 		).toBeVisible();
 		await expect( blueskyConnection ).toContainText( 'alice.bsky.social' );
 		await expect( blueskyConnection ).toContainText( 'did:plc:alice123' );
+
+		// The auto-publish toggle was removed from the unified Settings
+		// form (Atmosphere has no per-post manual publish UI to back it
+		// up); the Bluesky-specific settings section now renders nothing,
+		// so its container shouldn't appear at all.
 		await expect(
-			blueskySettings.locator( 'input[name="atmosphere_auto_publish"]' )
-		).not.toBeChecked();
+			page.locator( '#fosse-provider-bluesky-settings' )
+		).toHaveCount( 0 );
 
 		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
 
@@ -114,7 +114,10 @@ test.describe( 'Bluesky provider UI', () => {
 		await expect( blueskyCard ).toContainText( 'Connected' );
 		await expect( blueskyCard ).toContainText( 'alice.bsky.social' );
 		await expect( blueskyCard ).toContainText( 'did:plc:alice123' );
-		await expect( blueskyCard ).toContainText( 'Disabled' );
 		await expect( blueskyCard ).toContainText( 'OK' );
+
+		// Auto-publish row was removed from the status card alongside the
+		// Settings toggle.
+		await expect( blueskyCard ).not.toContainText( 'Auto Publish' );
 	} );
 } );

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -70,7 +70,10 @@ test.describe( 'Bluesky provider UI', () => {
 			.locator( '.fosse-status-card' )
 			.filter( { hasText: 'Bluesky' } );
 		await expect( blueskyCard ).toContainText( 'Disconnected' );
-		await expect( blueskyCard ).toContainText( 'Enabled' );
+		// Auto Publish row was removed alongside the Settings toggle —
+		// the status card no longer surfaces "Enabled" / "Disabled" text
+		// for it in any state.
+		await expect( blueskyCard ).not.toContainText( 'Auto Publish' );
 	} );
 
 	test( 'setup and status pages show mocked connected Bluesky details', async ( {

--- a/tests/e2e/test-helpers.ts
+++ b/tests/e2e/test-helpers.ts
@@ -15,6 +15,9 @@ import { type Browser, expect, type Page } from '@playwright/test';
  *                                       screen so wpApiSettings.nonce is available.
  * @param {Record<string, unknown>} body Connection state payload (connected,
  *                                       handle, did, pds_endpoint, auto_publish).
+ *                                       `auto_publish` is accepted by the seed
+ *                                       endpoint for backwards compatibility but
+ *                                       no longer surfaced in the UI.
  * @return {Promise<void>} Resolves when the seed succeeds; throws if not 200.
  */
 export const setBlueskyState = async (

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -131,7 +131,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Default status is disconnected with auto-publish enabled.
+	 * Default status is disconnected with empty connection fields.
 	 */
 	public function test_status_disconnected_by_default() {
 		$status = $this->provider->get_status();
@@ -140,7 +140,6 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertSame( '', $status['handle'] );
 		$this->assertSame( '', $status['did'] );
 		$this->assertSame( '', $status['pds_endpoint'] );
-		$this->assertTrue( $status['auto_publish'] );
 		$this->assertNull( $status['token_error'] );
 	}
 
@@ -157,7 +156,6 @@ class Bluesky_ProviderTest extends BaseTestCase {
 				'access_token' => Encryption::encrypt( 'token' ),
 			)
 		);
-		update_option( 'atmosphere_auto_publish', '0' );
 
 		$status = $this->provider->get_status();
 
@@ -165,7 +163,6 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertSame( 'alice.bsky.social', $status['handle'] );
 		$this->assertSame( 'did:plc:test123', $status['did'] );
 		$this->assertSame( 'https://bsky.social', $status['pds_endpoint'] );
-		$this->assertFalse( $status['auto_publish'] );
 		$this->assertNull( $status['token_error'] );
 	}
 
@@ -190,26 +187,28 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * The settings section is empty while disconnected — no auto-publish
-	 * toggle, no connect form. Connect/disconnect actions render via
-	 * `render_connection_actions()` outside the unified Settings form.
+	 * `render_setup_section()` is a no-op in both connected and disconnected
+	 * states. The auto-publish toggle that used to live here was removed
+	 * (Atmosphere has no per-post manual publish UI to back it up); the
+	 * connect / disconnect actions render via `render_connection_actions()`
+	 * outside the unified Settings form. Other interface methods (status
+	 * card, save_settings) keep working — this test just pins the
+	 * "nothing renders into the unified Settings form" contract.
 	 */
-	public function test_render_setup_section_disconnected_is_empty() {
+	public function test_render_setup_section_is_no_op_when_disconnected() {
 		ob_start();
 		$this->provider->render_setup_section();
 		$output = ob_get_clean();
 
 		$this->assertSame( '', trim( $output ) );
-		$this->assertStringNotContainsString( 'fosse_connect_bluesky', $output );
-		$this->assertStringNotContainsString( 'fosse_disconnect_bluesky', $output );
 	}
 
 	/**
-	 * Connected settings section exposes the auto-publish toggle as a
-	 * fields-only fragment (no opening `<form>` tag) so it can sit inside
-	 * the unified Settings form alongside General + AP fields.
+	 * Connected state also renders nothing — the toggle was the only thing
+	 * gated on `connected`, so removing it leaves no Bluesky-specific row
+	 * in the unified Settings form.
 	 */
-	public function test_render_setup_section_connected_renders_auto_publish_toggle() {
+	public function test_render_setup_section_is_no_op_when_connected() {
 		update_option(
 			'atmosphere_connection',
 			array(
@@ -224,68 +223,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_setup_section();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'class="fosse-settings-section"', $output );
-		$this->assertStringContainsString( '<h3>Bluesky publishing</h3>', $output );
-		$this->assertStringContainsString( 'name="atmosphere_auto_publish"', $output );
-		$this->assertStringContainsString( 'Auto-publish', $output );
-		$this->assertStringNotContainsString( '<form', $output );
-		$this->assertStringNotContainsString( 'fosse_connect_bluesky', $output );
-		$this->assertStringNotContainsString( 'fosse_disconnect_bluesky', $output );
-	}
-
-	/**
-	 * Auto-publish checkbox reflects the stored option. With Atmosphere's
-	 * default ('1' = enabled), an unset option still renders the box checked.
-	 */
-	public function test_render_setup_section_auto_publish_checked_by_default() {
-		update_option(
-			'atmosphere_connection',
-			array(
-				'did'          => 'did:plc:test123',
-				'handle'       => 'alice.bsky.social',
-				'pds_endpoint' => 'https://bsky.social',
-				'access_token' => Encryption::encrypt( 'token' ),
-			)
-		);
-		delete_option( 'atmosphere_auto_publish' );
-
-		ob_start();
-		$this->provider->render_setup_section();
-		$output = ob_get_clean();
-
-		// WordPress's `checked()` may emit `checked='checked'` or a bare
-		// `checked` attribute depending on core version; match either form
-		// so the assertion stays stable across the supported floor.
-		$this->assertMatchesRegularExpression(
-			'~<input[^>]+name="atmosphere_auto_publish"[^>]+(checked(?:=\'checked\'|="checked")?)~',
-			$output
-		);
-	}
-
-	/**
-	 * When auto-publish is explicitly disabled ('0'), the checkbox renders
-	 * unchecked.
-	 */
-	public function test_render_setup_section_auto_publish_unchecked_when_disabled() {
-		update_option(
-			'atmosphere_connection',
-			array(
-				'did'          => 'did:plc:test123',
-				'handle'       => 'alice.bsky.social',
-				'pds_endpoint' => 'https://bsky.social',
-				'access_token' => Encryption::encrypt( 'token' ),
-			)
-		);
-		update_option( 'atmosphere_auto_publish', '0' );
-
-		ob_start();
-		$this->provider->render_setup_section();
-		$output = ob_get_clean();
-
-		$this->assertDoesNotMatchRegularExpression(
-			'~<input[^>]+name="atmosphere_auto_publish"[^>]+(checked(?:=\'checked\'|="checked")?)~',
-			$output
-		);
+		$this->assertSame( '', trim( $output ) );
 	}
 
 	/**
@@ -1496,59 +1434,29 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	// --- save_settings ----------------------------------------------------
 
 	/**
-	 * A submitted, checked auto-publish input persists `'1'` so Atmosphere's
-	 * publish flow remains enabled after save.
+	 * `save_settings()` is currently a no-op (the auto-publish toggle was
+	 * removed from `render_setup_section()` because Atmosphere has no
+	 * per-post manual publish UI to back it up). It must still return
+	 * true so the unified Settings save's all-or-nothing semantics
+	 * succeed, and it must NOT touch `atmosphere_auto_publish` — the
+	 * option remains stored at its existing value (default `'1'`)
+	 * regardless of POST contents.
 	 */
-	public function test_save_settings_stores_auto_publish_when_checked() {
+	public function test_save_settings_is_no_op_and_returns_true() {
 		$this->seed_connected_atmosphere_connection();
+		update_option( 'atmosphere_auto_publish', '1' );
 
-		$ok = $this->provider->save_settings( array( 'atmosphere_auto_publish' => '1' ) );
+		// Even a payload that LOOKS like the legacy unchecked-checkbox
+		// shape (omitted key) must not flip the option to '0' — there's
+		// no input rendered, so its absence is meaningless.
+		$ok = $this->provider->save_settings( array() );
 
 		$this->assertTrue( $ok );
 		$this->assertSame( '1', get_option( 'atmosphere_auto_publish' ) );
-	}
 
-	/**
-	 * An omitted checkbox while connected is the legitimate "disabled"
-	 * submission — HTML forms drop unchecked checkboxes from the POST body,
-	 * so absence must persist `'0'` instead of preserving the previous value.
-	 */
-	public function test_save_settings_disables_auto_publish_when_unchecked() {
-		$this->seed_connected_atmosphere_connection();
-		update_option( 'atmosphere_auto_publish', '1' );
-
-		$ok = $this->provider->save_settings( array() );
-
-		$this->assertTrue( $ok );
-		$this->assertSame( '0', get_option( 'atmosphere_auto_publish' ) );
-	}
-
-	/**
-	 * An empty-string value (defensive) reads as "unchecked" and disables
-	 * auto-publish — guards against malformed POST bodies that submit the
-	 * field name without a value.
-	 */
-	public function test_save_settings_disables_auto_publish_for_empty_value() {
-		$this->seed_connected_atmosphere_connection();
-		update_option( 'atmosphere_auto_publish', '1' );
-
-		$this->provider->save_settings( array( 'atmosphere_auto_publish' => '' ) );
-
-		$this->assertSame( '0', get_option( 'atmosphere_auto_publish' ) );
-	}
-
-	/**
-	 * A Settings save while disconnected must NOT touch
-	 * `atmosphere_auto_publish` — the toggle isn't rendered in that state,
-	 * so an omitted checkbox is the absence of a setting, not an
-	 * intentional "uncheck". Without this guard a routine General-section
-	 * save would silently flip the option to `'0'`.
-	 */
-	public function test_save_settings_disconnected_preserves_auto_publish() {
-		// Provider is disconnected by set_up_provider() (no connection seed).
-		update_option( 'atmosphere_auto_publish', '1' );
-
-		$ok = $this->provider->save_settings( array() );
+		// And a payload that explicitly carries the legacy field is also
+		// ignored — safety against a stale form somehow being POSTed.
+		$ok = $this->provider->save_settings( array( 'atmosphere_auto_publish' => '0' ) );
 
 		$this->assertTrue( $ok );
 		$this->assertSame( '1', get_option( 'atmosphere_auto_publish' ) );

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -1492,6 +1492,42 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		);
 	}
 
+	// --- is_auto_publish_enabled --------------------------------------
+
+	/**
+	 * Helper returns true when the option is absent — encodes the
+	 * "default-on" contract upstream Atmosphere shares. Pairs with
+	 * `test_absent_atmosphere_auto_publish_option_defaults_to_enabled`,
+	 * which pins the raw `get_option()` half of the same contract.
+	 */
+	public function test_is_auto_publish_enabled_true_when_option_absent() {
+		delete_option( 'atmosphere_auto_publish' );
+
+		$this->assertTrue( Bluesky_Provider::is_auto_publish_enabled() );
+	}
+
+	/**
+	 * Helper returns true when the option is explicitly `'1'`.
+	 */
+	public function test_is_auto_publish_enabled_true_when_explicitly_on() {
+		update_option( 'atmosphere_auto_publish', '1' );
+
+		$this->assertTrue( Bluesky_Provider::is_auto_publish_enabled() );
+	}
+
+	/**
+	 * Helper returns false when the option is explicitly `'0'` — the
+	 * recovery-notice population. The recovery-notice gate uses a
+	 * separate raw read because it must distinguish "explicit `'0'`"
+	 * from "absent"; this helper conflates the two by design (absent
+	 * reads as enabled).
+	 */
+	public function test_is_auto_publish_enabled_false_when_explicitly_off() {
+		update_option( 'atmosphere_auto_publish', '0' );
+
+		$this->assertFalse( Bluesky_Provider::is_auto_publish_enabled() );
+	}
+
 	// --- maybe_render_auto_publish_disabled_notice ----------------------
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -1425,7 +1425,9 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		$this->assertNotFalse( has_action( 'admin_post_fosse_connect_bluesky', array( $this->provider, 'handle_connect' ) ) );
 		$this->assertNotFalse( has_action( 'admin_post_fosse_disconnect_bluesky', array( $this->provider, 'handle_disconnect' ) ) );
+		$this->assertNotFalse( has_action( 'admin_post_fosse_enable_bluesky_auto_publish', array( $this->provider, 'handle_enable_auto_publish' ) ) );
 		$this->assertNotFalse( has_action( 'admin_init', array( $this->provider, 'handle_oauth_callback' ) ) );
+		$this->assertNotFalse( has_action( 'admin_notices', array( $this->provider, 'maybe_render_auto_publish_disabled_notice' ) ) );
 		$this->assertSame( 1, has_action( 'init', array( $this->provider, 'serve_atproto_did_well_known' ) ) );
 		$this->assertSame( 1, has_action( 'template_redirect', array( $this->provider, 'maybe_suppress_atmosphere_well_known' ) ) );
 		$this->assertNotFalse( has_filter( 'atmosphere_oauth_redirect_uri', array( $this->provider, 'filter_oauth_redirect_uri' ) ) );
@@ -1460,6 +1462,226 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		$this->assertTrue( $ok );
 		$this->assertSame( '1', get_option( 'atmosphere_auto_publish' ) );
+	}
+
+	/**
+	 * Pins the upstream contract that FOSSE's "preserved option" claim
+	 * depends on: when `atmosphere_auto_publish` is absent from the
+	 * database, `get_option()` returns `'1'` (auto-publish enabled).
+	 * Atmosphere's publish hook reads the option with the same default,
+	 * so an absent option is functionally equivalent to "on."
+	 *
+	 * If a future Atmosphere bump flips the documented default, or if
+	 * something registers the option with a different default at
+	 * `register_setting()` time, this assertion catches the contract
+	 * change before it silently disables Bluesky publishing for every
+	 * default-state site.
+	 */
+	public function test_absent_atmosphere_auto_publish_option_defaults_to_enabled() {
+		delete_option( 'atmosphere_auto_publish' );
+
+		$this->assertFalse(
+			get_option( 'atmosphere_auto_publish' ),
+			'Sanity check: option should be absent so the default-fallback path runs.'
+		);
+		$this->assertSame(
+			'1',
+			get_option( 'atmosphere_auto_publish', '1' ),
+			'FOSSE removed the auto-publish UI on the assumption that an absent option reads as enabled. If this assertion fails, the assumption is no longer safe and the recovery notice / handler in Bluesky_Provider must be reconsidered.'
+		);
+	}
+
+	// --- maybe_render_auto_publish_disabled_notice ----------------------
+
+	/**
+	 * Notice fires when the option is explicitly `'0'` and Bluesky is
+	 * connected, on a FOSSE admin screen, for a user who can manage
+	 * options. Renders a warning notice with a one-click re-enable form.
+	 */
+	public function test_auto_publish_disabled_notice_renders_when_explicitly_off() {
+		$this->seed_connected_atmosphere_connection();
+		update_option( 'atmosphere_auto_publish', '0' );
+		$this->become_admin();
+		set_current_screen( 'toplevel_page_fosse' );
+
+		ob_start();
+		$this->provider->maybe_render_auto_publish_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'notice notice-warning', $output );
+		$this->assertStringContainsString( 'Bluesky auto-publishing is off.', $output );
+		$this->assertStringContainsString( 'fosse_enable_bluesky_auto_publish', $output );
+		$this->assertStringContainsString( 'Turn auto-publishing back on', $output );
+	}
+
+	/**
+	 * Notice does NOT fire when the option is at its absent / default-on
+	 * state — that's the silent-majority path and would be noise.
+	 */
+	public function test_auto_publish_disabled_notice_silent_when_option_absent() {
+		$this->seed_connected_atmosphere_connection();
+		delete_option( 'atmosphere_auto_publish' );
+		$this->become_admin();
+		set_current_screen( 'toplevel_page_fosse' );
+
+		ob_start();
+		$this->provider->maybe_render_auto_publish_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	/**
+	 * Notice does NOT fire when the option is explicitly `'1'` — same
+	 * default-on intent, just with the option materialized.
+	 */
+	public function test_auto_publish_disabled_notice_silent_when_explicitly_on() {
+		$this->seed_connected_atmosphere_connection();
+		update_option( 'atmosphere_auto_publish', '1' );
+		$this->become_admin();
+		set_current_screen( 'toplevel_page_fosse' );
+
+		ob_start();
+		$this->provider->maybe_render_auto_publish_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	/**
+	 * Notice does NOT fire on non-FOSSE screens — even when the user is
+	 * in the at-risk state, we limit the surface to avoid leaking across
+	 * wp-admin.
+	 */
+	public function test_auto_publish_disabled_notice_silent_off_fosse_screens() {
+		$this->seed_connected_atmosphere_connection();
+		update_option( 'atmosphere_auto_publish', '0' );
+		$this->become_admin();
+		set_current_screen( 'dashboard' );
+
+		ob_start();
+		$this->provider->maybe_render_auto_publish_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	/**
+	 * Notice does NOT fire when Bluesky is disconnected — there's nothing
+	 * for auto-publish to do anyway, so the notice would be misleading.
+	 */
+	public function test_auto_publish_disabled_notice_silent_when_disconnected() {
+		// No `seed_connected_atmosphere_connection()` — disconnected.
+		update_option( 'atmosphere_auto_publish', '0' );
+		$this->become_admin();
+		set_current_screen( 'toplevel_page_fosse' );
+
+		ob_start();
+		$this->provider->maybe_render_auto_publish_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	/**
+	 * Notice does NOT fire for users without `manage_options`.
+	 */
+	public function test_auto_publish_disabled_notice_silent_for_subscriber() {
+		$this->seed_connected_atmosphere_connection();
+		update_option( 'atmosphere_auto_publish', '0' );
+		set_current_screen( 'toplevel_page_fosse' );
+
+		$this->become_subscriber();
+
+		ob_start();
+		$this->provider->maybe_render_auto_publish_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	// --- handle_enable_auto_publish -----------------------------------
+
+	/**
+	 * The re-enable handler flips the option to `'1'` and redirects with
+	 * a success notice, recovering sites stranded by the toggle removal.
+	 */
+	public function test_handle_enable_auto_publish_flips_option_and_redirects() {
+		$this->seed_connected_atmosphere_connection();
+		update_option( 'atmosphere_auto_publish', '0' );
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => wp_create_nonce( 'fosse_enable_bluesky_auto_publish' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_enable_auto_publish();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( '1', get_option( 'atmosphere_auto_publish' ) );
+	}
+
+	/**
+	 * Re-enable handler rejects requests with a missing or invalid nonce.
+	 */
+	public function test_handle_enable_auto_publish_rejects_bad_nonce() {
+		$this->seed_connected_atmosphere_connection();
+		update_option( 'atmosphere_auto_publish', '0' );
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => 'invalid_nonce_value',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$this->install_wp_die_handler();
+		$this->expectException( \RuntimeException::class );
+		$this->provider->handle_enable_auto_publish();
+	}
+
+	/**
+	 * Re-enable handler rejects subscribers — option must not change for
+	 * users without `manage_options`.
+	 */
+	public function test_handle_enable_auto_publish_rejects_subscriber() {
+		$this->seed_connected_atmosphere_connection();
+		update_option( 'atmosphere_auto_publish', '0' );
+
+		$this->become_subscriber();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => wp_create_nonce( 'fosse_enable_bluesky_auto_publish' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$this->install_wp_die_handler();
+		$this->expectException( \RuntimeException::class );
+		try {
+			$this->provider->handle_enable_auto_publish();
+		} finally {
+			$this->assertSame(
+				'0',
+				get_option( 'atmosphere_auto_publish' ),
+				'Subscriber must not be able to flip the option.'
+			);
+		}
 	}
 
 	/**

--- a/tests/php/Admin/MenuTest.php
+++ b/tests/php/Admin/MenuTest.php
@@ -443,6 +443,57 @@ class MenuTest extends BaseTestCase {
 		$this->assertContains( 'admin_notices', $fired, 'Late-stage suppression must not affect unrelated screens.' );
 	}
 
+	// --- is_fosse_admin_screen ---
+
+	/**
+	 * The three FOSSE admin screen IDs match. Anchors the public helper
+	 * against the menu registration so adding a new admin page without
+	 * extending the helper would surface here.
+	 *
+	 * @dataProvider provide_fosse_admin_screens
+	 */
+	public function test_is_fosse_admin_screen_matches_known_screens( string $screen_id ): void {
+		$this->assertTrue(
+			Menu::is_fosse_admin_screen( $this->fake_screen( $screen_id ) ),
+			"Screen id {$screen_id} should be recognized as a FOSSE admin screen."
+		);
+	}
+
+	/**
+	 * Strict whitelist: substrings that contain "fosse" but aren't one of
+	 * the three registered FOSSE pages must not match. Guards against the
+	 * pre-fix `strpos( $id, 'fosse' )` regression where any third-party
+	 * plugin slug containing "fosse" would surface FOSSE-scoped notices.
+	 *
+	 * @dataProvider provide_non_fosse_screens
+	 */
+	public function test_is_fosse_admin_screen_rejects_unrelated_screens( string $screen_id ): void {
+		$this->assertFalse(
+			Menu::is_fosse_admin_screen( $this->fake_screen( $screen_id ) ),
+			"Screen id {$screen_id} must not be recognized as a FOSSE admin screen."
+		);
+	}
+
+	/**
+	 * @return iterable<string, array{0: string}>
+	 */
+	public static function provide_fosse_admin_screens(): iterable {
+		yield 'settings (top-level)' => array( 'toplevel_page_fosse' );
+		yield 'status (subpage)'     => array( 'fosse_page_fosse-status' );
+		yield 'wizard (hidden)'      => array( 'admin_page_fosse-wizard' );
+	}
+
+	/**
+	 * @return iterable<string, array{0: string}>
+	 */
+	public static function provide_non_fosse_screens(): iterable {
+		yield 'dashboard'                          => array( 'dashboard' );
+		yield 'plugins list'                       => array( 'plugins' );
+		yield 'third-party with fosse in slug'     => array( 'toplevel_page_fossify' );
+		yield 'third-party subpage with substring' => array( 'tools_page_fosse-clone' );
+		yield 'empty id'                           => array( '' );
+	}
+
 	/**
 	 * Register one canary callback per notice hook so the suppression
 	 * tests can observe which hooks still fire.

--- a/tests/php/Admin/MenuTest.php
+++ b/tests/php/Admin/MenuTest.php
@@ -310,29 +310,10 @@ class MenuTest extends BaseTestCase {
 	// --- notice suppression (#56) ---
 
 	/**
-	 * Foreign admin notice callbacks are stripped on the FOSSE Setup screen.
-	 *
-	 * Covers the four core notice hooks WordPress fires during admin header
-	 * rendering. The wizard / Setup page are focused flows; foreign notices
-	 * (host banners, plugin upsells) break the orientation.
-	 */
-	public function test_suppresses_admin_notices_on_setup_screen(): void {
-		$fired = array();
-		$this->register_notice_canaries( $fired );
-
-		Menu::maybe_suppress_admin_notices( $this->fake_screen( 'toplevel_page_fosse' ) );
-
-		do_action( 'admin_notices' );
-		do_action( 'all_admin_notices' );
-		do_action( 'network_admin_notices' );
-		do_action( 'user_admin_notices' );
-
-		$this->assertSame( array(), $fired, 'Foreign notices should be suppressed on the Setup screen.' );
-	}
-
-	/**
-	 * Same suppression on the Setup Wizard screen — the original incident
-	 * (Jurassic Ninja credentials banner) was on the wizard, not Setup.
+	 * Foreign admin notice callbacks are stripped on the FOSSE Setup
+	 * Wizard screen — the original incident (Jurassic Ninja credentials
+	 * banner) was on the wizard, and the wizard is a focused first-run
+	 * flow where foreign notices break the orientation.
 	 */
 	public function test_suppresses_admin_notices_on_wizard_screen(): void {
 		$fired = array();
@@ -349,7 +330,32 @@ class MenuTest extends BaseTestCase {
 	}
 
 	/**
-	 * Suppression is scoped to Setup + Wizard. The Status page is a
+	 * The Settings page (`toplevel_page_fosse`) does NOT suppress notices
+	 * — long-lived admin pages benefit from FOSSE's own
+	 * `admin_notices`-hooked banners (e.g. the auto-publish recovery
+	 * notice in Bluesky_Provider) and from legitimate cross-plugin
+	 * signal in the user's normal admin flow.
+	 */
+	public function test_does_not_suppress_admin_notices_on_settings_screen(): void {
+		$fired = array();
+		$this->register_notice_canaries( $fired );
+
+		Menu::maybe_suppress_admin_notices( $this->fake_screen( 'toplevel_page_fosse' ) );
+
+		do_action( 'admin_notices' );
+		do_action( 'all_admin_notices' );
+		do_action( 'network_admin_notices' );
+		do_action( 'user_admin_notices' );
+
+		$this->assertSame(
+			array( 'admin_notices', 'all_admin_notices', 'network_admin_notices', 'user_admin_notices' ),
+			$fired,
+			'Settings screen must preserve foreign notices so FOSSE-hooked banners can render.'
+		);
+	}
+
+	/**
+	 * Suppression is scoped to the Wizard. The Status page is a
 	 * long-lived dashboard; foreign notices are more legitimate there
 	 * and stripping them would risk masking real cross-plugin signal.
 	 */
@@ -392,13 +398,15 @@ class MenuTest extends BaseTestCase {
 	 * between `current_screen` and the actual notice hooks (e.g. via
 	 * `admin_head` or `admin_enqueue_scripts`). Mirrors the
 	 * `current_screen` test but exercises the `in_admin_header`-bound
-	 * `maybe_suppress_admin_notices_late()` wrapper.
+	 * `maybe_suppress_admin_notices_late()` wrapper. Targets the wizard
+	 * screen since that's the only screen the early stage suppresses
+	 * — the late stage must agree.
 	 */
 	public function test_late_suppression_strips_admin_head_added_notices(): void {
-		set_current_screen( 'toplevel_page_fosse' );
+		set_current_screen( 'admin_page_fosse-wizard' );
 		$current = get_current_screen();
 		if ( $current instanceof \WP_Screen ) {
-			$current->id = 'toplevel_page_fosse';
+			$current->id = 'admin_page_fosse-wizard';
 		}
 
 		$fired = array();

--- a/tests/php/Admin/MenuTest.php
+++ b/tests/php/Admin/MenuTest.php
@@ -13,6 +13,7 @@ use Automattic\Fosse\Admin\Menu;
 use Automattic\Fosse\Admin\Onboarding_Wizard;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 
 /**
@@ -450,8 +451,10 @@ class MenuTest extends BaseTestCase {
 	 * against the menu registration so adding a new admin page without
 	 * extending the helper would surface here.
 	 *
+	 * @param string $screen_id Screen id under test.
 	 * @dataProvider provide_fosse_admin_screens
 	 */
+	#[DataProvider( 'provide_fosse_admin_screens' )]
 	public function test_is_fosse_admin_screen_matches_known_screens( string $screen_id ): void {
 		$this->assertTrue(
 			Menu::is_fosse_admin_screen( $this->fake_screen( $screen_id ) ),
@@ -465,8 +468,10 @@ class MenuTest extends BaseTestCase {
 	 * pre-fix `strpos( $id, 'fosse' )` regression where any third-party
 	 * plugin slug containing "fosse" would surface FOSSE-scoped notices.
 	 *
+	 * @param string $screen_id Screen id under test.
 	 * @dataProvider provide_non_fosse_screens
 	 */
+	#[DataProvider( 'provide_non_fosse_screens' )]
 	public function test_is_fosse_admin_screen_rejects_unrelated_screens( string $screen_id ): void {
 		$this->assertFalse(
 			Menu::is_fosse_admin_screen( $this->fake_screen( $screen_id ) ),
@@ -475,6 +480,9 @@ class MenuTest extends BaseTestCase {
 	}
 
 	/**
+	 * Screen ids registered in {@see Menu::add_menu()} that the public
+	 * helper must recognize as FOSSE-owned.
+	 *
 	 * @return iterable<string, array{0: string}>
 	 */
 	public static function provide_fosse_admin_screens(): iterable {
@@ -484,6 +492,9 @@ class MenuTest extends BaseTestCase {
 	}
 
 	/**
+	 * Lookalike and unrelated screen ids that must not match — anchors the
+	 * strict whitelist against the substring-match regression.
+	 *
 	 * @return iterable<string, array{0: string}>
 	 */
 	public static function provide_non_fosse_screens(): iterable {

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -104,19 +104,21 @@ class Setup_PageTest extends BaseTestCase {
 	}
 
 	/**
-	 * A clean unified save persists post types (the cross-protocol option),
-	 * actor mode (AP-side), and auto-publish (Atmosphere-side) in one shot
-	 * and posts the success notice to the FOSSE settings group.
+	 * A clean unified save persists post types (the cross-protocol option)
+	 * and actor mode (AP-side) in one shot and posts the success notice to
+	 * the FOSSE settings group. The Bluesky provider's `save_settings()`
+	 * is currently a no-op (auto-publish toggle removed), so the unified
+	 * save must still succeed even though no Bluesky-side fields are sent.
 	 */
 	public function test_handle_save_persists_general_and_per_provider_settings(): void {
 		$this->seed_connected_atmosphere_connection();
+		update_option( 'atmosphere_auto_publish', '1' );
 		$this->become_admin();
 
 		$this->simulate_post(
 			array(
 				'activitypub_actor_mode'         => 'actor_blog',
 				'activitypub_support_post_types' => array( 'post', 'page' ),
-				'atmosphere_auto_publish'        => '1',
 			)
 		);
 
@@ -130,6 +132,9 @@ class Setup_PageTest extends BaseTestCase {
 
 		$this->assertSame( 'actor_blog', get_option( 'activitypub_actor_mode' ) );
 		$this->assertSame( array( 'post', 'page' ), get_option( 'activitypub_support_post_types' ) );
+		// Auto-publish option is preserved — the toggle was removed from
+		// the UI but the underlying option keeps its stored value (default
+		// `'1'`) so Atmosphere's publish flow is unaffected.
 		$this->assertSame( '1', get_option( 'atmosphere_auto_publish' ) );
 
 		$codes = array_column( get_settings_errors( 'fosse' ), 'code' );
@@ -137,50 +142,25 @@ class Setup_PageTest extends BaseTestCase {
 	}
 
 	/**
-	 * Unchecking the auto-publish box drops the field from the POST body —
-	 * the unified save must persist `'0'` instead of preserving the prior
-	 * value. Mirrors the Bluesky_Provider unit test through the full handler.
+	 * The unified save must NOT touch `atmosphere_auto_publish` regardless
+	 * of POST contents — the toggle was removed from the UI, so any
+	 * appearance of the field in POST is meaningless (likely a stale form
+	 * or an attacker probe). The provider's `save_settings()` is a no-op
+	 * for this option; this test exercises the full handler to confirm
+	 * end-to-end behavior.
 	 */
-	public function test_handle_save_disables_auto_publish_when_field_omitted(): void {
+	public function test_handle_save_does_not_modify_auto_publish_option(): void {
 		$this->seed_connected_atmosphere_connection();
 		update_option( 'atmosphere_auto_publish', '1' );
 		$this->become_admin();
 
+		// Even an explicit `'0'` payload should be ignored — there's no
+		// input rendered for it, so its presence has no semantic meaning.
 		$this->simulate_post(
 			array(
 				'activitypub_actor_mode'         => 'actor',
 				'activitypub_support_post_types' => array( 'post' ),
-				// `atmosphere_auto_publish` intentionally omitted (unchecked).
-			)
-		);
-
-		$this->arm_redirect_trap();
-
-		try {
-			Setup_Page::handle_save();
-		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
-
-		$this->assertSame( '0', get_option( 'atmosphere_auto_publish' ) );
-	}
-
-	/**
-	 * A Settings save while Bluesky is disconnected does NOT flip
-	 * `atmosphere_auto_publish` to `'0'` even though the toggle isn't in
-	 * the form. The Bluesky provider's disconnect guard owns the policy;
-	 * this test exercises it through the full unified handler.
-	 */
-	public function test_handle_save_disconnected_preserves_auto_publish(): void {
-		// No `seed_connected_atmosphere_connection()` — provider stays
-		// disconnected so save_settings() should bail out.
-		update_option( 'atmosphere_auto_publish', '1' );
-		$this->become_admin();
-
-		$this->simulate_post(
-			array(
-				'activitypub_actor_mode'         => 'actor',
-				'activitypub_support_post_types' => array( 'post' ),
+				'atmosphere_auto_publish'        => '0',
 			)
 		);
 


### PR DESCRIPTION
## Summary

Removes the Bluesky "Auto-publish" toggle from the FOSSE Settings page, the matching row from the Status page, and the matching row from the onboarding wizard summary. The underlying `atmosphere_auto_publish` option is preserved in the database with default `'1'` (on), so behavior is unchanged for every existing site — only the UI surface goes away.

For the narrow population whose option is explicitly `'0'` (set deliberately before the toggle was removed), a one-click recovery notice now surfaces on FOSSE admin pages so they're never stranded.

@RCowles — pulling you in for a sanity check on this one. The "Auto-publish to Bluesky" toggle currently exists alongside no per-post manual publish surface (no editor button, no pre-publish panel, no meta-box checkbox) — so flipping it off effectively means "Bluesky connection still exists but nothing new ships there." Old engagement keeps flowing back via the reaction-sync cron, but that's it. Feels like the toggle promises a workflow ("manual publishing") we don't actually offer.

This PR removes the toggle from the Settings UI but keeps the `atmosphere_auto_publish` option in the database with default `'1'` — so existing sites that explicitly turned it off continue to behave the same way, and a future per-post UI can re-introduce the toggle without a data migration. The pre-publish federation panel for Bluesky tracked in DOTCOM-17007 / [wordpress-atmosphere#50](https://github.com/Automattic/wordpress-atmosphere/issues/50) is the real long-term answer — when that lands, we can re-add the toggle here with actual control granularity behind it.

Two questions:
1. Are you OK with this as a v1 simplification, or would you rather we keep the toggle and ship the per-post UI alongside it?
2. Any user scenarios I'm missing where "connected but auto-publish off" is actually the right setup today?

## What changed

**Removed from UI:**
- The `Auto-publish` fieldset from the unified Settings form (`Bluesky_Provider::render_setup_section()` is now a no-op).
- The `Auto Publish` row from the Bluesky status card on the Status page.
- The `Auto Publish` row from the wizard summary screen.
- The `auto_publish` field from `Bluesky_Provider::get_status()` and the related `save_settings()` persistence path.

**Preserved:**
- The `atmosphere_auto_publish` option in the database with default `'1'` (on), so existing sites that explicitly turned it off continue to behave the same way.
- `Bluesky_Provider::save_settings()` as a no-op (interface contract).
- The e2e seed endpoint's `auto_publish` param (test fixture utility).

**Added (recovery for stranded sites):**
- `Bluesky_Provider::maybe_render_auto_publish_disabled_notice()` — fires on FOSSE admin screens for *connected* sites whose option is *explicitly* `'0'` (not absent / not default-on). Renders a warning notice with a one-click re-enable form. Silent for the silent-majority default-state sites.
- `Bluesky_Provider::handle_enable_auto_publish()` — admin-post handler that flips the option to `'1'` after capability + nonce checks, then redirects with a success notice.

## Test plan

- [x] `composer run-script lint-php` clean
- [x] `composer run-script test-php -- --filter '(Bluesky_Provider|Setup_Page|Onboarding_Wizard|Menu)Test'` — 165 tests, 470 assertions, all green
- [ ] CI green (full PHP unit + e2e Playwright)
- [ ] Visual smoke (default site): Settings page no longer shows the "Bluesky publishing" section, Status page Bluesky card no longer shows "Auto Publish" row, wizard summary no longer shows it either
- [ ] Visual smoke (stranded site): on a connected sandbox where `atmosphere_auto_publish === '0'`, confirm the warning notice appears at the top of FOSSE admin pages and the "Turn auto-publishing back on" button flips the option and surfaces a success notice
- [ ] Behavior smoke: publish a new post on a connected sandbox at the default — confirm it still federates (default `'1'` preserved)