### PR TITLE
Admin: polish settings and status pages

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -1,66 +1,72 @@
 /**
  * FOSSE admin styles.
  *
- * Leans on native WP admin classes (form-table, card, notice, widefat).
- * Custom styles only where WP's defaults don't cover the layout.
+ * The settings and status screens borrow the onboarding wizard's rounded
+ * surfaces, quiet borders, and restrained spacing while staying native to
+ * wp-admin forms and notices.
  */
 
-/* Status summary bar */
-.fosse-status-summary {
-	background: #fff;
-	border: 1px solid #c3c4c7;
-	border-left-width: 4px;
-	border-left-color: #00a32a;
-	border-radius: 4px;
-	padding: 12px 16px;
-	margin: 16px 0;
+.fosse-admin-page {
+	--fosse-admin-surface: #fff;
+	--fosse-admin-surface-muted: #f6f7f7;
+	--fosse-admin-border: #dcdcde;
+	--fosse-admin-border-strong: #c3c4c7;
+	--fosse-admin-border-soft: #e5e7eb;
+	--fosse-admin-border-faint: #eef0f2;
+	--fosse-admin-accent: #3858e9;
+	--fosse-admin-accent-soft: #f3f6ff;
+	--fosse-admin-accent-soft-border: rgba(56, 88, 233, 0.38);
+	--fosse-admin-success: #287340;
+	--fosse-admin-success-soft: #edf8f1;
+	--fosse-admin-danger: #b32d2e;
+	--fosse-admin-danger-soft: #fcf0f1;
+	--fosse-admin-warning: #8a6200;
+	--fosse-admin-warning-soft: #fff7e3;
+	--fosse-admin-text: #1d2327;
+	--fosse-admin-muted: #646970;
+
+	max-width: 1120px;
+	color: var(--fosse-admin-text);
 }
 
-.fosse-status-summary.has-attention {
-	border-left-color: #dba617;
+.fosse-admin-page__header {
+	margin: 14px 0 24px;
 }
 
-/* Status card grid.
-   `min(100%, 360px)` lets each card shrink below the 360px target on
-   narrow screens (single-column layouts in the wp-admin sidebar), while
-   `min-width: 0` on the cards themselves stops a long token from inflating
-   the implicit min-content width and pushing the grid wider than its
-   container. */
-.fosse-status-cards {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(min(100%, 360px), 1fr));
-	gap: 16px;
-	margin-top: 16px;
+.fosse-admin-page__eyebrow {
+	margin: 0 0 8px;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1.3;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--fosse-admin-muted);
 }
 
-.fosse-status-card {
-	background: #fff;
-	border: 1px solid #c3c4c7;
-	border-radius: 4px;
-	padding: 16px;
-	min-width: 0;
+.fosse-admin-page .fosse-admin-page__title {
+	max-width: 760px;
+	margin: 0;
+	font-size: 32px;
+	font-weight: 600;
+	line-height: 1.18;
+	letter-spacing: -0.01em;
+	color: var(--fosse-admin-text);
 }
 
-.fosse-status-card h2 {
-	margin-top: 0;
+.fosse-admin-page__description {
+	max-width: 700px;
+	margin: 12px 0 0;
+	font-size: 15px;
+	line-height: 1.6;
+	color: var(--fosse-admin-muted);
 }
 
-/* The status-card table is given `table-layout: fixed` so a long token in
-   the value cell can't widen the column past its share. The label column
-   is allocated a stable minimum so it stays readable while the value
-   column absorbs the wrap. */
-.fosse-status-card__table {
-	table-layout: fixed;
-	width: 100%;
+.fosse-admin-notice {
+	max-width: 860px;
 }
 
-.fosse-status-card__label {
-	width: 40%;
-	/* Reset the bold/centered defaults `<th>` carries so the row label
-	   reads at the same weight as a `<td>` would. The semantic upgrade
-	   to `<th scope="row">` is for assistive tech, not for visual style. */
-	font-weight: normal;
-	text-align: left;
+.fosse-admin-page .button {
+	border-radius: 6px;
 }
 
 /* Bluesky auto-publish recovery notice form sits above its description
@@ -71,93 +77,613 @@
 	margin-bottom: 6px;
 }
 
-/* Defense in depth: token wrappers carry their own wrap rules, but if a
-   future cell holds raw user input (e.g. a long error message, a long
-   site title) without going through Status_Formatter, this keeps the
-   value column from inflating the table beyond its container. */
-.fosse-status-card__value {
-	overflow-wrap: break-word;
-}
-
-/* Token-specific wrap behavior.
-   Tokens get `<wbr>` hints inserted at separator boundaries (see
-   Status_Formatter), so the browser will prefer those break points.
-   DID and URL identifiers can still contain a long unbroken run with
-   no separator (a `did:plc:` body, a slug-like path), so for those two
-   token shapes we additionally allow `overflow-wrap: anywhere` as a
-   last-resort break. Handles and AP addresses are domain-shaped and
-   always have a `.` to wrap on, so they don't need the fallback. */
+/* Shared inline token treatment for long handles, DIDs, AP addresses, and URLs. */
+.fosse-admin-token,
 .fosse-status-card__token {
+	display: inline-block;
+	box-sizing: border-box;
+	max-width: 100%;
 	word-break: normal;
+	white-space: normal;
 	overflow-wrap: break-word;
+	padding: 2px 5px;
+	border-radius: 5px;
+	background: var(--fosse-admin-surface-muted, #f6f7f7);
+	color: var(--fosse-admin-text, #1d2327);
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
 }
 
+.fosse-admin-token--did,
+.fosse-admin-token--url,
 .fosse-status-card__token--did,
 .fosse-status-card__token--url {
+	overflow-wrap: anywhere;
+}
+
+/* Status summary bar */
+.fosse-status-summary {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	overflow: hidden;
+	margin: 0 0 20px;
+	padding: 18px 20px;
+	border: 1px solid rgba(40, 115, 64, 0.18);
+	border-radius: 14px;
+	background: radial-gradient(
+			circle at right -20px bottom -38px,
+			rgba(40, 115, 64, 0.12),
+			transparent 118px
+		),
+		linear-gradient(135deg, #fff, #f8fcfa);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.fosse-status-summary::before {
+	content: "";
+	display: block;
+	flex: 0 0 auto;
+	width: 42px;
+	height: 42px;
+	border-radius: 50%;
+	background: var(--fosse-admin-success-soft);
+	box-shadow:
+		inset 0 0 0 1px rgba(40, 115, 64, 0.22),
+		0 0 0 8px rgba(40, 115, 64, 0.05);
+}
+
+.fosse-status-summary.has-attention {
+	border-color: rgba(138, 98, 0, 0.24);
+	background: radial-gradient(
+			circle at right -20px bottom -38px,
+			rgba(138, 98, 0, 0.12),
+			transparent 118px
+		),
+		linear-gradient(135deg, #fff, #fffaf0);
+}
+
+.fosse-status-summary.has-attention::before {
+	background: var(--fosse-admin-warning-soft);
+	box-shadow:
+		inset 0 0 0 1px rgba(138, 98, 0, 0.24),
+		0 0 0 8px rgba(138, 98, 0, 0.06);
+}
+
+.fosse-status-summary__body {
+	position: relative;
+	z-index: 1;
+	flex: 1;
+	min-width: 0;
+}
+
+.fosse-status-summary__label,
+.fosse-status-summary__count,
+.fosse-status-summary__description,
+.fosse-status-summary__actions {
+	margin: 0;
+}
+
+.fosse-status-summary__label {
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1.3;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--fosse-admin-muted);
+}
+
+.fosse-status-summary__count {
+	margin-top: 4px;
+	font-size: 18px;
+	font-weight: 600;
+	line-height: 1.35;
+	color: var(--fosse-admin-text);
+}
+
+.fosse-status-summary__description {
+	margin-top: 5px;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--fosse-admin-muted);
+}
+
+.fosse-status-summary__actions {
+	position: relative;
+	z-index: 1;
+	flex: 0 0 auto;
+}
+
+/* Status card grid.
+   The provider set is small and benefits from a stable two-column layout
+   once there is room; `minmax(0, 1fr)` lets long identifiers wrap instead
+   of forcing the cards wider than the container. */
+.fosse-status-cards {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 18px;
+	margin-top: 0;
+	align-items: start;
+}
+
+.fosse-status-card {
+	min-width: 0;
+	padding: 20px;
+	border: 1px solid var(--fosse-admin-border);
+	border-radius: 14px;
+	background: var(--fosse-admin-surface);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.fosse-status-card__header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 18px;
+}
+
+.fosse-status-card h2,
+.fosse-status-card__title {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin: 0;
+	font-size: 18px;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--fosse-admin-text);
+}
+
+.fosse-status-badge {
+	display: inline-flex;
+	align-items: center;
+	min-height: 24px;
+	padding: 3px 9px;
+	border: 1px solid var(--fosse-admin-border);
+	border-radius: 999px;
+	background: var(--fosse-admin-surface-muted);
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.2;
+	white-space: nowrap;
+	color: var(--fosse-admin-muted);
+}
+
+.fosse-status-badge.is-connected {
+	border-color: rgba(40, 115, 64, 0.22);
+	background: var(--fosse-admin-success-soft);
+	color: var(--fosse-admin-success);
+}
+
+.fosse-status-badge.is-disconnected {
+	border-color: rgba(179, 45, 46, 0.22);
+	background: var(--fosse-admin-danger-soft);
+	color: var(--fosse-admin-danger);
+}
+
+.fosse-status-card__table.widefat {
+	border: 0;
+	background: transparent;
+	box-shadow: none;
+}
+
+.fosse-status-card__table {
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 100%;
+	table-layout: auto;
+	border-collapse: separate;
+	border-spacing: 0;
+}
+
+.fosse-status-card__table tbody {
+	display: block;
+	box-sizing: border-box;
+	width: 100%;
+	min-width: 0;
+}
+
+.fosse-status-card__table tr {
+	display: grid;
+	box-sizing: border-box;
+	width: 100%;
+	min-width: 0;
+	grid-template-columns: minmax(158px, 0.38fr) minmax(0, 1fr);
+	gap: 18px;
+	padding: 12px 0;
+	border-top: 1px solid var(--fosse-admin-border-faint);
+	background: transparent !important;
+}
+
+.fosse-status-card__table tr:first-child {
+	padding-top: 0;
+	border-top: 0;
+}
+
+.fosse-status-card__table tr:last-child {
+	padding-bottom: 0;
+}
+
+.fosse-status-card__table th,
+.fosse-status-card__table td {
+	display: block;
+	box-sizing: border-box;
+	min-width: 0;
+	padding: 0;
+	border: 0;
+	background: transparent;
+	box-shadow: none;
+}
+
+.fosse-status-card__label {
+	width: auto;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1.45;
+	letter-spacing: 0.04em;
+	text-align: left;
+	text-transform: uppercase;
+	white-space: nowrap;
+	color: var(--fosse-admin-muted);
+}
+
+.fosse-status-card__row--stacked {
+	grid-template-columns: 1fr;
+	gap: 6px;
+}
+
+.fosse-status-card__row--stacked .fosse-status-card__label {
+	white-space: normal;
+}
+
+/* Defense in depth: token wrappers carry their own wrap rules, but if a
+   future cell holds raw user input without going through Status_Formatter,
+   this keeps the value column from inflating the card. */
+.fosse-status-card__value {
+	min-width: 0;
+	font-size: 13px;
+	line-height: 1.5;
+	overflow-wrap: break-word;
+	color: var(--fosse-admin-text);
+}
+
+.fosse-status-card__error {
+	margin-top: 8px;
+}
+
+.fosse-status-card__error code {
+	display: block;
+	margin-top: 6px;
+	white-space: normal;
 	overflow-wrap: anywhere;
 }
 
 /* Status indicator dots */
 .fosse-status-indicator {
 	display: inline-block;
+	flex: 0 0 auto;
 	width: 10px;
 	height: 10px;
 	border-radius: 50%;
-	margin-right: 6px;
 	vertical-align: middle;
+	transform: translateY(1px);
 }
 
 .fosse-status-indicator.connected {
-	background: #00a32a;
+	background: var(--fosse-admin-success);
+	box-shadow: 0 0 0 3px rgba(40, 115, 64, 0.12);
 }
 
 .fosse-status-indicator.disconnected {
-	background: #d63638;
+	background: var(--fosse-admin-danger);
+	box-shadow: 0 0 0 3px rgba(179, 45, 46, 0.1);
 }
 
 /* Settings page panels */
 .fosse-settings-panel,
 .fosse-provider-section {
-	background: #fff;
-	border: 1px solid #c3c4c7;
-	border-radius: 4px;
-	padding: 16px 24px;
-	margin: 16px 0;
+	margin: 20px 0;
+	padding: 24px;
+	border: 1px solid var(--fosse-admin-border);
+	border-radius: 14px;
+	background: var(--fosse-admin-surface);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.fosse-settings-panel__header {
+	margin-bottom: 24px;
 }
 
 .fosse-settings-panel h2,
 .fosse-provider-section h2 {
-	margin-top: 0;
+	margin: 0;
+	font-size: 20px;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--fosse-admin-text);
+}
+
+.fosse-settings-panel__description {
+	max-width: 680px;
+	margin: 8px 0 0;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--fosse-admin-muted);
 }
 
 .fosse-settings-section,
 .fosse-connection-section {
-	border-top: 1px solid #dcdcde;
-	margin-top: 16px;
-	padding-top: 16px;
+	margin-top: 24px;
+	padding-top: 24px;
+	border-top: 1px solid var(--fosse-admin-border-soft);
 }
 
-.fosse-settings-section:first-of-type,
-.fosse-connection-section:first-of-type {
-	border-top: 0;
+.fosse-settings-panel__header + .fosse-settings-section,
+.fosse-settings-panel__header + .fosse-connection-section {
 	margin-top: 0;
 	padding-top: 0;
+	border-top: 0;
 }
 
 .fosse-settings-section h3,
 .fosse-connection-section h3 {
-	font-size: 1.1em;
-	margin: 0 0 12px;
+	margin: 0 0 14px;
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 1.35;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--fosse-admin-muted);
+}
+
+.fosse-admin-page .form-table {
+	margin-top: 0;
+	border-collapse: separate;
+	border-spacing: 0;
+}
+
+.fosse-admin-page .form-table th {
+	width: 185px;
+	padding: 16px 22px 16px 0;
+	font-weight: 600;
+	line-height: 1.45;
+	color: var(--fosse-admin-text);
+}
+
+.fosse-admin-page .form-table td {
+	min-width: 0;
+	padding: 14px 0;
+	line-height: 1.5;
+	color: var(--fosse-admin-text);
+}
+
+.fosse-admin-page .form-table tr + tr th,
+.fosse-admin-page .form-table tr + tr td {
+	border-top: 1px solid var(--fosse-admin-border-faint);
+}
+
+.fosse-admin-page .description {
+	color: var(--fosse-admin-muted);
+}
+
+.fosse-admin-page input[type="text"],
+.fosse-admin-page input[type="url"],
+.fosse-admin-page input[type="email"],
+.fosse-admin-page input[type="password"],
+.fosse-admin-page textarea,
+.fosse-admin-page select {
+	border-color: var(--fosse-admin-border-strong);
+	border-radius: 6px;
+}
+
+.fosse-settings-choice-grid {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px 16px;
+	margin: 0;
+}
+
+.fosse-settings-choice-grid .description {
+	flex-basis: 100%;
+	margin: 2px 0 0;
+}
+
+.fosse-settings-choice-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	padding: 0;
+	border: 0;
+	border-radius: 0;
+	background: transparent;
+	font-weight: 400;
+	line-height: 1.2;
+	cursor: pointer;
+}
+
+.fosse-settings-choice-label input {
+	margin: 0;
+}
+
+.fosse-settings-radio-group {
+	display: grid;
+	gap: 10px;
+	max-width: 680px;
+	margin: 0;
+}
+
+.fosse-settings-card-option {
+	padding: 14px 16px;
+	border: 1px solid var(--fosse-admin-border-soft);
+	border-radius: 10px;
+	background: var(--fosse-admin-surface);
+	transition:
+		border-color 0.15s ease,
+		background-color 0.15s ease,
+		box-shadow 0.15s ease;
+}
+
+.fosse-settings-card-option:has(input:checked) {
+	border-color: var(--fosse-admin-accent-soft-border);
+	background: var(--fosse-admin-accent-soft);
+}
+
+.fosse-settings-card-option:focus-within,
+.fosse-settings-card-option:has(input:focus-visible) {
+	outline: 2px solid var(--fosse-admin-accent);
+	outline-offset: 2px;
+}
+
+.fosse-settings-card-option__label {
+	display: inline-flex;
+	align-items: center;
+	gap: 9px;
+	font-weight: 600;
+	cursor: pointer;
+}
+
+.fosse-settings-card-option__label input {
+	margin: 0;
+}
+
+.fosse-settings-card-option .description {
+	margin: 7px 0 0 25px;
+}
+
+.fosse-activitypub-actor-mode-note {
+	margin-top: 2px;
+	padding: 12px 14px;
+	border: 1px solid var(--fosse-admin-border-soft);
+	border-radius: 10px;
+	background: var(--fosse-admin-surface-muted);
+}
+
+.fosse-activitypub-actor-mode-note .description {
+	margin: 0;
+}
+
+.fosse-activitypub-actor-mode-note .description + .description {
+	margin-top: 6px;
+}
+
+.fosse-domain-handle-panel {
+	margin: 18px 0;
+	padding: 16px;
+	border: 1px solid var(--fosse-admin-border-soft);
+	border-radius: 12px;
+	background: linear-gradient(135deg, #fff, var(--fosse-admin-accent-soft));
+}
+
+.fosse-domain-handle-panel h4 {
+	margin: 0 0 8px;
+	font-size: 14px;
+	line-height: 1.4;
+}
+
+.fosse-domain-handle-panel p {
+	margin-top: 0;
+}
+
+.fosse-domain-handle-panel form {
+	margin-top: 12px;
 }
 
 .fosse-settings-actions {
-	border-top: 1px solid #dcdcde;
-	margin-top: 16px;
-	padding-top: 16px;
+	display: flex;
+	align-items: center;
+	margin-top: 24px;
+	padding-top: 20px;
+	border-top: 1px solid var(--fosse-admin-border-soft);
 }
 
 .fosse-settings-actions .button {
 	margin: 0;
+}
+
+@media (max-width: 782px) {
+	.fosse-admin-page {
+		max-width: none;
+	}
+
+	.fosse-admin-page .fosse-admin-page__title {
+		font-size: 26px;
+	}
+
+	.fosse-status-summary {
+		align-items: flex-start;
+		flex-wrap: wrap;
+	}
+
+	.fosse-status-summary__actions {
+		flex-basis: 100%;
+	}
+
+	.fosse-status-summary__actions .button {
+		text-align: center;
+	}
+
+	.fosse-status-cards {
+		grid-template-columns: 1fr;
+	}
+
+	.fosse-status-card,
+	.fosse-settings-panel,
+	.fosse-provider-section {
+		padding: 18px;
+	}
+
+	.fosse-status-card__header {
+		align-items: flex-start;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.fosse-status-card__table tr {
+		grid-template-columns: 1fr;
+		gap: 5px;
+	}
+
+	.fosse-status-card__label {
+		white-space: normal;
+	}
+
+	.fosse-admin-page .form-table,
+	.fosse-admin-page .form-table tbody,
+	.fosse-admin-page .form-table tr,
+	.fosse-admin-page .form-table th,
+	.fosse-admin-page .form-table td {
+		display: block;
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	.fosse-admin-page .form-table th,
+	.fosse-admin-page .form-table td {
+		padding-right: 0;
+		padding-left: 0;
+	}
+
+	.fosse-admin-page .form-table th {
+		padding-bottom: 4px;
+	}
+
+	.fosse-admin-page .form-table td {
+		padding-top: 0;
+	}
+
+	.fosse-admin-page .form-table tr + tr th {
+		padding-top: 16px;
+	}
+
+	.fosse-admin-page .form-table tr + tr td {
+		border-top: 0;
+	}
+
+	.fosse-settings-card-option .description {
+		margin-left: 0;
+	}
 }
 
 /* =============================================

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -273,52 +273,44 @@
 	box-sizing: border-box;
 	width: 100%;
 	max-width: 100%;
-	table-layout: auto;
+	table-layout: fixed;
 	border-collapse: separate;
 	border-spacing: 0;
 }
 
-.fosse-status-card__table tbody {
-	display: block;
-	box-sizing: border-box;
-	width: 100%;
-	min-width: 0;
-}
-
 .fosse-status-card__table tr {
-	display: grid;
 	box-sizing: border-box;
 	width: 100%;
 	min-width: 0;
-	grid-template-columns: minmax(158px, 0.38fr) minmax(0, 1fr);
-	gap: 18px;
-	padding: 12px 0;
-	border-top: 1px solid var(--fosse-admin-border-faint);
 	background: transparent !important;
 }
 
-.fosse-status-card__table tr:first-child {
+.fosse-status-card__table tr:first-child th,
+.fosse-status-card__table tr:first-child td {
 	padding-top: 0;
 	border-top: 0;
 }
 
-.fosse-status-card__table tr:last-child {
+.fosse-status-card__table tr:last-child th,
+.fosse-status-card__table tr:last-child td {
 	padding-bottom: 0;
 }
 
 .fosse-status-card__table th,
 .fosse-status-card__table td {
-	display: block;
 	box-sizing: border-box;
 	min-width: 0;
-	padding: 0;
+	padding: 12px 0;
 	border: 0;
+	border-top: 1px solid var(--fosse-admin-border-faint);
 	background: transparent;
 	box-shadow: none;
+	vertical-align: top;
 }
 
 .fosse-status-card__label {
-	width: auto;
+	width: 38%;
+	padding-right: 18px;
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 1.45;
@@ -329,11 +321,6 @@
 	color: var(--fosse-admin-muted);
 }
 
-.fosse-status-card__row--stacked {
-	grid-template-columns: 1fr;
-	gap: 6px;
-}
-
 .fosse-status-card__row--stacked .fosse-status-card__label {
 	white-space: normal;
 }
@@ -342,6 +329,7 @@
    future cell holds raw user input without going through Status_Formatter,
    this keeps the value column from inflating the card. */
 .fosse-status-card__value {
+	width: 62%;
 	min-width: 0;
 	font-size: 13px;
 	line-height: 1.5;
@@ -515,7 +503,22 @@
 }
 
 .fosse-settings-card-option {
-	padding: 14px 16px;
+	position: relative;
+	display: block;
+	cursor: pointer;
+}
+
+.fosse-settings-card-option__input {
+	position: absolute;
+	top: 17px;
+	left: 16px;
+	z-index: 1;
+	margin: 0;
+}
+
+.fosse-settings-card-option__body {
+	display: block;
+	padding: 14px 16px 14px 41px;
 	border: 1px solid var(--fosse-admin-border-soft);
 	border-radius: 10px;
 	background: var(--fosse-admin-surface);
@@ -525,31 +528,26 @@
 		box-shadow 0.15s ease;
 }
 
-.fosse-settings-card-option:has(input:checked) {
+.fosse-settings-card-option__input:checked + .fosse-settings-card-option__body {
 	border-color: var(--fosse-admin-accent-soft-border);
 	background: var(--fosse-admin-accent-soft);
 }
 
-.fosse-settings-card-option:focus-within,
-.fosse-settings-card-option:has(input:focus-visible) {
+.fosse-settings-card-option__input:focus-visible
+	+ .fosse-settings-card-option__body,
+.fosse-settings-card-option:focus-within .fosse-settings-card-option__body {
 	outline: 2px solid var(--fosse-admin-accent);
 	outline-offset: 2px;
 }
 
 .fosse-settings-card-option__label {
-	display: inline-flex;
-	align-items: center;
-	gap: 9px;
+	display: block;
 	font-weight: 600;
-	cursor: pointer;
 }
 
-.fosse-settings-card-option__label input {
-	margin: 0;
-}
-
-.fosse-settings-card-option .description {
-	margin: 7px 0 0 25px;
+.fosse-settings-card-option__body .description {
+	display: block;
+	margin: 7px 0 0;
 }
 
 .fosse-activitypub-actor-mode-note {
@@ -640,13 +638,14 @@
 		gap: 10px;
 	}
 
-	.fosse-status-card__table tr {
-		grid-template-columns: 1fr;
-		gap: 5px;
+	.fosse-status-card__label {
+		width: 42%;
+		padding-right: 12px;
+		white-space: normal;
 	}
 
-	.fosse-status-card__label {
-		white-space: normal;
+	.fosse-status-card__value {
+		width: 58%;
 	}
 
 	.fosse-admin-page .form-table,
@@ -681,7 +680,7 @@
 		border-top: 0;
 	}
 
-	.fosse-settings-card-option .description {
+	.fosse-settings-card-option__body .description {
 		margin-left: 0;
 	}
 }

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -235,7 +235,7 @@ class AP_Provider implements Connection_Provider {
 				<strong><?php esc_html_e( 'Connected automatically', 'fosse' ); ?></strong>
 			</p>
 			<p class="description">
-				<?php esc_html_e( 'ActivityPub is available because FOSSE loaded the ActivityPub backend for this site.', 'fosse' ); ?>
+				<?php esc_html_e( 'ActivityPub is active for this site, so no separate connection step is needed.', 'fosse' ); ?>
 			</p>
 		</div>
 		<?php
@@ -274,7 +274,7 @@ class AP_Provider implements Connection_Provider {
 			<table class="widefat striped fosse-status-card__table">
 				<tbody>
 					<tr>
-						<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></th>
+						<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'ActivityPub profile', 'fosse' ); ?></th>
 						<td class="fosse-status-card__value"><?php echo esc_html( $mode_label ); ?></td>
 					</tr>
 					<tr>
@@ -634,7 +634,7 @@ class AP_Provider implements Connection_Provider {
 					<?php
 					printf(
 						/* translators: 1: author follower count, 2: blog follower count */
-						esc_html__( 'Your followers: %1$s, Blog: %2$s', 'fosse' ),
+						esc_html__( 'Author followers: %1$s, site followers: %2$s', 'fosse' ),
 						esc_html( number_format_i18n( $user_count ) ),
 						esc_html( number_format_i18n( $blog_count ) )
 					);

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -185,14 +185,26 @@ class AP_Provider implements Connection_Provider {
 				<?php if ( $shows_user && $user_address ) : ?>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></th>
-						<td><code><?php echo esc_html( '@' . $user_address ); ?></code></td>
+						<td>
+							<code class="fosse-admin-token fosse-admin-token--ap-address">
+								<?php
+								echo Status_Formatter::ap_address( '@' . $user_address ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::ap_address() escapes input and returns safe HTML with <wbr>.
+								?>
+							</code>
+						</td>
 					</tr>
 				<?php endif; ?>
 
 				<?php if ( $shows_blog && $blog_address ) : ?>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></th>
-						<td><code><?php echo esc_html( '@' . $blog_address ); ?></code></td>
+						<td>
+							<code class="fosse-admin-token fosse-admin-token--ap-address">
+								<?php
+								echo Status_Formatter::ap_address( '@' . $blog_address ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::ap_address() escapes input and returns safe HTML with <wbr>.
+								?>
+							</code>
+						</td>
 					</tr>
 				<?php endif; ?>
 			</table>
@@ -235,9 +247,11 @@ class AP_Provider implements Connection_Provider {
 	 * @return void
 	 */
 	public function render_status_card(): void {
-		$status     = $this->get_status();
-		$mode_label = $this->get_actor_mode_label( $status['actor_mode'] );
-		$post_types = array_map(
+		$status       = $this->get_status();
+		$status_class = $status['connected'] ? 'connected' : 'disconnected';
+		$status_label = $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' );
+		$mode_label   = $this->get_actor_mode_label( $status['actor_mode'] );
+		$post_types   = array_map(
 			static function ( $pt_name ) {
 				$pt = get_post_type_object( $pt_name );
 				return $pt ? $pt->label : $pt_name;
@@ -246,14 +260,16 @@ class AP_Provider implements Connection_Provider {
 		);
 		?>
 		<div class="fosse-status-card">
-			<h2>
-				<span
-					class="fosse-status-indicator <?php echo $status['connected'] ? 'connected' : 'disconnected'; ?>"
-					role="img"
-					aria-label="<?php echo esc_attr( $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' ) ); ?>"
-				></span>
-				<?php esc_html_e( 'ActivityPub', 'fosse' ); ?>
-			</h2>
+			<div class="fosse-status-card__header">
+				<h2 class="fosse-status-card__title">
+					<span
+						class="fosse-status-indicator <?php echo esc_attr( $status_class ); ?>"
+						aria-hidden="true"
+					></span>
+					<?php esc_html_e( 'ActivityPub', 'fosse' ); ?>
+				</h2>
+				<span class="fosse-status-badge is-<?php echo esc_attr( $status_class ); ?>"><?php echo esc_html( $status_label ); ?></span>
+			</div>
 
 			<table class="widefat striped fosse-status-card__table">
 				<tbody>
@@ -266,7 +282,7 @@ class AP_Provider implements Connection_Provider {
 						<td class="fosse-status-card__value"><?php echo esc_html( implode( ', ', $post_types ) ); ?></td>
 					</tr>
 					<?php if ( $this->mode_includes_user( $status['actor_mode'] ) && ! empty( $status['user_address'] ) ) : ?>
-						<tr>
+						<tr class="fosse-status-card__row--stacked">
 							<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></th>
 							<td class="fosse-status-card__value">
 								<code class="fosse-status-card__token fosse-status-card__token--ap-address">
@@ -278,7 +294,7 @@ class AP_Provider implements Connection_Provider {
 						</tr>
 					<?php endif; ?>
 					<?php if ( $this->mode_includes_blog( $status['actor_mode'] ) && ! empty( $status['blog_address'] ) ) : ?>
-						<tr>
+						<tr class="fosse-status-card__row--stacked">
 							<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></th>
 							<td class="fosse-status-card__value">
 								<code class="fosse-status-card__token fosse-status-card__token--ap-address">

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -262,15 +262,33 @@ class Bluesky_Provider implements Connection_Provider {
 				<table class="form-table">
 					<tr>
 						<th scope="row"><?php esc_html_e( 'Handle', 'fosse' ); ?></th>
-						<td><strong><?php echo esc_html( $status['handle'] ); ?></strong></td>
+						<td>
+							<strong class="fosse-admin-token fosse-admin-token--handle">
+								<?php
+								echo Status_Formatter::handle( $status['handle'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::handle() escapes input and returns safe HTML with <wbr>.
+								?>
+							</strong>
+						</td>
 					</tr>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'DID', 'fosse' ); ?></th>
-						<td><code><?php echo esc_html( $status['did'] ); ?></code></td>
+						<td>
+							<code class="fosse-admin-token fosse-admin-token--did">
+								<?php
+								echo Status_Formatter::did( $status['did'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::did() escapes input and returns safe HTML with <wbr>.
+								?>
+							</code>
+						</td>
 					</tr>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'PDS', 'fosse' ); ?></th>
-						<td><code><?php echo esc_html( $status['pds_endpoint'] ); ?></code></td>
+						<td>
+							<code class="fosse-admin-token fosse-admin-token--url">
+								<?php
+								echo Status_Formatter::url( $status['pds_endpoint'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::url() escapes input and returns safe HTML with <wbr>.
+								?>
+							</code>
+						</td>
 					</tr>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'Token Health', 'fosse' ); ?></th>
@@ -392,23 +410,27 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return void
 	 */
 	public function render_status_card(): void {
-		$status = $this->get_status();
+		$status       = $this->get_status();
+		$status_class = $status['connected'] ? 'connected' : 'disconnected';
+		$status_label = $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' );
 		?>
 		<div class="fosse-status-card">
-			<h2>
-				<span
-					class="fosse-status-indicator <?php echo $status['connected'] ? 'connected' : 'disconnected'; ?>"
-					role="img"
-					aria-label="<?php echo esc_attr( $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' ) ); ?>"
-				></span>
-				<?php esc_html_e( 'Bluesky', 'fosse' ); ?>
-			</h2>
+			<div class="fosse-status-card__header">
+				<h2 class="fosse-status-card__title">
+					<span
+						class="fosse-status-indicator <?php echo esc_attr( $status_class ); ?>"
+						aria-hidden="true"
+					></span>
+					<?php esc_html_e( 'Bluesky', 'fosse' ); ?>
+				</h2>
+				<span class="fosse-status-badge is-<?php echo esc_attr( $status_class ); ?>"><?php echo esc_html( $status_label ); ?></span>
+			</div>
 
 			<table class="widefat striped fosse-status-card__table">
 				<tbody>
 					<tr>
 						<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Connection', 'fosse' ); ?></th>
-						<td class="fosse-status-card__value"><?php echo esc_html( $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' ) ); ?></td>
+						<td class="fosse-status-card__value"><?php echo esc_html( $status_label ); ?></td>
 					</tr>
 					<?php if ( $status['handle'] ) : ?>
 						<tr>

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -220,7 +220,7 @@ class Bluesky_Provider implements Connection_Provider {
 			<?php settings_errors( 'atmosphere' ); ?>
 
 			<?php if ( ! $status['connected'] ) : ?>
-				<p><?php esc_html_e( 'Connect your Bluesky account to let FOSSE publish through Atmosphere.', 'fosse' ); ?></p>
+				<p><?php esc_html_e( 'Connect your Bluesky account so FOSSE can publish new posts there.', 'fosse' ); ?></p>
 
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 					<input type="hidden" name="action" value="fosse_connect_bluesky" />
@@ -239,7 +239,7 @@ class Bluesky_Provider implements Connection_Provider {
 									id="fosse_bluesky_handle"
 									placeholder="alice.bsky.social"
 								/>
-								<p class="description"><?php esc_html_e( 'Your AT Protocol handle, e.g. alice.bsky.social or your own domain.', 'fosse' ); ?></p>
+								<p class="description"><?php esc_html_e( 'Your Bluesky/AT Protocol handle, for example alice.bsky.social or your own domain.', 'fosse' ); ?></p>
 								<p class="description fosse-bluesky-signup">
 									<?php
 									echo wp_kses_post(
@@ -281,7 +281,7 @@ class Bluesky_Provider implements Connection_Provider {
 						</td>
 					</tr>
 					<tr>
-						<th scope="row"><?php esc_html_e( 'PDS', 'fosse' ); ?></th>
+						<th scope="row"><?php esc_html_e( 'PDS endpoint', 'fosse' ); ?></th>
 						<td>
 							<code class="fosse-admin-token fosse-admin-token--url">
 								<?php
@@ -317,7 +317,7 @@ class Bluesky_Provider implements Connection_Provider {
 							echo esc_html(
 								sprintf(
 									/* translators: %s: previous Bluesky handle that disconnect will restore (e.g. alice.bsky.social). */
-									__( 'Disconnecting will also restore your previous Bluesky handle (%s) on the account.', 'fosse' ),
+									__( 'Disconnecting will also restore %s as this account\'s Bluesky handle.', 'fosse' ),
 									$pending_revert
 								)
 							);
@@ -367,7 +367,7 @@ class Bluesky_Provider implements Connection_Provider {
 					echo esc_html(
 						sprintf(
 							/* translators: 1: current Bluesky handle (e.g. alice.bsky.social); 2: target handle = site host (e.g. example.com). */
-							__( 'Your current Bluesky handle is %1$s. Click the button below to replace it with %2$s.', 'fosse' ),
+							__( 'Your current Bluesky handle is %1$s. You can replace it with %2$s.', 'fosse' ),
 							$current,
 							$target
 						)
@@ -376,7 +376,7 @@ class Bluesky_Provider implements Connection_Provider {
 					echo esc_html(
 						sprintf(
 							/* translators: %s: target handle = site host (e.g. example.com). */
-							__( 'Click the button below to set your Bluesky handle to %s.', 'fosse' ),
+							__( 'You can set your Bluesky handle to %s.', 'fosse' ),
 							$target
 						)
 					);
@@ -458,7 +458,7 @@ class Bluesky_Provider implements Connection_Provider {
 					<?php endif; ?>
 					<?php if ( $status['pds_endpoint'] ) : ?>
 						<tr>
-							<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'PDS', 'fosse' ); ?></th>
+							<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'PDS endpoint', 'fosse' ); ?></th>
 							<td class="fosse-status-card__value">
 								<code class="fosse-status-card__token fosse-status-card__token--url">
 									<?php
@@ -913,7 +913,7 @@ class Bluesky_Provider implements Connection_Provider {
 				<strong><?php esc_html_e( 'Bluesky auto-publishing is off.', 'fosse' ); ?></strong>
 				<?php
 				esc_html_e(
-					'New posts aren\'t being sent to Bluesky. The Settings toggle that controlled this was removed, so this notice is the only place to turn it back on. If leaving it off was intentional, no action is needed.',
+					'New posts aren\'t being sent to Bluesky. If this was intentional, no action is needed; otherwise, turn auto-publishing back on below.',
 					'fosse'
 				);
 				?>

--- a/src/Admin/templates/setup-page.php
+++ b/src/Admin/templates/setup-page.php
@@ -22,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
 		<p class="fosse-admin-page__eyebrow"><?php esc_html_e( 'Social web', 'fosse' ); ?></p>
 		<h1 class="fosse-admin-page__title"><?php esc_html_e( 'FOSSE Settings', 'fosse' ); ?></h1>
 		<p class="fosse-admin-page__description">
-			<?php esc_html_e( 'Choose what FOSSE publishes, how your site appears on ActivityPub, and which network accounts are connected.', 'fosse' ); ?>
+			<?php esc_html_e( 'Choose which content FOSSE publishes, how your site appears on ActivityPub, and which network accounts are connected.', 'fosse' ); ?>
 		</p>
 	</header>
 
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 				echo wp_kses_post(
 					sprintf(
 						/* translators: 1: opening anchor tag to setup wizard, 2: closing anchor tag */
-						__( 'First time here? %1$sRun the setup wizard%2$s to configure federation in a few steps.', 'fosse' ),
+						__( 'First time here? %1$sRun the setup wizard%2$s to set up social web publishing in a few steps.', 'fosse' ),
 						'<a href="' . esc_url( admin_url( 'admin.php?page=fosse-wizard' ) ) . '">',
 						'</a>'
 					)
@@ -50,7 +50,7 @@ defined( 'ABSPATH' ) || exit;
 			<p>
 				<?php
 				esc_html_e(
-					'FOSSE bundles ActivityPub and Atmosphere, so this state usually means one of the bundled backends failed to bootstrap (composer autoload missing, class-loading conflict with a manually installed copy, or a host-level disable). Check the PHP error log and FOSSE\'s plugin activation state.',
+					'FOSSE includes ActivityPub and Bluesky support, so this usually means a bundled component failed to load. Check the PHP error log and FOSSE\'s plugin activation state.',
 					'fosse'
 				);
 				?>
@@ -65,7 +65,7 @@ defined( 'ABSPATH' ) || exit;
 				<div class="fosse-settings-panel__header">
 					<h2><?php esc_html_e( 'Federation settings', 'fosse' ); ?></h2>
 					<p class="fosse-settings-panel__description">
-						<?php esc_html_e( 'Set the default publishing shape FOSSE uses across all configured providers.', 'fosse' ); ?>
+						<?php esc_html_e( 'Choose which post types FOSSE publishes and which ActivityPub profile publishes them.', 'fosse' ); ?>
 					</p>
 				</div>
 
@@ -90,7 +90,7 @@ defined( 'ABSPATH' ) || exit;
 										</label>
 									<?php endforeach; ?>
 									<p class="description">
-										<?php esc_html_e( 'Post types that FOSSE federates to your configured providers.', 'fosse' ); ?>
+										<?php esc_html_e( 'Selected post types can be published to your connected social web providers.', 'fosse' ); ?>
 									</p>
 								</fieldset>
 							</td>
@@ -98,7 +98,7 @@ defined( 'ABSPATH' ) || exit;
 
 						<?php if ( $ap_available ) : ?>
 							<tr>
-								<th scope="row"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></th>
+								<th scope="row"><?php esc_html_e( 'ActivityPub profile', 'fosse' ); ?></th>
 								<td>
 									<?php if ( \Automattic\Fosse\Admin\Actor_Mode_Lock::is_locked() ) : ?>
 										<?php
@@ -116,58 +116,67 @@ defined( 'ABSPATH' ) || exit;
 										<input type="hidden" name="activitypub_actor_mode" value="<?php echo esc_attr( $forced_mode ); ?>" />
 									<?php else : ?>
 										<fieldset class="fosse-settings-radio-group">
-											<legend class="screen-reader-text"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></legend>
-											<div class="fosse-settings-card-option">
-												<label class="fosse-settings-card-option__label">
-													<input
-														type="radio"
-														id="fosse-activitypub-actor-mode-actor"
-														name="activitypub_actor_mode"
-														value="actor"
-														aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"
-														<?php checked( 'actor', $actor_mode ); ?>
-													/>
-													<span><?php esc_html_e( 'Author profiles', 'fosse' ); ?></span>
-												</label>
-												<p id="fosse-activitypub-actor-mode-actor-desc" class="description">
-													<?php esc_html_e( 'Each WordPress author publishes from their own fediverse profile. People follow individual authors, and posts appear under each author\'s name.', 'fosse' ); ?>
-												</p>
-											</div>
-											<div class="fosse-settings-card-option">
-												<label class="fosse-settings-card-option__label">
-													<input
-														type="radio"
-														id="fosse-activitypub-actor-mode-blog"
-														name="activitypub_actor_mode"
-														value="blog"
-														aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"
-														<?php checked( 'blog', $actor_mode ); ?>
-													/>
-													<span><?php esc_html_e( 'Blog profile', 'fosse' ); ?></span>
-												</label>
-												<p id="fosse-activitypub-actor-mode-blog-desc" class="description">
-													<?php esc_html_e( 'One site-wide profile publishes every post, regardless of author. Use this when people should follow the site as one account.', 'fosse' ); ?>
-												</p>
-											</div>
-											<div class="fosse-settings-card-option">
-												<label class="fosse-settings-card-option__label">
-													<input
-														type="radio"
-														id="fosse-activitypub-actor-mode-actor-blog"
-														name="activitypub_actor_mode"
-														value="actor_blog"
-														aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"
-														<?php checked( 'actor_blog', $actor_mode ); ?>
-													/>
-													<span><?php esc_html_e( 'Both', 'fosse' ); ?></span>
-												</label>
-												<p id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
-													<?php esc_html_e( 'Authors keep individual profiles, and the site also has its own blog profile. People can follow either.', 'fosse' ); ?>
-												</p>
-											</div>
+											<legend class="screen-reader-text"><?php esc_html_e( 'ActivityPub profile', 'fosse' ); ?></legend>
+											<label class="fosse-settings-card-option">
+												<input
+													class="fosse-settings-card-option__input"
+													type="radio"
+													id="fosse-activitypub-actor-mode-actor"
+													name="activitypub_actor_mode"
+													value="actor"
+													aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"
+													<?php checked( 'actor', $actor_mode ); ?>
+												/>
+												<span class="fosse-settings-card-option__body">
+													<span class="fosse-settings-card-option__label">
+														<?php esc_html_e( 'Author profiles', 'fosse' ); ?>
+													</span>
+													<span id="fosse-activitypub-actor-mode-actor-desc" class="description">
+														<?php esc_html_e( 'Each WordPress author publishes from their own fediverse profile. People follow individual authors, and posts appear under each author\'s name.', 'fosse' ); ?>
+													</span>
+												</span>
+											</label>
+											<label class="fosse-settings-card-option">
+												<input
+													class="fosse-settings-card-option__input"
+													type="radio"
+													id="fosse-activitypub-actor-mode-blog"
+													name="activitypub_actor_mode"
+													value="blog"
+													aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"
+													<?php checked( 'blog', $actor_mode ); ?>
+												/>
+												<span class="fosse-settings-card-option__body">
+													<span class="fosse-settings-card-option__label">
+														<?php esc_html_e( 'Blog profile', 'fosse' ); ?>
+													</span>
+													<span id="fosse-activitypub-actor-mode-blog-desc" class="description">
+														<?php esc_html_e( 'One site-wide profile publishes every post, regardless of author. Use this when people should follow the site as one account.', 'fosse' ); ?>
+													</span>
+												</span>
+											</label>
+											<label class="fosse-settings-card-option">
+												<input
+													class="fosse-settings-card-option__input"
+													type="radio"
+													id="fosse-activitypub-actor-mode-actor-blog"
+													name="activitypub_actor_mode"
+													value="actor_blog"
+													aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"
+													<?php checked( 'actor_blog', $actor_mode ); ?>
+												/>
+												<span class="fosse-settings-card-option__body">
+													<span class="fosse-settings-card-option__label">
+														<?php esc_html_e( 'Both author and blog profiles', 'fosse' ); ?>
+													</span>
+													<span id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
+														<?php esc_html_e( 'Authors keep individual profiles, and the site also has its own blog profile. People can follow either.', 'fosse' ); ?>
+													</span>
+												</span>
+											</label>
 											<div class="fosse-activitypub-actor-mode-note">
 												<p id="fosse-activitypub-actor-mode-note" class="description">
-													<?php esc_html_e( 'Changing modes does not move followers between profiles. Future posts publish from the profiles enabled by the selected mode.', 'fosse' ); ?>
+													<?php esc_html_e( 'Changing this setting does not move followers between profiles. New posts use the profile choice selected here.', 'fosse' ); ?>
 												</p>
 												<p class="description">
 													<?php
@@ -212,7 +221,7 @@ defined( 'ABSPATH' ) || exit;
 			<div class="fosse-settings-panel__header">
 				<h2><?php esc_html_e( 'Connections', 'fosse' ); ?></h2>
 				<p class="fosse-settings-panel__description">
-					<?php esc_html_e( 'Review provider connection details and manage account-level actions.', 'fosse' ); ?>
+					<?php esc_html_e( 'Review connection details and connect or disconnect network accounts.', 'fosse' ); ?>
 				</p>
 			</div>
 

--- a/src/Admin/templates/setup-page.php
+++ b/src/Admin/templates/setup-page.php
@@ -17,13 +17,19 @@ defined( 'ABSPATH' ) || exit;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- variables set by Setup_Page::render().
 ?>
-<div class="wrap">
-	<h1><?php esc_html_e( 'FOSSE Settings', 'fosse' ); ?></h1>
+<div class="wrap fosse-admin-page fosse-admin-page--settings">
+	<header class="fosse-admin-page__header">
+		<p class="fosse-admin-page__eyebrow"><?php esc_html_e( 'Social web', 'fosse' ); ?></p>
+		<h1 class="fosse-admin-page__title"><?php esc_html_e( 'FOSSE Settings', 'fosse' ); ?></h1>
+		<p class="fosse-admin-page__description">
+			<?php esc_html_e( 'Choose what FOSSE publishes, how your site appears on ActivityPub, and which network accounts are connected.', 'fosse' ); ?>
+		</p>
+	</header>
 
 	<?php settings_errors( 'fosse' ); ?>
 
 	<?php if ( $wizard_incomplete ) : ?>
-		<div class="notice notice-info">
+		<div class="notice notice-info fosse-admin-notice">
 			<p>
 				<?php
 				echo wp_kses_post(
@@ -40,7 +46,7 @@ defined( 'ABSPATH' ) || exit;
 	<?php endif; ?>
 
 	<?php if ( empty( $providers ) ) : ?>
-		<div class="notice notice-warning">
+		<div class="notice notice-warning fosse-admin-notice">
 			<p>
 				<?php
 				esc_html_e(
@@ -56,7 +62,12 @@ defined( 'ABSPATH' ) || exit;
 				<input type="hidden" name="action" value="<?php echo esc_attr( \Automattic\Fosse\Admin\Setup_Page::SAVE_ACTION ); ?>" />
 				<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $save_nonce ); ?>" />
 
-				<h2><?php esc_html_e( 'Federation settings', 'fosse' ); ?></h2>
+				<div class="fosse-settings-panel__header">
+					<h2><?php esc_html_e( 'Federation settings', 'fosse' ); ?></h2>
+					<p class="fosse-settings-panel__description">
+						<?php esc_html_e( 'Set the default publishing shape FOSSE uses across all configured providers.', 'fosse' ); ?>
+					</p>
+				</div>
 
 				<div class="fosse-settings-section" id="fosse-section-general">
 					<h3><?php esc_html_e( 'General', 'fosse' ); ?></h3>
@@ -65,10 +76,10 @@ defined( 'ABSPATH' ) || exit;
 						<tr>
 							<th scope="row"><?php esc_html_e( 'Post Types', 'fosse' ); ?></th>
 							<td>
-								<fieldset>
+								<fieldset class="fosse-settings-choice-grid">
 									<legend class="screen-reader-text"><?php esc_html_e( 'Post Types', 'fosse' ); ?></legend>
 									<?php foreach ( $all_post_types as $pt ) : ?>
-										<label>
+										<label class="fosse-settings-choice-label">
 											<input
 												type="checkbox"
 												name="activitypub_support_post_types[]"
@@ -76,7 +87,7 @@ defined( 'ABSPATH' ) || exit;
 												<?php checked( in_array( $pt->name, $post_types, true ) ); ?>
 											/>
 											<?php echo esc_html( $pt->label ); ?>
-										</label><br />
+										</label>
 									<?php endforeach; ?>
 									<p class="description">
 										<?php esc_html_e( 'Post types that FOSSE federates to your configured providers.', 'fosse' ); ?>
@@ -104,50 +115,56 @@ defined( 'ABSPATH' ) || exit;
 										</p>
 										<input type="hidden" name="activitypub_actor_mode" value="<?php echo esc_attr( $forced_mode ); ?>" />
 									<?php else : ?>
-										<fieldset>
+										<fieldset class="fosse-settings-radio-group">
 											<legend class="screen-reader-text"><?php esc_html_e( 'Actor Mode', 'fosse' ); ?></legend>
-											<label>
-												<input
-													type="radio"
-													id="fosse-activitypub-actor-mode-actor"
-													name="activitypub_actor_mode"
-													value="actor"
-													aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"
-													<?php checked( 'actor', $actor_mode ); ?>
-												/>
-												<?php esc_html_e( 'Author profiles', 'fosse' ); ?>
-											</label>
-											<p id="fosse-activitypub-actor-mode-actor-desc" class="description">
-												<?php esc_html_e( 'Each WordPress author publishes from their own fediverse profile. People follow individual authors, and posts appear under each author\'s name.', 'fosse' ); ?>
-											</p>
-											<label>
-												<input
-													type="radio"
-													id="fosse-activitypub-actor-mode-blog"
-													name="activitypub_actor_mode"
-													value="blog"
-													aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"
-													<?php checked( 'blog', $actor_mode ); ?>
-												/>
-												<?php esc_html_e( 'Blog profile', 'fosse' ); ?>
-											</label>
-											<p id="fosse-activitypub-actor-mode-blog-desc" class="description">
-												<?php esc_html_e( 'One site-wide profile publishes every post, regardless of author. Use this when people should follow the site as one account.', 'fosse' ); ?>
-											</p>
-											<label>
-												<input
-													type="radio"
-													id="fosse-activitypub-actor-mode-actor-blog"
-													name="activitypub_actor_mode"
-													value="actor_blog"
-													aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"
-													<?php checked( 'actor_blog', $actor_mode ); ?>
-												/>
-												<?php esc_html_e( 'Both', 'fosse' ); ?>
-											</label>
-											<p id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
-												<?php esc_html_e( 'Authors keep individual profiles, and the site also has its own blog profile. People can follow either.', 'fosse' ); ?>
-											</p>
+											<div class="fosse-settings-card-option">
+												<label class="fosse-settings-card-option__label">
+													<input
+														type="radio"
+														id="fosse-activitypub-actor-mode-actor"
+														name="activitypub_actor_mode"
+														value="actor"
+														aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"
+														<?php checked( 'actor', $actor_mode ); ?>
+													/>
+													<span><?php esc_html_e( 'Author profiles', 'fosse' ); ?></span>
+												</label>
+												<p id="fosse-activitypub-actor-mode-actor-desc" class="description">
+													<?php esc_html_e( 'Each WordPress author publishes from their own fediverse profile. People follow individual authors, and posts appear under each author\'s name.', 'fosse' ); ?>
+												</p>
+											</div>
+											<div class="fosse-settings-card-option">
+												<label class="fosse-settings-card-option__label">
+													<input
+														type="radio"
+														id="fosse-activitypub-actor-mode-blog"
+														name="activitypub_actor_mode"
+														value="blog"
+														aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"
+														<?php checked( 'blog', $actor_mode ); ?>
+													/>
+													<span><?php esc_html_e( 'Blog profile', 'fosse' ); ?></span>
+												</label>
+												<p id="fosse-activitypub-actor-mode-blog-desc" class="description">
+													<?php esc_html_e( 'One site-wide profile publishes every post, regardless of author. Use this when people should follow the site as one account.', 'fosse' ); ?>
+												</p>
+											</div>
+											<div class="fosse-settings-card-option">
+												<label class="fosse-settings-card-option__label">
+													<input
+														type="radio"
+														id="fosse-activitypub-actor-mode-actor-blog"
+														name="activitypub_actor_mode"
+														value="actor_blog"
+														aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"
+														<?php checked( 'actor_blog', $actor_mode ); ?>
+													/>
+													<span><?php esc_html_e( 'Both', 'fosse' ); ?></span>
+												</label>
+												<p id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
+													<?php esc_html_e( 'Authors keep individual profiles, and the site also has its own blog profile. People can follow either.', 'fosse' ); ?>
+												</p>
+											</div>
 											<div class="fosse-activitypub-actor-mode-note">
 												<p id="fosse-activitypub-actor-mode-note" class="description">
 													<?php esc_html_e( 'Changing modes does not move followers between profiles. Future posts publish from the profiles enabled by the selected mode.', 'fosse' ); ?>
@@ -192,7 +209,12 @@ defined( 'ABSPATH' ) || exit;
 		</div>
 
 		<div class="fosse-settings-panel" id="fosse-connections">
-			<h2><?php esc_html_e( 'Connections', 'fosse' ); ?></h2>
+			<div class="fosse-settings-panel__header">
+				<h2><?php esc_html_e( 'Connections', 'fosse' ); ?></h2>
+				<p class="fosse-settings-panel__description">
+					<?php esc_html_e( 'Review provider connection details and manage account-level actions.', 'fosse' ); ?>
+				</p>
+			</div>
 
 			<?php
 			foreach ( $providers as $provider ) {

--- a/src/Admin/templates/status-page.php
+++ b/src/Admin/templates/status-page.php
@@ -10,32 +10,52 @@
 defined( 'ABSPATH' ) || exit;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- $providers set by Status_Page::render().
-$available = array_filter(
+$available       = array_filter(
 	$providers,
 	static fn( $p ) => $p->is_available()
 );
-$connected = array_filter(
+$connected       = array_filter(
 	$available,
 	static fn( $p ) => ! empty( $p->get_status()['connected'] )
 );
+$available_count = count( $available );
+$connected_count = count( $connected );
+
+if ( 0 === $connected_count ) {
+	$summary_description = __( 'Connect a provider to start publishing your WordPress posts across the social web.', 'fosse' );
+} elseif ( $connected_count < $available_count ) {
+	$summary_description = __( 'Some available providers still need attention before every connection is ready.', 'fosse' );
+} else {
+	$summary_description = __( 'All available providers are connected and ready to publish.', 'fosse' );
+}
 ?>
-<div class="wrap">
-	<h1><?php esc_html_e( 'FOSSE Status', 'fosse' ); ?></h1>
+<div class="wrap fosse-admin-page fosse-admin-page--status">
+	<header class="fosse-admin-page__header">
+		<p class="fosse-admin-page__eyebrow"><?php esc_html_e( 'Social web', 'fosse' ); ?></p>
+		<h1 class="fosse-admin-page__title"><?php esc_html_e( 'FOSSE Status', 'fosse' ); ?></h1>
+		<p class="fosse-admin-page__description">
+			<?php esc_html_e( 'Monitor connection health and the identities FOSSE uses when publishing to each network.', 'fosse' ); ?>
+		</p>
+	</header>
 
 	<?php if ( ! empty( $available ) ) : ?>
-		<div class="fosse-status-summary<?php echo count( $connected ) < count( $available ) ? ' has-attention' : ''; ?>">
-			<p>
-				<?php
-				printf(
-					/* translators: 1: number of active connections, 2: total available connections */
-					esc_html__( '%1$d of %2$d connections active', 'fosse' ),
-					count( $connected ),
-					count( $available )
-				);
-				?>
-			</p>
+		<div class="fosse-status-summary<?php echo esc_attr( $connected_count < $available_count ? ' has-attention' : '' ); ?>">
+			<div class="fosse-status-summary__body">
+				<p class="fosse-status-summary__label"><?php esc_html_e( 'Connection health', 'fosse' ); ?></p>
+				<p class="fosse-status-summary__count">
+					<?php
+					printf(
+						/* translators: 1: number of active connections, 2: total available connections */
+						esc_html__( '%1$s of %2$s connections active', 'fosse' ),
+						esc_html( number_format_i18n( $connected_count ) ),
+						esc_html( number_format_i18n( $available_count ) )
+					);
+					?>
+				</p>
+				<p class="fosse-status-summary__description"><?php echo esc_html( $summary_description ); ?></p>
+			</div>
 			<?php if ( empty( $connected ) ) : ?>
-				<p>
+				<p class="fosse-status-summary__actions">
 					<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=fosse' ) ); ?>">
 						<?php esc_html_e( 'Set up FOSSE', 'fosse' ); ?>
 					</a>
@@ -51,7 +71,7 @@ $connected = array_filter(
 			?>
 		</div>
 	<?php else : ?>
-		<div class="notice notice-warning">
+		<div class="notice notice-warning fosse-admin-notice">
 			<p>
 				<?php
 				esc_html_e(

--- a/src/Admin/templates/status-page.php
+++ b/src/Admin/templates/status-page.php
@@ -24,7 +24,16 @@ $connected_count = count( $connected );
 if ( 0 === $connected_count ) {
 	$summary_description = __( 'Connect a provider to start publishing your WordPress posts across the social web.', 'fosse' );
 } elseif ( $connected_count < $available_count ) {
-	$summary_description = __( 'Some available providers still need attention before every connection is ready.', 'fosse' );
+	$summary_description = sprintf(
+		/* translators: %s: number of connected providers */
+		_n(
+			'FOSSE can publish through %s connected provider. Connect another provider if you want to publish there too.',
+			'FOSSE can publish through %s connected providers. Connect another provider if you want to publish there too.',
+			$connected_count,
+			'fosse'
+		),
+		number_format_i18n( $connected_count )
+	);
 } else {
 	$summary_description = __( 'All available providers are connected and ready to publish.', 'fosse' );
 }
@@ -34,19 +43,19 @@ if ( 0 === $connected_count ) {
 		<p class="fosse-admin-page__eyebrow"><?php esc_html_e( 'Social web', 'fosse' ); ?></p>
 		<h1 class="fosse-admin-page__title"><?php esc_html_e( 'FOSSE Status', 'fosse' ); ?></h1>
 		<p class="fosse-admin-page__description">
-			<?php esc_html_e( 'Monitor connection health and the identities FOSSE uses when publishing to each network.', 'fosse' ); ?>
+			<?php esc_html_e( 'See whether each network is connected and which identities FOSSE will publish from.', 'fosse' ); ?>
 		</p>
 	</header>
 
 	<?php if ( ! empty( $available ) ) : ?>
 		<div class="fosse-status-summary<?php echo esc_attr( $connected_count < $available_count ? ' has-attention' : '' ); ?>">
 			<div class="fosse-status-summary__body">
-				<p class="fosse-status-summary__label"><?php esc_html_e( 'Connection health', 'fosse' ); ?></p>
+				<p class="fosse-status-summary__label"><?php esc_html_e( 'Provider status', 'fosse' ); ?></p>
 				<p class="fosse-status-summary__count">
 					<?php
 					printf(
 						/* translators: 1: number of active connections, 2: total available connections */
-						esc_html__( '%1$s of %2$s connections active', 'fosse' ),
+						esc_html__( '%1$s of %2$s providers connected', 'fosse' ),
 						esc_html( number_format_i18n( $connected_count ) ),
 						esc_html( number_format_i18n( $available_count ) )
 					);
@@ -75,7 +84,7 @@ if ( 0 === $connected_count ) {
 			<p>
 				<?php
 				esc_html_e(
-					'FOSSE bundles ActivityPub and Atmosphere, so this state usually means one of the bundled backends failed to bootstrap (composer autoload missing, class-loading conflict with a manually installed copy, or a host-level disable). Check the PHP error log and FOSSE\'s plugin activation state.',
+					'FOSSE includes ActivityPub and Bluesky support, so this usually means a bundled component failed to load. Check the PHP error log and FOSSE\'s plugin activation state.',
 					'fosse'
 				);
 				?>

--- a/src/Admin/templates/status-page.php
+++ b/src/Admin/templates/status-page.php
@@ -54,7 +54,7 @@ if ( 0 === $connected_count ) {
 				<p class="fosse-status-summary__count">
 					<?php
 					printf(
-						/* translators: 1: number of active connections, 2: total available connections */
+						/* translators: 1: number of connected providers, 2: total available providers */
 						esc_html__( '%1$s of %2$s providers connected', 'fosse' ),
 						esc_html( number_format_i18n( $connected_count ) ),
 						esc_html( number_format_i18n( $available_count ) )

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -2158,7 +2158,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'fosse_set_bluesky_domain_handle', $output );
-		$this->assertStringContainsString( 'Click the button below to set your Bluesky handle to example.com', $output );
+		$this->assertStringContainsString( 'You can set your Bluesky handle to example.com', $output );
 		$this->assertStringContainsString( 'Use example.com as my Bluesky handle', $output );
 		$this->assertStringContainsString( 'Heads up: replacing your handle is destructive', $output );
 	}
@@ -2607,7 +2607,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_connection_actions();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'Disconnecting will also restore your previous Bluesky handle', $output );
+		$this->assertStringContainsString( 'Disconnecting will also restore alice.bsky.social as this account\'s Bluesky handle', html_entity_decode( $output, ENT_QUOTES, 'UTF-8' ) );
 		$this->assertStringContainsString( 'alice.bsky.social', $output );
 	}
 

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -549,6 +549,24 @@ class Setup_PageTest extends BaseTestCase {
 	}
 
 	/**
+	 * Actor-mode card highlighting follows the live checked radio state, not
+	 * a server-rendered saved-state class that would go stale before save.
+	 */
+	public function test_render_actor_mode_cards_style_from_checked_radio_state(): void {
+		$this->become_admin();
+
+		$output = $this->capture_render();
+
+		$this->assertStringNotContainsString( 'is-selected', $output );
+		$this->assertStringContainsString( 'class="fosse-settings-card-option__input"', $output );
+		$this->assertStringContainsString( 'class="fosse-settings-card-option__body"', $output );
+		$this->assertMatchesRegularExpression(
+			'/id="fosse-activitypub-actor-mode-actor"[\s\S]+?class="fosse-settings-card-option__body"/',
+			$output
+		);
+	}
+
+	/**
 	 * When the actor mode is constant-locked, the radios are replaced
 	 * by a hidden input + locked notice. Regression guard against the
 	 * locked branch ever being deleted by accident.


### PR DESCRIPTION
## Summary
- Refresh the FOSSE Settings and Status admin pages with shared page headers, rounded panels, status summaries, and responsive provider cards.
- Improve long handle, DID, URL, and fediverse address wrapping using existing Status_Formatter helpers.
- Keep Settings post type controls as native checkboxes while improving spacing and focus treatment.

## Testing
- git diff --check
- composer run-script lint-php
- pnpm run format:check
- pnpm run lint
- composer run-script test-php
- pnpm test -- --runInBand
- pnpm run test:e2e