### PR TITLE
add: async publish-path metrics subscriber

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -188,6 +188,26 @@ add_action(
 );
 
 /*
+ * Async publish-path metrics subscriber.
+ *
+ * Listens to bundled ActivityPub's outbox dispatch hooks and bundled
+ * Atmosphere's `atmosphere_publish_post_result` hook (added upstream in
+ * wordpress-atmosphere PR 56; subscriber is dormant until that lands and
+ * gets resynced). Emits `fosse_post_published` + `fosse_publish_result`
+ * per the metrics SDD. See `sdd/fosse-metrics-strategy/` and
+ * `DOTCOM-17031`. Same degradation posture as the projectors above.
+ */
+add_action(
+	'init',
+	static function () {
+		if ( ! class_exists( \Automattic\Fosse\Metrics\Publish_Events::class ) ) {
+			return;
+		}
+		\Automattic\Fosse\Metrics\Publish_Events::register();
+	}
+);
+
+/*
  * One-time migration of FOSSE-side projector options to canonical
  * upstream options (`fosse_object_type` → `activitypub_object_type`,
  * `fosse_long_form_strategy` → `atmosphere_long_form_composition`).

--- a/src/Metrics/class-publish-events.php
+++ b/src/Metrics/class-publish-events.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Publish-event metrics subscriber.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Metrics;
+
+/**
+ * Translates bundled ActivityPub + bundled Atmosphere publish hooks into
+ * the `fosse_post_published` and `fosse_publish_result` events documented
+ * in `sdd/fosse-metrics-strategy/implementation.md` § Publishing.
+ *
+ * Listens to:
+ *
+ * - `activitypub_sent_to_inbox` — accumulates per-inbox results indexed by
+ *   the outbox item id.
+ * - `activitypub_outbox_processing_complete` — emits one aggregated
+ *   `fosse_publish_result` event with `network: 'activitypub'`.
+ * - `atmosphere_publish_post_result` — emits one `fosse_post_published`
+ *   plus one `fosse_publish_result` event with `network: 'bluesky'`. The
+ *   upstream hook is being added in wordpress-atmosphere PR 56; this
+ *   subscriber pre-lands assuming it will land. If the hook never lands,
+ *   the callback is dormant and emits nothing.
+ *
+ * For v1, `fosse_post_published` is only emitted from the Atmosphere
+ * path, where the originating `WP_Post` is available directly. AP's
+ * outbox dispatch only exposes the outbox-item id; mapping that back to
+ * the originating post is a follow-up. Until that lands, AP-only sites
+ * undercount the entry-step of the publish funnel — accept and document.
+ */
+class Publish_Events {
+
+	/**
+	 * Per-request state of in-flight AP outbox dispatches.
+	 *
+	 * Keyed by outbox item id. Each entry tracks success count and
+	 * the WP_Error codes collected from per-inbox failures, so the
+	 * `activitypub_outbox_processing_complete` handler can emit a
+	 * single aggregated `fosse_publish_result` event.
+	 *
+	 * @var array<int, array{successes:int, failures:list<string>}>
+	 */
+	private static array $ap_dispatch_state = array();
+
+	/**
+	 * Wire the subscriber to the publish hooks.
+	 *
+	 * Idempotent — repeated calls re-add the same listeners but
+	 * WordPress dedupes them by callback identity.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		\add_action( 'activitypub_sent_to_inbox', array( self::class, 'on_ap_sent_to_inbox' ), 10, 5 );
+		\add_action( 'activitypub_outbox_processing_complete', array( self::class, 'on_ap_outbox_processing_complete' ), 10, 6 );
+		\add_action( 'atmosphere_publish_post_result', array( self::class, 'on_atmosphere_publish_post_result' ), 10, 2 );
+	}
+
+	/**
+	 * Accumulate per-inbox AP send results for later aggregation.
+	 *
+	 * @param array|\WP_Error $result         Result of the inbox send.
+	 * @param string          $inbox          Inbox URL (unused here).
+	 * @param string          $json           Activity JSON (unused here).
+	 * @param int             $actor_id       Sending actor (unused here).
+	 * @param int             $outbox_item_id Outbox item id — keys the per-dispatch aggregate.
+	 * @return void
+	 */
+	public static function on_ap_sent_to_inbox( $result, $inbox, $json, $actor_id, $outbox_item_id ) {
+		unset( $inbox, $json, $actor_id );
+
+		$outbox_item_id = (int) $outbox_item_id;
+		if ( ! isset( self::$ap_dispatch_state[ $outbox_item_id ] ) ) {
+			self::$ap_dispatch_state[ $outbox_item_id ] = array(
+				'successes' => 0,
+				'failures'  => array(),
+			);
+		}
+
+		if ( \is_wp_error( $result ) ) {
+			self::$ap_dispatch_state[ $outbox_item_id ]['failures'][] = $result->get_error_code();
+		} else {
+			++self::$ap_dispatch_state[ $outbox_item_id ]['successes'];
+		}
+	}
+
+	/**
+	 * Emit the aggregated `fosse_publish_result` for an AP outbox item.
+	 *
+	 * Status policy: success if at least one inbox accepted the
+	 * activity; otherwise failure. Matches "did this post reach the
+	 * fediverse at all?" rather than "did every inbox succeed" — a
+	 * single follower's malformed inbox shouldn't downgrade the
+	 * post-level publish status.
+	 *
+	 * @param array  $inboxes        Inbox list (unused).
+	 * @param string $json           Activity JSON (unused).
+	 * @param int    $actor_id       Sending actor (unused).
+	 * @param int    $outbox_item_id Outbox item id — looked up in the per-dispatch aggregate.
+	 * @param int    $batch_size     Batch size (unused).
+	 * @param int    $offset         Batch offset (unused).
+	 * @return void
+	 */
+	public static function on_ap_outbox_processing_complete( $inboxes, $json, $actor_id, $outbox_item_id, $batch_size, $offset ) {
+		unset( $inboxes, $json, $actor_id, $batch_size, $offset );
+
+		$outbox_item_id = (int) $outbox_item_id;
+		$state          = self::$ap_dispatch_state[ $outbox_item_id ] ?? null;
+		unset( self::$ap_dispatch_state[ $outbox_item_id ] );
+
+		if ( null === $state ) {
+			// No `activitypub_sent_to_inbox` ever fired for this id (zero-inbox publish).
+			// Don't emit — there is no signal to report.
+			return;
+		}
+
+		$status = $state['successes'] > 0 ? 'success' : 'failure';
+
+		$properties = array(
+			'network' => 'activitypub',
+			'status'  => $status,
+		);
+
+		if ( 'failure' === $status && ! empty( $state['failures'] ) ) {
+			$properties['error_category'] = self::classify_error( $state['failures'][0] );
+		}
+
+		Recorder::record( 'fosse_publish_result', $properties );
+
+		if ( 'success' === $status ) {
+			Recorder::bump( 'fosse-publish-success-activitypub' );
+		}
+	}
+
+	/**
+	 * Handle the Atmosphere publish-result action.
+	 *
+	 * Emits `fosse_post_published` once (network-agnostic entry-step
+	 * signal) plus `fosse_publish_result` once with `network: 'bluesky'`.
+	 *
+	 * @param \WP_Post        $post   Post that was published.
+	 * @param array|\WP_Error $result `applyWrites` response on success, `WP_Error` on failure.
+	 * @return void
+	 */
+	public static function on_atmosphere_publish_post_result( $post, $result ) {
+		if ( ! $post instanceof \WP_Post ) {
+			return;
+		}
+
+		Recorder::record(
+			'fosse_post_published',
+			array(
+				'post_format' => self::resolve_post_format( $post ),
+				'has_image'   => self::resolve_has_image( $post ),
+			)
+		);
+
+		$status = \is_wp_error( $result ) ? 'failure' : 'success';
+
+		$properties = array(
+			'network'  => 'bluesky',
+			'status'   => $status,
+			'strategy' => self::resolve_strategy( $post ),
+		);
+
+		if ( 'failure' === $status && $result instanceof \WP_Error ) {
+			$properties['error_category'] = self::classify_error( (string) $result->get_error_code() );
+		}
+
+		Recorder::record( 'fosse_publish_result', $properties );
+
+		if ( 'success' === $status ) {
+			Recorder::bump( 'fosse-publish-success-bluesky' );
+		}
+	}
+
+	/**
+	 * Resolve the post format property for `fosse_post_published`.
+	 *
+	 * Normalizes a missing format to `'standard'` so the dimension
+	 * is always populated rather than dropping into a null bucket.
+	 *
+	 * @param \WP_Post $post Post.
+	 * @return string
+	 */
+	private static function resolve_post_format( \WP_Post $post ): string {
+		$format = \get_post_format( $post->ID );
+		return false === $format || '' === $format ? 'standard' : (string) $format;
+	}
+
+	/**
+	 * Resolve the `has_image` boolean for `fosse_post_published`.
+	 *
+	 * Featured-image-only for v1 — keeps the signal cheap and avoids
+	 * parsing post content. Inline-image detection is a follow-up.
+	 *
+	 * @param \WP_Post $post Post.
+	 * @return bool
+	 */
+	private static function resolve_has_image( \WP_Post $post ): bool {
+		return \has_post_thumbnail( $post->ID );
+	}
+
+	/**
+	 * Resolve the `strategy` enum for `fosse_publish_result` (Bluesky network).
+	 *
+	 * Maps Atmosphere's classification onto the three spec-pinned
+	 * values: `'short-form-note'`, `'long-form-teaser-thread'`,
+	 * `'link-card-fallback'`. Atmosphere's `truncate-link` long-form
+	 * strategy collapses to `'link-card-fallback'` for v1 — both
+	 * render as a single record with a link to the source post.
+	 *
+	 * @param \WP_Post $post Post.
+	 * @return string One of the documented strategy enum values.
+	 */
+	private static function resolve_strategy( \WP_Post $post ): string {
+		if ( (bool) \apply_filters( 'atmosphere_is_short_form_post', false, $post ) ) {
+			return 'short-form-note';
+		}
+
+		$composition = (string) \apply_filters( 'atmosphere_long_form_composition', 'link-card' );
+		return 'teaser-thread' === $composition ? 'long-form-teaser-thread' : 'link-card-fallback';
+	}
+
+	/**
+	 * Map a raw WP_Error code into one of the documented `error_category` values.
+	 *
+	 * The documented enum is `'auth_failed' | 'rate_limited' |
+	 * 'network_timeout' | 'other'`. Unknown codes fall to `'other'`
+	 * rather than leaking raw codes into the Tracks payload (privacy
+	 * contract).
+	 *
+	 * @param string $code WP_Error code.
+	 * @return string
+	 */
+	private static function classify_error( string $code ): string {
+		$auth_codes = array(
+			'unauthorized',
+			'forbidden',
+			'oauth_failed',
+			'auth_failed',
+			'token_expired',
+			'atmosphere_no_credentials',
+		);
+		if ( \in_array( $code, $auth_codes, true ) ) {
+			return 'auth_failed';
+		}
+
+		$rate_codes = array(
+			'rate_limited',
+			'too_many_requests',
+		);
+		if ( \in_array( $code, $rate_codes, true ) ) {
+			return 'rate_limited';
+		}
+
+		$timeout_codes = array(
+			'http_request_failed',
+			'http_request_not_executed',
+			'curl_error',
+			'network_timeout',
+			'connection_timeout',
+		);
+		if ( \in_array( $code, $timeout_codes, true ) ) {
+			return 'network_timeout';
+		}
+
+		return 'other';
+	}
+}

--- a/src/Metrics/class-publish-events.php
+++ b/src/Metrics/class-publish-events.php
@@ -33,16 +33,16 @@ namespace Automattic\Fosse\Metrics;
 class Publish_Events {
 
 	/**
-	 * Per-request state of in-flight AP outbox dispatches.
+	 * Outbox-item post meta key for the per-dispatch aggregate.
 	 *
-	 * Keyed by outbox item id. Each entry tracks success count and
-	 * the WP_Error codes collected from per-inbox failures, so the
-	 * `activitypub_outbox_processing_complete` handler can emit a
-	 * single aggregated `fosse_publish_result` event.
-	 *
-	 * @var array<int, array{successes:int, failures:list<string>}>
+	 * Stores `array{successes:int, failures:list<string>}` keyed to the
+	 * outbox item id. Persisted (not in-memory) because AP dispatch
+	 * spans multiple cron requests when an outbox item has more
+	 * followers than the per-batch limit; the final batch fires
+	 * `activitypub_outbox_processing_complete` in a different PHP
+	 * process than the earlier `activitypub_sent_to_inbox` events.
 	 */
-	private static array $ap_dispatch_state = array();
+	private const AP_DISPATCH_STATE_META_KEY = '_fosse_metrics_ap_dispatch_state';
 
 	/**
 	 * Wire the subscriber to the publish hooks.
@@ -61,29 +61,39 @@ class Publish_Events {
 	/**
 	 * Accumulate per-inbox AP send results for later aggregation.
 	 *
+	 * State persists on the outbox item's post meta so multi-batch
+	 * dispatches that span cron requests stay coherent.
+	 *
 	 * @param array|\WP_Error $result         Result of the inbox send.
 	 * @param string          $inbox          Inbox URL (unused here).
 	 * @param string          $json           Activity JSON (unused here).
 	 * @param int             $actor_id       Sending actor (unused here).
-	 * @param int             $outbox_item_id Outbox item id — keys the per-dispatch aggregate.
+	 * @param int             $outbox_item_id Outbox item id — used as the post meta key.
 	 * @return void
 	 */
 	public static function on_ap_sent_to_inbox( $result, $inbox, $json, $actor_id, $outbox_item_id ) {
 		unset( $inbox, $json, $actor_id );
 
 		$outbox_item_id = (int) $outbox_item_id;
-		if ( ! isset( self::$ap_dispatch_state[ $outbox_item_id ] ) ) {
-			self::$ap_dispatch_state[ $outbox_item_id ] = array(
+		if ( $outbox_item_id <= 0 ) {
+			return;
+		}
+
+		$state = \get_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, true );
+		if ( ! \is_array( $state ) ) {
+			$state = array(
 				'successes' => 0,
 				'failures'  => array(),
 			);
 		}
 
 		if ( \is_wp_error( $result ) ) {
-			self::$ap_dispatch_state[ $outbox_item_id ]['failures'][] = $result->get_error_code();
+			$state['failures'][] = (string) $result->get_error_code();
 		} else {
-			++self::$ap_dispatch_state[ $outbox_item_id ]['successes'];
+			++$state['successes'];
 		}
+
+		\update_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, $state );
 	}
 
 	/**
@@ -107,10 +117,14 @@ class Publish_Events {
 		unset( $inboxes, $json, $actor_id, $batch_size, $offset );
 
 		$outbox_item_id = (int) $outbox_item_id;
-		$state          = self::$ap_dispatch_state[ $outbox_item_id ] ?? null;
-		unset( self::$ap_dispatch_state[ $outbox_item_id ] );
+		if ( $outbox_item_id <= 0 ) {
+			return;
+		}
 
-		if ( null === $state ) {
+		$state = \get_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, true );
+		\delete_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY );
+
+		if ( ! \is_array( $state ) ) {
 			// No `activitypub_sent_to_inbox` ever fired for this id (zero-inbox publish).
 			// Don't emit — there is no signal to report.
 			return;
@@ -220,7 +234,7 @@ class Publish_Events {
 			return 'short-form-note';
 		}
 
-		$composition = (string) \apply_filters( 'atmosphere_long_form_composition', 'link-card' );
+		$composition = (string) \apply_filters( 'atmosphere_long_form_composition', 'link-card', $post );
 		return 'teaser-thread' === $composition ? 'long-form-teaser-thread' : 'link-card-fallback';
 	}
 
@@ -232,11 +246,20 @@ class Publish_Events {
 	 * rather than leaking raw codes into the Tracks payload (privacy
 	 * contract).
 	 *
+	 * AP's outbox dispatch surfaces remote-POST failures as `WP_Error`
+	 * codes carrying the raw HTTP status as an integer-shaped string
+	 * (e.g. `'401'`, `'429'`, `'504'`) — those are mapped into the
+	 * appropriate bucket alongside the named string codes Atmosphere
+	 * and the WP HTTP API emit. `0` covers a connection that never
+	 * opened.
+	 *
 	 * @param string $code WP_Error code.
 	 * @return string
 	 */
 	private static function classify_error( string $code ): string {
-		$auth_codes = array(
+		$numeric_code = \ctype_digit( $code ) ? (int) $code : null;
+
+		$auth_codes  = array(
 			'unauthorized',
 			'forbidden',
 			'oauth_failed',
@@ -244,7 +267,8 @@ class Publish_Events {
 			'token_expired',
 			'atmosphere_no_credentials',
 		);
-		if ( \in_array( $code, $auth_codes, true ) ) {
+		$auth_status = array( 401, 403, 407 );
+		if ( \in_array( $code, $auth_codes, true ) || ( null !== $numeric_code && \in_array( $numeric_code, $auth_status, true ) ) ) {
 			return 'auth_failed';
 		}
 
@@ -252,18 +276,19 @@ class Publish_Events {
 			'rate_limited',
 			'too_many_requests',
 		);
-		if ( \in_array( $code, $rate_codes, true ) ) {
+		if ( \in_array( $code, $rate_codes, true ) || 429 === $numeric_code ) {
 			return 'rate_limited';
 		}
 
-		$timeout_codes = array(
+		$timeout_codes  = array(
 			'http_request_failed',
 			'http_request_not_executed',
 			'curl_error',
 			'network_timeout',
 			'connection_timeout',
 		);
-		if ( \in_array( $code, $timeout_codes, true ) ) {
+		$timeout_status = array( 0, 408, 502, 503, 504 );
+		if ( \in_array( $code, $timeout_codes, true ) || ( null !== $numeric_code && \in_array( $numeric_code, $timeout_status, true ) ) ) {
 			return 'network_timeout';
 		}
 

--- a/src/Metrics/class-publish-events.php
+++ b/src/Metrics/class-publish-events.php
@@ -14,15 +14,27 @@ namespace Automattic\Fosse\Metrics;
  *
  * Listens to:
  *
- * - `activitypub_sent_to_inbox` — accumulates per-inbox results indexed by
- *   the outbox item id.
- * - `activitypub_outbox_processing_complete` — emits one aggregated
- *   `fosse_publish_result` event with `network: 'activitypub'`.
+ * - `activitypub_sent_to_inbox` — accumulates per-inbox results in an
+ *   in-memory aggregator (one update per inbox, no DB write per send).
+ * - `activitypub_outbox_processing_batch_complete` — flushes the
+ *   in-memory aggregate to post meta on the outbox item once per
+ *   intermediate batch, so multi-batch dispatches that span cron
+ *   requests stay coherent. AP fires this for every batch except the
+ *   final one.
+ * - `activitypub_outbox_processing_complete` — merges any final-batch
+ *   in-memory state with the persisted aggregate, emits one
+ *   `fosse_publish_result` event with `network: 'activitypub'`, and
+ *   clears both. AP fires this only on the final batch.
  * - `atmosphere_publish_post_result` — emits one `fosse_post_published`
  *   plus one `fosse_publish_result` event with `network: 'bluesky'`. The
- *   upstream hook is being added in wordpress-atmosphere PR 56; this
- *   subscriber pre-lands assuming it will land. If the hook never lands,
- *   the callback is dormant and emits nothing.
+ *   upstream hook lands in wordpress-atmosphere PR 56; this subscriber
+ *   pre-lands assuming it will land. If the hook never lands, the
+ *   callback is dormant and emits nothing.
+ *
+ * The in-memory + per-batch-flush split keeps multi-batch correctness
+ * (post meta survives cron-request boundaries) without paying the
+ * ~`ACTIVITYPUB_OUTBOX_PROCESSING_BATCH_SIZE` extra DB writes per batch
+ * a per-inbox flush would impose.
  *
  * For v1, `fosse_post_published` is only emitted from the Atmosphere
  * path, where the originating `WP_Post` is available directly. AP's
@@ -33,16 +45,26 @@ namespace Automattic\Fosse\Metrics;
 class Publish_Events {
 
 	/**
-	 * Outbox-item post meta key for the per-dispatch aggregate.
+	 * Outbox-item post meta key for the cross-request dispatch aggregate.
 	 *
 	 * Stores `array{successes:int, failures:list<string>}` keyed to the
-	 * outbox item id. Persisted (not in-memory) because AP dispatch
-	 * spans multiple cron requests when an outbox item has more
-	 * followers than the per-batch limit; the final batch fires
-	 * `activitypub_outbox_processing_complete` in a different PHP
-	 * process than the earlier `activitypub_sent_to_inbox` events.
+	 * outbox item id. Flushed from `$ap_dispatch_state` on
+	 * `activitypub_outbox_processing_batch_complete`, then read and
+	 * deleted on `activitypub_outbox_processing_complete`.
 	 */
 	private const AP_DISPATCH_STATE_META_KEY = '_fosse_metrics_ap_dispatch_state';
+
+	/**
+	 * Per-request in-memory aggregator for AP outbox sends.
+	 *
+	 * Keyed by outbox item id. Updated on every `activitypub_sent_to_inbox`
+	 * to avoid a DB write per inbox; flushed into post meta on each
+	 * `activitypub_outbox_processing_batch_complete`, and merged with the
+	 * persisted aggregate on `activitypub_outbox_processing_complete`.
+	 *
+	 * @var array<int, array{successes:int, failures:list<string>}>
+	 */
+	private static array $ap_dispatch_state = array();
 
 	/**
 	 * Wire the subscriber to the publish hooks.
@@ -54,21 +76,24 @@ class Publish_Events {
 	 */
 	public static function register(): void {
 		\add_action( 'activitypub_sent_to_inbox', array( self::class, 'on_ap_sent_to_inbox' ), 10, 5 );
+		\add_action( 'activitypub_outbox_processing_batch_complete', array( self::class, 'on_ap_outbox_processing_batch_complete' ), 10, 6 );
 		\add_action( 'activitypub_outbox_processing_complete', array( self::class, 'on_ap_outbox_processing_complete' ), 10, 6 );
 		\add_action( 'atmosphere_publish_post_result', array( self::class, 'on_atmosphere_publish_post_result' ), 10, 2 );
 	}
 
 	/**
-	 * Accumulate per-inbox AP send results for later aggregation.
+	 * Accumulate per-inbox AP send results in the in-memory aggregator.
 	 *
-	 * State persists on the outbox item's post meta so multi-batch
-	 * dispatches that span cron requests stay coherent.
+	 * No DB write here — flushed to post meta on
+	 * `activitypub_outbox_processing_batch_complete` (intermediate
+	 * batches) and merged into the emit on
+	 * `activitypub_outbox_processing_complete` (final batch).
 	 *
 	 * @param array|\WP_Error $result         Result of the inbox send.
 	 * @param string          $inbox          Inbox URL (unused here).
 	 * @param string          $json           Activity JSON (unused here).
 	 * @param int             $actor_id       Sending actor (unused here).
-	 * @param int             $outbox_item_id Outbox item id — used as the post meta key.
+	 * @param int             $outbox_item_id Outbox item id — keys the per-dispatch aggregate.
 	 * @return void
 	 */
 	public static function on_ap_sent_to_inbox( $result, $inbox, $json, $actor_id, $outbox_item_id ) {
@@ -79,21 +104,68 @@ class Publish_Events {
 			return;
 		}
 
-		$state = \get_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, true );
-		if ( ! \is_array( $state ) ) {
-			$state = array(
+		if ( ! isset( self::$ap_dispatch_state[ $outbox_item_id ] ) ) {
+			self::$ap_dispatch_state[ $outbox_item_id ] = array(
 				'successes' => 0,
 				'failures'  => array(),
 			);
 		}
 
 		if ( \is_wp_error( $result ) ) {
-			$state['failures'][] = (string) $result->get_error_code();
+			self::$ap_dispatch_state[ $outbox_item_id ]['failures'][] = (string) $result->get_error_code();
 		} else {
-			++$state['successes'];
+			++self::$ap_dispatch_state[ $outbox_item_id ]['successes'];
+		}
+	}
+
+	/**
+	 * Flush the in-memory aggregator into post meta at the end of an
+	 * intermediate batch.
+	 *
+	 * Fires for every batch except the final one (AP's
+	 * `processing_batch_complete` and `processing_complete` are
+	 * mutually exclusive — see
+	 * `bundled/activitypub/includes/class-dispatcher.php`). Merges with
+	 * whatever is already persisted so multi-batch dispatches that
+	 * span cron requests accumulate correctly. Clears the in-memory
+	 * slot after the flush so a re-fired batch in the same request
+	 * doesn't double-count.
+	 *
+	 * @param array  $inboxes        Inbox list (unused).
+	 * @param string $json           Activity JSON (unused).
+	 * @param int    $actor_id       Sending actor (unused).
+	 * @param int    $outbox_item_id Outbox item id — keys the per-dispatch aggregate.
+	 * @param int    $batch_size     Batch size (unused).
+	 * @param int    $offset         Batch offset (unused).
+	 * @return void
+	 */
+	public static function on_ap_outbox_processing_batch_complete( $inboxes, $json, $actor_id, $outbox_item_id, $batch_size, $offset ) {
+		unset( $inboxes, $json, $actor_id, $batch_size, $offset );
+
+		$outbox_item_id = (int) $outbox_item_id;
+		if ( $outbox_item_id <= 0 ) {
+			return;
 		}
 
-		\update_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, $state );
+		$in_memory = self::$ap_dispatch_state[ $outbox_item_id ] ?? null;
+		unset( self::$ap_dispatch_state[ $outbox_item_id ] );
+
+		if ( null === $in_memory ) {
+			return;
+		}
+
+		$persisted = \get_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, true );
+		if ( ! \is_array( $persisted ) ) {
+			$persisted = array(
+				'successes' => 0,
+				'failures'  => array(),
+			);
+		}
+
+		$persisted['successes'] += $in_memory['successes'];
+		$persisted['failures']   = \array_merge( $persisted['failures'], $in_memory['failures'] );
+
+		\update_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, $persisted );
 	}
 
 	/**
@@ -121,13 +193,27 @@ class Publish_Events {
 			return;
 		}
 
-		$state = \get_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, true );
+		// The final batch's per-inbox events have only landed in memory —
+		// AP's `processing_complete` and `processing_batch_complete` are
+		// mutually exclusive, so the final batch never flushed.
+		$in_memory = self::$ap_dispatch_state[ $outbox_item_id ] ?? null;
+		unset( self::$ap_dispatch_state[ $outbox_item_id ] );
+
+		$persisted = \get_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, true );
 		\delete_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY );
 
-		if ( ! \is_array( $state ) ) {
-			// No `activitypub_sent_to_inbox` ever fired for this id (zero-inbox publish).
-			// Don't emit — there is no signal to report.
+		if ( null === $in_memory && ! \is_array( $persisted ) ) {
+			// No `activitypub_sent_to_inbox` ever fired (zero-inbox publish).
 			return;
+		}
+
+		$state = \is_array( $persisted ) ? $persisted : array(
+			'successes' => 0,
+			'failures'  => array(),
+		);
+		if ( null !== $in_memory ) {
+			$state['successes'] += $in_memory['successes'];
+			$state['failures']   = \array_merge( $state['failures'], $in_memory['failures'] );
 		}
 
 		$status = $state['successes'] > 0 ? 'success' : 'failure';

--- a/src/Metrics/class-publish-events.php
+++ b/src/Metrics/class-publish-events.php
@@ -47,8 +47,8 @@ class Publish_Events {
 	/**
 	 * Outbox-item post meta key for the cross-request dispatch aggregate.
 	 *
-	 * Stores `array{successes:int, failures:list<string>}` keyed to the
-	 * outbox item id. Flushed from `$ap_dispatch_state` on
+	 * Stores `array{successes:int, failures:int, first_failure_code:?string}`
+	 * keyed to the outbox item id. Flushed from `$ap_dispatch_state` on
 	 * `activitypub_outbox_processing_batch_complete`, then read and
 	 * deleted on `activitypub_outbox_processing_complete`.
 	 */
@@ -62,19 +62,41 @@ class Publish_Events {
 	 * `activitypub_outbox_processing_batch_complete`, and merged with the
 	 * persisted aggregate on `activitypub_outbox_processing_complete`.
 	 *
-	 * @var array<int, array{successes:int, failures:list<string>}>
+	 * Stores only counts plus the first failure code (rather than every
+	 * per-inbox failure entry) so the persisted post-meta payload stays
+	 * bounded even on sites with very large follower sets and high
+	 * failure rates. The emit only uses the first failure code anyway.
+	 *
+	 * @var array<int, array{successes:int, failures:int, first_failure_code:?string}>
 	 */
 	private static array $ap_dispatch_state = array();
 
 	/**
+	 * Cross-call guard against duplicate hook registration.
+	 *
+	 * `add_action()` does NOT dedupe identical callbacks — calling
+	 * `register()` twice without this guard would attach each listener
+	 * twice and double every event / bump.
+	 *
+	 * @var bool
+	 */
+	private static bool $registered = false;
+
+	/**
 	 * Wire the subscriber to the publish hooks.
 	 *
-	 * Idempotent — repeated calls re-add the same listeners but
-	 * WordPress dedupes them by callback identity.
+	 * Idempotent: the static `$registered` flag short-circuits repeat
+	 * calls so duplicate listeners can't be attached. `add_action()`
+	 * itself does not dedupe identical callbacks.
 	 *
 	 * @return void
 	 */
 	public static function register(): void {
+		if ( self::$registered ) {
+			return;
+		}
+		self::$registered = true;
+
 		\add_action( 'activitypub_sent_to_inbox', array( self::class, 'on_ap_sent_to_inbox' ), 10, 5 );
 		\add_action( 'activitypub_outbox_processing_batch_complete', array( self::class, 'on_ap_outbox_processing_batch_complete' ), 10, 6 );
 		\add_action( 'activitypub_outbox_processing_complete', array( self::class, 'on_ap_outbox_processing_complete' ), 10, 6 );
@@ -105,17 +127,30 @@ class Publish_Events {
 		}
 
 		if ( ! isset( self::$ap_dispatch_state[ $outbox_item_id ] ) ) {
-			self::$ap_dispatch_state[ $outbox_item_id ] = array(
-				'successes' => 0,
-				'failures'  => array(),
-			);
+			self::$ap_dispatch_state[ $outbox_item_id ] = self::empty_state();
 		}
 
 		if ( \is_wp_error( $result ) ) {
-			self::$ap_dispatch_state[ $outbox_item_id ]['failures'][] = (string) $result->get_error_code();
+			++self::$ap_dispatch_state[ $outbox_item_id ]['failures'];
+			if ( null === self::$ap_dispatch_state[ $outbox_item_id ]['first_failure_code'] ) {
+				self::$ap_dispatch_state[ $outbox_item_id ]['first_failure_code'] = (string) $result->get_error_code();
+			}
 		} else {
 			++self::$ap_dispatch_state[ $outbox_item_id ]['successes'];
 		}
+	}
+
+	/**
+	 * Empty dispatch-state record used as the initialization seed.
+	 *
+	 * @return array{successes:int, failures:int, first_failure_code:?string}
+	 */
+	private static function empty_state(): array {
+		return array(
+			'successes'          => 0,
+			'failures'           => 0,
+			'first_failure_code' => null,
+		);
 	}
 
 	/**
@@ -156,16 +191,31 @@ class Publish_Events {
 
 		$persisted = \get_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, true );
 		if ( ! \is_array( $persisted ) ) {
-			$persisted = array(
-				'successes' => 0,
-				'failures'  => array(),
-			);
+			$persisted = self::empty_state();
 		}
 
-		$persisted['successes'] += $in_memory['successes'];
-		$persisted['failures']   = \array_merge( $persisted['failures'], $in_memory['failures'] );
+		\update_post_meta(
+			$outbox_item_id,
+			self::AP_DISPATCH_STATE_META_KEY,
+			self::merge_states( $persisted, $in_memory )
+		);
+	}
 
-		\update_post_meta( $outbox_item_id, self::AP_DISPATCH_STATE_META_KEY, $persisted );
+	/**
+	 * Combine two dispatch-state records, preserving the earliest
+	 * `first_failure_code` (the persisted one wins when both have a
+	 * value, matching the "first failure across the dispatch" semantics
+	 * of the emit).
+	 *
+	 * @param array{successes:int, failures:int, first_failure_code:?string} $base    Existing state (e.g. persisted).
+	 * @param array{successes:int, failures:int, first_failure_code:?string} $overlay State to merge in (e.g. in-memory).
+	 * @return array{successes:int, failures:int, first_failure_code:?string}
+	 */
+	private static function merge_states( array $base, array $overlay ): array {
+		$base['successes']         += $overlay['successes'];
+		$base['failures']          += $overlay['failures'];
+		$base['first_failure_code'] = $base['first_failure_code'] ?? $overlay['first_failure_code'];
+		return $base;
 	}
 
 	/**
@@ -207,13 +257,9 @@ class Publish_Events {
 			return;
 		}
 
-		$state = \is_array( $persisted ) ? $persisted : array(
-			'successes' => 0,
-			'failures'  => array(),
-		);
+		$state = \is_array( $persisted ) ? $persisted : self::empty_state();
 		if ( null !== $in_memory ) {
-			$state['successes'] += $in_memory['successes'];
-			$state['failures']   = \array_merge( $state['failures'], $in_memory['failures'] );
+			$state = self::merge_states( $state, $in_memory );
 		}
 
 		$status = $state['successes'] > 0 ? 'success' : 'failure';
@@ -223,8 +269,8 @@ class Publish_Events {
 			'status'  => $status,
 		);
 
-		if ( 'failure' === $status && ! empty( $state['failures'] ) ) {
-			$properties['error_category'] = self::classify_error( $state['failures'][0] );
+		if ( 'failure' === $status && null !== $state['first_failure_code'] ) {
+			$properties['error_category'] = self::classify_error( $state['first_failure_code'] );
 		}
 
 		Recorder::record( 'fosse_publish_result', $properties );

--- a/tests/php/Metrics/PublishEventsTest.php
+++ b/tests/php/Metrics/PublishEventsTest.php
@@ -122,12 +122,116 @@ class PublishEventsTest extends BaseTestCase {
 
 	/**
 	 * AP outbox-complete with no prior per-inbox events emits nothing
-	 * (zero-inbox dispatch).
+	 * (zero-inbox dispatch). Uses a real outbox post id so the post-meta
+	 * read path is exercised; the meta is just empty.
 	 */
 	public function test_ap_outbox_complete_without_sends_is_silent(): void {
-		\do_action( 'activitypub_outbox_processing_complete', array(), '{}', 1, 9999, 0, 0 );
+		$outbox_id = \wp_insert_post(
+			array(
+				'post_title'  => 'outbox item',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		\do_action( 'activitypub_outbox_processing_complete', array(), '{}', 1, $outbox_id, 0, 0 );
 
 		$this->assertNoEventRecorded( 'fosse_publish_result' );
+	}
+
+	/**
+	 * Multi-batch AP dispatch — successes/failures accumulated across
+	 * separate `activitypub_sent_to_inbox` events still aggregate
+	 * correctly when the final `activitypub_outbox_processing_complete`
+	 * fires. State is persisted in post meta, so this works even when
+	 * batches run in different cron requests.
+	 */
+	public function test_ap_outbox_multi_batch_aggregation(): void {
+		$outbox_id = \wp_insert_post(
+			array(
+				'post_title'  => 'outbox item',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		// First batch — 1 fail, 2 successes.
+		\do_action( 'activitypub_sent_to_inbox', new \WP_Error( '503', 'gateway' ), 'https://a.example/inbox', '{}', 1, $outbox_id );
+		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://b.example/inbox', '{}', 1, $outbox_id );
+		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://c.example/inbox', '{}', 1, $outbox_id );
+
+		// Second batch — 1 success, 1 fail.
+		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://d.example/inbox', '{}', 1, $outbox_id );
+		\do_action( 'activitypub_sent_to_inbox', new \WP_Error( '429', 'slow down' ), 'https://e.example/inbox', '{}', 1, $outbox_id );
+
+		// Final batch fires completion.
+		\do_action( 'activitypub_outbox_processing_complete', array(), '{}', 1, $outbox_id, 2, 3 );
+
+		// Cumulative: 3 successes → status = success.
+		$this->assertEventRecorded(
+			'fosse_publish_result',
+			array(
+				'network' => 'activitypub',
+				'status'  => 'success',
+			)
+		);
+
+		// Post meta cleaned up after the final emit.
+		$this->assertSame( '', \get_post_meta( $outbox_id, '_fosse_metrics_ap_dispatch_state', true ) );
+	}
+
+	/**
+	 * Numeric HTTP status codes from AP's remote-POST WP_Error path
+	 * classify into the documented `error_category` enum:
+	 *   401/403 → auth_failed, 429 → rate_limited,
+	 *   408/502/503/504 → network_timeout, others → other.
+	 *
+	 * AP wraps any HTTP `>= 400` response into a WP_Error keyed by the
+	 * status code (see `bundled/activitypub/includes/class-http.php`),
+	 * so these are the codes the subscriber actually sees in practice.
+	 * Code `0` is intentionally not tested here — `empty( '0' )` is
+	 * true in PHP and `WP_Error::__construct` drops it before
+	 * `get_error_code()` could ever return `'0'`. The numeric `0`
+	 * handling in `classify_error()` is defense-in-depth.
+	 */
+	public function test_ap_numeric_http_codes_classify_correctly(): void {
+		$cases = array(
+			array( '401', 'auth_failed' ),
+			array( '403', 'auth_failed' ),
+			array( '429', 'rate_limited' ),
+			array( '408', 'network_timeout' ),
+			array( '504', 'network_timeout' ),
+			array( '502', 'network_timeout' ),
+			array( '500', 'other' ),
+			array( '404', 'other' ),
+		);
+
+		foreach ( $cases as $i => $case ) {
+			[ $code, $expected ] = $case;
+
+			$outbox_id = \wp_insert_post(
+				array(
+					'post_title'  => 'outbox-' . $i,
+					'post_status' => 'publish',
+					'post_type'   => 'post',
+				)
+			);
+
+			\do_action( 'activitypub_sent_to_inbox', new \WP_Error( $code, $code ), 'https://x.example/inbox', '{}', 1, $outbox_id );
+			\do_action( 'activitypub_outbox_processing_complete', array( 'https://x.example/inbox' ), '{}', 1, $outbox_id, 1, 0 );
+		}
+
+		$publish_events = $this->tracks_channel()->events_for( 'fosse_publish_result' );
+		$this->assertCount( \count( $cases ), $publish_events );
+
+		foreach ( $cases as $i => $case ) {
+			[ $code, $expected ] = $case;
+			$this->assertSame(
+				$expected,
+				$publish_events[ $i ]['properties']['error_category'] ?? null,
+				\sprintf( 'HTTP code %s should classify as %s', $code, $expected )
+			);
+		}
 	}
 
 	/**

--- a/tests/php/Metrics/PublishEventsTest.php
+++ b/tests/php/Metrics/PublishEventsTest.php
@@ -32,6 +32,7 @@ class PublishEventsTest extends BaseTestCase {
 		\remove_all_filters( 'atmosphere_is_short_form_post' );
 		\remove_all_filters( 'atmosphere_long_form_composition' );
 		\remove_all_actions( 'activitypub_sent_to_inbox' );
+		\remove_all_actions( 'activitypub_outbox_processing_batch_complete' );
 		\remove_all_actions( 'activitypub_outbox_processing_complete' );
 		\remove_all_actions( 'atmosphere_publish_post_result' );
 		Publish_Events::register();
@@ -140,11 +141,15 @@ class PublishEventsTest extends BaseTestCase {
 	}
 
 	/**
-	 * Multi-batch AP dispatch — successes/failures accumulated across
-	 * separate `activitypub_sent_to_inbox` events still aggregate
-	 * correctly when the final `activitypub_outbox_processing_complete`
-	 * fires. State is persisted in post meta, so this works even when
-	 * batches run in different cron requests.
+	 * Multi-batch AP dispatch — `activitypub_outbox_processing_batch_complete`
+	 * fires per intermediate batch (flushing in-memory state to post
+	 * meta), and `activitypub_outbox_processing_complete` fires for the
+	 * final batch. Aggregation merges everything correctly.
+	 *
+	 * Verifies that after each intermediate `batch_complete`:
+	 *   - persisted post meta carries the cumulative counts
+	 *   - the in-memory slot for the outbox id is cleared
+	 * so a re-fired batch in the same request can't double-count.
 	 */
 	public function test_ap_outbox_multi_batch_aggregation(): void {
 		$outbox_id = \wp_insert_post(
@@ -155,19 +160,24 @@ class PublishEventsTest extends BaseTestCase {
 			)
 		);
 
-		// First batch — 1 fail, 2 successes.
+		// First batch — 1 fail, 2 successes — then batch_complete (intermediate).
 		\do_action( 'activitypub_sent_to_inbox', new \WP_Error( '503', 'gateway' ), 'https://a.example/inbox', '{}', 1, $outbox_id );
 		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://b.example/inbox', '{}', 1, $outbox_id );
 		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://c.example/inbox', '{}', 1, $outbox_id );
+		\do_action( 'activitypub_outbox_processing_batch_complete', array(), '{}', 1, $outbox_id, 3, 0 );
 
-		// Second batch — 1 success, 1 fail.
+		// After the intermediate batch_complete, persisted meta carries the cumulative state.
+		$persisted = \get_post_meta( $outbox_id, '_fosse_metrics_ap_dispatch_state', true );
+		$this->assertIsArray( $persisted );
+		$this->assertSame( 2, $persisted['successes'] );
+		$this->assertSame( array( '503' ), $persisted['failures'] );
+
+		// Second batch — 1 success, 1 fail — then the FINAL batch fires processing_complete.
 		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://d.example/inbox', '{}', 1, $outbox_id );
 		\do_action( 'activitypub_sent_to_inbox', new \WP_Error( '429', 'slow down' ), 'https://e.example/inbox', '{}', 1, $outbox_id );
-
-		// Final batch fires completion.
 		\do_action( 'activitypub_outbox_processing_complete', array(), '{}', 1, $outbox_id, 2, 3 );
 
-		// Cumulative: 3 successes → status = success.
+		// Cumulative: 3 successes total → status = success.
 		$this->assertEventRecorded(
 			'fosse_publish_result',
 			array(
@@ -178,6 +188,46 @@ class PublishEventsTest extends BaseTestCase {
 
 		// Post meta cleaned up after the final emit.
 		$this->assertSame( '', \get_post_meta( $outbox_id, '_fosse_metrics_ap_dispatch_state', true ) );
+	}
+
+	/**
+	 * Cross-request persistence — between intermediate batches the
+	 * persisted state survives an in-memory reset (simulating the
+	 * second cron request starting fresh). Locks in the property the
+	 * post-meta flush is there to provide.
+	 */
+	public function test_ap_outbox_persisted_state_survives_request_boundary(): void {
+		$outbox_id = \wp_insert_post(
+			array(
+				'post_title'  => 'outbox item',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		// Cron request 1: batch fires + batch_complete (state flushes to post meta).
+		\do_action( 'activitypub_sent_to_inbox', new \WP_Error( '401', 'unauthorized' ), 'https://x.example/inbox', '{}', 1, $outbox_id );
+		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://y.example/inbox', '{}', 1, $outbox_id );
+		\do_action( 'activitypub_outbox_processing_batch_complete', array(), '{}', 1, $outbox_id, 2, 0 );
+
+		// Simulate request boundary: a fresh PHP process has no in-memory state.
+		// (The subscriber's flush already clears the slot, but be explicit.)
+		$reflection = new \ReflectionClass( Publish_Events::class );
+		$prop       = $reflection->getProperty( 'ap_dispatch_state' );
+		$prop->setValue( null, array() );
+
+		// Cron request 2: more inbox events + final processing_complete.
+		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://z.example/inbox', '{}', 1, $outbox_id );
+		\do_action( 'activitypub_outbox_processing_complete', array(), '{}', 1, $outbox_id, 1, 2 );
+
+		// 2 cumulative successes (one from each request) + 1 failure across the boundary.
+		$this->assertEventRecorded(
+			'fosse_publish_result',
+			array(
+				'network' => 'activitypub',
+				'status'  => 'success',
+			)
+		);
 	}
 
 	/**

--- a/tests/php/Metrics/PublishEventsTest.php
+++ b/tests/php/Metrics/PublishEventsTest.php
@@ -139,7 +139,7 @@ class PublishEventsTest extends BaseTestCase {
 
 	/**
 	 * AP outbox-complete with no prior per-inbox events emits nothing
-	 * (zero-inbox dispatch). Uses a real outbox post id so the post-meta
+	 * (zero-inbox dispatch). Uses a real post id so the post-meta
 	 * read path is exercised; the meta is just empty.
 	 */
 	public function test_ap_outbox_complete_without_sends_is_silent(): void {
@@ -188,6 +188,11 @@ class PublishEventsTest extends BaseTestCase {
 		$this->assertSame( 2, $persisted['successes'] );
 		$this->assertSame( 1, $persisted['failures'] );
 		$this->assertSame( '503', $persisted['first_failure_code'] );
+
+		// And the in-memory slot for this outbox id is cleared, so a re-fired
+		// batch in the same request can't double-count.
+		$state_prop = ( new \ReflectionClass( Publish_Events::class ) )->getProperty( 'ap_dispatch_state' );
+		$this->assertArrayNotHasKey( $outbox_id, $state_prop->getValue() );
 
 		// Second batch — 1 success, 1 fail — then the FINAL batch fires processing_complete.
 		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://d.example/inbox', '{}', 1, $outbox_id );

--- a/tests/php/Metrics/PublishEventsTest.php
+++ b/tests/php/Metrics/PublishEventsTest.php
@@ -35,7 +35,23 @@ class PublishEventsTest extends BaseTestCase {
 		\remove_all_actions( 'activitypub_outbox_processing_batch_complete' );
 		\remove_all_actions( 'activitypub_outbox_processing_complete' );
 		\remove_all_actions( 'atmosphere_publish_post_result' );
+		// register() is idempotent — guarded by a static flag so duplicate
+		// listeners can't be attached in production. Tests reset both
+		// statics so each case starts with a fully clean wiring.
+		$this->reset_publish_events_statics();
 		Publish_Events::register();
+	}
+
+	/**
+	 * Wipe both static properties on Publish_Events so each test starts
+	 * with no in-memory dispatch state AND with the idempotency guard
+	 * cleared (otherwise the second test's `register()` would early-return
+	 * after `set_up_state()` has removed all the actions).
+	 */
+	private function reset_publish_events_statics(): void {
+		$reflection = new \ReflectionClass( Publish_Events::class );
+		$reflection->getProperty( 'ap_dispatch_state' )->setValue( null, array() );
+		$reflection->getProperty( 'registered' )->setValue( null, false );
 	}
 
 	/**
@@ -170,7 +186,8 @@ class PublishEventsTest extends BaseTestCase {
 		$persisted = \get_post_meta( $outbox_id, '_fosse_metrics_ap_dispatch_state', true );
 		$this->assertIsArray( $persisted );
 		$this->assertSame( 2, $persisted['successes'] );
-		$this->assertSame( array( '503' ), $persisted['failures'] );
+		$this->assertSame( 1, $persisted['failures'] );
+		$this->assertSame( '503', $persisted['first_failure_code'] );
 
 		// Second batch — 1 success, 1 fail — then the FINAL batch fires processing_complete.
 		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://d.example/inbox', '{}', 1, $outbox_id );
@@ -228,6 +245,39 @@ class PublishEventsTest extends BaseTestCase {
 				'status'  => 'success',
 			)
 		);
+	}
+
+	/**
+	 * Repeated `register()` calls must not double-attach listeners.
+	 * `add_action()` does not dedupe identical callbacks, so without
+	 * the static guard a second call would cause every event to be
+	 * recorded twice and every MC bump to fire twice.
+	 */
+	public function test_register_is_idempotent(): void {
+		// setUp already called register() once. Call it twice more.
+		Publish_Events::register();
+		Publish_Events::register();
+
+		$post_id = \wp_insert_post(
+			array(
+				'post_title'  => 'Idempotency post',
+				'post_status' => 'publish',
+			)
+		);
+		$post    = \get_post( $post_id );
+
+		\add_filter( 'atmosphere_is_short_form_post', '__return_true' );
+		\do_action( 'atmosphere_publish_post_result', $post, array( 'commit' => array( 'cid' => 'baf' ) ) );
+
+		// Exactly one event each — not three.
+		$this->assertCount( 1, $this->tracks_channel()->events_for( 'fosse_post_published' ) );
+		$this->assertCount( 1, $this->tracks_channel()->events_for( 'fosse_publish_result' ) );
+
+		$bumps = array_filter(
+			$this->mc_channel()->bumps(),
+			static fn ( $name ) => 'fosse-publish-success-bluesky' === $name
+		);
+		$this->assertCount( 1, $bumps, 'success bump fires exactly once even after repeated register() calls' );
 	}
 
 	/**

--- a/tests/php/Metrics/PublishEventsTest.php
+++ b/tests/php/Metrics/PublishEventsTest.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Tests for Publish_Events.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests\Metrics;
+
+use Automattic\Fosse\Metrics\Publish_Events;
+use PHPUnit\Framework\Attributes\Before;
+use WorDBless\BaseTestCase;
+
+/**
+ * Verifies the AP outbox-aggregate path and the Atmosphere result-hook
+ * path: each emits the documented events with correct status, strategy,
+ * and error_category enums. Locks down per-inbox failure aggregation so a
+ * single bad inbox doesn't flip a multi-inbox publish to `failure`.
+ */
+class PublishEventsTest extends BaseTestCase {
+
+	use Asserts_Metrics;
+
+	/**
+	 * Reset metrics channels and re-register the subscriber.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function set_up_state(): void {
+		$this->reset_metrics_channels();
+		\remove_all_filters( 'atmosphere_is_short_form_post' );
+		\remove_all_filters( 'atmosphere_long_form_composition' );
+		\remove_all_actions( 'activitypub_sent_to_inbox' );
+		\remove_all_actions( 'activitypub_outbox_processing_complete' );
+		\remove_all_actions( 'atmosphere_publish_post_result' );
+		Publish_Events::register();
+	}
+
+	/**
+	 * AP dispatch with at least one successful inbox emits a
+	 * `success` `fosse_publish_result` and bumps the MC counter.
+	 */
+	public function test_ap_outbox_success_emits_success_event(): void {
+		$outbox_id = 4242;
+
+		\do_action( 'activitypub_sent_to_inbox', array( 'response' => array( 'code' => 202 ) ), 'https://example.com/inbox', '{}', 1, $outbox_id );
+		\do_action( 'activitypub_outbox_processing_complete', array( 'https://example.com/inbox' ), '{}', 1, $outbox_id, 1, 0 );
+
+		$this->assertEventRecorded(
+			'fosse_publish_result',
+			array(
+				'network' => 'activitypub',
+				'status'  => 'success',
+			)
+		);
+		$this->assertMcBumped( 'fosse-publish-success-activitypub' );
+	}
+
+	/**
+	 * AP dispatch where every inbox returned a WP_Error emits a
+	 * `failure` event with the first failure code classified into the
+	 * `error_category` enum, and does NOT bump the success counter.
+	 */
+	public function test_ap_outbox_all_failures_emits_failure_event(): void {
+		$outbox_id = 4243;
+
+		\do_action(
+			'activitypub_sent_to_inbox',
+			new \WP_Error( 'unauthorized', 'nope' ),
+			'https://example.com/inbox',
+			'{}',
+			1,
+			$outbox_id
+		);
+		\do_action( 'activitypub_outbox_processing_complete', array( 'https://example.com/inbox' ), '{}', 1, $outbox_id, 1, 0 );
+
+		$this->assertEventRecorded(
+			'fosse_publish_result',
+			array(
+				'network'        => 'activitypub',
+				'status'         => 'failure',
+				'error_category' => 'auth_failed',
+			)
+		);
+		$this->assertNoMcBumped( 'fosse-publish-success-activitypub' );
+	}
+
+	/**
+	 * Mixed AP results count as success — a single bad inbox in a
+	 * multi-inbox dispatch shouldn't downgrade the whole publish.
+	 */
+	public function test_ap_outbox_partial_success_emits_success_event(): void {
+		$outbox_id = 4244;
+
+		\do_action(
+			'activitypub_sent_to_inbox',
+			new \WP_Error( 'http_request_failed', 'transient' ),
+			'https://bad.example/inbox',
+			'{}',
+			1,
+			$outbox_id
+		);
+		\do_action(
+			'activitypub_sent_to_inbox',
+			array( 'response' => array( 'code' => 202 ) ),
+			'https://good.example/inbox',
+			'{}',
+			1,
+			$outbox_id
+		);
+		\do_action( 'activitypub_outbox_processing_complete', array( 'https://bad.example/inbox', 'https://good.example/inbox' ), '{}', 1, $outbox_id, 2, 0 );
+
+		$this->assertEventRecorded(
+			'fosse_publish_result',
+			array(
+				'network' => 'activitypub',
+				'status'  => 'success',
+			)
+		);
+	}
+
+	/**
+	 * AP outbox-complete with no prior per-inbox events emits nothing
+	 * (zero-inbox dispatch).
+	 */
+	public function test_ap_outbox_complete_without_sends_is_silent(): void {
+		\do_action( 'activitypub_outbox_processing_complete', array(), '{}', 1, 9999, 0, 0 );
+
+		$this->assertNoEventRecorded( 'fosse_publish_result' );
+	}
+
+	/**
+	 * Atmosphere success path emits both events with strategy resolved
+	 * to `short-form-note` when the post is short-form.
+	 */
+	public function test_atmosphere_success_short_form_emits_both_events(): void {
+		\add_filter( 'atmosphere_is_short_form_post', '__return_true' );
+
+		$post_id = \wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+		$post    = \get_post( $post_id );
+
+		\do_action( 'atmosphere_publish_post_result', $post, array( 'commit' => array( 'cid' => 'baf' ) ) );
+
+		$this->assertEventRecorded( 'fosse_post_published', array( 'has_image' => false ) );
+		$this->assertEventRecorded(
+			'fosse_publish_result',
+			array(
+				'network'  => 'bluesky',
+				'status'   => 'success',
+				'strategy' => 'short-form-note',
+			)
+		);
+		$this->assertMcBumped( 'fosse-publish-success-bluesky' );
+	}
+
+	/**
+	 * Long-form posts with `teaser-thread` composition map to
+	 * `long-form-teaser-thread`.
+	 */
+	public function test_atmosphere_long_form_teaser_thread_strategy(): void {
+		\add_filter( 'atmosphere_is_short_form_post', '__return_false' );
+		\add_filter( 'atmosphere_long_form_composition', static fn () => 'teaser-thread' );
+
+		$post_id = \wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+		$post    = \get_post( $post_id );
+
+		\do_action( 'atmosphere_publish_post_result', $post, array( 'commit' => array( 'cid' => 'baf' ) ) );
+
+		$this->assertEventRecorded(
+			'fosse_publish_result',
+			array(
+				'network'  => 'bluesky',
+				'strategy' => 'long-form-teaser-thread',
+			)
+		);
+	}
+
+	/**
+	 * Long-form posts with `link-card` composition collapse to
+	 * `link-card-fallback`.
+	 */
+	public function test_atmosphere_long_form_link_card_strategy(): void {
+		\add_filter( 'atmosphere_is_short_form_post', '__return_false' );
+		\add_filter( 'atmosphere_long_form_composition', static fn () => 'link-card' );
+
+		$post_id = \wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+		$post    = \get_post( $post_id );
+
+		\do_action( 'atmosphere_publish_post_result', $post, array( 'commit' => array( 'cid' => 'baf' ) ) );
+
+		$this->assertEventRecorded(
+			'fosse_publish_result',
+			array(
+				'network'  => 'bluesky',
+				'strategy' => 'link-card-fallback',
+			)
+		);
+	}
+
+	/**
+	 * Atmosphere failure with a WP_Error result emits a `failure`
+	 * `fosse_publish_result` and skips the MC success bump.
+	 */
+	public function test_atmosphere_failure_emits_failure_event(): void {
+		\add_filter( 'atmosphere_is_short_form_post', '__return_true' );
+
+		$post_id = \wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+		$post    = \get_post( $post_id );
+
+		\do_action(
+			'atmosphere_publish_post_result',
+			$post,
+			new \WP_Error( 'rate_limited', 'slow down' )
+		);
+
+		$this->assertEventRecorded(
+			'fosse_publish_result',
+			array(
+				'network'        => 'bluesky',
+				'status'         => 'failure',
+				'error_category' => 'rate_limited',
+			)
+		);
+		$this->assertNoMcBumped( 'fosse-publish-success-bluesky' );
+	}
+
+	/**
+	 * Unknown `WP_Error` codes fall to `error_category: 'other'`
+	 * rather than leaking the raw code into the payload.
+	 */
+	public function test_unknown_error_classifies_as_other(): void {
+		\add_filter( 'atmosphere_is_short_form_post', '__return_true' );
+
+		$post_id = \wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Content',
+				'post_status'  => 'publish',
+			)
+		);
+		$post    = \get_post( $post_id );
+
+		\do_action(
+			'atmosphere_publish_post_result',
+			$post,
+			new \WP_Error( 'something_weird_we_dont_recognize', 'mystery' )
+		);
+
+		$this->assertEventRecorded(
+			'fosse_publish_result',
+			array(
+				'error_category' => 'other',
+			)
+		);
+	}
+
+	/**
+	 * Non-post argument is ignored — Atmosphere only ever fires this
+	 * hook with a `WP_Post`, but the subscriber guards defensively so
+	 * a misbehaving fork can't poison the recorder.
+	 */
+	public function test_non_post_argument_is_ignored(): void {
+		\do_action( 'atmosphere_publish_post_result', new \stdClass(), array() );
+
+		$this->assertNoEventRecorded( 'fosse_post_published' );
+		$this->assertNoEventRecorded( 'fosse_publish_result' );
+	}
+}


### PR DESCRIPTION
Related to DOTCOM-17031 (Phase 4 of the FOSSE metrics rollout, parent DOTCOM-16879).

## Proposed changes

Adds `\Automattic\Fosse\Metrics\Publish_Events` — wires the bundled ActivityPub outbox-dispatch hooks and bundled Atmosphere's `atmosphere_publish_post_result` hook into the recorder. After this lands, the long-allowlisted `fosse_post_published` and `fosse_publish_result` events in `src/Metrics/class-schema.php` actually emit.

**ActivityPub side**

- `activitypub_sent_to_inbox` accumulates per-inbox results indexed by outbox item id.
- `activitypub_outbox_processing_complete` emits one aggregated `fosse_publish_result` per outbox item with `network: 'activitypub'`. Status policy: "at least one inbox accepted the activity = success" — a single malformed follower inbox shouldn't downgrade a multi-inbox publish.

**Atmosphere side**

- `atmosphere_publish_post_result` emits one `fosse_post_published` plus one `fosse_publish_result` with `network: 'bluesky'`. Strategy resolves via `atmosphere_is_short_form_post` and `atmosphere_long_form_composition` filters into the three spec-pinned values (`short-form-note`, `long-form-teaser-thread`, `link-card-fallback`); Atmosphere's `truncate-link` collapses to `link-card-fallback`.
- The upstream `atmosphere_publish_post_result` action is added in [wordpress-atmosphere PR 56](https://github.com/Automattic/wordpress-atmosphere/pull/56). This subscriber pre-lands assuming the hook will land — the callback is dormant until upstream releases and the bundle is resynced.

**Error classification**

`error_category` is derived via a small static table that maps known WP_Error codes into the documented enum (`auth_failed` / `rate_limited` / `network_timeout` / `other`). Unknown codes fall to `other` rather than leaking raw codes into the Tracks payload (privacy contract).

## Why

Per the metrics SDD: the synchronous `publish_post` hook fires before the cron-driven Atmosphere publish path actually runs, so any subscriber there can't know success or failure. AP's outbox dispatch is similarly cron-driven. This subscriber attaches to the actual result-bearing hooks so the emitted events carry real status/error data instead of placeholders.

## Out of scope (documented v1 gaps)

- `fosse_post_published` only emits from the Atmosphere path. AP's outbox dispatch exposes only an outbox item id; mapping it back to the originating `WP_Post` is a follow-up. AP-only sites undercount the entry-step of the publish funnel until then.
- Atmosphere's `truncate-link` long-form strategy collapses to `link-card-fallback`. A fourth enum value can be added when the data warrants it.
- Inline-image detection — `has_image` is featured-image-only for v1 to keep the signal cheap.

## Testing

- `composer run-script lint-php` clean (run before this PR was opened).
- `vendor/bin/phpunit --filter PublishEventsTest` — 10 tests, 16 assertions, all green. Covers AP success / partial-success / all-failure / zero-inbox paths, Atmosphere short-form / long-form-teaser / long-form-link-card / failure paths, unknown-error classification, and defensive non-post argument.

## Dependencies

- [wordpress-atmosphere PR 56](https://github.com/Automattic/wordpress-atmosphere/pull/56) — adds `atmosphere_publish_post_result`. Must land + be resynced into `bundled/atmosphere/` before the Atmosphere half of this subscriber actually emits anything in production.