### PR TITLE
Tests: tighten Bluesky handle normalization assertion

### DIFF
--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -1526,13 +1526,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		// Intercept the HTTP request that Client::authorize() makes to
-		// the handle's auth server, and capture the handle it resolved.
+		// the handle's auth server, and capture the normalized handle it resolved.
 		$captured_handle = null;
 		add_filter(
 			'pre_http_request',
 			static function ( $preempt, $args, $url ) use ( &$captured_handle ) {
 				// The first HTTP call from authorize() is handle resolution.
-				// Capture the URL to verify no leading @ was passed.
+				// Capture the URL to verify the normalized handle was passed.
 				$captured_handle = $url;
 				// Return an error to short-circuit the flow.
 				return new \WP_Error( 'fosse_test_intercept', 'intercepted' );
@@ -1559,7 +1559,9 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			$captured_handle,
 			'Expected pre_http_request to fire from Client::authorize() — handle normalization could not be verified.'
 		);
+		$this->assertStringContainsString( 'alice.bsky.social', $captured_handle );
 		$this->assertStringNotContainsString( '@alice', $captured_handle );
+		$this->assertStringNotContainsString( '%40alice', $captured_handle );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Strengthen the leading-@ Bluesky connect test so it proves the normalized handle is passed to the authorize flow.
- Assert the intercepted authorize URL contains alice.bsky.social and excludes both raw and URL-encoded @alice forms.

## Testing
- composer run-script test-php -- --filter test_handle_connect_strips_leading_at
- composer run-script lint-php