### PR TITLE
chore: sync bundled plugins (AP trunk + Atmo PR 51)

### DIFF
--- a/bundled/activitypub/includes/class-migration.php
+++ b/bundled/activitypub/includes/class-migration.php
@@ -208,9 +208,9 @@ class Migration {
 		if ( \version_compare( $version_from_db, '7.9.0', '<' ) ) {
 			\wp_schedule_single_event( \time(), 'activitypub_migrate_actor_emoji' );
 		}
-		if ( \version_compare( $version_from_db, '8.1.0', '<' ) ) {
-			// Backfill historical statistics data (delay to avoid load immediately after upgrade).
-			\wp_schedule_single_event( \time() + HOUR_IN_SECONDS, 'activitypub_backfill_statistics' );
+		if ( \version_compare( $version_from_db, '8.1.0', '<' ) && ! \wp_next_scheduled( 'activitypub_backfill_statistics' ) ) {
+			// Backfill historical statistics data (delay + jitter to avoid load spikes on hosts running many sites).
+			\wp_schedule_single_event( \time() + HOUR_IN_SECONDS + \wp_rand( 0, 6 * HOUR_IN_SECONDS ), 'activitypub_backfill_statistics' );
 		}
 
 		/*

--- a/bundled/atmosphere/includes/oauth/class-client.php
+++ b/bundled/atmosphere/includes/oauth/class-client.php
@@ -22,9 +22,22 @@ class Client {
 	/**
 	 * Scopes requested from the auth server.
 	 *
+	 * `identity:handle` is required for `com.atproto.identity.updateHandle`
+	 * — the canonical AT Protocol permission scope per
+	 * https://atproto.com/specs/permission. `transition:generic` is the
+	 * App Password-equivalent bucket and explicitly does not include
+	 * identity operations, so it must be paired with `identity:handle`
+	 * for any flow that lets users change their handle through the PDS.
+	 *
+	 * MUST stay in lockstep with the `scope` value advertised in the
+	 * client-metadata REST endpoint
+	 * ({@see \Atmosphere\Admin::serve_client_metadata()}). The auth
+	 * server validates the requested scope against the metadata; a drift
+	 * silently downgrades every connection to whichever value is smaller.
+	 *
 	 * @var string
 	 */
-	private const SCOPES = 'atproto transition:generic';
+	private const SCOPES = 'atproto transition:generic identity:handle';
 
 	/**
 	 * Get the client_id URL (= client metadata endpoint).

--- a/bundled/atmosphere/includes/wp-admin/class-admin.php
+++ b/bundled/atmosphere/includes/wp-admin/class-admin.php
@@ -638,7 +638,10 @@ class Admin {
 			'grant_types'                => array( 'authorization_code', 'refresh_token' ),
 			'response_types'             => array( 'code' ),
 			'token_endpoint_auth_method' => 'none',
-			'scope'                      => 'atproto transition:generic',
+			// MUST match the scope string requested by Client::authorize().
+			// The auth server validates the request scope against the metadata;
+			// a drift here silently downgrades to the smaller of the two.
+			'scope'                      => 'atproto transition:generic identity:handle',
 			'dpop_bound_access_tokens'   => true,
 			'application_type'           => 'web',
 		);
@@ -650,6 +653,23 @@ class Admin {
 		 */
 		$metadata = \apply_filters( 'atmosphere_client_metadata', $metadata );
 
-		return new \WP_REST_Response( $metadata, 200 );
+		$response = new \WP_REST_Response( $metadata, 200 );
+
+		// Cap intermediate-cache TTL well under the AT Protocol auth
+		// server's own metadata cache (10 min in Bluesky's reference impl),
+		// so that when the metadata document changes — e.g. a new OAuth
+		// scope is added in an Atmosphere release — every layer between
+		// us and the auth server has refreshed before the auth server
+		// itself does its next refresh. Without an explicit header,
+		// hosted environments like wp.com Atomic apply their own (much
+		// longer) heuristic-based edge cache and can serve a stale scope
+		// to every auth server that asks, surfacing as "Scope X is not
+		// declared in the client metadata" on every authorization attempt.
+		// 5 minutes gives the auth-server cache cycle plenty of room
+		// without flat-out disabling cheap caching of an otherwise
+		// rarely-changing document.
+		$response->header( 'Cache-Control', 'public, max-age=300' );
+
+		return $response;
 	}
 }

--- a/bundled/atmosphere/vendor/composer/installed.php
+++ b/bundled/atmosphere/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'automattic/atmosphere',
         'pretty_version' => 'dev-trunk',
         'version' => 'dev-trunk',
-        'reference' => '3b50792d2ef794dc5d1f92426462611831398f85',
+        'reference' => '802bef4f88c3943302b33eef5bf5a96622a94e30',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'automattic/atmosphere' => array(
             'pretty_version' => 'dev-trunk',
             'version' => 'dev-trunk',
-            'reference' => '3b50792d2ef794dc5d1f92426462611831398f85',
+            'reference' => '802bef4f88c3943302b33eef5bf5a96622a94e30',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary

Refreshes `bundled/activitypub/` and `bundled/atmosphere/` from upstream:

- **wordpress-activitypub**: `c84b4c0b` → `e9194efa` (trunk; jitter on the backfill-statistics migration is the only behavior delta).
- **wordpress-atmosphere**: `3b50792` → `802bef4` (head of [PR 51 — Collapse teaser-thread to a single record when the body is the entire hook](https://github.com/Automattic/wordpress-atmosphere/pull/51)). PR 51 has trunk merged into it twice since last sync, so this also picks up:
  - **OAuth `identity:handle` scope** ([wordpress-atmosphere#53](https://github.com/Automattic/wordpress-atmosphere/pull/53)) — required for `com.atproto.identity.updateHandle`. Scope on the OAuth client and the advertised client-metadata endpoint move in lockstep.
  - Cache-Control hardening on the client-metadata endpoint.

The teaser-thread collapse work itself stays as-is (already on PR 51's head from the previous sync).

Generated via `tools/sync-bundled.sh`. Atmosphere `composer.lock` + `vendor/` were scrubbed before the rebuild (per the gitignored-lockfile gotcha) so we ship deps resolved fresh against the current `composer.json`.

## Test plan

- [ ] `composer run-script test-php` (CI)
- [ ] Sandbox: connect a Bluesky account through the wizard; verify the OAuth consent screen now requests `identity:handle` alongside `atproto transition:generic`.
- [ ] Sandbox: change the Bluesky handle from WP admin (the `bluesky-handle-setup` flow) and confirm `com.atproto.identity.updateHandle` no longer 403s.
- [ ] Sandbox: publish a long-form post that contains a single hook line; verify the teaser-thread collapses to one record (PR 51's primary behavior).