### PR TITLE
fix: escape Bluesky notice text + cover bad-nonce save

### DIFF
--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -779,13 +779,26 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Persist an admin notice and redirect back to the originating FOSSE screen.
 	 *
-	 * @param string $message        Notice message.
+	 * Messages are escaped with `esc_html()` before storage. The `'atmosphere'`
+	 * settings-error group is rendered both via the explicit
+	 * `settings_errors( 'atmosphere' )` call in {@see self::render_connection_actions()}
+	 * and automatically by WordPress on any `options-*.php` screen where the
+	 * core `_default_wp_die_handler` / `wp_auto_admin_notice_settings_error()`
+	 * path fires — both render the stored `message` field as raw HTML.
+	 * Several callers here pass untrusted text (`WP_Error` messages from
+	 * Atmosphere's OAuth client, the PDS, or `Publisher::sync_publication()`)
+	 * which could otherwise inject markup into wp-admin. Escaping at this
+	 * single chokepoint frees every caller from remembering the constraint.
+	 * Notice messages that need rich HTML must be added through a different
+	 * code path; nothing in FOSSE needs that today.
+	 *
+	 * @param string $message        Notice message (treated as plain text).
 	 * @param string $type           Notice type.
 	 * @param string $return_context Optional return context.
 	 * @return void
 	 */
 	private function redirect_with_notice( string $message, string $type, string $return_context = '' ): void {
-		add_settings_error( 'atmosphere', 'fosse_bluesky_notice', $message, $type );
+		add_settings_error( 'atmosphere', 'fosse_bluesky_notice', esc_html( $message ), $type );
 		set_transient( 'settings_errors', get_settings_errors(), 30 );
 
 		wp_safe_redirect( $this->get_redirect_url( $return_context ) );

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -779,12 +779,13 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Persist an admin notice and redirect back to the originating FOSSE screen.
 	 *
-	 * Messages are escaped with `esc_html()` before storage. The `'atmosphere'`
-	 * settings-error group is rendered both via the explicit
-	 * `settings_errors( 'atmosphere' )` call in {@see self::render_connection_actions()}
-	 * and automatically by WordPress on any `options-*.php` screen where the
-	 * core `_default_wp_die_handler` / `wp_auto_admin_notice_settings_error()`
-	 * path fires — both render the stored `message` field as raw HTML.
+	 * Messages are escaped with `esc_html()` before storage. Every consumer of
+	 * the `'atmosphere'` settings-error group renders the stored `message`
+	 * field as HTML: the explicit `settings_errors( 'atmosphere' )` call in
+	 * {@see self::render_connection_actions()}, the `get_settings_errors(...)`
+	 * loop in {@see Onboarding_Wizard::render_step_bluesky()}, and any
+	 * `options-*.php` screen where WordPress core's automatic
+	 * `settings_errors()` invocation fires for queued settings errors.
 	 * Several callers here pass untrusted text (`WP_Error` messages from
 	 * Atmosphere's OAuth client, the PDS, or `Publisher::sync_publication()`)
 	 * which could otherwise inject markup into wp-admin. Escaping at this

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -314,6 +314,80 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * `redirect_with_notice()` escapes the message before storing it in the
+	 * `'atmosphere'` settings-error group. The audit's escaping finding turns
+	 * on this — `settings_errors()` (and WP's auto-render via `admin_notices`)
+	 * output the stored `message` field as raw HTML, so any `WP_Error` text
+	 * from upstream OAuth/PDS/`sync_publication()` paths must be neutralized
+	 * at storage so every render site is safe.
+	 *
+	 * Drives the helper through reflection (it's private and ends in `exit`,
+	 * which the redirect trap converts to a thrown exception) and inspects
+	 * the resulting global to assert escape happened.
+	 */
+	public function test_redirect_with_notice_escapes_message_at_storage(): void {
+		$this->arm_redirect_trap();
+
+		try {
+			$this->invoke_redirect_with_notice( '<img src=x onerror="alert(1)">', 'error' );
+			$this->fail( 'Expected redirect_with_notice to redirect.' );
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$this->assertNotEmpty( $errors );
+
+		$message = (string) ( $errors[0]['message'] ?? '' );
+		$this->assertStringNotContainsString( '<img', $message );
+		$this->assertStringContainsString( '&lt;img', $message );
+		$this->assertSame( 'error', $errors[0]['type'] ?? '' );
+	}
+
+	/**
+	 * The escape applies on every type, not just errors. A success notice
+	 * with HTML from an upstream payload (unlikely but conceivable) is also
+	 * neutralized.
+	 */
+	public function test_redirect_with_notice_escapes_message_on_success_type(): void {
+		$this->arm_redirect_trap();
+
+		try {
+			$this->invoke_redirect_with_notice( '<b>Connected</b>', 'success' );
+			$this->fail( 'Expected redirect_with_notice to redirect.' );
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$this->assertNotEmpty( $errors );
+
+		$message = (string) ( $errors[0]['message'] ?? '' );
+		$this->assertStringNotContainsString( '<b>', $message );
+		$this->assertStringContainsString( '&lt;b&gt;', $message );
+	}
+
+	/**
+	 * Plain ASCII messages survive the escape unchanged so the routine
+	 * notices ("Disconnected from Bluesky.", "Successfully connected to
+	 * Bluesky.") still read naturally.
+	 */
+	public function test_redirect_with_notice_passes_plain_text_through(): void {
+		$this->arm_redirect_trap();
+
+		try {
+			$this->invoke_redirect_with_notice( 'Disconnected from Bluesky.', 'info' );
+			$this->fail( 'Expected redirect_with_notice to redirect.' );
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$this->assertNotEmpty( $errors );
+		$this->assertSame( 'Disconnected from Bluesky.', $errors[0]['message'] ?? '' );
+	}
+
+	/**
 	 * Status card surfaces the reconnect UI and a details element with the
 	 * raw error when the stored access token can't be decrypted.
 	 */
@@ -1750,6 +1824,37 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			2
 		);
 		return $capture;
+	}
+
+	/**
+	 * Install a `wp_redirect` filter that throws `RedirectFired` so a
+	 * helper that ends in `wp_safe_redirect( ... ); exit;` can be tested
+	 * without process-killing.
+	 *
+	 * @return void
+	 */
+	private function arm_redirect_trap(): void {
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+	}
+
+	/**
+	 * Drive the private `redirect_with_notice( message, type )` helper for
+	 * tests that need to exercise the storage-side escape without going
+	 * through a full handler path. Reflection is appropriate here because
+	 * the callers in question are themselves private code paths.
+	 *
+	 * @param string $message Notice message.
+	 * @param string $type    Notice type.
+	 * @return void
+	 */
+	private function invoke_redirect_with_notice( string $message, string $type ): void {
+		( new ReflectionMethod( Bluesky_Provider::class, 'redirect_with_notice' ) )
+			->invoke( $this->provider, $message, $type );
 	}
 
 	/**

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -370,6 +370,83 @@ class Setup_PageTest extends BaseTestCase {
 	}
 
 	/**
+	 * A POST without `_wpnonce` (or with a stale/forged value) is rejected
+	 * by `check_admin_referer()` before any option write happens. Locks in
+	 * the nonce gate so a future refactor of the handler can't quietly
+	 * bypass CSRF protection.
+	 */
+	public function test_handle_save_rejects_missing_nonce(): void {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'action'                         => Setup_Page::SAVE_ACTION,
+			'activitypub_actor_mode'         => 'blog',
+			'activitypub_support_post_types' => array( 'post' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_die_handler',
+			static function () {
+				return static function ( $message ) {
+					throw new \RuntimeException( wp_kses( (string) $message, array() ) );
+				};
+			}
+		);
+
+		try {
+			Setup_Page::handle_save();
+			$this->fail( 'Expected check_admin_referer to wp_die on missing nonce.' );
+		} catch ( \RuntimeException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- wp_die is expected.
+			unset( $e );
+		}
+
+		// Sanity: the actor-mode write that the body of handle_save() would
+		// otherwise perform never happened, proving check_admin_referer
+		// short-circuited before any option mutation.
+		$this->assertNotSame( 'blog', get_option( 'activitypub_actor_mode' ) );
+	}
+
+	/**
+	 * A POST with a forged `_wpnonce` value is also rejected. Distinct from
+	 * the missing-nonce case so a future "missing → empty default" refactor
+	 * can't silently skip the check.
+	 */
+	public function test_handle_save_rejects_forged_nonce(): void {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'                       => 'not-a-real-nonce',
+			'action'                         => Setup_Page::SAVE_ACTION,
+			'activitypub_actor_mode'         => 'blog',
+			'activitypub_support_post_types' => array( 'post' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_die_handler',
+			static function () {
+				return static function ( $message ) {
+					throw new \RuntimeException( wp_kses( (string) $message, array() ) );
+				};
+			}
+		);
+
+		try {
+			Setup_Page::handle_save();
+			$this->fail( 'Expected check_admin_referer to wp_die on forged nonce.' );
+		} catch ( \RuntimeException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- wp_die is expected.
+			unset( $e );
+		}
+
+		$this->assertNotSame( 'blog', get_option( 'activitypub_actor_mode' ) );
+	}
+
+	/**
 	 * Saved redirect lands back on the FOSSE Settings page so users see the
 	 * post-save notice.
 	 */

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -78,6 +78,10 @@ class Setup_PageTest extends BaseTestCase {
 		$_REQUEST = array();
 		remove_all_filters( 'wp_redirect' );
 		remove_all_filters( 'sanitize_option_activitypub_blog_identifier' );
+		// Clear the wp_die_handler tests in this file install — leaks
+		// would convert any later test's `wp_die()` into a thrown
+		// exception and confuse failure attribution.
+		remove_all_filters( 'wp_die_handler' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Hardens FOSSE's Bluesky/OAuth notice surface against HTML injection and locks in CSRF coverage on the unified Settings save.

**Escape at storage.** `Bluesky_Provider::redirect_with_notice()` now passes the message through `esc_html()` before storing it via `add_settings_error( 'atmosphere', ... )`. Notices in the `'atmosphere'` group are rendered both via the explicit `settings_errors( 'atmosphere' )` call in `render_connection_actions()` and automatically by WordPress via `_default_wp_die_handler` / `wp_auto_admin_notice_settings_error()` on options-* screens — both render the stored `message` field as raw HTML. Several callers pass `WP_Error` text from upstream OAuth/PDS/`Publisher::sync_publication()` paths that we treat as untrusted (a hostile PDS or crafted handle could otherwise inject markup into wp-admin). Escaping at the single chokepoint frees every caller from remembering the constraint.

**Bad-nonce coverage.** Two new `Setup_PageTest` cases (`test_handle_save_rejects_missing_nonce`, `test_handle_save_rejects_forged_nonce`) exercise `check_admin_referer()` rejecting requests with no nonce and with a forged nonce respectively, and assert the actor-mode option write that `handle_save()` would otherwise perform never happens. Distinct cases so a future "missing → empty default" refactor can't silently skip the check.

Surfaced by the 2026-05-06 deep audit (PR #103, `audits/2026-05-06-fosse-plugin-audit-report.md` finding "P1/P2: Bluesky/OAuth error notices can render unescaped error text" + backlog item "Add bad-nonce coverage for Settings save").

## Test plan

- [x] `composer run-script test-php` — full suite: 317 tests, 767 assertions, all green
- [x] `composer run-script lint-php` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [ ] CI: tests.yml across PHP 8.2/8.3/8.4/8.5 × WP 6.9/trunk
- [ ] CI: linting.yml