### PR TITLE
test: e2e status-page cleanup uses resetBlueskyState helper

### DIFF
--- a/tests/e2e/status-page.spec.ts
+++ b/tests/e2e/status-page.spec.ts
@@ -1,43 +1,18 @@
 import { test, expect, type Page } from '@playwright/test';
-
-const setBlueskyState = async (
-	page: Page,
-	body: Record< string, unknown >
-) => {
-	const result = await page.evaluate( async ( payload ) => {
-		const res = await fetch( '/wp-json/fosse-e2e/v1/bluesky-state', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
-			},
-			body: JSON.stringify( payload ),
-		} );
-
-		return { status: res.status, text: await res.text() };
-	}, body );
-
-	expect(
-		result.status,
-		`fosse-e2e/v1/bluesky-state returned: ${ result.text.slice( 0, 300 ) }`
-	).toBe( 200 );
-};
+import { resetBlueskyState, setBlueskyState } from './test-helpers';
 
 test.describe( 'Status page polish', () => {
 	// Connected-state writes leak across specs (the wizard's connect step
 	// flips to its summary branch when atmosphere_connection is set), so
 	// reset to disconnected on the way out — mirrors bluesky-provider.spec.ts.
-	test.afterAll( async ( { browser } ) => {
-		const page = await browser.newPage();
-		await page.goto( '/wp-admin/post-new.php' );
-		await page.waitForFunction(
-			() => !! ( window as any ).wpApiSettings?.nonce
-		);
-		await setBlueskyState( page, {
-			connected: false,
-			auto_publish: true,
-		} );
-		await page.close();
+	test.afterAll( async ( { browser }, testInfo ) => {
+		const baseURL = testInfo.project.use.baseURL;
+		if ( ! baseURL ) {
+			throw new Error(
+				'baseURL must be configured in playwright.config.ts'
+			);
+		}
+		await resetBlueskyState( browser, baseURL );
 	} );
 
 	test.beforeEach( async ( { page } ) => {


### PR DESCRIPTION
## Summary

The `status-page.spec.ts` `afterAll` cleanup creates a fresh Playwright page via `browser.newPage()` and calls `page.goto( '/wp-admin/post-new.php' )` with a relative URL. Per `tests/e2e/test-helpers.ts`, `browser.newPage()` does NOT inherit the project's `baseURL` from `playwright.config.ts`, so relative `page.goto()` would fail without an explicit base. The shared `resetBlueskyState()` helper exists for exactly this case (and `bluesky-provider.spec.ts` already uses it).

This PR replaces the inline cleanup with `resetBlueskyState( browser, baseURL )`, mirroring `bluesky-provider.spec.ts`. Also drops the locally-duplicated `setBlueskyState` helper (now imported from `test-helpers`).

Surfaced by the 2026-05-06 deep audit (see PR #103, `audits/2026-05-06-fosse-plugin-audit-report.md` finding "P2: \`status-page.spec.ts\` afterAll cleanup uses a page without \`baseURL\`").

## Test plan

- [ ] CI: `e2e.yml` passes — both `status-page.spec.ts` tests still pass
- [ ] Connected state from the long-values test does not leak into later specs (run e2e suite end-to-end)