### PR TITLE
fix: harden wizard content-step post-types sanitization

### DIFF
--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -301,7 +301,14 @@ class Onboarding_Wizard {
 		}
 
 		if ( 'content' === $step ) {
-			$submitted   = array_map( 'sanitize_text_field', wp_unslash( (array) ( $_POST['activitypub_support_post_types'] ?? array() ) ) );
+			// Filter to strings before `sanitize_text_field` so a crafted POST
+			// submitting nested arrays for an element can't trip the function's
+			// array-to-string warning (which `phpunit.xml.dist` promotes to a
+			// hard failure via `failOnWarning`, and which would otherwise emit
+			// a notice in production). Mirrors {@see Setup_Page::save_general_settings()}.
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized via array_map below; sniffer does not recognize the wrapping pattern.
+			$raw         = wp_unslash( (array) ( $_POST['activitypub_support_post_types'] ?? array() ) );
+			$submitted   = array_map( 'sanitize_text_field', array_filter( $raw, 'is_string' ) );
 			$valid_types = get_post_types( array( 'public' => true ) );
 			$post_types  = array_values( array_intersect( $submitted, $valid_types ) );
 

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -264,6 +264,100 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertNotContains( 'faketype', $saved );
 	}
 
+	/**
+	 * Nested arrays inside the post-types payload (e.g. a crafted POST with
+	 * `activitypub_support_post_types[0][]=post`) are filtered out before
+	 * `sanitize_text_field()` runs, so the array-to-string warning that
+	 * `phpunit.xml.dist` promotes to a hard failure via `failOnWarning` does
+	 * not fire and the option is not overwritten with an invalid shape.
+	 *
+	 * Mirrors the Settings page's `test_handle_save_drops_nested_array_post_types`
+	 * coverage so the wizard path matches the hardened Settings path.
+	 */
+	public function test_handle_save_content_drops_nested_array_post_types(): void {
+		update_option( 'activitypub_support_post_types', array( 'post' ) );
+
+		$this->simulate_save_request(
+			'content',
+			array(
+				'activitypub_support_post_types' => array(
+					array( 'post' ),
+					'page',
+				),
+			)
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$saved = get_option( 'activitypub_support_post_types' );
+		$this->assertNotContains( 'post', $saved, 'Nested-array element must not survive sanitization.' );
+		$this->assertContains( 'page', $saved, 'Sibling string element must still pass through.' );
+	}
+
+	/**
+	 * A scalar (non-array) post-types payload is coerced to an array
+	 * containing the scalar — the existing `(array) $value` cast handles
+	 * the shape, and `is_string` filtering keeps it sane. Locks in the
+	 * coercion so a future refactor can't quietly start rejecting scalars.
+	 */
+	public function test_handle_save_content_coerces_scalar_post_types(): void {
+		$this->simulate_save_request(
+			'content',
+			array( 'activitypub_support_post_types' => 'page' )
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$saved = get_option( 'activitypub_support_post_types' );
+		$this->assertSame( array( 'page' ), $saved );
+	}
+
+	/**
+	 * A payload that is entirely nested arrays (no string elements) becomes
+	 * an empty selection after sanitization and triggers the
+	 * `empty_post_types` redirect rather than overwriting the option.
+	 */
+	public function test_handle_save_content_invalid_only_redirects_with_error(): void {
+		update_option( 'activitypub_support_post_types', array( 'post' ) );
+
+		$captured = null;
+		$this->simulate_save_request(
+			'content',
+			array(
+				'activitypub_support_post_types' => array(
+					array( 'post' ),
+					array( 'page' ),
+				),
+			)
+		);
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new RedirectFired( 'redirect' );
+			},
+			9
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertStringContainsString( 'step=content', (string) $captured );
+		$this->assertStringContainsString( 'error=empty_post_types', (string) $captured );
+		$this->assertSame( array( 'post' ), get_option( 'activitypub_support_post_types' ) );
+	}
+
 	// --- handle_skip ---
 
 	/**


### PR DESCRIPTION
## Summary

The onboarding wizard's content step at `Onboarding_Wizard::handle_save()` cast `$_POST['activitypub_support_post_types']` to an array and ran `sanitize_text_field()` over each element directly. A crafted POST submitting nested arrays for an element (e.g. `activitypub_support_post_types[0][]=post`) would trip `sanitize_text_field()`'s array-to-string warning — promoted to a hard failure by `phpunit.xml.dist`'s `failOnWarning` and emitting a notice in production.

`Setup_Page::save_general_settings()` already has the hardened version (filter to strings via `array_filter( $raw, 'is_string' )` before `sanitize_text_field()`). This PR mirrors that pattern in the wizard so both Settings save paths handle malformed input the same way.

Adds three test cases on `Onboarding_WizardTest`:

- `test_handle_save_content_drops_nested_array_post_types` — nested-array element silently filtered out, sibling string element passes through, no warning.
- `test_handle_save_content_coerces_scalar_post_types` — scalar payload coerces to a one-element array.
- `test_handle_save_content_invalid_only_redirects_with_error` — payload that's entirely nested arrays results in empty selection and triggers the existing `error=empty_post_types` redirect rather than overwriting the option with `[]`.

Surfaced by the 2026-05-06 deep audit (PR #103, finding "P2: Onboarding content save can warn on nested post-type payloads").

## Test plan

- [x] `composer run-script test-php` — full suite: 315 tests, 763 assertions, all green
- [x] `composer run-script lint-php` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [ ] CI: tests.yml across PHP 8.2/8.3/8.4/8.5 × WP 6.9/trunk