### PR TITLE
Wizard: refresh onboarding UI

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -152,14 +152,13 @@
    ============================================= */
 
 .fosse-wizard {
-	--fosse-wizard-canvas: #f7faf9;
 	--fosse-wizard-surface: #fff;
 	--fosse-wizard-border: #dcdcde;
 	--fosse-wizard-border-strong: #c3c4c7;
 	--fosse-wizard-accent: #3858e9;
 	--fosse-wizard-accent-soft: #f3f6ff;
 	--fosse-wizard-accent-icon: #e6ecff;
-	--fosse-wizard-accent-border-soft: rgba(56, 88, 233, 0.38);
+	--fosse-wizard-accent-soft-border: rgba(56, 88, 233, 0.38);
 	--fosse-wizard-success: #168a4a;
 	--fosse-wizard-success-soft: #edf8f1;
 	--fosse-wizard-text: #1d2327;
@@ -775,7 +774,7 @@
 }
 
 .fosse-post-type-item:has(input:checked) {
-	border-color: var(--fosse-wizard-accent-border-soft);
+	border-color: var(--fosse-wizard-accent-soft-border);
 	background: var(--fosse-wizard-accent-soft);
 }
 

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -899,6 +899,10 @@
 	color: var(--fosse-wizard-text);
 }
 
+.fosse-summary__value code {
+	overflow-wrap: anywhere;
+}
+
 .fosse-summary__value--muted {
 	color: var(--fosse-wizard-muted);
 	font-weight: 400;

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -152,88 +152,151 @@
    ============================================= */
 
 .fosse-wizard {
-	max-width: 700px;
+	--fosse-wizard-canvas: #f7faf9;
+	--fosse-wizard-surface: #fff;
+	--fosse-wizard-border: #dcdcde;
+	--fosse-wizard-border-strong: #c3c4c7;
+	--fosse-wizard-accent: #3858e9;
+	--fosse-wizard-accent-soft: #f3f6ff;
+	--fosse-wizard-accent-icon: #e6ecff;
+	--fosse-wizard-accent-border-soft: rgba(56, 88, 233, 0.38);
+	--fosse-wizard-success: #168a4a;
+	--fosse-wizard-success-soft: #edf8f1;
+	--fosse-wizard-text: #1d2327;
+	--fosse-wizard-muted: #646970;
+	--fosse-wizard-warm: #fff4cf;
+	--fosse-wizard-warm-text: #6f5700;
+
+	max-width: 860px;
 	margin: 0 auto;
+	padding-top: 32px;
+	color: var(--fosse-wizard-text);
 }
 
 /* Progress indicator */
 .fosse-wizard__progress {
 	display: flex;
 	align-items: center;
-	gap: 8px;
-	margin: 0 0 32px;
-	padding: 0;
+	gap: 10px;
+	margin: 0 0 42px;
+	padding: 8px 12px;
 	list-style: none;
+	background: rgba(255, 255, 255, 0.78);
+	border: 1px solid rgba(220, 220, 222, 0.82);
+	border-radius: 999px;
 }
 
 .fosse-wizard__progress-step {
-	display: flex;
+	display: inline-flex;
 	align-items: center;
-	gap: 4px;
+	gap: 6px;
+	height: 24px;
 	font-size: 12px;
-	color: #949494;
+	font-weight: 500;
+	line-height: 1;
+	color: var(--fosse-wizard-muted);
+	white-space: nowrap;
+}
+
+.fosse-wizard__progress-label {
+	display: block;
+	line-height: 1;
+	transform: translateY(1px);
 }
 
 .fosse-wizard__progress-step.is-active {
-	color: #3858e9;
-	font-weight: 500;
+	color: var(--fosse-wizard-text);
+	font-weight: 600;
 }
 
 .fosse-wizard__progress-step.is-complete {
-	color: #4ab866;
+	color: var(--fosse-wizard-success);
 }
 
 .fosse-wizard__progress-dot {
-	width: 8px;
-	height: 8px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 9px;
+	height: 9px;
 	border-radius: 50%;
-	background: #ddd;
+	background: var(--fosse-wizard-border-strong);
 	flex-shrink: 0;
+	transform: translateY(1px);
 }
 
 .fosse-wizard__progress-step.is-active .fosse-wizard__progress-dot {
-	background: #3858e9;
-	width: 10px;
-	height: 10px;
+	width: 11px;
+	height: 11px;
+	background: var(--fosse-wizard-accent);
+	box-shadow: 0 0 0 3px rgba(56, 88, 233, 0.12);
 }
 
 .fosse-wizard__progress-step.is-complete .fosse-wizard__progress-dot {
-	background: #4ab866;
+	width: 14px;
+	height: 14px;
+	background: var(--fosse-wizard-success);
+}
+
+.fosse-wizard__progress-step.is-complete .fosse-wizard__progress-dot::before {
+	content: "";
+	width: 4px;
+	height: 7px;
+	margin-top: -1px;
+	border: solid #fff;
+	border-width: 0 1.5px 1.5px 0;
+	transform: rotate(45deg);
 }
 
 .fosse-wizard__progress-line {
+	align-self: center;
 	flex: 1;
-	height: 2px;
-	background: #ddd;
+	min-width: 18px;
+	height: 1px;
+	background: var(--fosse-wizard-border);
+	transform: translateY(1px);
 }
 
 .fosse-wizard__progress-line.is-complete {
-	background: #4ab866;
+	background: var(--fosse-wizard-success);
 }
 
 /* Title and description */
-.fosse-wizard__title {
+.fosse-wizard .fosse-wizard__title {
+	max-width: 650px;
 	font-size: 32px;
-	font-weight: 500;
-	line-height: 1.2;
-	margin-bottom: 12px;
+	font-weight: 600;
+	line-height: 1.18;
+	letter-spacing: -0.01em;
+	text-align: center;
+	color: var(--fosse-wizard-text);
+	margin: 0 auto 20px;
 }
 
-.fosse-wizard__description {
+.fosse-wizard .fosse-wizard__description {
+	max-width: 590px;
 	font-size: 15px;
-	color: #757575;
-	line-height: 1.6;
-	margin-bottom: 32px;
-	max-width: 560px;
+	line-height: 1.65;
+	text-align: center;
+	color: var(--fosse-wizard-muted);
+	margin: 0 auto 50px;
 }
 
 /* Main content card */
 .fosse-wizard__card {
-	background: #fff;
-	border: 1px solid #c3c4c7;
-	border-radius: 8px;
-	padding: 32px;
-	margin-bottom: 24px;
+	background: var(--fosse-wizard-surface);
+	border: 1px solid var(--fosse-wizard-border);
+	border-radius: 14px;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+	padding: 36px;
+	margin-bottom: 0;
+}
+
+.fosse-wizard__card:has(.fosse-destination-cards) {
+	padding: 0;
+	background: transparent;
+	border: 0;
+	box-shadow: none;
 }
 
 /* Action bar */
@@ -241,12 +304,13 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	padding-top: 16px;
+	gap: 16px;
+	margin-top: 32px;
+	padding-top: 0;
 }
 
 .fosse-wizard__actions--center {
 	justify-content: center;
-	gap: 12px;
 }
 
 .fosse-wizard__actions-primary {
@@ -259,17 +323,20 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	gap: 12px;
+	gap: 10px;
 }
 
 .fosse-wizard__skip {
 	font-size: 12px;
-	color: #757575;
+	line-height: 1.4;
+	color: var(--fosse-wizard-muted);
 	text-decoration: none;
+	text-underline-offset: 3px;
 }
 
-.fosse-wizard__skip:hover {
-	color: #1e1e1e;
+.fosse-wizard__skip:hover,
+.fosse-wizard__skip:focus {
+	color: var(--fosse-wizard-text);
 	text-decoration: underline;
 }
 
@@ -277,13 +344,15 @@
 .fosse-wizard__hint {
 	margin-top: 16px;
 	padding: 12px 16px;
-	background: #f0f0f0;
-	border-radius: 4px;
+	background: #f6f7f7;
+	border: 1px solid #e5e7eb;
+	border-radius: 8px;
 }
 
 .fosse-wizard__hint p {
 	font-size: 12px;
-	color: #757575;
+	line-height: 1.5;
+	color: var(--fosse-wizard-muted);
 	margin: 0;
 }
 
@@ -296,26 +365,31 @@
 .fosse-destination-cards {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 16px;
+	gap: 18px;
 }
 
 .fosse-destination-card {
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	min-height: 140px;
-	padding: 18px 20px;
-	border: 2px solid #dcdcde;
-	border-radius: 8px;
-	background: #fff;
+	min-height: 168px;
+	padding: 20px 22px 22px;
+	border: 1px solid var(--fosse-wizard-border);
+	border-radius: 12px;
+	background: var(--fosse-wizard-surface);
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.025);
 	cursor: pointer;
 	transition:
 		border-color 0.15s ease,
-		background-color 0.15s ease;
+		background-color 0.15s ease,
+		box-shadow 0.15s ease,
+		transform 0.15s ease;
 }
 
 .fosse-destination-card:hover {
-	border-color: #a7aaad;
+	border-color: var(--fosse-wizard-border-strong);
+	box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
+	transform: translateY(-1px);
 }
 
 .fosse-destination-card__input {
@@ -325,73 +399,161 @@
 }
 
 .fosse-destination-card:has(.fosse-destination-card__input:checked) {
-	border-color: #3858e9;
-	background: #f7f9ff;
+	border-color: var(--fosse-wizard-accent);
+	background: var(--fosse-wizard-accent-soft);
+	box-shadow: 0 3px 10px rgba(56, 88, 233, 0.07);
 }
 
-.fosse-destination-card:has(.fosse-destination-card__input:focus-visible),
 .fosse-destination-card:focus-within {
-	border-color: #3858e9;
-	outline: 2px solid #3858e9;
-	outline-offset: 2px;
+	border-color: var(--fosse-wizard-accent);
+}
+
+.fosse-destination-card:has(.fosse-destination-card__input:focus-visible) {
+	border-color: var(--fosse-wizard-accent);
+	outline: 2px solid var(--fosse-wizard-accent);
+	outline-offset: 3px;
+}
+
+.fosse-destination-card__header {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 16px;
+}
+
+.fosse-destination-card__icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 34px;
+	height: 34px;
+	border-radius: 50%;
+	background: var(--fosse-wizard-warm);
+	color: var(--fosse-wizard-warm-text);
+	flex-shrink: 0;
+}
+
+.fosse-destination-card--fediverse-only .fosse-destination-card__icon {
+	background: var(--fosse-wizard-success-soft);
+	color: var(--fosse-wizard-success);
+}
+
+.fosse-destination-card__icon .dashicons {
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
+}
+
+.fosse-destination-card:has(.fosse-destination-card__input:checked)
+	.fosse-destination-card__icon {
+	background: var(--fosse-wizard-accent-icon);
+	color: var(--fosse-wizard-accent);
 }
 
 .fosse-destination-card__badge {
-	align-self: flex-start;
-	margin-bottom: 10px;
 	font-size: 11px;
 	font-weight: 600;
+	line-height: 1.3;
+	letter-spacing: 0.03em;
 	text-transform: uppercase;
-	color: #3858e9;
+	color: var(--fosse-wizard-muted);
+}
+
+.fosse-destination-card:has(.fosse-destination-card__input:checked)
+	.fosse-destination-card__badge {
+	color: var(--fosse-wizard-accent);
 }
 
 .fosse-destination-card__title {
-	margin-bottom: 6px;
-	font-size: 17px;
+	margin-bottom: 8px;
+	font-size: 18px;
 	font-weight: 600;
-	color: #1e1e1e;
+	line-height: 1.3;
+	color: var(--fosse-wizard-text);
 }
 
 .fosse-destination-card__desc {
 	font-size: 13px;
-	line-height: 1.5;
-	color: #646970;
+	line-height: 1.55;
+	color: var(--fosse-wizard-muted);
 }
 
 .fosse-destination-card__check {
 	position: absolute;
 	right: 14px;
 	top: 14px;
-	color: #dcdcde;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border-radius: 50%;
+	background: var(--fosse-wizard-accent);
+	color: #fff;
+	opacity: 0;
+	transform: scale(0.86);
+	transition:
+		opacity 0.15s ease,
+		transform 0.15s ease;
+}
+
+.fosse-destination-card__check .dashicons {
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
 }
 
 .fosse-destination-card:has(.fosse-destination-card__input:checked)
 	.fosse-destination-card__check {
-	color: #3858e9;
+	opacity: 1;
+	transform: scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.fosse-destination-card,
+	.fosse-destination-card__check,
+	.fosse-mode-card,
+	.fosse-mode-card__check,
+	.fosse-post-type-item {
+		transition: none;
+	}
+
+	.fosse-destination-card:hover,
+	.fosse-mode-card:hover {
+		transform: none;
+	}
 }
 
 /* Actor mode cards */
 .fosse-mode-cards {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
+	gap: 10px;
 	margin-bottom: 24px;
 }
 
 .fosse-mode-card {
+	position: relative;
 	display: flex;
 	align-items: flex-start;
 	gap: 16px;
-	padding: 16px 24px;
-	border: 2px solid #e0e0e0;
-	border-radius: 8px;
+	padding: 18px 22px;
+	border: 1px solid var(--fosse-wizard-border);
+	border-radius: 12px;
 	cursor: pointer;
-	transition: border-color 0.15s ease;
-	background: #fff;
+	background: var(--fosse-wizard-surface);
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.025);
+	transition:
+		border-color 0.15s ease,
+		background-color 0.15s ease,
+		box-shadow 0.15s ease,
+		transform 0.15s ease;
 }
 
 .fosse-mode-card:hover {
-	border-color: #ccc;
+	border-color: var(--fosse-wizard-border-strong);
+	box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+	transform: translateY(-1px);
 }
 
 /* Hide the real radio input */
@@ -403,53 +565,46 @@
 
 /* Selected state via :has(:checked) */
 .fosse-mode-card:has(.fosse-mode-card__input:checked) {
-	border-color: #3858e9;
-	background: rgba(56, 88, 233, 0.02);
+	border-color: var(--fosse-wizard-accent);
+	background: var(--fosse-wizard-accent-soft);
+	box-shadow: 0 3px 10px rgba(56, 88, 233, 0.07);
 }
 
 /* Keyboard focus state — radio is visually hidden, so surface focus on the card. */
 .fosse-mode-card:has(.fosse-mode-card__input:focus-visible) {
-	border-color: #3858e9;
-	outline: 2px solid #3858e9;
-	outline-offset: 2px;
+	border-color: var(--fosse-wizard-accent);
+	outline: 2px solid var(--fosse-wizard-accent);
+	outline-offset: 3px;
 }
 
-/* :focus-within fallback for browsers without :focus-visible (older Safari, etc.).
-   Same outline treatment so keyboard navigation surfaces a focus ring on the
-   card even when :focus-visible isn't honored on the visually-hidden radio. */
+/* :focus-within fallback keeps the selected card border visible for browsers
+   without :focus-visible support. */
 .fosse-mode-card:focus-within {
-	border-color: #3858e9;
-	outline: 2px solid #3858e9;
-	outline-offset: 2px;
+	border-color: var(--fosse-wizard-accent);
 }
 
 .fosse-mode-card__icon {
-	width: 40px;
-	height: 40px;
-	border-radius: 8px;
-	background: #f0f0f0;
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	width: 34px;
+	height: 34px;
+	border-radius: 50%;
+	background: #f6f7f7;
+	color: var(--fosse-wizard-muted);
 	flex-shrink: 0;
-	margin-top: 2px;
 }
 
 .fosse-mode-card:has(.fosse-mode-card__input:checked) .fosse-mode-card__icon {
-	background: rgba(56, 88, 233, 0.08);
+	background: var(--fosse-wizard-accent-icon);
+	color: var(--fosse-wizard-accent);
 }
 
 .fosse-mode-card__icon .dashicons {
-	font-size: 20px;
-	width: 20px;
-	height: 20px;
-	color: #757575;
-}
-
-.fosse-mode-card:has(.fosse-mode-card__input:checked)
-	.fosse-mode-card__icon
-	.dashicons {
-	color: #3858e9;
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
+	color: currentColor;
 }
 
 .fosse-mode-card__content {
@@ -458,60 +613,76 @@
 
 .fosse-mode-card__title {
 	font-size: 15px;
-	font-weight: 500;
+	font-weight: 600;
+	line-height: 1.35;
 	margin-bottom: 4px;
+	color: var(--fosse-wizard-text);
 }
 
 .fosse-mode-card__desc {
 	font-size: 13px;
-	color: #757575;
 	line-height: 1.5;
+	color: var(--fosse-wizard-muted);
 }
 
 .fosse-mode-card__check {
-	width: 24px;
-	height: 24px;
-	flex-shrink: 0;
-	margin-top: 4px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border-radius: 50%;
+	background: var(--fosse-wizard-accent);
+	color: #fff;
+	flex-shrink: 0;
+	opacity: 0;
+	transform: scale(0.86);
+	transition:
+		opacity 0.15s ease,
+		transform 0.15s ease;
 }
 
 .fosse-mode-card__check .dashicons {
-	font-size: 24px;
-	width: 24px;
-	height: 24px;
-	color: #ddd;
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
+	color: currentColor;
 }
 
-.fosse-mode-card:has(.fosse-mode-card__input:checked)
-	.fosse-mode-card__check
-	.dashicons {
-	color: #3858e9;
+.fosse-mode-card:has(.fosse-mode-card__input:checked) .fosse-mode-card__check {
+	opacity: 1;
+	transform: scale(1);
 }
 
 /* Fediverse address preview */
 .fosse-address-preview {
 	display: flex;
 	align-items: center;
-	gap: 8px;
-	background: #f0f0f0;
-	border-radius: 4px;
-	padding: 12px 16px;
+	flex-wrap: wrap;
+	gap: 10px 12px;
+	background: #f6f7f7;
+	border: 1px solid #e5e7eb;
+	border-radius: 8px;
+	padding: 13px 16px;
 	font-size: 13px;
 }
 
+.fosse-address-preview__row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
 .fosse-address-preview__label {
-	color: #757575;
+	color: var(--fosse-wizard-muted);
 }
 
 .fosse-address-preview__address {
 	font-size: 12px;
 	background: #fff;
 	padding: 4px 8px;
-	border-radius: 2px;
-	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	border: 1px solid var(--fosse-wizard-border);
 }
 
 /* Wizard Appearance step swaps which fediverse-address preview is visible
@@ -528,86 +699,111 @@
    page treatment but slimmer — sits inside the wizard card next to the
    address preview. */
 .fosse-wizard__blog-handle {
-	margin-top: 16px;
+	margin-top: 18px;
+	padding-top: 18px;
+	border-top: 1px solid #e5e7eb;
 }
 
 .fosse-wizard__blog-handle-label {
 	display: block;
 	font-size: 11px;
-	font-weight: 500;
+	font-weight: 600;
+	letter-spacing: 0.03em;
 	text-transform: uppercase;
-	color: #757575;
+	color: var(--fosse-wizard-muted);
 	margin-bottom: 8px;
+}
+
+.fosse-wizard__blog-handle .regular-text {
+	width: min(100%, 360px);
 }
 
 .fosse-wizard__blog-handle .description {
 	margin-top: 6px;
 	font-size: 12px;
-	color: #757575;
+	color: var(--fosse-wizard-muted);
 }
 
 /* Post type selection */
 .fosse-post-types {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
+	gap: 22px;
 }
 
 .fosse-post-types__group {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
+	gap: 10px;
 }
 
 .fosse-post-types__group + .fosse-post-types__group {
-	margin-top: 20px;
+	margin-top: 0;
 }
 
 .fosse-post-types__group-label {
 	font-size: 11px;
 	font-weight: 600;
+	line-height: 1.3;
+	letter-spacing: 0.03em;
 	text-transform: uppercase;
-	color: #646970;
+	color: var(--fosse-wizard-muted);
 }
 
 .fosse-post-type-item {
 	display: flex;
 	align-items: center;
 	gap: 12px;
-	padding: 12px 16px;
-	border: 1px solid #e0e0e0;
-	border-radius: 4px;
-	background: #fff;
+	padding: 13px 16px;
+	border: 1px solid var(--fosse-wizard-border);
+	border-radius: 8px;
+	background: var(--fosse-wizard-surface);
 	cursor: pointer;
+	transition:
+		border-color 0.15s ease,
+		background-color 0.15s ease,
+		box-shadow 0.15s ease;
+}
+
+.fosse-post-type-item:hover {
+	border-color: var(--fosse-wizard-border-strong);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
 }
 
 .fosse-post-type-item:has(input:checked) {
-	border-color: rgba(56, 88, 233, 0.3);
-	background: rgba(56, 88, 233, 0.02);
+	border-color: var(--fosse-wizard-accent-border-soft);
+	background: var(--fosse-wizard-accent-soft);
 }
 
 .fosse-post-type-item input[type="checkbox"] {
 	margin: 0;
 }
 
+.fosse-post-type-item:has(input:focus-visible) {
+	outline: 2px solid var(--fosse-wizard-accent);
+	outline-offset: 2px;
+}
+
 .fosse-post-type-item__label {
 	font-size: 13px;
-	font-weight: 500;
-	color: #1e1e1e;
+	font-weight: 600;
+	color: var(--fosse-wizard-text);
 	flex: 1;
 }
 
 /* Bluesky wizard */
 .fosse-bluesky-form {
-	margin-top: 16px;
+	margin-top: 0;
 }
 
 .fosse-bluesky-form__label {
 	display: block;
 	font-size: 11px;
-	font-weight: 500;
+	font-weight: 600;
+	line-height: 1.3;
+	letter-spacing: 0.03em;
 	text-transform: uppercase;
-	color: #757575;
+	color: var(--fosse-wizard-muted);
 	margin-bottom: 8px;
 }
 
@@ -618,43 +814,58 @@
 
 .fosse-bluesky-form__controls .regular-text {
 	flex: 1;
+	width: 100%;
+	max-width: none;
+	min-height: 36px;
+	border-color: var(--fosse-wizard-border-strong);
+	border-radius: 4px;
+}
+
+.fosse-bluesky-form .description {
+	margin-top: 6px;
+	color: var(--fosse-wizard-muted);
 }
 
 /* Completion screen */
-.fosse-wizard__complete-header,
 .fosse-wizard__complete-header + .fosse-wizard__card {
 	text-align: left;
 }
 
 .fosse-wizard__complete-header {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 	text-align: center;
-	margin-bottom: 16px;
+	margin-bottom: 28px;
 }
 
-/* On the Complete step, the description's narrower 560px max-width left it
-   visually offset from the title (700px) and summary card (also 700px).
-   Drop the narrower cap here so all three share the wizard's own
-   max-width and read as one centered column. */
+/* Keep the Complete step hero copy visually grouped under the success icon. */
+.fosse-wizard__complete-header .fosse-wizard__title,
 .fosse-wizard__complete-header .fosse-wizard__description {
-	max-width: none;
+	max-width: 620px;
 }
 
 .fosse-complete-icon {
 	width: 64px;
 	height: 64px;
 	border-radius: 50%;
-	background: #e6f6e9;
+	background: var(--fosse-wizard-success-soft);
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	margin: 0 auto 24px;
+	box-shadow: 0 0 0 8px rgba(22, 138, 74, 0.06);
 }
 
 .fosse-complete-icon .dashicons {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	font-size: 32px;
 	width: 32px;
 	height: 32px;
-	color: #4ab866;
+	color: var(--fosse-wizard-success);
+	transform: translateY(1px);
 }
 
 /* Summary table */
@@ -665,7 +876,7 @@
 }
 
 .fosse-summary tr {
-	border-bottom: 1px solid #e0e0e0;
+	border-bottom: 1px solid #eef0f2;
 }
 
 .fosse-summary tr:last-child {
@@ -673,22 +884,23 @@
 }
 
 .fosse-summary td {
-	padding: 12px 0;
+	padding: 14px 0;
 	font-size: 13px;
+	line-height: 1.5;
 }
 
 .fosse-summary__label {
-	color: #757575;
+	color: var(--fosse-wizard-muted);
 	width: 40%;
 }
 
 .fosse-summary__value {
-	font-weight: 500;
-	color: #1e1e1e;
+	font-weight: 600;
+	color: var(--fosse-wizard-text);
 }
 
 .fosse-summary__value--muted {
-	color: #757575;
+	color: var(--fosse-wizard-muted);
 	font-weight: 400;
 }
 
@@ -700,11 +912,12 @@
 }
 
 .fosse-wizard__reset a {
-	color: #757575;
+	color: var(--fosse-wizard-muted);
+	text-underline-offset: 3px;
 }
 
 .fosse-wizard__reset a:hover {
-	color: #1e1e1e;
+	color: var(--fosse-wizard-text);
 }
 
 /* WordPress's default `.button-hero` leaves anchor labels left-aligned, which
@@ -722,9 +935,9 @@
 
 .fosse-wizard__cta-help {
 	text-align: center;
-	margin: 8px 0 16px;
+	margin: 16px 0 22px;
 	font-size: 13px;
-	color: #50575e;
+	color: var(--fosse-wizard-muted);
 }
 
 .fosse-wizard__actions--secondary {
@@ -740,11 +953,18 @@
 	.fosse-wizard {
 		max-width: none;
 		margin: 0;
+		padding-top: 18px;
 	}
 
 	.fosse-wizard__progress {
+		align-items: flex-start;
 		flex-wrap: wrap;
-		row-gap: 10px;
+		gap: 8px 12px;
+		border-radius: 14px;
+	}
+
+	.fosse-wizard__title {
+		font-size: 26px;
 	}
 
 	.fosse-wizard__progress-line {
@@ -757,6 +977,24 @@
 
 	.fosse-destination-cards {
 		grid-template-columns: 1fr;
+	}
+
+	.fosse-destination-card {
+		min-height: auto;
+	}
+
+	.fosse-mode-card {
+		padding: 16px;
+	}
+
+	.fosse-address-preview,
+	.fosse-address-preview__row {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.fosse-wizard__blog-handle .regular-text {
+		width: 100%;
 	}
 
 	.fosse-wizard__actions,

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -153,8 +153,11 @@
 
 .fosse-wizard {
 	--fosse-wizard-surface: #fff;
+	--fosse-wizard-surface-muted: #f6f7f7;
 	--fosse-wizard-border: #dcdcde;
 	--fosse-wizard-border-strong: #c3c4c7;
+	--fosse-wizard-border-soft: #e5e7eb;
+	--fosse-wizard-border-faint: #eef0f2;
 	--fosse-wizard-accent: #3858e9;
 	--fosse-wizard-accent-soft: #f3f6ff;
 	--fosse-wizard-accent-icon: #e6ecff;
@@ -343,8 +346,8 @@
 .fosse-wizard__hint {
 	margin-top: 16px;
 	padding: 12px 16px;
-	background: #f6f7f7;
-	border: 1px solid #e5e7eb;
+	background: var(--fosse-wizard-surface-muted);
+	border: 1px solid var(--fosse-wizard-border-soft);
 	border-radius: 8px;
 }
 
@@ -593,7 +596,7 @@
 	width: 34px;
 	height: 34px;
 	border-radius: 50%;
-	background: #f6f7f7;
+	background: var(--fosse-wizard-surface-muted);
 	color: var(--fosse-wizard-muted);
 	flex-shrink: 0;
 }
@@ -663,8 +666,8 @@
 	align-items: center;
 	flex-wrap: wrap;
 	gap: 10px 12px;
-	background: #f6f7f7;
-	border: 1px solid #e5e7eb;
+	background: var(--fosse-wizard-surface-muted);
+	border: 1px solid var(--fosse-wizard-border-soft);
 	border-radius: 8px;
 	padding: 13px 16px;
 	font-size: 13px;
@@ -704,7 +707,7 @@
 .fosse-wizard__blog-handle {
 	margin-top: 18px;
 	padding-top: 18px;
-	border-top: 1px solid #e5e7eb;
+	border-top: 1px solid var(--fosse-wizard-border-soft);
 }
 
 .fosse-wizard__blog-handle-label {
@@ -887,7 +890,7 @@
 }
 
 .fosse-summary tr {
-	border-bottom: 1px solid #eef0f2;
+	border-bottom: 1px solid var(--fosse-wizard-border-faint);
 }
 
 .fosse-summary tr:last-child {

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -853,7 +853,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	margin: 0 auto 24px;
+	margin: 0 auto 34px;
 	box-shadow: 0 0 0 8px rgba(22, 138, 74, 0.06);
 }
 
@@ -939,13 +939,14 @@
 
 .fosse-wizard__cta-help {
 	text-align: center;
-	margin: 16px 0 22px;
+	margin: 18px auto 0;
 	font-size: 13px;
 	color: var(--fosse-wizard-muted);
+	max-width: 590px;
 }
 
 .fosse-wizard__actions--secondary {
-	margin-top: 8px;
+	margin-top: 28px;
 }
 
 /* Bluesky signup affordance */

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -963,7 +963,7 @@
 		border-radius: 14px;
 	}
 
-	.fosse-wizard__title {
+	.fosse-wizard .fosse-wizard__title {
 		font-size: 26px;
 	}
 

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -788,6 +788,14 @@
 	outline-offset: 2px;
 }
 
+/* `:focus-within` fallback for browsers without `:has()` / `:focus-visible`,
+   matching the destination-card and mode-card fallbacks above so keyboard
+   focus stays visible across all three interactive card types. */
+.fosse-post-type-item:focus-within {
+	outline: 2px solid var(--fosse-wizard-accent);
+	outline-offset: 2px;
+}
+
 .fosse-post-type-item__label {
 	font-size: 13px;
 	font-weight: 600;

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -406,6 +406,8 @@
 
 .fosse-destination-card:focus-within {
 	border-color: var(--fosse-wizard-accent);
+	outline: 2px solid var(--fosse-wizard-accent);
+	outline-offset: 3px;
 }
 
 .fosse-destination-card:has(.fosse-destination-card__input:focus-visible) {
@@ -577,10 +579,12 @@
 	outline-offset: 3px;
 }
 
-/* :focus-within fallback keeps the selected card border visible for browsers
-   without :focus-visible support. */
+/* :focus-within keeps keyboard focus visible when :has() / :focus-visible
+   support is missing or inconsistent. */
 .fosse-mode-card:focus-within {
 	border-color: var(--fosse-wizard-accent);
+	outline: 2px solid var(--fosse-wizard-accent);
+	outline-offset: 3px;
 }
 
 .fosse-mode-card__icon {

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -869,7 +869,7 @@ class Onboarding_Wizard {
 			),
 			self::DESTINATION_FEDIVERSE_ONLY    => array(
 				'class' => 'fosse-destination-card--fediverse-only',
-				'icon'  => 'dashicons-yes',
+				'icon'  => 'dashicons-networking',
 				'badge' => __( 'Simple setup', 'fosse' ),
 				'title' => __( 'Fediverse only', 'fosse' ),
 				'desc'  => __( 'Let people follow your site from apps like Mastodon. You can connect Bluesky later.', 'fosse' ),

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -1276,15 +1276,6 @@ class Onboarding_Wizard {
 	 * @return void
 	 */
 	private static function render_step_bluesky(): void {
-		// Defense in depth: render() routes through get_render_step() before
-		// dispatching here, so the live admin path can't reach this branch
-		// with a fediverse-only destination. Kept as a guard against any
-		// future direct caller in this class.
-		if ( ! self::destination_includes_bluesky() ) {
-			self::render_step_content();
-			return;
-		}
-
 		self::render_progress( 'bluesky' );
 		$status = self::get_bluesky_status();
 
@@ -1444,17 +1435,6 @@ class Onboarding_Wizard {
 	 * @return void
 	 */
 	private static function render_step_complete(): void {
-		// Defense in depth: render() routes through get_render_step() before
-		// dispatching here, so the live admin path can't reach this branch
-		// with !is_complete(). Kept as a guard against any future direct
-		// caller in this class. Direct GET to ?step=complete on an incomplete
-		// wizard is the case get_render_step() handles by substituting a
-		// useful in-flow step.
-		if ( ! self::is_complete() ) {
-			self::render_step_destinations();
-			return;
-		}
-
 		self::render_progress( 'complete' );
 
 		$actor_mode        = get_option( 'activitypub_actor_mode', 'actor' );

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -164,7 +164,7 @@ class Onboarding_Wizard {
 			return;
 		}
 
-		$step = self::get_current_step();
+		$step = self::get_render_step( self::get_current_step() );
 
 		switch ( $step ) {
 			case 'destinations':
@@ -465,6 +465,29 @@ class Onboarding_Wizard {
 	}
 
 	/**
+	 * Normalize the requested step for read-only rendering.
+	 *
+	 * Admin page callbacks run after WordPress has already printed part of the
+	 * admin shell, so render-only navigation cannot safely redirect. Keep
+	 * redirects in admin-post handlers and degrade crafted or stale wizard URLs
+	 * to the nearest useful step.
+	 *
+	 * @param string $step Requested step.
+	 * @return string
+	 */
+	private static function get_render_step( string $step ): string {
+		if ( 'complete' === $step && ! self::is_complete() ) {
+			return 'destinations';
+		}
+
+		if ( 'bluesky' === $step && ! self::destination_includes_bluesky() ) {
+			return 'content';
+		}
+
+		return $step;
+	}
+
+	/**
 	 * Get the saved destination intent, falling back to the recommended path.
 	 *
 	 * @return string
@@ -564,7 +587,7 @@ class Onboarding_Wizard {
 	}
 
 	/**
-	 * Format the "Site appears as" summary label for the completion step.
+	 * Format the "People follow" summary value for the completion step.
 	 *
 	 * Embeds the resolved fediverse handle(s) so users see the actual
 	 * identity they just stood up rather than just the bare host. Falls
@@ -584,18 +607,18 @@ class Onboarding_Wizard {
 			case 'actor':
 				if ( '' !== $user_handle ) {
 					return esc_html__( 'As you', 'fosse' )
-						. '<br /><code>' . esc_html( $user_handle ) . '</code>';
+						. ' <code>' . esc_html( $user_handle ) . '</code>';
 				}
 				return esc_html__( 'As you (author profiles)', 'fosse' );
 
 			case 'blog':
 				if ( '' !== $blog_handle ) {
 					return esc_html__( 'As your site', 'fosse' )
-						. '<br /><code>' . esc_html( $blog_handle ) . '</code>';
+						. ' <code>' . esc_html( $blog_handle ) . '</code>';
 				}
 				$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
 				return esc_html__( 'As your site', 'fosse' )
-					. '<br /><code>' . esc_html( $site_host ? $site_host : 'yoursite.com' ) . '</code>';
+					. ' <code>' . esc_html( $site_host ? $site_host : 'yoursite.com' ) . '</code>';
 
 			case 'actor_blog':
 				$lines = array( esc_html__( 'Both (site + authors)', 'fosse' ) );
@@ -818,7 +841,7 @@ class Onboarding_Wizard {
 				<?php endif; ?>
 				<li class="<?php echo esc_attr( $classes ); ?>"<?php echo $is_active ? ' aria-current="step"' : ''; ?>>
 					<span class="fosse-wizard__progress-dot" aria-hidden="true"></span>
-					<?php echo esc_html( $labels[ $key ] ); ?>
+					<span class="fosse-wizard__progress-label"><?php echo esc_html( $labels[ $key ] ); ?></span>
 				</li>
 			<?php endforeach; ?>
 		</ol>
@@ -838,20 +861,24 @@ class Onboarding_Wizard {
 
 		$destinations = array(
 			self::DESTINATION_FEDIVERSE_BLUESKY => array(
+				'class' => 'fosse-destination-card--fediverse-bluesky',
+				'icon'  => 'dashicons-star-filled',
 				'badge' => __( 'Recommended', 'fosse' ),
 				'title' => __( 'Fediverse + Bluesky', 'fosse' ),
-				'desc'  => __( 'Let people follow your site from Mastodon-compatible apps and publish eligible posts to Bluesky.', 'fosse' ),
+				'desc'  => __( 'Let people follow your site from apps like Mastodon, and share eligible posts to Bluesky.', 'fosse' ),
 			),
 			self::DESTINATION_FEDIVERSE_ONLY    => array(
+				'class' => 'fosse-destination-card--fediverse-only',
+				'icon'  => 'dashicons-yes',
 				'badge' => __( 'Simple setup', 'fosse' ),
 				'title' => __( 'Fediverse only', 'fosse' ),
-				'desc'  => __( 'Let people follow your site from Mastodon-compatible apps without setting up Bluesky in this wizard.', 'fosse' ),
+				'desc'  => __( 'Let people follow your site from apps like Mastodon. You can connect Bluesky later.', 'fosse' ),
 			),
 		);
 		?>
 		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Where should your WordPress posts appear?', 'fosse' ); ?></h1>
 		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Choose where FOSSE should share your posts. You can connect Bluesky or change these settings later in FOSSE Settings.', 'fosse' ); ?>
+			<?php esc_html_e( 'Fediverse sharing is enabled by default, so people can follow your site from Mastodon and similar apps. You can also connect Bluesky now or set it up later.', 'fosse' ); ?>
 		</p>
 
 		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
@@ -862,7 +889,7 @@ class Onboarding_Wizard {
 			<div class="fosse-wizard__card">
 				<div class="fosse-destination-cards">
 					<?php foreach ( $destinations as $value => $destination ) : ?>
-						<label class="fosse-destination-card">
+						<label class="fosse-destination-card <?php echo esc_attr( $destination['class'] ); ?>">
 							<input
 								type="radio"
 								name="fosse_onboarding_destination"
@@ -870,11 +897,16 @@ class Onboarding_Wizard {
 								class="fosse-destination-card__input"
 								<?php checked( $value, $current_destination ); ?>
 							/>
-							<span class="fosse-destination-card__badge"><?php echo esc_html( $destination['badge'] ); ?></span>
+							<span class="fosse-destination-card__header">
+								<span class="fosse-destination-card__icon" aria-hidden="true">
+									<span class="dashicons <?php echo esc_attr( $destination['icon'] ); ?>"></span>
+								</span>
+								<span class="fosse-destination-card__badge"><?php echo esc_html( $destination['badge'] ); ?></span>
+							</span>
 							<span class="fosse-destination-card__title"><?php echo esc_html( $destination['title'] ); ?></span>
 							<span class="fosse-destination-card__desc"><?php echo esc_html( $destination['desc'] ); ?></span>
-							<span class="fosse-destination-card__check">
-								<span class="dashicons dashicons-yes-alt"></span>
+							<span class="fosse-destination-card__check" aria-hidden="true">
+								<span class="dashicons dashicons-yes"></span>
 							</span>
 						</label>
 					<?php endforeach; ?>
@@ -918,7 +950,7 @@ class Onboarding_Wizard {
 				'title' => __( 'As you', 'fosse' ),
 				'desc'  => sprintf(
 					/* translators: 1: opening <strong> tag, 2: closing </strong> tag */
-					__( 'People follow %1$syou%2$s personally. Posts appear under your author name. Best for personal sites.', 'fosse' ),
+					__( 'People follow %1$syou%2$s, and posts show your author name. Best for personal sites.', 'fosse' ),
 					'<strong>',
 					'</strong>'
 				),
@@ -929,19 +961,19 @@ class Onboarding_Wizard {
 				'desc'  => $site_host
 					? sprintf(
 						/* translators: 1: opening <strong> tag, 2: closing </strong> tag, 3: site domain. */
-						__( 'People follow %1$s%3$s%2$s. All posts appear from your site\'s name. Best for blogs and publications.', 'fosse' ),
+						__( 'People follow %1$s%3$s%2$s, and posts show your site name. Best for blogs and publications.', 'fosse' ),
 						'<strong>',
 						'</strong>',
 						esc_html( $site_host )
 					)
-					: __( 'People follow your site. All posts appear from your site\'s name. Best for blogs and publications.', 'fosse' ),
+					: __( 'People follow your site, and posts show your site name. Best for blogs and publications.', 'fosse' ),
 			),
 			'actor_blog' => array(
 				'icon'  => 'dashicons-groups',
 				'title' => __( 'Both', 'fosse' ),
 				'desc'  => sprintf(
 					/* translators: 1: opening <strong> tag, 2: closing </strong> tag */
-					__( 'People can follow your site %1$sor%2$s individual authors separately. Best for multi-author sites.', 'fosse' ),
+					__( 'People can follow your site %1$sor%2$s individual authors separately. Best for sites with several writers.', 'fosse' ),
 					'<strong>',
 					'</strong>'
 				),
@@ -969,7 +1001,7 @@ class Onboarding_Wizard {
 		?>
 		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Who should people follow?', 'fosse' ); ?></h1>
 		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Choose the identity people follow from social apps. This affects who appears as the publisher when your selected content is shared.', 'fosse' ); ?>
+			<?php esc_html_e( 'Choose how your site appears in social apps. This controls the name people see when your posts are shared.', 'fosse' ); ?>
 		</p>
 
 		<?php settings_errors( 'fosse' ); ?>
@@ -1012,8 +1044,8 @@ class Onboarding_Wizard {
 									<div class="fosse-mode-card__title"><?php echo esc_html( $mode['title'] ); ?></div>
 									<div class="fosse-mode-card__desc"><?php echo wp_kses( $mode['desc'], array( 'strong' => array() ) ); ?></div>
 								</div>
-								<div class="fosse-mode-card__check">
-									<span class="dashicons dashicons-yes-alt"></span>
+								<div class="fosse-mode-card__check" aria-hidden="true">
+									<span class="dashicons dashicons-yes"></span>
 								</div>
 							</label>
 						<?php endforeach; ?>
@@ -1059,10 +1091,10 @@ class Onboarding_Wizard {
 								</div>
 							<?php endif; ?>
 						<?php elseif ( 'actor' === $preview_mode && '' !== $user_handle ) : ?>
-							<span class="fosse-address-preview__label"><?php esc_html_e( 'Your fediverse address:', 'fosse' ); ?></span>
+							<span class="fosse-address-preview__label"><?php esc_html_e( 'Your follow address:', 'fosse' ); ?></span>
 							<code class="fosse-address-preview__address"><?php echo esc_html( $user_handle ); ?></code>
 						<?php elseif ( 'blog' === $preview_mode && '' !== $blog_handle ) : ?>
-							<span class="fosse-address-preview__label"><?php esc_html_e( 'Site fediverse address:', 'fosse' ); ?></span>
+							<span class="fosse-address-preview__label"><?php esc_html_e( 'Site follow address:', 'fosse' ); ?></span>
 							<code class="fosse-address-preview__address"><?php echo esc_html( $blog_handle ); ?></code>
 						<?php endif; ?>
 					</div>
@@ -1076,7 +1108,7 @@ class Onboarding_Wizard {
 				?>
 				<div class="<?php echo esc_attr( $blog_handle_classes ); ?>" data-fosse-when="includes-blog">
 					<label for="fosse-wizard-blog-identifier" class="fosse-wizard__blog-handle-label">
-						<?php esc_html_e( 'Site Handle', 'fosse' ); ?>
+						<?php esc_html_e( 'Site handle', 'fosse' ); ?>
 					</label>
 					<input
 						type="text"
@@ -1088,7 +1120,7 @@ class Onboarding_Wizard {
 						aria-describedby="fosse-wizard-blog-identifier-desc"
 					/>
 					<p id="fosse-wizard-blog-identifier-desc" class="description">
-						<?php esc_html_e( 'The username people use to follow your site from the fediverse. Cannot match an existing author login or nicename.', 'fosse' ); ?>
+						<?php esc_html_e( 'The username people use to follow your site. It cannot match an existing author username.', 'fosse' ); ?>
 					</p>
 				</div>
 			</div>
@@ -1126,12 +1158,12 @@ class Onboarding_Wizard {
 		?>
 		<h1 class="fosse-wizard__title"><?php esc_html_e( 'What do you want to share?', 'fosse' ); ?></h1>
 		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Choose which types of content appear in people\'s feeds when they follow you. You can change this anytime.', 'fosse' ); ?>
+			<?php esc_html_e( 'Choose what to share with people who follow your site. You can change this anytime.', 'fosse' ); ?>
 		</p>
 
 		<?php if ( $has_empty_error ) : ?>
 			<div class="notice notice-error inline">
-				<p><?php esc_html_e( 'Pick at least one content type so federated followers have something to receive.', 'fosse' ); ?></p>
+				<p><?php esc_html_e( 'Pick at least one content type to share.', 'fosse' ); ?></p>
 			</div>
 		<?php endif; ?>
 
@@ -1188,7 +1220,7 @@ class Onboarding_Wizard {
 				</div>
 
 				<div class="fosse-wizard__hint">
-					<p><?php esc_html_e( 'Only future posts will be shared. Existing content won\'t be sent to anyone\'s feed retroactively.', 'fosse' ); ?></p>
+					<p><?php esc_html_e( 'Only new posts will be shared. Existing content will not be sent to followers.', 'fosse' ); ?></p>
 				</div>
 			</div>
 
@@ -1219,7 +1251,7 @@ class Onboarding_Wizard {
 	 */
 	private static function render_step_bluesky(): void {
 		if ( ! self::destination_includes_bluesky() ) {
-			self::redirect_to_step( 'content' );
+			self::render_step_content();
 			return;
 		}
 
@@ -1236,8 +1268,8 @@ class Onboarding_Wizard {
 			: __( 'Connect to Bluesky', 'fosse' );
 
 		$description = $is_connected
-			? __( 'Your posts will also appear on Bluesky. Review the details below before finishing setup.', 'fosse' )
-			: __( 'Link your Bluesky account so your posts also appear on Bluesky. This step is optional. You can always connect later from the FOSSE Settings page.', 'fosse' );
+			? __( 'Bluesky is connected. Review the details below before finishing setup.', 'fosse' )
+			: __( 'Connect your Bluesky account to share eligible WordPress posts there too. This is optional, and you can do it later in FOSSE Settings.', 'fosse' );
 		?>
 		<h1 class="fosse-wizard__title"><?php echo esc_html( $title ); ?></h1>
 		<p class="fosse-wizard__description">
@@ -1270,7 +1302,7 @@ class Onboarding_Wizard {
 				<div class="notice notice-info inline fosse-wizard__notice">
 					<p>
 						<strong><?php esc_html_e( 'Bluesky setup is unavailable.', 'fosse' ); ?></strong>
-						<?php esc_html_e( 'Skip this step for now and connect from the FOSSE Settings page once Bluesky support is available.', 'fosse' ); ?>
+						<?php esc_html_e( 'You can finish setup now and connect from FOSSE Settings later.', 'fosse' ); ?>
 					</p>
 				</div>
 			<?php elseif ( $is_connected ) : ?>
@@ -1278,7 +1310,7 @@ class Onboarding_Wizard {
 				<div class="notice notice-success inline fosse-wizard__notice">
 					<p>
 						<strong><?php esc_html_e( 'Bluesky is connected.', 'fosse' ); ?></strong>
-						<?php esc_html_e( 'FOSSE can publish eligible posts to this account.', 'fosse' ); ?>
+						<?php esc_html_e( 'FOSSE can share eligible posts with this account.', 'fosse' ); ?>
 					</p>
 				</div>
 
@@ -1291,19 +1323,19 @@ class Onboarding_Wizard {
 					<?php endif; ?>
 					<?php if ( $status['did'] ) : ?>
 						<tr>
-							<td class="fosse-summary__label"><?php esc_html_e( 'DID', 'fosse' ); ?></td>
+							<td class="fosse-summary__label"><?php esc_html_e( 'Account ID', 'fosse' ); ?></td>
 							<td class="fosse-summary__value"><code><?php echo esc_html( $status['did'] ); ?></code></td>
 						</tr>
 					<?php endif; ?>
 					<?php if ( ! empty( $handle_previews['user'] ) ) : ?>
 						<tr>
-							<td class="fosse-summary__label"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></td>
+							<td class="fosse-summary__label"><?php esc_html_e( 'Your follow address', 'fosse' ); ?></td>
 							<td class="fosse-summary__value"><code><?php echo esc_html( $handle_previews['user'] ); ?></code></td>
 						</tr>
 					<?php endif; ?>
 					<?php if ( ! empty( $handle_previews['blog'] ) ) : ?>
 						<tr>
-							<td class="fosse-summary__label"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></td>
+							<td class="fosse-summary__label"><?php esc_html_e( 'Site follow address', 'fosse' ); ?></td>
 							<td class="fosse-summary__value"><code><?php echo esc_html( $handle_previews['blog'] ); ?></code></td>
 						</tr>
 					<?php endif; ?>
@@ -1316,7 +1348,7 @@ class Onboarding_Wizard {
 
 					<div class="fosse-bluesky-form">
 						<label for="fosse-bsky-handle" class="fosse-bluesky-form__label">
-							<?php esc_html_e( 'Bluesky or AT Protocol handle', 'fosse' ); ?>
+							<?php esc_html_e( 'Bluesky handle', 'fosse' ); ?>
 						</label>
 						<div class="fosse-bluesky-form__controls">
 							<input
@@ -1329,7 +1361,7 @@ class Onboarding_Wizard {
 							/>
 						</div>
 						<p id="fosse-bsky-handle-description" class="description">
-							<?php esc_html_e( 'Use your Bluesky handle, or a custom domain handle if you have one.', 'fosse' ); ?>
+							<?php esc_html_e( 'Enter your Bluesky handle, such as yourname.bsky.social. If you use your own domain as your handle, enter that.', 'fosse' ); ?>
 						</p>
 					</div>
 				</form>
@@ -1340,7 +1372,7 @@ class Onboarding_Wizard {
 						echo wp_kses_post(
 							sprintf(
 								/* translators: 1: opening Bluesky signup anchor tag, 2: closing anchor tag, 3: opening domain-handle help anchor tag, 4: closing anchor tag. */
-								__( 'Need help getting started? %1$sCreate a Bluesky account%2$s, or %3$slearn how to use your domain as your handle%4$s.', 'fosse' ),
+								__( 'Need a Bluesky account? %1$sCreate one%2$s, or %3$slearn how to use your own domain as your handle%4$s.', 'fosse' ),
 								'<a href="' . esc_url( 'https://bsky.app/' ) . '" target="_blank" rel="noopener noreferrer" class="fosse-bluesky-signup__link">',
 								'</a>',
 								'<a href="' . esc_url( 'https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial' ) . '" target="_blank" rel="noopener noreferrer">',
@@ -1386,7 +1418,7 @@ class Onboarding_Wizard {
 		// otherwise render the success screen without ever marking the wizard
 		// complete via handle_complete(), leaving the Setup notice nagging.
 		if ( ! self::is_complete() ) {
-			self::redirect_to_step( 'destinations' );
+			self::render_step_destinations();
 			return;
 		}
 
@@ -1430,11 +1462,11 @@ class Onboarding_Wizard {
 		?>
 		<div class="fosse-wizard__complete-header">
 			<div class="fosse-complete-icon">
-				<span class="dashicons dashicons-yes-alt"></span>
+				<span class="dashicons dashicons-yes"></span>
 			</div>
 			<h1 class="fosse-wizard__title"><?php esc_html_e( 'You\'re all set!', 'fosse' ); ?></h1>
 			<p class="fosse-wizard__description">
-				<?php esc_html_e( 'Review your setup, then publish from WordPress when you are ready.', 'fosse' ); ?>
+				<?php esc_html_e( 'Your sharing setup is ready. Review it below, then publish from WordPress when you are ready.', 'fosse' ); ?>
 			</p>
 		</div>
 
@@ -1445,7 +1477,7 @@ class Onboarding_Wizard {
 					<td class="fosse-summary__value"><?php echo esc_html( $destination_label ); ?></td>
 				</tr>
 				<tr>
-					<td class="fosse-summary__label"><?php esc_html_e( 'Site appears as', 'fosse' ); ?></td>
+					<td class="fosse-summary__label"><?php esc_html_e( 'People follow', 'fosse' ); ?></td>
 					<td class="fosse-summary__value">
 						<?php
 						echo wp_kses(
@@ -1459,7 +1491,7 @@ class Onboarding_Wizard {
 					</td>
 				</tr>
 				<tr>
-					<td class="fosse-summary__label"><?php esc_html_e( 'Sharing', 'fosse' ); ?></td>
+					<td class="fosse-summary__label"><?php esc_html_e( 'Content shared', 'fosse' ); ?></td>
 					<td class="fosse-summary__value"><?php echo esc_html( implode( ', ', $type_labels ) ); ?></td>
 				</tr>
 				<tr>
@@ -1476,13 +1508,13 @@ class Onboarding_Wizard {
 		<?php
 		$cta = self::resolve_publish_cta( $post_types );
 		if ( $publishes_bluesky ) {
-			$cta_help = __( 'Your post will reach followers across Mastodon-compatible apps and Bluesky.', 'fosse' );
+			$cta_help = __( 'Your post can reach people on Fediverse apps like Mastodon and on Bluesky.', 'fosse' );
 		} elseif ( $bluesky['connected'] ) {
-			$cta_help = __( 'Your post will reach followers across Mastodon-compatible apps. Bluesky is connected, but automatic publishing is off.', 'fosse' );
+			$cta_help = __( 'Your post can reach people on Fediverse apps like Mastodon. Bluesky is connected, but automatic sharing is off.', 'fosse' );
 		} elseif ( $includes_bluesky ) {
-			$cta_help = __( 'Your post will reach followers across Mastodon-compatible apps and Bluesky if connected.', 'fosse' );
+			$cta_help = __( 'Your post can reach people on Fediverse apps like Mastodon. Connect Bluesky to share there too.', 'fosse' );
 		} else {
-			$cta_help = __( 'Your post will reach followers across Mastodon-compatible apps.', 'fosse' );
+			$cta_help = __( 'Your post can reach people on Fediverse apps like Mastodon.', 'fosse' );
 		}
 		?>
 		<div class="fosse-wizard__actions fosse-wizard__actions--center">

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -477,7 +477,7 @@ class Onboarding_Wizard {
 	 */
 	private static function get_render_step( string $step ): string {
 		if ( 'complete' === $step && ! self::is_complete() ) {
-			return 'destinations';
+			return self::resolve_pre_completion_step();
 		}
 
 		if ( 'bluesky' === $step && ! self::destination_includes_bluesky() ) {
@@ -485,6 +485,30 @@ class Onboarding_Wizard {
 		}
 
 		return $step;
+	}
+
+	/**
+	 * Pick the most useful step to substitute for a pre-completion `?step=complete` URL.
+	 *
+	 * A user who lands on `?step=complete` before `is_complete()` is true has
+	 * either crafted the URL by hand, hit browser-back from a fresh
+	 * `mark_complete()` -> `delete_option()` cycle, or bookmarked the link
+	 * after a wizard reset. Sending all of those cases back to step 1 throws
+	 * away whatever progress they had — pick the latest in-flow step instead
+	 * so a partially-finished run resumes near where it left off.
+	 *
+	 * Use the raw stored option (with `false` as the un-saved sentinel) rather
+	 * than `get_destination()`, which always returns the recommended default
+	 * and would mask a brand-new wizard run as Fediverse + Bluesky.
+	 *
+	 * @return string
+	 */
+	private static function resolve_pre_completion_step(): string {
+		if ( false === get_option( self::DESTINATION_OPTION, false ) ) {
+			return 'destinations';
+		}
+
+		return self::destination_includes_bluesky() ? 'bluesky' : 'content';
 	}
 
 	/**
@@ -594,8 +618,10 @@ class Onboarding_Wizard {
 	 * back gracefully when a handle is missing (AP not loaded, user
 	 * actor unavailable) — never shows an `@` with no local-part.
 	 *
-	 * Returns an HTML string; the consumer escapes via `wp_kses` with
-	 * `code` and `br` allowed.
+	 * Returns an HTML string. Single-identity branches inline the handle
+	 * after a space; the multi-identity `actor_blog` branch separates
+	 * label and handle with `<br />` and joins lines with `<br />`. The
+	 * consumer escapes via `wp_kses` with `code` and `br` allowed.
 	 *
 	 * @param string $mode        Actor mode value.
 	 * @param string $user_handle Normalized `@user@host` for the current user, or empty.
@@ -1250,6 +1276,10 @@ class Onboarding_Wizard {
 	 * @return void
 	 */
 	private static function render_step_bluesky(): void {
+		// Defense in depth: render() routes through get_render_step() before
+		// dispatching here, so the live admin path can't reach this branch
+		// with a fediverse-only destination. Kept as a guard against any
+		// future direct caller in this class.
 		if ( ! self::destination_includes_bluesky() ) {
 			self::render_step_content();
 			return;
@@ -1414,9 +1444,12 @@ class Onboarding_Wizard {
 	 * @return void
 	 */
 	private static function render_step_complete(): void {
-		// Direct GET to ?step=complete (URL crafting, browser back/forward) would
-		// otherwise render the success screen without ever marking the wizard
-		// complete via handle_complete(), leaving the Setup notice nagging.
+		// Defense in depth: render() routes through get_render_step() before
+		// dispatching here, so the live admin path can't reach this branch
+		// with !is_complete(). Kept as a guard against any future direct
+		// caller in this class. Direct GET to ?step=complete on an incomplete
+		// wizard is the case get_render_step() handles by substituting a
+		// useful in-flow step.
 		if ( ! self::is_complete() ) {
 			self::render_step_destinations();
 			return;

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -341,8 +341,8 @@ test( 'Completion step shows summary', async ( { page } ) => {
 	await expect(
 		page.locator( '.fosse-summary__label', { hasText: 'Destinations' } )
 	).toBeVisible();
-	await expect( page.locator( 'text=Site appears as' ) ).toBeVisible();
-	await expect( page.locator( 'text=Sharing' ) ).toBeVisible();
+	await expect( page.locator( 'text=People follow' ) ).toBeVisible();
+	await expect( page.locator( 'text=Content shared' ) ).toBeVisible();
 	await expect(
 		page.locator( '.fosse-summary__label', { hasText: 'Bluesky' } )
 	).toBeVisible();

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1099,6 +1099,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'As your site', $output );
 		$this->assertMatchesRegularExpression( '~As your site\s*<code>@[^<]+@[^<]+</code>~', $output );
+		// Mirror the actor-mode guard so a future revert of the inline-space
+		// change in `format_mode_label()` (back to `<br /><code>`) is caught
+		// for the blog branch too — the assertion above's `\s*` accepts both
+		// shapes and would not flag the regression on its own.
+		$this->assertDoesNotMatchRegularExpression( '~As your site<br\s*/?>~', $output );
 	}
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1263,12 +1263,44 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 	/**
 	 * Direct GETs to the review step before completion fall back to the first
-	 * wizard step instead of attempting a late admin-page redirect.
+	 * wizard step when no destination has been saved yet — a brand-new wizard
+	 * run shouldn't skip past the destination decision.
 	 */
 	public function test_render_complete_step_before_completion_falls_back_to_destinations(): void {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
+		$this->assertStringNotContainsString( 'You&#039;re all set!', $output );
+	}
+
+	/**
+	 * Direct GETs to the review step on an incomplete Fediverse + Bluesky
+	 * wizard land on the Bluesky step — the latest in-flow step before
+	 * completion — so a partially-finished run resumes near where the
+	 * user left off instead of restarting from step 1.
+	 */
+	public function test_render_complete_step_before_completion_routes_to_bluesky_for_saved_bluesky_destination(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_bluesky' );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'Connect to Bluesky', $output );
+		$this->assertStringNotContainsString( 'Where should your WordPress posts appear?', $output );
+		$this->assertStringNotContainsString( 'You&#039;re all set!', $output );
+	}
+
+	/**
+	 * Direct GETs to the review step on an incomplete Fediverse-only wizard
+	 * land on the Content step — the last step that submits and marks the
+	 * wizard complete on this destination path.
+	 */
+	public function test_render_complete_step_before_completion_routes_to_content_for_saved_fediverse_only(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'What do you want to share?', $output );
+		$this->assertStringNotContainsString( 'Where should your WordPress posts appear?', $output );
 		$this->assertStringNotContainsString( 'You&#039;re all set!', $output );
 	}
 

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -444,11 +444,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( '' );
 
 		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
-		$this->assertStringContainsString( 'Choose where FOSSE should share your posts. You can connect Bluesky or change these settings later in FOSSE Settings.', $output );
+		$this->assertStringContainsString( 'Fediverse sharing is enabled by default, so people can follow your site from Mastodon and similar apps. You can also connect Bluesky now or set it up later.', $output );
 		$this->assertStringContainsString( 'Fediverse + Bluesky', $output );
 		$this->assertStringContainsString( 'Fediverse only', $output );
 		$this->assertStringContainsString( 'Simple setup', $output );
-		$this->assertStringContainsString( 'Let people follow your site from Mastodon-compatible apps without setting up Bluesky in this wizard.', $output );
+		$this->assertStringContainsString( 'Let people follow your site from apps like Mastodon. You can connect Bluesky later.', $output );
 		$this->assertStringContainsString( 'name="fosse_onboarding_destination"', $output );
 		$this->assertStringNotContainsString( 'Welcome to FOSSE', $output );
 		$this->assertStringNotContainsString( '>Later<', $output );
@@ -827,8 +827,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Connect Bluesky', $output );
 		$this->assertStringContainsString( 'Skip Bluesky for now', $output );
 		$this->assertStringContainsString( 'fosse-bluesky-form', $output );
-		$this->assertStringContainsString( 'Bluesky or AT Protocol handle', $output );
-		$this->assertStringContainsString( 'Use your Bluesky handle, or a custom domain handle if you have one.', $output );
+		$this->assertStringContainsString( 'Bluesky handle', $output );
+		$this->assertStringContainsString( 'Enter your Bluesky handle, such as yourname.bsky.social. If you use your own domain as your handle, enter that.', $output );
 		$this->assertStringNotContainsString( 'fosse-bluesky-placeholder', $output );
 		$this->assertStringNotContainsString( 'Coming Soon', $output );
 		$this->assertStringNotContainsString( 'Bluesky Handle', $output );
@@ -855,27 +855,13 @@ class Onboarding_WizardTest extends BaseTestCase {
 	/**
 	 * A fediverse-only destination does not render the Bluesky connect form.
 	 */
-	public function test_render_bluesky_step_fediverse_only_redirects_away(): void {
+	public function test_render_bluesky_step_fediverse_only_falls_back_to_content(): void {
 		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
 
-		$captured = null;
-		add_filter(
-			'wp_redirect',
-			static function ( $location ) use ( &$captured ) {
-				$captured = (string) $location;
-				throw new RedirectFired( 'redirect' );
-			},
-			9
-		);
+		$output = $this->render_wizard_step( 'bluesky' );
 
-		try {
-			$this->render_wizard_step( 'bluesky' );
-		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
-			unset( $e );
-		}
-
-		$this->assertNotNull( $captured );
-		$this->assertStringContainsString( 'step=content', $captured );
+		$this->assertStringContainsString( 'What do you want to share?', $output );
+		$this->assertStringNotContainsString( 'fosse_connect_bluesky', $output );
 	}
 
 	/**
@@ -1112,17 +1098,14 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertStringContainsString( 'As your site', $output );
-		// Long handles previously wrapped awkwardly mid-token; the label and
-		// handle now sit on separate lines with a `<br />` between them (#72).
-		$this->assertMatchesRegularExpression( '~As your site<br\s*/?>\s*<code>@[^<]+@[^<]+</code>~', $output );
+		$this->assertMatchesRegularExpression( '~As your site\s*<code>@[^<]+@[^<]+</code>~', $output );
 	}
 
 	/**
-	 * In `actor` mode the user handle drops to its own line (#72), so a long
-	 * `@user@host` token in a narrow summary cell can't push the row's
-	 * intrinsic width past the wizard column.
+	 * In `actor` mode the user handle stays with the "As you" label so the
+	 * single-value summary reads as one phrase.
 	 */
-	public function test_complete_summary_breaks_handle_to_new_line_in_actor_mode(): void {
+	public function test_complete_summary_keeps_handle_inline_in_actor_mode(): void {
 		Onboarding_Wizard::mark_complete();
 		update_option( 'activitypub_actor_mode', 'actor' );
 
@@ -1134,10 +1117,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		}
 
 		$this->assertStringContainsString( 'As you', $output );
-		$this->assertMatchesRegularExpression( '~As you<br\s*/?>\s*<code>@[^<]+@[^<]+</code>~', $output );
+		$this->assertMatchesRegularExpression( '~As you\s*<code>@[^<]+@[^<]+</code>~', $output );
 		// The pre-fix wrapper used parens around the handle on the same line;
 		// guard against the parenthesized shape regressing here.
 		$this->assertDoesNotMatchRegularExpression( '~As you \(<code>~', $output );
+		$this->assertDoesNotMatchRegularExpression( '~As you<br\s*/?>~', $output );
 	}
 
 	// --- Bluesky signup help (#58) ---
@@ -1152,9 +1136,9 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertSame( 1, substr_count( $output, 'fosse-wizard__hint fosse-bluesky-signup' ) );
 		$this->assertStringContainsString( 'https://bsky.app/', $output );
 		$this->assertStringContainsString( 'https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial', $output );
-		$this->assertStringContainsString( 'Need help getting started?', $output );
-		$this->assertStringContainsString( 'Create a Bluesky account', $output );
-		$this->assertStringContainsString( 'learn how to use your domain as your handle', $output );
+		$this->assertStringContainsString( 'Need a Bluesky account?', $output );
+		$this->assertStringContainsString( 'Create one', $output );
+		$this->assertStringContainsString( 'learn how to use your own domain as your handle', $output );
 		$this->assertStringNotContainsString( 'Want your domain as your handle?', $output );
 	}
 
@@ -1259,7 +1243,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 			remove_filter( 'activitypub_user_can_activitypub', '__return_true' );
 		}
 
-		$this->assertStringContainsString( 'Your fediverse address', $output );
+		$this->assertStringContainsString( 'Your follow address', $output );
 		$this->assertMatchesRegularExpression( '/<code>@[^<]+@[^<]+<\/code>/', $output );
 	}
 
@@ -1271,11 +1255,22 @@ class Onboarding_WizardTest extends BaseTestCase {
 	public function test_render_bluesky_step_disconnected_omits_fediverse_identity(): void {
 		$output = $this->render_wizard_step( 'bluesky' );
 
-		$this->assertStringNotContainsString( 'Your fediverse address', $output );
-		$this->assertStringNotContainsString( 'Site fediverse address', $output );
+		$this->assertStringNotContainsString( 'Your follow address', $output );
+		$this->assertStringNotContainsString( 'Site follow address', $output );
 	}
 
 	// --- Publish CTA on completion step (#63) ---
+
+	/**
+	 * Direct GETs to the review step before completion fall back to the first
+	 * wizard step instead of attempting a late admin-page redirect.
+	 */
+	public function test_render_complete_step_before_completion_falls_back_to_destinations(): void {
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
+		$this->assertStringNotContainsString( 'You&#039;re all set!', $output );
+	}
 
 	/**
 	 * The completion step renders a primary CTA to publish the user's first
@@ -1307,7 +1302,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertMatchesRegularExpression(
-			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Mastodon-compatible apps and Bluesky~i',
+			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Fediverse apps like Mastodon.*Connect Bluesky~i',
 			$output,
 			'The publish CTA helper copy must describe the selected destinations.'
 		);
@@ -1325,7 +1320,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertMatchesRegularExpression(
-			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Mastodon-compatible apps and Bluesky\.~i',
+			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Fediverse apps like Mastodon and on Bluesky\\.~i',
 			$output,
 			'The publish CTA helper copy must mention Bluesky when existing settings will publish there.'
 		);
@@ -1344,11 +1339,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertMatchesRegularExpression(
-			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*automatic publishing is off\.~i',
+			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*automatic sharing is off\\.~i',
 			$output,
 			'The publish CTA helper copy must explain why a connected account will not receive the next post.'
 		);
-		$this->assertStringNotContainsString( 'Mastodon-compatible apps and Bluesky.', $output );
+		$this->assertStringNotContainsString( 'Fediverse apps like Mastodon and on Bluesky.', $output );
 	}
 
 	/**


### PR DESCRIPTION
<img width="1167" height="652" alt="SCR-20260506-oxyi" src="https://github.com/user-attachments/assets/0d73397e-f79e-47c8-8df0-4eb55bd6dcea" />

## Summary
- Refresh the first-run onboarding wizard visual design, including the progress tracker, selection cards, and completion screen spacing.
- Polish onboarding copy across destination, Bluesky, and completion flows.
- Keep crafted or stale wizard URLs from showing the completion screen before setup is actually complete.
- Improve follow-address summary wrapping and completion CTA affordances.

## Testing
- `composer run-script lint-php`
- `pnpm run format:check`
- `pnpm run lint`
- `composer run-script test-php -- --filter Onboarding_WizardTest`
- `pnpm exec playwright test tests/e2e/onboarding-wizard.spec.ts --project=chromium`