### PR TITLE
add: drift-detection copy on Bluesky domain-handle panel

### DIFF
--- a/src/Admin/class-bluesky-domain-handle.php
+++ b/src/Admin/class-bluesky-domain-handle.php
@@ -273,6 +273,30 @@ class Bluesky_Domain_Handle {
 	}
 
 	/**
+	 * Whether the current state represents drift from a prior FOSSE-set handle.
+	 *
+	 * True when {@see self::should_offer()} is true AND a snapshot exists
+	 * for the connected DID. Catches both "user changed their site
+	 * domain after FOSSE set the handle" and "user changed their handle
+	 * on bsky.app after FOSSE set it" — the two are indistinguishable
+	 * from server state, and the caller renders neutral copy for both.
+	 *
+	 * Cheap drop-in for the wizard and Settings-page renders: when this
+	 * returns true, surface a contextual explanation instead of the
+	 * first-time-setup copy (the button does the same thing in both
+	 * cases — only the framing changes).
+	 *
+	 * @param array<string, mixed> $bluesky_status Bluesky provider status snapshot.
+	 * @return bool
+	 */
+	public static function is_drift( array $bluesky_status ): bool {
+		if ( ! self::should_offer( $bluesky_status ) ) {
+			return false;
+		}
+		return '' !== self::get_pending_revert_handle();
+	}
+
+	/**
 	 * Whether the confirm-handle UI should render for the given Bluesky status.
 	 *
 	 * Same gate for both the wizard step and the Settings page — both

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -364,7 +364,7 @@ class Bluesky_Provider implements Connection_Provider {
 			<h4>
 				<?php
 				if ( $is_drift ) {
-					esc_html_e( 'Re-align your Bluesky handle with this site', 'fosse' );
+					esc_html_e( 'Realign your Bluesky handle with this site', 'fosse' );
 				} else {
 					esc_html_e( 'Use your domain as your Bluesky handle', 'fosse' );
 				}
@@ -380,7 +380,7 @@ class Bluesky_Provider implements Connection_Provider {
 					echo esc_html(
 						sprintf(
 							/* translators: 1: current Bluesky handle (e.g. example.com); 2: target handle = site host (e.g. newdomain.com). */
-							__( 'FOSSE previously set your Bluesky handle, but it no longer matches this site. Your handle on Bluesky is %1$s; this site is %2$s. Re-set to align them.', 'fosse' ),
+							__( 'FOSSE previously set your Bluesky handle, but it no longer matches this site. Your handle on Bluesky is %1$s; this site is %2$s. Set it again to align them.', 'fosse' ),
 							$current,
 							$target
 						)

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -356,14 +356,36 @@ class Bluesky_Provider implements Connection_Provider {
 			return;
 		}
 
-		$current = isset( $status['handle'] ) ? (string) $status['handle'] : '';
-		$target  = Bluesky_Domain_Handle::get_target_handle();
+		$current  = isset( $status['handle'] ) ? (string) $status['handle'] : '';
+		$target   = Bluesky_Domain_Handle::get_target_handle();
+		$is_drift = Bluesky_Domain_Handle::is_drift( $status );
 		?>
 		<div class="fosse-domain-handle-panel">
-			<h4><?php esc_html_e( 'Use your domain as your Bluesky handle', 'fosse' ); ?></h4>
+			<h4>
+				<?php
+				if ( $is_drift ) {
+					esc_html_e( 'Re-align your Bluesky handle with this site', 'fosse' );
+				} else {
+					esc_html_e( 'Use your domain as your Bluesky handle', 'fosse' );
+				}
+				?>
+			</h4>
 			<p>
 				<?php
-				if ( '' !== $current ) {
+				if ( $is_drift ) {
+					// Either the site domain changed since FOSSE set the
+					// handle, or the user changed their handle on bsky.app
+					// directly. Server-side we can't tell which, so the copy
+					// stays neutral.
+					echo esc_html(
+						sprintf(
+							/* translators: 1: current Bluesky handle (e.g. example.com); 2: target handle = site host (e.g. newdomain.com). */
+							__( 'FOSSE previously set your Bluesky handle, but it no longer matches this site. Your handle on Bluesky is %1$s; this site is %2$s. Re-set to align them.', 'fosse' ),
+							$current,
+							$target
+						)
+					);
+				} elseif ( '' !== $current ) {
 					echo esc_html(
 						sprintf(
 							/* translators: 1: current Bluesky handle (e.g. alice.bsky.social); 2: target handle = site host (e.g. example.com). */

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -1470,19 +1470,43 @@ class Onboarding_Wizard {
 				// subdirectory, or when the feature is disabled.
 				if ( Bluesky_Domain_Handle::should_offer( $status ) ) :
 					$target_host = Bluesky_Domain_Handle::get_target_handle();
+					$is_drift    = Bluesky_Domain_Handle::is_drift( $status );
 					?>
 					<div class="fosse-wizard__domain-handle">
-						<h3><?php esc_html_e( 'Use your domain as your Bluesky handle', 'fosse' ); ?></h3>
+						<h3>
+							<?php
+							if ( $is_drift ) {
+								esc_html_e( 'Re-align your Bluesky handle with this site', 'fosse' );
+							} else {
+								esc_html_e( 'Use your domain as your Bluesky handle', 'fosse' );
+							}
+							?>
+						</h3>
 						<p>
 							<?php
-							echo esc_html(
-								sprintf(
-									/* translators: 1: current Bluesky handle (e.g. alice.bsky.social); 2: target handle = site host (e.g. example.com). */
-									__( 'Your handle is currently %1$s. Replace it with %2$s so people can find you on Bluesky by your site\'s domain.', 'fosse' ),
-									(string) $status['handle'],
-									$target_host
-								)
-							);
+							if ( $is_drift ) {
+								// Either the site domain changed since FOSSE
+								// set the handle, or the user changed it on
+								// bsky.app directly. Server-side we can't
+								// tell which, so the copy stays neutral.
+								echo esc_html(
+									sprintf(
+										/* translators: 1: current Bluesky handle (e.g. example.com); 2: target handle = site host (e.g. newdomain.com). */
+										__( 'FOSSE previously set your Bluesky handle, but it no longer matches this site. Your handle on Bluesky is %1$s; this site is %2$s. Re-set to align them.', 'fosse' ),
+										(string) $status['handle'],
+										$target_host
+									)
+								);
+							} else {
+								echo esc_html(
+									sprintf(
+										/* translators: 1: current Bluesky handle (e.g. alice.bsky.social); 2: target handle = site host (e.g. example.com). */
+										__( 'Your handle is currently %1$s. Replace it with %2$s so people can find you on Bluesky by your site\'s domain.', 'fosse' ),
+										(string) $status['handle'],
+										$target_host
+									)
+								);
+							}
 							?>
 						</p>
 						<?php Bluesky_Domain_Handle::render_destructive_warning_notice(); ?>

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -1476,7 +1476,7 @@ class Onboarding_Wizard {
 						<h3>
 							<?php
 							if ( $is_drift ) {
-								esc_html_e( 'Re-align your Bluesky handle with this site', 'fosse' );
+								esc_html_e( 'Realign your Bluesky handle with this site', 'fosse' );
 							} else {
 								esc_html_e( 'Use your domain as your Bluesky handle', 'fosse' );
 							}
@@ -1492,7 +1492,7 @@ class Onboarding_Wizard {
 								echo esc_html(
 									sprintf(
 										/* translators: 1: current Bluesky handle (e.g. example.com); 2: target handle = site host (e.g. newdomain.com). */
-										__( 'FOSSE previously set your Bluesky handle, but it no longer matches this site. Your handle on Bluesky is %1$s; this site is %2$s. Re-set to align them.', 'fosse' ),
+										__( 'FOSSE previously set your Bluesky handle, but it no longer matches this site. Your handle on Bluesky is %1$s; this site is %2$s. Set it again to align them.', 'fosse' ),
 										(string) $status['handle'],
 										$target_host
 									)

--- a/tests/php/Admin/Bluesky_Domain_HandleTest.php
+++ b/tests/php/Admin/Bluesky_Domain_HandleTest.php
@@ -360,6 +360,89 @@ class Bluesky_Domain_HandleTest extends BaseTestCase {
 		);
 	}
 
+	// ---- is_drift ----
+
+	/**
+	 * A first-time connected user with no snapshot is NOT in drift —
+	 * the offer is a fresh setup, not a re-alignment.
+	 */
+	public function test_is_drift_false_when_no_snapshot(): void {
+		$this->force_home_url( 'https://example.com' );
+
+		$this->assertFalse(
+			Bluesky_Domain_Handle::is_drift(
+				array(
+					'connected' => true,
+					'handle'    => 'alice.bsky.social',
+				)
+			)
+		);
+	}
+
+	/**
+	 * A snapshot bound to the connected DID plus a current handle that
+	 * doesn't match the target IS drift — FOSSE set the handle before
+	 * and the two have since gone out of sync (either the site domain
+	 * changed or the user changed the handle on bsky.app directly).
+	 */
+	public function test_is_drift_true_when_snapshot_exists_for_current_did(): void {
+		$this->force_home_url( 'https://newdomain.example' );
+		$this->seed_connection( 'oldhandle.example', 'did:plc:test123' );
+		$this->seed_snapshot( 'did:plc:test123', 'alice.bsky.social' );
+
+		$this->assertTrue(
+			Bluesky_Domain_Handle::is_drift(
+				array(
+					'connected' => true,
+					'handle'    => 'oldhandle.example',
+				)
+			)
+		);
+	}
+
+	/**
+	 * `is_drift()` defers to `should_offer()` — when the offer wouldn't
+	 * surface at all (e.g. handle already matches), drift is irrelevant
+	 * and the answer is false even with a snapshot present.
+	 */
+	public function test_is_drift_false_when_offer_would_not_surface(): void {
+		$this->force_home_url( 'https://example.com' );
+		$this->seed_connection( 'example.com', 'did:plc:test123' );
+		$this->seed_snapshot( 'did:plc:test123', 'alice.bsky.social' );
+
+		// handle === target, so should_offer is false → is_drift cascades to false.
+		$this->assertFalse(
+			Bluesky_Domain_Handle::is_drift(
+				array(
+					'connected' => true,
+					'handle'    => 'example.com',
+				)
+			)
+		);
+	}
+
+	/**
+	 * A snapshot bound to a DIFFERENT DID than the currently-connected
+	 * account doesn't count as drift — the snapshot belongs to a prior
+	 * account FOSSE managed, not this one. Same guard `should_offer` +
+	 * the auto-revert path use to avoid touching identities FOSSE did
+	 * not previously set.
+	 */
+	public function test_is_drift_false_when_snapshot_bound_to_different_did(): void {
+		$this->force_home_url( 'https://newdomain.example' );
+		$this->seed_connection( 'oldhandle.example', 'did:plc:current' );
+		$this->seed_snapshot( 'did:plc:other', 'alice.bsky.social' );
+
+		$this->assertFalse(
+			Bluesky_Domain_Handle::is_drift(
+				array(
+					'connected' => true,
+					'handle'    => 'oldhandle.example',
+				)
+			)
+		);
+	}
+
 	// ---- set_handle ----
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -377,7 +377,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_connection_actions();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'Re-align your Bluesky handle with this site', $output );
+		$this->assertStringContainsString( 'Realign your Bluesky handle with this site', $output );
 		$this->assertStringContainsString( 'FOSSE previously set your Bluesky handle', $output );
 		// First-time-setup copy must not also surface.
 		$this->assertStringNotContainsString( 'You can replace it with', $output );

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -349,6 +349,43 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * When a snapshot exists for the connected DID and the current
+	 * handle no longer matches the site host, the Settings panel
+	 * surfaces drift-specific copy instead of the first-time setup
+	 * copy. Same CTA button — only the framing changes.
+	 */
+	public function test_render_connection_actions_renders_drift_copy_when_snapshot_exists() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'oldhandle.example',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+		update_option(
+			Bluesky_Domain_Handle::OPTION_PREVIOUS_HANDLE,
+			array(
+				'did'    => 'did:plc:test123',
+				'handle' => 'alice.bsky.social',
+			),
+			false
+		);
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Re-align your Bluesky handle with this site', $output );
+		$this->assertStringContainsString( 'FOSSE previously set your Bluesky handle', $output );
+		// First-time-setup copy must not also surface.
+		$this->assertStringNotContainsString( 'You can replace it with', $output );
+		// CTA button itself is unchanged.
+		$this->assertStringContainsString( 'fosse_set_bluesky_domain_handle', $output );
+	}
+
+	/**
 	 * Disconnected connection panel links out to bsky.app so users without
 	 * an account aren't dead-ended at the connect form.
 	 */

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1236,6 +1236,34 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
+	 * When FOSSE has previously set the handle and it no longer matches
+	 * the site (domain change, or user changed it on bsky.app), the
+	 * wizard panel surfaces the drift-specific copy instead of the
+	 * first-time-setup copy. Same CTA button — only the framing changes.
+	 */
+	public function test_render_bluesky_step_renders_drift_copy_when_snapshot_exists(): void {
+		$this->seed_bluesky_connection( 'oldhandle.example', 'did:plc:alice123' );
+		update_option(
+			\Automattic\Fosse\Admin\Bluesky_Domain_Handle::OPTION_PREVIOUS_HANDLE,
+			array(
+				'did'    => 'did:plc:alice123',
+				'handle' => 'alice.bsky.social',
+			),
+			false
+		);
+
+		$output = $this->render_wizard_step( 'bluesky' );
+
+		// Drift heading + drift copy present; first-time copy absent.
+		$this->assertStringContainsString( 'Re-align your Bluesky handle with this site', $output );
+		$this->assertStringContainsString( 'FOSSE previously set your Bluesky handle', $output );
+		$this->assertStringNotContainsString( 'Replace it with', $output );
+
+		// CTA button itself is unchanged.
+		$this->assertStringContainsString( 'fosse_set_bluesky_domain_handle', $output );
+	}
+
+	/**
 	 * The pre-OAuth connect form must NOT carry a domain-handle checkbox.
 	 *
 	 * The earlier design used a checkbox to opt into setting the handle

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1255,7 +1255,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'bluesky' );
 
 		// Drift heading + drift copy present; first-time copy absent.
-		$this->assertStringContainsString( 'Re-align your Bluesky handle with this site', $output );
+		$this->assertStringContainsString( 'Realign your Bluesky handle with this site', $output );
 		$this->assertStringContainsString( 'FOSSE previously set your Bluesky handle', $output );
 		$this->assertStringNotContainsString( 'Replace it with', $output );
 


### PR DESCRIPTION
Related to DOTCOM-17010.

## Proposed changes

Detect when FOSSE has previously set a user's Bluesky handle but the handle on Bluesky no longer matches the site (because the user changed their site domain, or because they changed the handle on bsky.app directly). On drift, the existing "Use your domain as your Bluesky handle" panel surfaces an explanation instead of first-time-setup copy.

- `Bluesky_Domain_Handle::is_drift( array $bluesky_status ): bool` — true when `should_offer()` is true AND a snapshot exists for the connected DID.
- Settings page (`class-bluesky-provider.php`) and onboarding wizard (`class-onboarding-wizard.php`) panel renders branch on `is_drift()` to pick the right heading + intro paragraph. CTA button is unchanged.

## Why

Closes the design questions in DOTCOM-17010. Per the Linear issue body, most lifecycle behavior was already implemented as part of DOTCOM-17009 (set-handle, auto-revert on disconnect, DID-bound snapshot, recovery path). The one real gap was that a user who used FOSSE to set their Bluesky handle and then changed their site domain (or undid the handle change on bsky.app) would see the original first-time-setup CTA copy on subsequent renders, with no acknowledgment that FOSSE had been here before.

The drift signal can't distinguish "site domain changed" from "user manually changed handle on bsky.app" — those are server-state-equivalent. The copy stays neutral so it reads correctly in both cases.

## Out of scope (per the Linear issue's resolved decisions)

- Standalone "revert handle but stay connected" UI. Users can change their handle directly on bsky.app.
- Multi-step snapshot stack. Current "one-step-back" `OPTION_PREVIOUS_HANDLE` semantics retained.
- Admin-wide `admin_notices`. Settings + wizard only.
- Background drift check. Page-load detection is enough.

## Testing

- `composer run-script lint-php` clean.
- `vendor/bin/phpunit --filter "Bluesky_Domain_HandleTest|Bluesky_ProviderTest|Onboarding_WizardTest"` — 249 tests / 677 assertions, all green. New coverage:
  - `Bluesky_Domain_HandleTest`: `is_drift()` truth table — no snapshot → false; snapshot bound to current DID + non-matching handle → true; `should_offer()` false → false (cascades); snapshot bound to a different DID → false.
  - `Bluesky_ProviderTest`: settings panel renders the drift heading + drift copy and suppresses the first-time copy.
  - `Onboarding_WizardTest`: wizard step renders the drift heading + drift copy and suppresses the first-time copy.