### PR TITLE
add: FOSSE_VERSION load-sentinel constant

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -18,6 +18,15 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/*
+ * Load sentinel. Defined unconditionally so embedders (e.g. wp.com's
+ * `wp-content/mu-plugins/fosse-loader.php`) can detect that FOSSE has
+ * been required without probing internal classes. Mirrors the
+ * `ACTIVITYPUB_PLUGIN_VERSION` / `ATMOSPHERE_VERSION` pattern of the
+ * bundled backends. Keep in sync with the `Version:` header above.
+ */
+define( 'FOSSE_VERSION', '0.0.1' );
+
 if ( file_exists( __DIR__ . '/vendor/autoload_packages.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload_packages.php';
 }


### PR DESCRIPTION
Related to DOTCOM-16981.

## Proposed changes

Add a public `FOSSE_VERSION` constant at the top of `fosse.php`, defined unconditionally with the same value as the plugin header `Version:` field.

## Why

wp.com's `wp-content/mu-plugins/fosse-loader.php` needs a stable, public sentinel to detect that FOSSE has been required. Today the loader falls back to probing `\Automattic\Fosse\Bundled\Bootstrap`:

```php
function wpcom_fosse_is_loaded() {
    return defined( 'FOSSE_VERSION' )
        || class_exists( '\Automattic\Fosse\Bundled\Bootstrap', false );
}
```

…with an inline comment flagging the class-existence probe as a follow-up. This PR is that follow-up: define a stable constant so embedders don't have to reach into internals.

Mirrors the `ACTIVITYPUB_PLUGIN_VERSION` / `ATMOSPHERE_VERSION` convention of the bundled backends.

## Testing

`composer run-script lint-php` clean. A separate draft PR will land on wpcom to switch `wpcom_fosse_is_loaded()` over to a clean `defined( 'FOSSE_VERSION' )` once a new FOSSE artifact carrying this constant is vendored onto wp.com.