### PR TITLE
Hide Media (attachment) from FOSSE post-type chooser

### DIFF
--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -356,14 +356,22 @@ class Onboarding_Wizard {
 			// hard failure via `failOnWarning`, and which would otherwise emit
 			// a notice in production). Mirrors {@see Setup_Page::save_general_settings()}.
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized via array_map below; sniffer does not recognize the wrapping pattern.
-			$raw         = wp_unslash( (array) ( $_POST['activitypub_support_post_types'] ?? array() ) );
-			$submitted   = array_map( 'sanitize_text_field', array_filter( $raw, 'is_string' ) );
-			$valid_types = get_post_types( array( 'public' => true ) );
-			$post_types  = array_values( array_intersect( $submitted, $valid_types ) );
+			$raw       = wp_unslash( (array) ( $_POST['activitypub_support_post_types'] ?? array() ) );
+			$submitted = array_map( 'sanitize_text_field', array_filter( $raw, 'is_string' ) );
+			$existing  = (array) get_option( 'activitypub_support_post_types', array( 'post' ) );
 
-			// Empty selection would silently disable federation. Bounce back
-			// with an error rather than overwrite the option with [].
-			if ( empty( $post_types ) ) {
+			// Reconcile against the chooser's managed set so a user can't
+			// submit `attachment` (the chooser doesn't render it), and an
+			// upstream-enabled `attachment` survives a FOSSE save.
+			$post_types = Post_Type_Chooser::reconcile_submission( $submitted, $existing );
+
+			// Empty *managed* selection would silently disable post/page
+			// federation. Bounce back with an error rather than overwrite
+			// the chooser-managed slice with []. Preserved upstream values
+			// (e.g. `attachment`) are not enough on their own — the wizard
+			// step is explicitly about picking content types to share.
+			$managed_selected = array_intersect( $post_types, Post_Type_Chooser::names() );
+			if ( empty( $managed_selected ) ) {
 				self::redirect_to_step( 'content', array( 'error' => 'empty_post_types' ) );
 			}
 
@@ -1257,7 +1265,7 @@ class Onboarding_Wizard {
 		self::render_progress( 'content' );
 
 		$post_types     = get_option( 'activitypub_support_post_types', array( 'post' ) );
-		$all_post_types = get_post_types( array( 'public' => true ), 'objects' );
+		$all_post_types = Post_Type_Chooser::types();
 		$nonce          = wp_create_nonce( 'fosse_wizard' );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only check on a redirect-back error code.

--- a/src/Admin/class-post-type-chooser.php
+++ b/src/Admin/class-post-type-chooser.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Post types FOSSE offers in its chooser UIs.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Admin;
+
+/**
+ * Centralizes the list of post types FOSSE surfaces in its wizard and
+ * Settings choosers, and provides the merge pattern that preserves
+ * upstream-configured values FOSSE doesn't manage.
+ *
+ * Why not just use `get_post_types( array( 'public' => true ) )` everywhere:
+ *
+ * - `attachment` is a public post type, so it falls out of that filter and
+ *   would surface as a "Media" checkbox alongside Posts and Pages. The
+ *   wizard's question is "what kind of content do I want to share?" - Media
+ *   doesn't fit that frame. The actual behavior is also surprising:
+ *   enabling it federates every image upload as its own ActivityPub object
+ *   the moment it's uploaded, including images attached to unpublished
+ *   drafts. The FOSSE UI shouldn't put that footgun in front of users.
+ * - Power users who deliberately want Media federation can still flip
+ *   `attachment` on via bundled ActivityPub's own settings. FOSSE's
+ *   contract on `activitypub_support_post_types` is "manage the curated
+ *   subset, preserve anything else" so that upstream choice survives a
+ *   FOSSE save.
+ *
+ * See DOTCOM-17047 for the discussion that motivated this.
+ */
+final class Post_Type_Chooser {
+
+	/**
+	 * Post types FOSSE deliberately omits from its chooser UIs even though
+	 * `get_post_types( array( 'public' => true ) )` returns them.
+	 *
+	 * @var array<string>
+	 */
+	private const EXCLUDED = array( 'attachment' );
+
+	/**
+	 * Post-type objects FOSSE offers in its chooser UIs.
+	 *
+	 * @return array<string, \WP_Post_Type>
+	 */
+	public static function types(): array {
+		$types = get_post_types( array( 'public' => true ), 'objects' );
+		foreach ( self::EXCLUDED as $name ) {
+			unset( $types[ $name ] );
+		}
+		return $types;
+	}
+
+	/**
+	 * Post-type names FOSSE offers in its chooser UIs.
+	 *
+	 * @return array<string>
+	 */
+	public static function names(): array {
+		$names = get_post_types( array( 'public' => true ) );
+		return array_values( array_diff( $names, self::EXCLUDED ) );
+	}
+
+	/**
+	 * Reconcile a chooser submission with the stored option, preserving
+	 * any values FOSSE doesn't manage.
+	 *
+	 * Without this, saving the wizard or Settings page would silently strip
+	 * an upstream-enabled `attachment` from `activitypub_support_post_types`
+	 * because FOSSE's UI doesn't surface a checkbox for it.
+	 *
+	 * @param array<string> $submitted Sanitized post-type names from `$_POST`.
+	 * @param array<string> $existing  Current value of the stored option.
+	 * @return array<string>
+	 */
+	public static function reconcile_submission( array $submitted, array $existing ): array {
+		$managed   = self::names();
+		$preserved = array_diff( $existing, $managed );
+		$selected  = array_intersect( $submitted, $managed );
+		return array_values( array_unique( array_merge( $selected, $preserved ) ) );
+	}
+}

--- a/src/Admin/class-setup-page.php
+++ b/src/Admin/class-setup-page.php
@@ -55,7 +55,7 @@ class Setup_Page {
 		$ap_available      = $ap_provider instanceof Connection_Provider && $ap_provider->is_available();
 		$post_types        = (array) get_option( 'activitypub_support_post_types', array( 'post' ) );
 		$actor_mode        = $ap_available ? (string) get_option( 'activitypub_actor_mode', 'actor' ) : 'actor';
-		$all_post_types    = get_post_types( array( 'public' => true ), 'objects' );
+		$all_post_types    = Post_Type_Chooser::types();
 		$save_nonce        = wp_create_nonce( self::SAVE_ACTION );
 		// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
@@ -138,12 +138,17 @@ class Setup_Page {
 		// hard failure via `failOnWarning`, and which would otherwise emit
 		// a notice in production). Mirrors the defensive guard in
 		// {@see AP_Provider::save_settings()} for `activitypub_blog_identifier`.
-		$raw         = isset( $post_data['activitypub_support_post_types'] )
+		$raw       = isset( $post_data['activitypub_support_post_types'] )
 			? wp_unslash( (array) $post_data['activitypub_support_post_types'] )
 			: array();
-		$submitted   = array_map( 'sanitize_text_field', array_filter( $raw, 'is_string' ) );
-		$valid_types = get_post_types( array( 'public' => true ) );
-		$post_types  = array_values( array_intersect( $submitted, $valid_types ) );
+		$submitted = array_map( 'sanitize_text_field', array_filter( $raw, 'is_string' ) );
+		$existing  = (array) get_option( 'activitypub_support_post_types', array( 'post' ) );
+
+		// Reconcile against the chooser's managed set so a user can't
+		// submit `attachment` (the Settings UI doesn't render it), and an
+		// upstream-enabled `attachment` survives a FOSSE save.
+		$post_types = Post_Type_Chooser::reconcile_submission( $submitted, $existing );
+
 		update_option( 'activitypub_support_post_types', $post_types );
 	}
 }

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -232,6 +232,23 @@ class Onboarding_WizardTest extends BaseTestCase {
 	// --- handle_save: content step ---
 
 	/**
+	 * The wizard's "what do you want to share?" step deliberately omits
+	 * `attachment` from the rendered checkboxes (DOTCOM-17047). Power
+	 * users who want Media federation can still toggle it via bundled
+	 * ActivityPub's own settings.
+	 */
+	public function test_render_content_step_omits_attachment_checkbox(): void {
+		$output = $this->render_wizard_step( 'content' );
+
+		$this->assertStringContainsString( 'name="activitypub_support_post_types[]"', $output );
+		$this->assertStringNotContainsString(
+			'value="attachment"',
+			$output,
+			'Wizard content step should not render a Media (attachment) checkbox.'
+		);
+	}
+
+	/**
 	 * Saving the content step stores post types.
 	 */
 	public function test_handle_save_content_stores_post_types() {
@@ -263,6 +280,90 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$saved = get_option( 'activitypub_support_post_types' );
 		$this->assertContains( 'post', $saved );
 		$this->assertNotContains( 'faketype', $saved );
+	}
+
+	/**
+	 * `attachment` is registered as a public post type but the chooser
+	 * deliberately hides it (DOTCOM-17047). A crafted POST that submits
+	 * `attachment` must not slip past the save handler.
+	 */
+	public function test_handle_save_content_rejects_attachment_in_submission() {
+		$this->simulate_save_request(
+			'content',
+			array( 'activitypub_support_post_types' => array( 'post', 'attachment' ) )
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$saved = (array) get_option( 'activitypub_support_post_types' );
+		$this->assertContains( 'post', $saved );
+		$this->assertNotContains( 'attachment', $saved );
+	}
+
+	/**
+	 * If `attachment` is already set in the stored option (enabled via
+	 * bundled ActivityPub's own settings), the wizard's content step
+	 * must preserve that value rather than silently nuking the
+	 * upstream choice.
+	 */
+	public function test_handle_save_content_preserves_existing_attachment_value() {
+		update_option( 'activitypub_support_post_types', array( 'post', 'attachment' ) );
+
+		$this->simulate_save_request(
+			'content',
+			array( 'activitypub_support_post_types' => array( 'post', 'page' ) )
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$saved = (array) get_option( 'activitypub_support_post_types' );
+		$this->assertContains( 'post', $saved );
+		$this->assertContains( 'page', $saved );
+		$this->assertContains( 'attachment', $saved );
+	}
+
+	/**
+	 * An empty managed selection still bounces back with the
+	 * `empty_post_types` error even when a preserved upstream value
+	 * (e.g. `attachment`) is present. The wizard step is explicitly
+	 * about picking content types to share, so a preserved Media-only
+	 * state isn't enough to satisfy the step.
+	 */
+	public function test_handle_save_content_empty_managed_with_preserved_attachment_redirects_with_error() {
+		update_option( 'activitypub_support_post_types', array( 'post', 'attachment' ) );
+
+		$captured = null;
+		$this->simulate_save_request(
+			'content',
+			array( 'activitypub_support_post_types' => array() )
+		);
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new RedirectFired( 'redirect' );
+			},
+			9
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertStringContainsString( 'step=content', (string) $captured );
+		$this->assertStringContainsString( 'error=empty_post_types', (string) $captured );
+		// Stored option untouched on the error path.
+		$this->assertSame( array( 'post', 'attachment' ), get_option( 'activitypub_support_post_types' ) );
 	}
 
 	/**

--- a/tests/php/Admin/Post_Type_ChooserTest.php
+++ b/tests/php/Admin/Post_Type_ChooserTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Tests for Post_Type_Chooser.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests\Admin;
+
+use Automattic\Fosse\Admin\Post_Type_Chooser;
+use WorDBless\BaseTestCase;
+
+/**
+ * Pins the chooser's "FOSSE-managed post types" semantics:
+ *  - `attachment` is never offered, even though WordPress registers it
+ *    as a public type.
+ *  - The reconcile pattern preserves any stored value FOSSE doesn't
+ *    manage (e.g. `attachment` enabled upstream).
+ */
+class Post_Type_ChooserTest extends BaseTestCase {
+
+	/**
+	 * `attachment` is a public post type, but the chooser hides it from
+	 * the wizard / Settings UI to avoid surfacing an option whose actual
+	 * behavior (federate every image upload, including ones attached to
+	 * drafts) doesn't match what the wizard's label implies.
+	 */
+	public function test_types_excludes_attachment(): void {
+		$names = array_keys( Post_Type_Chooser::types() );
+
+		$this->assertContains( 'post', $names );
+		$this->assertContains( 'page', $names );
+		$this->assertNotContains( 'attachment', $names );
+	}
+
+	/**
+	 * `names()` mirrors `types()` minus the `WP_Post_Type` payload, so
+	 * the chooser's save path can validate submissions without paying
+	 * the `'objects'` cost.
+	 */
+	public function test_names_matches_types_keys(): void {
+		$this->assertSame(
+			array_values( array_keys( Post_Type_Chooser::types() ) ),
+			array_values( Post_Type_Chooser::names() )
+		);
+	}
+
+	/**
+	 * The reconcile pattern intersects the submission with the managed
+	 * set so a submission missing valid types collapses cleanly to the
+	 * managed subset only.
+	 */
+	public function test_reconcile_intersects_submission_with_managed(): void {
+		$result = Post_Type_Chooser::reconcile_submission(
+			array( 'post', 'page', 'nonexistent_type' ),
+			array()
+		);
+
+		sort( $result );
+		$this->assertSame( array( 'page', 'post' ), $result );
+	}
+
+	/**
+	 * A submission can't sneak `attachment` past the chooser even if
+	 * someone crafts a POST that includes it. The wizard and Settings
+	 * UI deliberately don't render that checkbox; the save path needs
+	 * to match that intent.
+	 */
+	public function test_reconcile_rejects_attachment_in_submission(): void {
+		$result = Post_Type_Chooser::reconcile_submission(
+			array( 'post', 'attachment' ),
+			array()
+		);
+
+		$this->assertSame( array( 'post' ), $result );
+	}
+
+	/**
+	 * If `attachment` is already in the stored option (the user enabled
+	 * it via bundled ActivityPub's own settings), a FOSSE save must not
+	 * silently strip it. The chooser doesn't manage it, so the reconcile
+	 * preserves it.
+	 */
+	public function test_reconcile_preserves_existing_attachment(): void {
+		$result = Post_Type_Chooser::reconcile_submission(
+			array( 'post', 'page' ),
+			array( 'post', 'attachment' )
+		);
+
+		sort( $result );
+		$this->assertSame( array( 'attachment', 'page', 'post' ), $result );
+	}
+
+	/**
+	 * An empty submission with an existing `attachment` value preserves
+	 * the upstream choice without re-adding any managed types. Empty-
+	 * managed-selection is a UI-layer concern (the wizard re-prompts
+	 * the user) — the chooser itself stays mechanical.
+	 */
+	public function test_reconcile_empty_submission_preserves_only_unmanaged(): void {
+		$result = Post_Type_Chooser::reconcile_submission(
+			array(),
+			array( 'post', 'attachment' )
+		);
+
+		$this->assertSame( array( 'attachment' ), $result );
+	}
+
+	/**
+	 * Duplicates in the submission collapse to a single entry — the
+	 * stored option shouldn't grow on every save just because the
+	 * form serializer doubled up a value.
+	 */
+	public function test_reconcile_dedupes(): void {
+		$result = Post_Type_Chooser::reconcile_submission(
+			array( 'post', 'post', 'page' ),
+			array( 'post' )
+		);
+
+		sort( $result );
+		$this->assertSame( array( 'page', 'post' ), $result );
+	}
+}

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -549,6 +549,85 @@ class Setup_PageTest extends BaseTestCase {
 	}
 
 	/**
+	 * The Settings post-types chooser deliberately hides `attachment`
+	 * (Media). DOTCOM-17047: enabling it federates every image upload
+	 * - including images attached to drafts - which doesn't match what
+	 * the chooser's label implies. Power users who want it can flip it
+	 * via bundled ActivityPub's own settings.
+	 */
+	public function test_render_general_section_omits_attachment_checkbox(): void {
+		$this->become_admin();
+
+		$output = $this->capture_render();
+
+		$this->assertStringNotContainsString(
+			'value="attachment"',
+			$output,
+			'Settings chooser should not render a Media (attachment) checkbox.'
+		);
+	}
+
+	/**
+	 * If `attachment` is already set in the stored option (the user
+	 * enabled it through bundled ActivityPub's settings), saving the
+	 * FOSSE Settings page must preserve that value rather than silently
+	 * stripping it.
+	 */
+	public function test_handle_save_preserves_existing_attachment_value(): void {
+		update_option( 'activitypub_support_post_types', array( 'post', 'attachment' ) );
+
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_actor_mode'         => 'blog',
+				'activitypub_support_post_types' => array( 'post', 'page' ),
+			)
+		);
+
+		$this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$saved = (array) get_option( 'activitypub_support_post_types' );
+		$this->assertContains( 'post', $saved );
+		$this->assertContains( 'page', $saved );
+		$this->assertContains( 'attachment', $saved );
+	}
+
+	/**
+	 * A submission can't sneak `attachment` past the save handler even
+	 * if a crafted POST includes it. The chooser doesn't render the
+	 * checkbox and the save layer matches that intent.
+	 */
+	public function test_handle_save_rejects_attachment_in_submission(): void {
+		$this->become_admin();
+
+		$this->simulate_post(
+			array(
+				'activitypub_actor_mode'         => 'blog',
+				'activitypub_support_post_types' => array( 'post', 'attachment' ),
+			)
+		);
+
+		$this->arm_redirect_trap();
+
+		try {
+			Setup_Page::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$saved = (array) get_option( 'activitypub_support_post_types' );
+		$this->assertContains( 'post', $saved );
+		$this->assertNotContains( 'attachment', $saved );
+	}
+
+	/**
 	 * When the actor mode is constant-locked, the radios are replaced
 	 * by a hidden input + locked notice. Regression guard against the
 	 * locked branch ever being deleted by accident.


### PR DESCRIPTION
Related to [DOTCOM-17047](https://linear.app/a8c/issue/DOTCOM-17047/wizardsettings-should-media-be-a-federation-option).

## Summary

The wizard's "what do you want to share?" step and the Settings post-types chooser pulled every public post type via `get_post_types( ['public' => true] )`, so `attachment` showed up as a Media checkbox alongside Posts and Pages. The actual behavior of enabling it is louder than the label suggests: every image upload federates as its own ActivityPub object the moment it's uploaded, *including* images attached to unpublished drafts. That's not what the chooser implies and not what most users would expect.

This PR hides `attachment` from both FOSSE choosers, while preserving the upstream escape hatch.

## What changed

- New `Automattic\Fosse\Admin\Post_Type_Chooser` helper owns the FOSSE-managed post-type set (public types minus `attachment`) and provides a `reconcile_submission()` pattern for save handlers.
- `Onboarding_Wizard::render_step_content()` builds checkboxes from `Post_Type_Chooser::types()`.
- `Setup_Page::render()` does the same for Settings.
- Both save handlers (`Onboarding_Wizard::handle_save()` content step + `Setup_Page::save_general_settings()`) route through `Post_Type_Chooser::reconcile_submission()`. A crafted POST that includes `attachment` is rejected. An existing `attachment` value in the stored option is preserved.
- Wizard's `empty_post_types` redirect now checks the *managed* selection so a preserved-only `attachment` state still bounces the user back with the error (the wizard step is explicitly about picking content types to share).

## What didn't change

- `AP_Provider::get_status()` still reads the option as-is. The status display reflects actual federation state; if a user enabled `attachment` upstream, the status surface should honestly say so. Just the choosers don't *offer* it.
- The bundled ActivityPub plugin's own settings UI is untouched. Power users who deliberately want Media federation can still flip it there, consistent with the pattern in DOTCOM-16802 (sensible defaults in FOSSE, advanced knobs upstream).
- `templates/setup-page.php` is untouched. Filtering happens upstream in `class-setup-page.php` before `$all_post_types` is passed to the template, which sidesteps overlap with #122.

## Testing

- `vendor/bin/phpunit tests/php/Admin/` - all 417 tests pass (14 new).
- `composer run-script lint-php` - clean.
- New test coverage:
  - `Post_Type_ChooserTest` - 7 tests covering the chooser's managed set, reconcile semantics, attachment exclusion, preservation, and dedup.
  - `Setup_PageTest` - render omits attachment, save rejects attachment submissions, save preserves existing attachment value.
  - `Onboarding_WizardTest` - same three cases plus a regression for the `empty_post_types` redirect under preserved-only state.

## Discussion thread

[Linear DOTCOM-17047](https://linear.app/a8c/issue/DOTCOM-17047/wizardsettings-should-media-be-a-federation-option) captures the decision between options A (wizard only), B (wizard + Settings, this PR), and C (keep with explicit warning).