### PR TITLE
add: metrics recorder, schema, channel interfaces

### DIFF
--- a/src/Metrics/Channels/class-in-memory-mc-channel.php
+++ b/src/Metrics/Channels/class-in-memory-mc-channel.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * In-memory MC channel for tests.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Metrics\Channels;
+
+use Automattic\Fosse\Metrics\Mc_Channel;
+
+/**
+ * Captures every `bump()` invocation in memory for assertions.
+ *
+ * Same registration pattern as `In_Memory_Tracks_Channel` — autoloaded
+ * via classmap but only registered by tests through
+ * `fosse_metrics_mc_channels`.
+ */
+final class In_Memory_Mc_Channel implements Mc_Channel {
+
+	/**
+	 * Captured bump names in call order.
+	 *
+	 * @var list<string>
+	 */
+	private array $bumps = array();
+
+	/**
+	 * Bump a counter.
+	 *
+	 * @param string $name Counter name.
+	 * @return void
+	 */
+	public function bump( string $name ): void {
+		$this->bumps[] = $name;
+	}
+
+	/**
+	 * All bumped counter names in call order.
+	 *
+	 * @return list<string>
+	 */
+	public function bumps(): array {
+		return $this->bumps;
+	}
+
+	/**
+	 * Drop all captured bumps.
+	 *
+	 * @return void
+	 */
+	public function reset(): void {
+		$this->bumps = array();
+	}
+}

--- a/src/Metrics/Channels/class-in-memory-tracks-channel.php
+++ b/src/Metrics/Channels/class-in-memory-tracks-channel.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * In-memory Tracks channel for tests.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Metrics\Channels;
+
+use Automattic\Fosse\Metrics\Tracks_Channel;
+
+/**
+ * Captures every `record()` invocation in memory for assertions.
+ *
+ * Lives under `src/` so the production classmap autoloads it, but
+ * registration is opt-in via `fosse_metrics_tracks_channels`. Production
+ * code never registers this — only tests do, via the `Asserts_Metrics`
+ * trait's `setUp` helper.
+ *
+ * Each captured entry is `array{ event: string, properties: array }`,
+ * preserving call order so tests can assert sequence.
+ */
+final class In_Memory_Tracks_Channel implements Tracks_Channel {
+
+	/**
+	 * Captured events in call order.
+	 *
+	 * @var list<array{event: string, properties: array<string, mixed>}>
+	 */
+	private array $captured = array();
+
+	/**
+	 * Record a single event.
+	 *
+	 * @param string               $event      Event name.
+	 * @param array<string, mixed> $properties Allowlist-filtered properties.
+	 * @return void
+	 */
+	public function record( string $event, array $properties ): void {
+		$this->captured[] = array(
+			'event'      => $event,
+			'properties' => $properties,
+		);
+	}
+
+	/**
+	 * All captured events in call order.
+	 *
+	 * @return list<array{event: string, properties: array<string, mixed>}>
+	 */
+	public function events(): array {
+		return $this->captured;
+	}
+
+	/**
+	 * Captured events filtered by name.
+	 *
+	 * @param string $event Event name to filter on.
+	 * @return list<array{event: string, properties: array<string, mixed>}>
+	 */
+	public function events_for( string $event ): array {
+		return \array_values(
+			\array_filter(
+				$this->captured,
+				static fn ( array $entry ) => $entry['event'] === $event
+			)
+		);
+	}
+
+	/**
+	 * Drop all captured events.
+	 *
+	 * @return void
+	 */
+	public function reset(): void {
+		$this->captured = array();
+	}
+}

--- a/src/Metrics/class-recorder.php
+++ b/src/Metrics/class-recorder.php
@@ -34,6 +34,14 @@ namespace Automattic\Fosse\Metrics;
 final class Recorder {
 
 	/**
+	 * Re-entrancy guard. A channel or enrichment callback that calls back
+	 * into `record()` / `bump()` would otherwise recurse without bound.
+	 *
+	 * @var bool
+	 */
+	private static bool $in_flight = false;
+
+	/**
 	 * Record a Tracks-style funnel event.
 	 *
 	 * Pipeline:
@@ -55,6 +63,10 @@ final class Recorder {
 	 * @return void
 	 */
 	public static function record( string $event, array $properties = array() ): void {
+		if ( self::$in_flight ) {
+			return;
+		}
+
 		if ( ! Schema::is_known( $event ) ) {
 			if ( self::is_debugging() ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- intentional WP_DEBUG-only schema-drift surface.
@@ -69,28 +81,41 @@ final class Recorder {
 			return;
 		}
 
-		/**
-		 * Filters the property bag for a FOSSE metrics event before
-		 * allowlist validation.
-		 *
-		 * Hosts use this to attach cohort / population — see the
-		 * wpcom-loader's Phase 2 implementation. Filter callbacks MUST
-		 * NOT add keys that violate the privacy contract (no IPs, UAs,
-		 * URLs); the allowlist will drop them but `WP_DEBUG` will warn.
-		 *
-		 * @param array<string, mixed> $properties Properties bag.
-		 * @param string               $event      Event name.
-		 */
-		$properties = (array) \apply_filters( 'fosse_metrics_event_context', $properties, $event );
-
-		$properties = Schema::filter_properties( $event, $properties );
-
-		foreach ( self::tracks_channels() as $channel ) {
+		self::$in_flight = true;
+		try {
+			/**
+			 * Filters the property bag for a FOSSE metrics event before
+			 * allowlist validation.
+			 *
+			 * Hosts use this to attach cohort / population — see the
+			 * wpcom-loader's Phase 2 implementation. Filter callbacks MUST
+			 * NOT add keys that violate the privacy contract (no IPs, UAs,
+			 * URLs); the allowlist will drop them but `WP_DEBUG` will warn.
+			 *
+			 * A throwing callback is contained: the recorder logs and
+			 * proceeds with the un-enriched property bag rather than
+			 * letting a misbehaving filter break the user-facing flow.
+			 *
+			 * @param array<string, mixed> $properties Properties bag.
+			 * @param string               $event      Event name.
+			 */
 			try {
-				$channel->record( $event, $properties );
+				$properties = (array) \apply_filters( 'fosse_metrics_event_context', $properties, $event );
 			} catch ( \Throwable $e ) {
 				self::log_throwable( $e, $event );
 			}
+
+			$properties = Schema::filter_properties( $event, $properties );
+
+			foreach ( self::tracks_channels() as $channel ) {
+				try {
+					$channel->record( $event, $properties );
+				} catch ( \Throwable $e ) {
+					self::log_throwable( $e, $event );
+				}
+			}
+		} finally {
+			self::$in_flight = false;
 		}
 	}
 
@@ -104,12 +129,21 @@ final class Recorder {
 	 * @return void
 	 */
 	public static function bump( string $name ): void {
-		foreach ( self::mc_channels() as $channel ) {
-			try {
-				$channel->bump( $name );
-			} catch ( \Throwable $e ) {
-				self::log_throwable( $e, $name );
+		if ( self::$in_flight ) {
+			return;
+		}
+
+		self::$in_flight = true;
+		try {
+			foreach ( self::mc_channels() as $channel ) {
+				try {
+					$channel->bump( $name );
+				} catch ( \Throwable $e ) {
+					self::log_throwable( $e, $name );
+				}
 			}
+		} finally {
+			self::$in_flight = false;
 		}
 	}
 
@@ -128,7 +162,12 @@ final class Recorder {
 		 *
 		 * @param list<Tracks_Channel> $channels Channels to deliver every recorded event.
 		 */
-		$channels = (array) \apply_filters( 'fosse_metrics_tracks_channels', array() );
+		try {
+			$channels = (array) \apply_filters( 'fosse_metrics_tracks_channels', array() );
+		} catch ( \Throwable $e ) {
+			self::log_throwable( $e, 'fosse_metrics_tracks_channels' );
+			return array();
+		}
 
 		return \array_values(
 			\array_filter(
@@ -141,6 +180,9 @@ final class Recorder {
 	/**
 	 * Resolve the registered MC channels.
 	 *
+	 * Non-conforming entries are filtered out so a misbehaving filter
+	 * can't crash the recorder.
+	 *
 	 * @return list<Mc_Channel>
 	 */
 	private static function mc_channels(): array {
@@ -149,7 +191,12 @@ final class Recorder {
 		 *
 		 * @param list<Mc_Channel> $channels Channels to deliver every recorded bump.
 		 */
-		$channels = (array) \apply_filters( 'fosse_metrics_mc_channels', array() );
+		try {
+			$channels = (array) \apply_filters( 'fosse_metrics_mc_channels', array() );
+		} catch ( \Throwable $e ) {
+			self::log_throwable( $e, 'fosse_metrics_mc_channels' );
+			return array();
+		}
 
 		return \array_values(
 			\array_filter(

--- a/src/Metrics/class-recorder.php
+++ b/src/Metrics/class-recorder.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * FOSSE metrics recorder — central event entry point.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Metrics;
+
+/**
+ * Funnel-event and aggregate-counter entry point.
+ *
+ * Two transport channels are registered independently:
+ *
+ * - `Tracks_Channel` instances for funnel events (`record()`).
+ * - `Mc_Channel` instances for aggregate counters (`bump()`).
+ *
+ * Either, both, or neither may be present. A pure self-host install with
+ * neither channel registered turns every recorder call into a no-op,
+ * which is the FOSSE-on-no-Jetpack posture.
+ *
+ * Three properties hold for every call:
+ *
+ * 1. **Fire-and-forget.** Channel exceptions never propagate; the
+ *    user-facing flow can't be broken by a transport failure.
+ * 2. **Default is silence.** No registered channel → no events emit.
+ * 3. **Channels are independent.** Tracks and MC have different consent
+ *    surfaces and dashboards; coupling them at the recorder would force
+ *    every host to opt into both or neither.
+ *
+ * See `sdd/fosse-metrics-strategy/implementation.md` for the strategy
+ * background.
+ */
+final class Recorder {
+
+	/**
+	 * Record a Tracks-style funnel event.
+	 *
+	 * Pipeline:
+	 *
+	 * 1. If `$event` is unknown to `Schema`, drop silently in production
+	 *    or `E_USER_WARNING` in `WP_DEBUG`.
+	 * 2. Run the `fosse_metrics_event_context` filter to let host code
+	 *    attach cohort / population (Phases 2 / 6).
+	 * 3. Filter `$properties` against `Schema::ALLOWED[ $event ]`. This
+	 *    drops both call-site mistakes and channel-decoration leaks
+	 *    (e.g. `_via_ip`-shaped keys an enrichment filter accidentally
+	 *    introduces).
+	 * 4. Forward to every channel registered through
+	 *    `fosse_metrics_tracks_channels`. Each channel runs inside a
+	 *    `try` block; throwables are swallowed so user paths continue.
+	 *
+	 * @param string               $event      Event name (must appear in `Schema::ALLOWED`).
+	 * @param array<string, mixed> $properties Call-site properties.
+	 * @return void
+	 */
+	public static function record( string $event, array $properties = array() ): void {
+		if ( ! Schema::is_known( $event ) ) {
+			if ( self::is_debugging() ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- intentional WP_DEBUG-only schema-drift surface.
+				\trigger_error(
+					\sprintf(
+						'FOSSE metrics: unknown event %s — dropped.',
+						\esc_html( $event )
+					),
+					\E_USER_WARNING
+				);
+			}
+			return;
+		}
+
+		/**
+		 * Filters the property bag for a FOSSE metrics event before
+		 * allowlist validation.
+		 *
+		 * Hosts use this to attach cohort / population — see the
+		 * wpcom-loader's Phase 2 implementation. Filter callbacks MUST
+		 * NOT add keys that violate the privacy contract (no IPs, UAs,
+		 * URLs); the allowlist will drop them but `WP_DEBUG` will warn.
+		 *
+		 * @param array<string, mixed> $properties Properties bag.
+		 * @param string               $event      Event name.
+		 */
+		$properties = (array) \apply_filters( 'fosse_metrics_event_context', $properties, $event );
+
+		$properties = Schema::filter_properties( $event, $properties );
+
+		foreach ( self::tracks_channels() as $channel ) {
+			try {
+				$channel->record( $event, $properties );
+			} catch ( \Throwable $e ) {
+				self::log_throwable( $e, $event );
+			}
+		}
+	}
+
+	/**
+	 * Bump an aggregate counter on every registered MC channel.
+	 *
+	 * No enrichment, no allowlist — `$name` is opaque. Channels handle
+	 * their own grouping and namespacing.
+	 *
+	 * @param string $name Counter name.
+	 * @return void
+	 */
+	public static function bump( string $name ): void {
+		foreach ( self::mc_channels() as $channel ) {
+			try {
+				$channel->bump( $name );
+			} catch ( \Throwable $e ) {
+				self::log_throwable( $e, $name );
+			}
+		}
+	}
+
+	/**
+	 * Resolve the registered Tracks channels.
+	 *
+	 * Filter callbacks must return an array of `Tracks_Channel` instances.
+	 * Non-conforming entries are filtered out so a misbehaving filter
+	 * can't crash the recorder.
+	 *
+	 * @return list<Tracks_Channel>
+	 */
+	private static function tracks_channels(): array {
+		/**
+		 * Filters the registered Tracks channels.
+		 *
+		 * @param list<Tracks_Channel> $channels Channels to deliver every recorded event.
+		 */
+		$channels = (array) \apply_filters( 'fosse_metrics_tracks_channels', array() );
+
+		return \array_values(
+			\array_filter(
+				$channels,
+				static fn ( $channel ) => $channel instanceof Tracks_Channel
+			)
+		);
+	}
+
+	/**
+	 * Resolve the registered MC channels.
+	 *
+	 * @return list<Mc_Channel>
+	 */
+	private static function mc_channels(): array {
+		/**
+		 * Filters the registered MC bump channels.
+		 *
+		 * @param list<Mc_Channel> $channels Channels to deliver every recorded bump.
+		 */
+		$channels = (array) \apply_filters( 'fosse_metrics_mc_channels', array() );
+
+		return \array_values(
+			\array_filter(
+				$channels,
+				static fn ( $channel ) => $channel instanceof Mc_Channel
+			)
+		);
+	}
+
+	/**
+	 * Log a swallowed channel exception when `WP_DEBUG` is on.
+	 *
+	 * Uses `error_log` rather than `trigger_error` because a transport
+	 * failure is operational noise, not a contract violation.
+	 *
+	 * @param \Throwable $error   The thrown error.
+	 * @param string     $context Event name or counter name for context.
+	 * @return void
+	 */
+	private static function log_throwable( \Throwable $error, string $context ): void {
+		if ( ! self::is_debugging() ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- intentional WP_DEBUG-only diagnostic for swallowed channel exceptions.
+		\error_log(
+			\sprintf(
+				'FOSSE metrics channel threw on %s: %s',
+				$context,
+				$error->getMessage()
+			)
+		);
+	}
+
+	/**
+	 * Whether `WP_DEBUG` is on.
+	 *
+	 * @return bool
+	 */
+	private static function is_debugging(): bool {
+		return \defined( 'WP_DEBUG' ) && WP_DEBUG;
+	}
+}

--- a/src/Metrics/class-schema.php
+++ b/src/Metrics/class-schema.php
@@ -26,7 +26,7 @@ namespace Automattic\Fosse\Metrics;
  *   than break a user-facing flow.
  *
  * The hardcoded `ALLOWED` map is the source of truth — updates must match
- * `implementation.md` § Event taxonomy. `Schema_Test::test_event_coverage`
+ * `implementation.md` § Event taxonomy. `SchemaTest::test_event_coverage`
  * iterates a parallel list to detect drift between docs and code.
  */
 final class Schema {

--- a/src/Metrics/class-schema.php
+++ b/src/Metrics/class-schema.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * FOSSE metrics event schema and property allowlist.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Metrics;
+
+/**
+ * Static allowlist for the v1 FOSSE metrics event taxonomy.
+ *
+ * Every documented event in `sdd/fosse-metrics-strategy/implementation.md`
+ * has an entry in `ALLOWED` listing the property names that may accompany
+ * it. The recorder calls `filter_properties()` AFTER the
+ * `fosse_metrics_event_context` enrichment filter runs, so cohort/population
+ * (added by host-specific enrichment in Phase 2 / Phase 6) flow through the
+ * same allowlist as call-site-supplied properties.
+ *
+ * Two enforcement modes:
+ *
+ * - In `WP_DEBUG`, schema violations (unknown event, disallowed property)
+ *   trigger `E_USER_WARNING`. CI catches schema drift loudly.
+ * - In production, violations are dropped silently. The event still emits
+ *   with the surviving allowlisted properties; we'd rather lose a property
+ *   than break a user-facing flow.
+ *
+ * The hardcoded `ALLOWED` map is the source of truth — updates must match
+ * `implementation.md` § Event taxonomy. `Schema_Test::test_event_coverage`
+ * iterates a parallel list to detect drift between docs and code.
+ */
+final class Schema {
+
+	/**
+	 * Property allowlist per event.
+	 *
+	 * Every value array universally permits `cohort` and `population`;
+	 * those are added by enrichment (Phase 2 + Phase 6) and must pass
+	 * the same allowlist check as call-site properties.
+	 *
+	 * @var array<string, list<string>>
+	 */
+	public const ALLOWED = array(
+		'fosse_wizard_started'                       => array(
+			'entry',
+			'cohort',
+			'population',
+		),
+		'fosse_wizard_completed'                     => array(
+			'destination',
+			'actor_mode',
+			'post_types_count_bucket',
+			'bluesky_state',
+			'cohort',
+			'population',
+		),
+		'fosse_connection_attempt'                   => array(
+			'network',
+			'source',
+			'cohort',
+			'population',
+		),
+		'fosse_connection_completed'                 => array(
+			'network',
+			'source',
+			'cohort',
+			'population',
+		),
+		'fosse_connection_failed'                    => array(
+			'network',
+			'source',
+			'error_category',
+			'cohort',
+			'population',
+		),
+		'fosse_bluesky_handle_setup_started'         => array(
+			'eligibility',
+			'cohort',
+			'population',
+		),
+		'fosse_bluesky_handle_active'                => array(
+			'cohort',
+			'population',
+		),
+		'fosse_post_published'                       => array(
+			'post_format',
+			'has_image',
+			'cohort',
+			'population',
+		),
+		'fosse_publish_result'                       => array(
+			'network',
+			'status',
+			'strategy',
+			'error_category',
+			'cohort',
+			'population',
+		),
+		'fosse_inbound_interaction'                  => array(
+			'network',
+			'kind',
+			'days_since_publish_bucket',
+			'cohort',
+			'population',
+		),
+		'fosse_author_engaged'                       => array(
+			'network',
+			'kind',
+			'days_since_interaction_bucket',
+			'cohort',
+			'population',
+		),
+		'fosse_search_indexing_disabled_post_active' => array(
+			'cohort',
+			'population',
+		),
+	);
+
+	/**
+	 * Whether the given event name appears in `ALLOWED`.
+	 *
+	 * @param string $event Event name to check.
+	 * @return bool
+	 */
+	public static function is_known( string $event ): bool {
+		return isset( self::ALLOWED[ $event ] );
+	}
+
+	/**
+	 * Filter `$properties` against the allowlist for `$event`.
+	 *
+	 * Disallowed keys are dropped. In `WP_DEBUG`, each disallowed key
+	 * triggers a separate `E_USER_WARNING` so the offending names are
+	 * visible in CI logs. Unknown events return an empty array.
+	 *
+	 * `null`-valued properties are dropped — channels treat absence and
+	 * null identically, and dropping at the schema layer keeps cohort
+	 * enrichment "no cohort to attach" cases from emitting a literal
+	 * `null` over the wire.
+	 *
+	 * @param string               $event      Event name.
+	 * @param array<string, mixed> $properties Caller- and enrichment-supplied properties.
+	 * @return array<string, mixed> Allowlist-filtered, null-stripped properties.
+	 */
+	public static function filter_properties( string $event, array $properties ): array {
+		if ( ! self::is_known( $event ) ) {
+			return array();
+		}
+
+		$allowed   = self::ALLOWED[ $event ];
+		$filtered  = array();
+		$debugging = self::is_debugging();
+
+		foreach ( $properties as $key => $value ) {
+			if ( ! \in_array( $key, $allowed, true ) ) {
+				if ( $debugging ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- intentional WP_DEBUG-only schema-violation surface.
+					\trigger_error(
+						\sprintf(
+							'FOSSE metrics: disallowed property %s on event %s — dropped.',
+							\esc_html( (string) $key ),
+							\esc_html( $event )
+						),
+						\E_USER_WARNING
+					);
+				}
+				continue;
+			}
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			$filtered[ $key ] = $value;
+		}
+
+		return $filtered;
+	}
+
+	/**
+	 * Whether `WP_DEBUG` is on.
+	 *
+	 * Wrapper exists so tests can stub strict-mode behavior without the
+	 * test process having to be booted with WP_DEBUG=true.
+	 *
+	 * @return bool
+	 */
+	private static function is_debugging(): bool {
+		return \defined( 'WP_DEBUG' ) && WP_DEBUG;
+	}
+}

--- a/src/Metrics/interface-mc-channel.php
+++ b/src/Metrics/interface-mc-channel.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * MC channel interface — aggregate-counter transport.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Metrics;
+
+/**
+ * Contract for a transport that bumps anonymous, low-cardinality counters
+ * (e.g. `bump_stats_extras` on wpcom, the Jetpack stats bump path on
+ * Jetpack-connected self-hosted). Channels are registered via the
+ * `fosse_metrics_mc_channels` filter; the recorder iterates registered
+ * channels for every `bump()` call.
+ *
+ * MC bumps are intentionally separate from `Tracks_Channel` — Tracks and
+ * MC have different consent surfaces, different transport costs, and
+ * different dashboard surfaces. A single composite sink would couple
+ * those independent concerns.
+ *
+ * Implementations MUST be fire-and-forget; the recorder catches any
+ * `\Throwable` raised by `bump()`.
+ */
+interface Mc_Channel {
+
+	/**
+	 * Bump an aggregate counter.
+	 *
+	 * `$name` is interpreted by the channel — typically appended to a
+	 * group identifier (e.g. wpcom uses group `fosse`, surfacing on
+	 * `mc.wordpress.com/?v=fosse`).
+	 *
+	 * @param string $name Counter name (e.g. `wizard-completed`).
+	 * @return void
+	 */
+	public function bump( string $name ): void;
+}

--- a/src/Metrics/interface-tracks-channel.php
+++ b/src/Metrics/interface-tracks-channel.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Tracks channel interface — funnel-event transport.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Metrics;
+
+/**
+ * Contract for a transport that delivers identified, rich-property funnel
+ * events. Channels are registered via the `fosse_metrics_tracks_channels`
+ * filter; the recorder iterates registered channels for every `record()`
+ * call. Multiple channels may be registered simultaneously (e.g. an
+ * in-memory test channel alongside a production transport).
+ *
+ * Implementations MUST be fire-and-forget — the recorder catches any
+ * `\Throwable` raised by `record()` so user paths never see a transport
+ * failure. Implementations SHOULD NOT decorate properties with values
+ * that violate the privacy contract (no IPs, no UAs, no URLs); see
+ * `sdd/fosse-metrics-strategy/implementation.md` § Privacy contract
+ * enforcement for the full list.
+ */
+interface Tracks_Channel {
+
+	/**
+	 * Deliver an event with allowlisted, enriched properties.
+	 *
+	 * Called by `Recorder::record()` after schema validation and the
+	 * `fosse_metrics_event_context` enrichment filter have run. The
+	 * `$properties` array contains only keys present in
+	 * `Schema::ALLOWED[ $event ]`.
+	 *
+	 * @param string               $event      Allowlisted event name (e.g. `fosse_wizard_started`).
+	 * @param array<string, mixed> $properties Allowlist-filtered property bag.
+	 * @return void
+	 */
+	public function record( string $event, array $properties ): void;
+}

--- a/tests/php/Metrics/Asserts_Metrics.php
+++ b/tests/php/Metrics/Asserts_Metrics.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * PHPUnit trait for asserting on FOSSE metrics events and bumps.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests\Metrics;
+
+use Automattic\Fosse\Metrics\Channels\In_Memory_Mc_Channel;
+use Automattic\Fosse\Metrics\Channels\In_Memory_Tracks_Channel;
+
+/**
+ * Test convenience for in-memory metrics capture and assertion.
+ *
+ * Mix into a `BaseTestCase` subclass and call `reset_metrics_channels()`
+ * from `setUp()` (or via a `#[Before]` hook). The trait wires fresh
+ * `In_Memory_*` channel instances into the metrics filters and exposes
+ * helpers for asserting captured events / bumps.
+ *
+ * Each `reset_metrics_channels()` call removes any previously-registered
+ * test channels so leakage across cases can't manifest as duplicate
+ * captures.
+ */
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- mirrors PHPUnit's native camelCase assertion convention.
+trait Asserts_Metrics {
+
+	/**
+	 * Currently-registered tracks channel (one per test).
+	 *
+	 * @var In_Memory_Tracks_Channel|null
+	 */
+	private ?In_Memory_Tracks_Channel $tracks_channel = null;
+
+	/**
+	 * Currently-registered MC channel (one per test).
+	 *
+	 * @var In_Memory_Mc_Channel|null
+	 */
+	private ?In_Memory_Mc_Channel $mc_channel = null;
+
+	/**
+	 * Wipe channel registrations + previously-captured state and
+	 * register fresh in-memory channels via the metrics filters.
+	 *
+	 * @return void
+	 */
+	protected function reset_metrics_channels(): void {
+		\remove_all_filters( 'fosse_metrics_tracks_channels' );
+		\remove_all_filters( 'fosse_metrics_mc_channels' );
+		\remove_all_filters( 'fosse_metrics_event_context' );
+
+		$this->tracks_channel = new In_Memory_Tracks_Channel();
+		$this->mc_channel     = new In_Memory_Mc_Channel();
+
+		\add_filter(
+			'fosse_metrics_tracks_channels',
+			fn ( array $channels ): array => array_merge( $channels, array( $this->tracks_channel ) )
+		);
+		\add_filter(
+			'fosse_metrics_mc_channels',
+			fn ( array $channels ): array => array_merge( $channels, array( $this->mc_channel ) )
+		);
+	}
+
+	/**
+	 * Get the registered tracks channel for assertions.
+	 *
+	 * @return In_Memory_Tracks_Channel
+	 */
+	protected function tracks_channel(): In_Memory_Tracks_Channel {
+		if ( null === $this->tracks_channel ) {
+			$this->fail( 'Asserts_Metrics: call reset_metrics_channels() before asserting.' );
+		}
+		return $this->tracks_channel;
+	}
+
+	/**
+	 * Get the registered MC channel for assertions.
+	 *
+	 * @return In_Memory_Mc_Channel
+	 */
+	protected function mc_channel(): In_Memory_Mc_Channel {
+		if ( null === $this->mc_channel ) {
+			$this->fail( 'Asserts_Metrics: call reset_metrics_channels() before asserting.' );
+		}
+		return $this->mc_channel;
+	}
+
+	/**
+	 * Assert a single event was recorded with the given name.
+	 *
+	 * If `$expected_subset` is non-empty, asserts the event's properties
+	 * are a superset of those keys/values. Properties not listed in
+	 * `$expected_subset` are ignored — partial assertion is intentional
+	 * so tests don't have to know about cohort enrichment, etc.
+	 *
+	 * @param string               $event           Expected event name.
+	 * @param array<string, mixed> $expected_subset Optional property subset to require.
+	 * @return void
+	 */
+	protected function assertEventRecorded( string $event, array $expected_subset = array() ): void {
+		$matches = $this->tracks_channel()->events_for( $event );
+
+		$this->assertNotEmpty(
+			$matches,
+			\sprintf( 'Expected event "%s" to be recorded; nothing captured.', $event )
+		);
+
+		if ( empty( $expected_subset ) ) {
+			return;
+		}
+
+		foreach ( $matches as $captured ) {
+			$properties = $captured['properties'];
+			$missing    = false;
+			foreach ( $expected_subset as $key => $value ) {
+				if ( ! \array_key_exists( $key, $properties ) || $properties[ $key ] !== $value ) {
+					$missing = true;
+					break;
+				}
+			}
+			if ( ! $missing ) {
+				return;
+			}
+		}
+
+		$this->fail(
+			\sprintf(
+				'No "%s" event matched expected property subset %s. Captured: %s',
+				$event,
+				\wp_json_encode( $expected_subset, \JSON_UNESCAPED_SLASHES ),
+				\wp_json_encode( $matches, \JSON_UNESCAPED_SLASHES )
+			)
+		);
+	}
+
+	/**
+	 * Assert the given event was never recorded.
+	 *
+	 * @param string $event Event name.
+	 * @return void
+	 */
+	protected function assertNoEventRecorded( string $event ): void {
+		$matches = $this->tracks_channel()->events_for( $event );
+		$this->assertEmpty(
+			$matches,
+			\sprintf( 'Expected no "%s" events; captured %d.', $event, \count( $matches ) )
+		);
+	}
+
+	/**
+	 * Assert a counter was bumped at least once with the given name.
+	 *
+	 * @param string $name Counter name.
+	 * @return void
+	 */
+	protected function assertMcBumped( string $name ): void {
+		$this->assertContains(
+			$name,
+			$this->mc_channel()->bumps(),
+			\sprintf( 'Expected MC bump "%s"; captured: %s', $name, \wp_json_encode( $this->mc_channel()->bumps(), \JSON_UNESCAPED_SLASHES ) )
+		);
+	}
+
+	/**
+	 * Assert a counter was never bumped with the given name.
+	 *
+	 * @param string $name Counter name.
+	 * @return void
+	 */
+	protected function assertNoMcBumped( string $name ): void {
+		$this->assertNotContains(
+			$name,
+			$this->mc_channel()->bumps(),
+			\sprintf( 'Expected no MC bump "%s"; captured: %s', $name, \wp_json_encode( $this->mc_channel()->bumps(), \JSON_UNESCAPED_SLASHES ) )
+		);
+	}
+}
+// phpcs:enable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid

--- a/tests/php/Metrics/RecorderTest.php
+++ b/tests/php/Metrics/RecorderTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Tests for the metrics Recorder pipeline.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests\Metrics;
+
+use Automattic\Fosse\Metrics\Recorder;
+use Automattic\Fosse\Metrics\Tracks_Channel;
+use PHPUnit\Framework\Attributes\Before;
+use WorDBless\BaseTestCase;
+
+/**
+ * Locks the recorder's pipeline in: unknown events drop, `WP_DEBUG`
+ * warns, allowlist runs after enrichment, channel exceptions don't
+ * propagate, no-channel default is silent.
+ */
+class RecorderTest extends BaseTestCase {
+
+	use Asserts_Metrics;
+
+	/**
+	 * Reset metrics filters + in-memory channels before each test.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function reset_metrics(): void {
+		$this->reset_metrics_channels();
+	}
+
+	/**
+	 * Unknown events are dropped silently in production.
+	 */
+	public function test_unknown_event_dropped_in_production(): void {
+		Recorder::record( 'fosse_not_a_real_event', array( 'foo' => 'bar' ) );
+
+		$this->assertEmpty(
+			$this->tracks_channel()->events(),
+			'Unknown event must not reach any channel.'
+		);
+	}
+
+	/**
+	 * Disallowed properties (e.g. `_via_ip`-shaped sink decorations) are
+	 * dropped before the channel sees them.
+	 */
+	public function test_disallowed_property_dropped(): void {
+		Recorder::record(
+			'fosse_wizard_started',
+			array(
+				'entry'   => 'auto',
+				'_via_ip' => '1.2.3.4',
+			)
+		);
+
+		$this->assertEventRecorded( 'fosse_wizard_started', array( 'entry' => 'auto' ) );
+		$captured = $this->tracks_channel()->events_for( 'fosse_wizard_started' );
+		$this->assertArrayNotHasKey( '_via_ip', $captured[0]['properties'] );
+	}
+
+	/**
+	 * Enrichment runs before the allowlist, so an enrichment filter
+	 * adding a non-allowlisted key still gets dropped.
+	 */
+	public function test_enrich_filter_runs_before_allowlist(): void {
+		\add_filter(
+			'fosse_metrics_event_context',
+			static function ( array $properties ): array {
+				$properties['cohort']      = 'A';
+				$properties['leaked_html'] = '<script>nope</script>';
+				return $properties;
+			}
+		);
+
+		Recorder::record( 'fosse_wizard_started', array( 'entry' => 'auto' ) );
+
+		$captured = $this->tracks_channel()->events_for( 'fosse_wizard_started' );
+		$this->assertCount( 1, $captured );
+		$this->assertSame(
+			array(
+				'entry'  => 'auto',
+				'cohort' => 'A',
+			),
+			$captured[0]['properties']
+		);
+	}
+
+	/**
+	 * A channel that throws does not propagate; subsequent channels
+	 * still run.
+	 */
+	public function test_channel_exception_does_not_propagate(): void {
+		$throwing_channel = new class() implements Tracks_Channel {
+			/**
+			 * Always throws to verify recorder swallows transport failures.
+			 *
+			 * @param string               $event      Unused.
+			 * @param array<string, mixed> $properties Unused.
+			 * @return void
+			 * @throws \RuntimeException Always.
+			 */
+			public function record( string $event, array $properties ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- interface contract requires the parameters.
+				throw new \RuntimeException( 'transport down' );
+			}
+		};
+
+		\add_filter(
+			'fosse_metrics_tracks_channels',
+			static fn ( array $channels ): array => \array_merge( array( $throwing_channel ), $channels )
+		);
+
+		Recorder::record( 'fosse_wizard_started', array( 'entry' => 'auto' ) );
+
+		// The in-memory channel after the throwing one still ran.
+		$this->assertEventRecorded( 'fosse_wizard_started', array( 'entry' => 'auto' ) );
+	}
+
+	/**
+	 * With no channels registered, `record()` is a no-op (no fatal).
+	 */
+	public function test_no_channels_registered_no_op(): void {
+		\remove_all_filters( 'fosse_metrics_tracks_channels' );
+
+		Recorder::record( 'fosse_wizard_started', array( 'entry' => 'auto' ) );
+
+		$this->assertTrue( true, 'Recorder must not raise when no channels are registered.' );
+	}
+
+	/**
+	 * `bump()` reaches every registered MC channel and is fire-and-forget.
+	 */
+	public function test_bump_dispatches_to_mc_channels(): void {
+		Recorder::bump( 'wizard-completed' );
+
+		$this->assertMcBumped( 'wizard-completed' );
+	}
+
+	/**
+	 * MC channel exceptions don't propagate.
+	 */
+	public function test_bump_swallows_channel_exceptions(): void {
+		$throwing_channel = new class() implements \Automattic\Fosse\Metrics\Mc_Channel {
+			/**
+			 * Always throws to verify recorder swallows transport failures.
+			 *
+			 * @param string $name Unused.
+			 * @return void
+			 * @throws \RuntimeException Always.
+			 */
+			public function bump( string $name ): void { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- interface contract requires the parameter.
+				throw new \RuntimeException( 'pixel.wp.com down' );
+			}
+		};
+
+		\add_filter(
+			'fosse_metrics_mc_channels',
+			static fn ( array $channels ): array => \array_merge( array( $throwing_channel ), $channels )
+		);
+
+		Recorder::bump( 'wizard-completed' );
+
+		$this->assertMcBumped( 'wizard-completed' );
+	}
+
+	/**
+	 * Filter callbacks returning non-`Tracks_Channel` entries are
+	 * filtered out so a misbehaving filter can't crash the recorder.
+	 */
+	public function test_non_channel_filter_entries_ignored(): void {
+		\add_filter(
+			'fosse_metrics_tracks_channels',
+			static fn ( array $channels ): array => \array_merge( $channels, array( 'not-a-channel', 42, null ) )
+		);
+
+		Recorder::record( 'fosse_wizard_started', array( 'entry' => 'auto' ) );
+
+		// The in-memory channel still saw the event; the bogus filter entries did not crash anything.
+		$this->assertEventRecorded( 'fosse_wizard_started', array( 'entry' => 'auto' ) );
+	}
+}

--- a/tests/php/Metrics/RecorderTest.php
+++ b/tests/php/Metrics/RecorderTest.php
@@ -126,7 +126,13 @@ class RecorderTest extends BaseTestCase {
 
 		Recorder::record( 'fosse_wizard_started', array( 'entry' => 'auto' ) );
 
-		$this->assertTrue( true, 'Recorder must not raise when no channels are registered.' );
+		// The trait's in-memory channel was unregistered before the call;
+		// nothing should have been dispatched to it (and no fatal escaped).
+		$this->assertSame(
+			array(),
+			$this->tracks_channel()->events_for( 'fosse_wizard_started' ),
+			'Recorder must not dispatch events when no channels are registered.'
+		);
 	}
 
 	/**

--- a/tests/php/Metrics/SchemaTest.php
+++ b/tests/php/Metrics/SchemaTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Tests for the metrics event schema allowlist.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests\Metrics;
+
+use Automattic\Fosse\Metrics\Schema;
+use WorDBless\BaseTestCase;
+
+/**
+ * Locks the v1 event taxonomy in: every documented event is in the
+ * allowlist, and `cohort` + `population` are universally permitted so
+ * Phase 2 / Phase 6 enrichment can attach them to any event.
+ */
+class SchemaTest extends BaseTestCase {
+
+	/**
+	 * Hardcoded list of every event documented in
+	 * `sdd/fosse-metrics-strategy/implementation.md` § Event taxonomy.
+	 *
+	 * Drift between docs and code surfaces as a test failure — adding
+	 * an event to `Schema::ALLOWED` without updating this list, or
+	 * vice versa, fails CI.
+	 *
+	 * @var list<string>
+	 */
+	private const DOCUMENTED_EVENTS = array(
+		'fosse_wizard_started',
+		'fosse_wizard_completed',
+		'fosse_connection_attempt',
+		'fosse_connection_completed',
+		'fosse_connection_failed',
+		'fosse_bluesky_handle_setup_started',
+		'fosse_bluesky_handle_active',
+		'fosse_post_published',
+		'fosse_publish_result',
+		'fosse_inbound_interaction',
+		'fosse_author_engaged',
+		'fosse_search_indexing_disabled_post_active',
+	);
+
+	/**
+	 * Every documented event has an allowlist entry.
+	 */
+	public function test_event_coverage(): void {
+		foreach ( self::DOCUMENTED_EVENTS as $event ) {
+			$this->assertTrue(
+				Schema::is_known( $event ),
+				\sprintf( 'Event "%s" missing from Schema::ALLOWED.', $event )
+			);
+		}
+	}
+
+	/**
+	 * The allowlist contains no events that aren't documented (drift in
+	 * the other direction).
+	 */
+	public function test_no_undocumented_events(): void {
+		$allowed = \array_keys( Schema::ALLOWED );
+		\sort( $allowed );
+
+		$documented = self::DOCUMENTED_EVENTS;
+		\sort( $documented );
+
+		$this->assertSame(
+			$documented,
+			$allowed,
+			'Schema::ALLOWED contains events not in DOCUMENTED_EVENTS.'
+		);
+	}
+
+	/**
+	 * Every event allows `cohort` and `population` so enrichment can
+	 * attach them universally.
+	 */
+	public function test_cohort_and_population_universally_allowed(): void {
+		foreach ( Schema::ALLOWED as $event => $allowed_keys ) {
+			$this->assertContains(
+				'cohort',
+				$allowed_keys,
+				\sprintf( 'Event "%s" must permit "cohort".', $event )
+			);
+			$this->assertContains(
+				'population',
+				$allowed_keys,
+				\sprintf( 'Event "%s" must permit "population".', $event )
+			);
+		}
+	}
+
+	/**
+	 * Filter drops disallowed keys silently when `WP_DEBUG` is off.
+	 */
+	public function test_filter_properties_drops_disallowed(): void {
+		$filtered = Schema::filter_properties(
+			'fosse_wizard_started',
+			array(
+				'entry'      => 'auto',
+				'_via_ip'    => '1.2.3.4',
+				'random_key' => 'should-disappear',
+			)
+		);
+
+		$this->assertSame( array( 'entry' => 'auto' ), $filtered );
+	}
+
+	/**
+	 * Filter drops null-valued allowlisted keys (channels treat absence
+	 * and null identically).
+	 */
+	public function test_filter_properties_drops_null_values(): void {
+		$filtered = Schema::filter_properties(
+			'fosse_wizard_started',
+			array(
+				'entry'  => 'auto',
+				'cohort' => null,
+			)
+		);
+
+		$this->assertSame( array( 'entry' => 'auto' ), $filtered );
+	}
+
+	/**
+	 * Unknown events return an empty array (recorder uses `is_known`
+	 * separately to decide whether to even reach this method).
+	 */
+	public function test_filter_properties_unknown_event_returns_empty(): void {
+		$filtered = Schema::filter_properties(
+			'fosse_not_a_real_event',
+			array( 'entry' => 'auto' )
+		);
+
+		$this->assertSame( array(), $filtered );
+	}
+}


### PR DESCRIPTION
Phase 1 of the FOSSE metrics implementation per [`sdd/fosse-metrics-strategy/`](https://github.com/Automattic/fosse/tree/trunk/sdd/fosse-metrics-strategy) (the strategy SDD landed in PR 41). Establishes the FOSSE-side spine; no production events emit until Phase 2 ([DOTCOM-17029](https://linear.app/a8c/issue/DOTCOM-17029)) wires the wpcom Tracks channel.

## Summary

- `src/Metrics/Recorder` — `record()` and `bump()` entry points. Fire-and-forget by design: channel exceptions are caught with `\Throwable` and never propagate to user paths.
- `src/Metrics/Schema` — v1 event allowlist + property filter. Disallowed keys drop silently in production, trigger `E_USER_WARNING` in `WP_DEBUG` so CI catches schema drift and channel-decoration leaks (`_via_ip`-shaped sink mistakes).
- `Tracks_Channel` + `Mc_Channel` interfaces, registered independently via `fosse_metrics_tracks_channels` and `fosse_metrics_mc_channels` filters. Tracks and MC have separate consent surfaces and separate dashboards; coupling them at the recorder would force every host to opt into both or neither.
- `In_Memory_Tracks_Channel` + `In_Memory_Mc_Channel` autoload via the classmap but only register when tests opt them in via the channel filters.
- `Asserts_Metrics` PHPUnit trait for ergonomic event/bump assertions in test cases that mix it in.

## What this PR is not

No channel is registered in production. `Recorder::record()` calls from anywhere are no-ops until Phase 2 lands the wpcom Tracks channel and Phase 3 ([DOTCOM-17030](https://linear.app/a8c/issue/DOTCOM-17030)) wires call sites. The privacy-contract test for "outgoing payload doesn't include `_via_ip` after Tracks decoration" is a wpcom-side concern and lives in Phase 2.

## File-layout note (overrules the SDD)

The SDD writes `src/Metrics/Recorder.php`, `Schema.php`, etc. — that doesn't match FOSSE convention (classmap autoload, `class-snake-case.php` filenames, `Snake_Case` class names). Reconciled to project convention:

| Symbol | File |
| -- | -- |
| `Automattic\Fosse\Metrics\Recorder` | `src/Metrics/class-recorder.php` |
| `Automattic\Fosse\Metrics\Schema` | `src/Metrics/class-schema.php` |
| `Automattic\Fosse\Metrics\Tracks_Channel` | `src/Metrics/interface-tracks-channel.php` |
| `Automattic\Fosse\Metrics\Mc_Channel` | `src/Metrics/interface-mc-channel.php` |
| `Automattic\Fosse\Metrics\Channels\In_Memory_Tracks_Channel` | `src/Metrics/Channels/class-in-memory-tracks-channel.php` |
| `Automattic\Fosse\Metrics\Channels\In_Memory_Mc_Channel` | `src/Metrics/Channels/class-in-memory-mc-channel.php` |
| `Automattic\Fosse\Tests\Metrics\Asserts_Metrics` (trait) | `tests/php/Metrics/Asserts_Metrics.php` |

## Test plan

- [x] `composer test-php` — 326 tests pass, 14 new under `Metrics`.
- [x] `composer lint-php` — clean.
- [ ] No user-facing surface in this PR; manual verification deferred to Phase 3.

The 14 new tests cover: every documented event has a Schema entry; the docs/code lists agree in both directions; `cohort` and `population` are universally allowed; allowlist drops disallowed keys (including `_via_ip`-shaped sink decorations); allowlist drops `null`-valued keys; unknown events drop silently; the `fosse_metrics_event_context` filter runs before the allowlist; channel exceptions don't propagate; the no-channel-registered case is a safe no-op; non-channel filter entries are ignored.

Fixes [DOTCOM-17028](https://linear.app/a8c/issue/DOTCOM-17028).