### PR TITLE
refactor: link Post_Type_Chooser names() to types() as single source

### DIFF
--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -370,7 +370,10 @@ class Onboarding_Wizard {
 			// the chooser-managed slice with []. Preserved upstream values
 			// (e.g. `attachment`) are not enough on their own — the wizard
 			// step is explicitly about picking content types to share.
-			$managed_selected = array_intersect( $post_types, Post_Type_Chooser::names() );
+			// Check the raw submission against the chooser's managed set
+			// directly rather than re-deriving from `$post_types`, which
+			// has already merged in preserved-non-managed values.
+			$managed_selected = array_intersect( $submitted, Post_Type_Chooser::names() );
 			if ( empty( $managed_selected ) ) {
 				self::redirect_to_step( 'content', array( 'error' => 'empty_post_types' ) );
 			}

--- a/src/Admin/class-post-type-chooser.php
+++ b/src/Admin/class-post-type-chooser.php
@@ -55,11 +55,14 @@ final class Post_Type_Chooser {
 	/**
 	 * Post-type names FOSSE offers in its chooser UIs.
 	 *
+	 * Derives from `types()` so the exclusion logic has a single source
+	 * of truth — adding a new EXCLUDED entry, or any future runtime
+	 * filtering inside `types()`, automatically propagates here.
+	 *
 	 * @return array<string>
 	 */
 	public static function names(): array {
-		$names = get_post_types( array( 'public' => true ) );
-		return array_values( array_diff( $names, self::EXCLUDED ) );
+		return array_values( array_keys( self::types() ) );
 	}
 
 	/**

--- a/tests/php/Admin/Post_Type_ChooserTest.php
+++ b/tests/php/Admin/Post_Type_ChooserTest.php
@@ -48,8 +48,11 @@ class Post_Type_ChooserTest extends BaseTestCase {
 	/**
 	 * Adding a runtime-registered public post type surfaces in BOTH
 	 * `types()` and `names()` without source-of-truth drift. Locks down
-	 * the invariant that the two methods stay in sync even when the
-	 * caller adds an exclusion or filter at runtime to `types()`.
+	 * the invariant that the two methods stay in sync against the only
+	 * runtime input `types()` reacts to today — `register_post_type()` —
+	 * so future internal changes to `types()` (additional EXCLUDED
+	 * entries, conditional filtering, etc.) propagate to `names()`
+	 * automatically.
 	 */
 	public function test_names_and_types_stay_in_sync_with_runtime_registration(): void {
 		register_post_type(

--- a/tests/php/Admin/Post_Type_ChooserTest.php
+++ b/tests/php/Admin/Post_Type_ChooserTest.php
@@ -46,6 +46,33 @@ class Post_Type_ChooserTest extends BaseTestCase {
 	}
 
 	/**
+	 * Adding a runtime-registered public post type surfaces in BOTH
+	 * `types()` and `names()` without source-of-truth drift. Locks down
+	 * the invariant that the two methods stay in sync even when the
+	 * caller adds an exclusion or filter at runtime to `types()`.
+	 */
+	public function test_names_and_types_stay_in_sync_with_runtime_registration(): void {
+		register_post_type(
+			'fosse_runtime_cpt',
+			array(
+				'public' => true,
+				'label'  => 'Runtime chooser type',
+			)
+		);
+
+		try {
+			$this->assertContains( 'fosse_runtime_cpt', Post_Type_Chooser::names() );
+			$this->assertArrayHasKey( 'fosse_runtime_cpt', Post_Type_Chooser::types() );
+			$this->assertSame(
+				array_values( array_keys( Post_Type_Chooser::types() ) ),
+				array_values( Post_Type_Chooser::names() )
+			);
+		} finally {
+			unregister_post_type( 'fosse_runtime_cpt' );
+		}
+	}
+
+	/**
 	 * The reconcile pattern intersects the submission with the managed
 	 * set so a submission missing valid types collapses cleanly to the
 	 * managed subset only.


### PR DESCRIPTION
Follow-up to PR 124 (DOTCOM-17047).

## Proposed changes

- `Post_Type_Chooser::names()` now derives from `types()` via `array_keys()` instead of independently calling `get_post_types( ['public' => true] )` and applying `array_diff( $names, self::EXCLUDED )`. Single source of truth for the excluded set.
- `Onboarding_Wizard::handle_content_submit()` checks `$submitted` directly against `Post_Type_Chooser::names()` for the empty-managed-selection guard, instead of re-deriving from `$post_types` (which has already merged in preserved-non-managed values).
- New test `test_names_and_types_stay_in_sync_with_runtime_registration` registers a runtime public post type and asserts both `names()` and `types()` pick it up, locking down the source-of-truth invariant.

## Why

Pre-merge review of PR 124 flagged two maintainability nits that the original PR's author preferred to address in a follow-up (per the user's direction). Both reduce drift risk in the chooser surface:

- If a future maintainer adds runtime filtering inside `types()` (e.g., a registered-but-suppressed-from-FOSSE post type), the prior `names()` implementation would silently disagree. Now they stay in sync by construction.
- The wizard's empty-managed-selection check no longer relies on the reader internalizing that `array_intersect( $post_types, names() )` is identical to `array_intersect( $submitted, names() )` after `reconcile_submission()` has merged in preserved non-managed values.

No behavior change for callers; refactor only.

## Testing

- `composer run-script lint-php` clean.
- `vendor/bin/phpunit --filter Post_Type_ChooserTest` — 8 tests, 12 assertions, all green (1 new test added).
- `vendor/bin/phpunit --filter Onboarding_WizardTest` — 94 tests, 335 assertions, all green.