### PR TITLE
add: native short-form for Bluesky posts that fit one record

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -169,6 +169,27 @@ add_action(
 );
 
 /*
+ * Length-based Bluesky short-form bridge.
+ *
+ * When a long-form post's rendered body fits inside a single Bluesky
+ * record (300 chars), force `atmosphere_is_short_form_post` to true so
+ * Atmosphere publishes the body natively (no title prefix, no permalink,
+ * no link-card embed) instead of attaching a card to a post whose URL is
+ * already in the visible text. Opt back into the long-form path via the
+ * `fosse_bsky_link_card_when_post_fits` filter. See `DOTCOM-17097`.
+ * Same registration posture as the `Object_Type` bridge above.
+ */
+add_action(
+	'init',
+	static function () {
+		if ( ! class_exists( \Automattic\Fosse\Bsky_Short_Form_Fit::class ) ) {
+			return;
+		}
+		\Automattic\Fosse\Bsky_Short_Form_Fit::register();
+	}
+);
+
+/*
  * Cross-network post-type projector.
  *
  * Feeds ActivityPub's stored `activitypub_support_post_types` option into

--- a/src/class-bsky-short-form-fit.php
+++ b/src/class-bsky-short-form-fit.php
@@ -13,19 +13,26 @@ namespace Automattic\Fosse;
  *
  * Atmosphere's built-in `is_short_form()` discriminator keys off post
  * shape (no title support, empty title, or any non-empty `post_format`),
- * not length. A standard post with a title and no format therefore always
+ * not length. A titleless standard post with no format therefore always
  * takes the long-form path, which by default builds an
- * `app.bsky.embed.external` link card — even when the title, excerpt, and
- * permalink already fit comfortably inside 300 chars. The result on
- * microblog-length posts is a redundant link-card preview attached to a
- * post whose URL is already in the visible text.
+ * `app.bsky.embed.external` link card — even when the body already fits
+ * comfortably inside 300 chars. The result on microblog-length posts is
+ * a redundant link-card preview attached to a post whose URL is already
+ * in the visible text.
  *
  * This bridge adds a length-based discriminator on top of upstream's
- * shape-based one. When the rendered post content fits in 300 chars, we
- * force `atmosphere_is_short_form_post` to true so Atmosphere takes its
- * existing short-form path: the post body becomes the Bluesky text (no
- * title prefix, no permalink, no card). Sibling to `Object_Type`, which
- * uses the same filter to project ActivityPub's "note" object type.
+ * shape-based one. When the rendered post content fits in 300 chars
+ * AND the post has no title, we force `atmosphere_is_short_form_post`
+ * to true so Atmosphere takes its existing short-form path: the post
+ * body becomes the Bluesky text (no title prefix, no permalink, no
+ * card). Sibling to `Object_Type`, which uses the same filter to
+ * project ActivityPub's "note" object type.
+ *
+ * Title-bearing posts are intentionally excluded: a non-empty title is
+ * Atmosphere's own long-form signal (`build_text()` composes title +
+ * excerpt + permalink + link-card embed for them), and dropping the
+ * card on a titled-short post would silently strip the title from the
+ * Bluesky surface even though the author meant to publish it.
  *
  * Opt-out hook: `fosse_bsky_link_card_when_post_fits` (default `false`).
  * Returning `true` from the filter keeps today's long-form-with-card
@@ -45,6 +52,22 @@ class Bsky_Short_Form_Fit {
 	 * @var int
 	 */
 	public const BSKY_RECORD_LIMIT = 300;
+
+	/**
+	 * Per-request memo of `filter_atmosphere()` results.
+	 *
+	 * The `atmosphere_is_short_form_post` filter fires multiple times per
+	 * publish — at minimum once inside Atmosphere's transformer, again
+	 * inside the publisher's strategy selection, and a third time when
+	 * FOSSE's metrics subscriber resolves `strategy` for the
+	 * `fosse_publish_result` event. Each call would otherwise re-run
+	 * `apply_filters( 'the_content', ... )`, which expands shortcodes /
+	 * oEmbeds and can be expensive on rich posts. Cache the decision per
+	 * post id so the work happens once.
+	 *
+	 * @var array<int, bool>
+	 */
+	private static array $decision_cache = array();
 
 	/**
 	 * Register the Atmosphere short-form bridge filter. Safe to call more
@@ -67,6 +90,11 @@ class Bsky_Short_Form_Fit {
 	 *     trampling another callback in the chain.
 	 *   - `$post` isn't a `WP_Post` — defensive guard for filter contract
 	 *     drift; upstream always passes a post in normal contexts.
+	 *   - `$post->post_title` is non-empty — Atmosphere treats title-
+	 *     presence as a long-form signal, and the long-form composition
+	 *     surfaces the title inside the link card. Flipping a titled
+	 *     post to short-form silently drops the title, which the author
+	 *     clearly intended to publish.
 	 *   - Body renders to empty text — forcing short-form would publish a
 	 *     zero-length Bluesky post. Defer to upstream long-form, which at
 	 *     least carries the title + permalink.
@@ -77,18 +105,18 @@ class Bsky_Short_Form_Fit {
 	 *     (or a per-post hook) explicitly wants the long-form behavior
 	 *     preserved.
 	 *
-	 * The "rendered" length uses the same pipeline Atmosphere's
-	 * `render_post_content_plain()` uses (`the_content` filter chain plus
-	 * tag stripping). That means shortcodes and oEmbeds are expanded
-	 * before measurement, so a post whose raw `post_content` is short but
-	 * whose expansion is long doesn't get misclassified. The cost is
-	 * running `the_content` once per evaluation; Atmosphere already runs
-	 * it during composition, so the overhead is one extra pass per
-	 * publish for posts that take this code path.
+	 * The "rendered" length is measured through the same normalization
+	 * pipeline Atmosphere applies before publishing (`the_content` filter
+	 * chain, then `\Atmosphere\sanitize_text` — strip tags + decode HTML
+	 * entities + collapse Unicode whitespace + trim). Without this
+	 * alignment, posts that hover near the 300-char boundary can be
+	 * misclassified: a body containing `&amp;` counts as 5 chars to a
+	 * naive measurement and 1 to the sanitized form Atmosphere will
+	 * eventually compare against. Falls back to `wp_strip_all_tags`
+	 * + `trim` when Atmosphere isn't loaded (defense in depth).
 	 *
-	 * `$post`'s type is loosened from `WP_Post` to `mixed` for the same
-	 * reason as in `Object_Type::filter_atmosphere()` — defense in depth
-	 * if the upstream filter contract ever ships an unexpected value.
+	 * Memoized per request via `$decision_cache` — see that property's
+	 * docblock for why it matters.
 	 *
 	 * @param bool  $is_short Upstream-computed short-form default.
 	 * @param mixed $post     The post being transformed.
@@ -103,10 +131,26 @@ class Bsky_Short_Form_Fit {
 			return $is_short;
 		}
 
-		$plain  = \wp_strip_all_tags( \apply_filters( 'the_content', $post->post_content ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
-		$length = \mb_strlen( \trim( $plain ) );
+		// Title-presence is Atmosphere's long-form signal — the long-form
+		// path composes the title into the link card. Flipping a titled
+		// post to short-form would silently drop the title from Bluesky.
+		if ( '' !== \trim( (string) $post->post_title ) ) {
+			return $is_short;
+		}
+
+		if ( isset( self::$decision_cache[ $post->ID ] ) ) {
+			return self::$decision_cache[ $post->ID ];
+		}
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
+		$rendered = (string) \apply_filters( 'the_content', $post->post_content );
+		$plain    = \function_exists( '\Atmosphere\sanitize_text' )
+			? \Atmosphere\sanitize_text( $rendered )
+			: \trim( \wp_strip_all_tags( $rendered ) );
+		$length   = \mb_strlen( $plain );
 
 		if ( 0 === $length || $length > self::BSKY_RECORD_LIMIT ) {
+			self::$decision_cache[ $post->ID ] = $is_short;
 			return $is_short;
 		}
 
@@ -129,9 +173,25 @@ class Bsky_Short_Form_Fit {
 		 * @param \WP_Post $post      The post being evaluated.
 		 */
 		if ( \apply_filters( 'fosse_bsky_link_card_when_post_fits', false, $post ) ) {
+			self::$decision_cache[ $post->ID ] = $is_short;
 			return $is_short;
 		}
 
+		self::$decision_cache[ $post->ID ] = true;
 		return true;
+	}
+
+	/**
+	 * Clear the per-request decision cache.
+	 *
+	 * Test-only entry point — production never needs to invalidate
+	 * mid-request because the cache key is the post id, and the
+	 * `post_content` / `post_title` of an in-flight post is stable
+	 * inside a single PHP process. Public so test setUp can call it.
+	 *
+	 * @return void
+	 */
+	public static function reset_cache_for_testing(): void {
+		self::$decision_cache = array();
 	}
 }

--- a/src/class-bsky-short-form-fit.php
+++ b/src/class-bsky-short-form-fit.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Length-based short-form discriminator for Bluesky.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse;
+
+/**
+ * Flips long-form posts onto Atmosphere's short-form path when the
+ * rendered post body already fits inside a single Bluesky record.
+ *
+ * Atmosphere's built-in `is_short_form()` discriminator keys off post
+ * shape (no title support, empty title, or any non-empty `post_format`),
+ * not length. A standard post with a title and no format therefore always
+ * takes the long-form path, which by default builds an
+ * `app.bsky.embed.external` link card — even when the title, excerpt, and
+ * permalink already fit comfortably inside 300 chars. The result on
+ * microblog-length posts is a redundant link-card preview attached to a
+ * post whose URL is already in the visible text.
+ *
+ * This bridge adds a length-based discriminator on top of upstream's
+ * shape-based one. When the rendered post content fits in 300 chars, we
+ * force `atmosphere_is_short_form_post` to true so Atmosphere takes its
+ * existing short-form path: the post body becomes the Bluesky text (no
+ * title prefix, no permalink, no card). Sibling to `Object_Type`, which
+ * uses the same filter to project ActivityPub's "note" object type.
+ *
+ * Opt-out hook: `fosse_bsky_link_card_when_post_fits` (default `false`).
+ * Returning `true` from the filter keeps today's long-form-with-card
+ * behavior for the post being evaluated.
+ */
+class Bsky_Short_Form_Fit {
+
+	/**
+	 * Maximum character count for a single Bluesky post record.
+	 *
+	 * Mirrors Atmosphere's `truncate_text()` default and the 300 char
+	 * cap enforced by `build_short_form_text()` /
+	 * `build_text()` in `transformer/class-post.php`. Lives here as a
+	 * constant so the boundary the bridge checks against is the same
+	 * one Atmosphere will measure later in the same publish pass.
+	 *
+	 * @var int
+	 */
+	public const BSKY_RECORD_LIMIT = 300;
+
+	/**
+	 * Register the Atmosphere short-form bridge filter. Safe to call more
+	 * than once per request — WordPress dedupes identical
+	 * callable-as-array registrations.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		\add_filter( 'atmosphere_is_short_form_post', array( self::class, 'filter_atmosphere' ), 10, 2 );
+	}
+
+	/**
+	 * Force short-form when the rendered body fits inside one Bluesky record.
+	 *
+	 * Pass-through cases (keep upstream's decision):
+	 *   - `$is_short` is already `true` — Atmosphere or a sibling bridge
+	 *     (e.g. `Object_Type`) already decided this post is short-form.
+	 *     Returning anything other than `$is_short` here would risk
+	 *     trampling another callback in the chain.
+	 *   - `$post` isn't a `WP_Post` — defensive guard for filter contract
+	 *     drift; upstream always passes a post in normal contexts.
+	 *   - Body renders to empty text — forcing short-form would publish a
+	 *     zero-length Bluesky post. Defer to upstream long-form, which at
+	 *     least carries the title + permalink.
+	 *   - Body length exceeds `BSKY_RECORD_LIMIT` — doesn't fit, so the
+	 *     short-form fallback wouldn't avoid truncation; the long-form
+	 *     teaser strategies exist precisely for this case.
+	 *   - `fosse_bsky_link_card_when_post_fits` returns truthy — the site
+	 *     (or a per-post hook) explicitly wants the long-form behavior
+	 *     preserved.
+	 *
+	 * The "rendered" length uses the same pipeline Atmosphere's
+	 * `render_post_content_plain()` uses (`the_content` filter chain plus
+	 * tag stripping). That means shortcodes and oEmbeds are expanded
+	 * before measurement, so a post whose raw `post_content` is short but
+	 * whose expansion is long doesn't get misclassified. The cost is
+	 * running `the_content` once per evaluation; Atmosphere already runs
+	 * it during composition, so the overhead is one extra pass per
+	 * publish for posts that take this code path.
+	 *
+	 * `$post`'s type is loosened from `WP_Post` to `mixed` for the same
+	 * reason as in `Object_Type::filter_atmosphere()` — defense in depth
+	 * if the upstream filter contract ever ships an unexpected value.
+	 *
+	 * @param bool  $is_short Upstream-computed short-form default.
+	 * @param mixed $post     The post being transformed.
+	 * @return bool True when we force short-form, otherwise pass-through.
+	 */
+	public static function filter_atmosphere( bool $is_short, $post ): bool {
+		if ( $is_short ) {
+			return $is_short;
+		}
+
+		if ( ! $post instanceof \WP_Post ) {
+			return $is_short;
+		}
+
+		$plain  = \wp_strip_all_tags( \apply_filters( 'the_content', $post->post_content ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
+		$length = \mb_strlen( \trim( $plain ) );
+
+		if ( 0 === $length || $length > self::BSKY_RECORD_LIMIT ) {
+			return $is_short;
+		}
+
+		/**
+		 * Filters whether to keep Atmosphere's long-form-with-link-card
+		 * behavior for a post whose body already fits inside a single
+		 * Bluesky record.
+		 *
+		 * Default `false` — FOSSE drops the card and publishes the body
+		 * as a native short-form Bluesky post. Return `true` to opt back
+		 * into today's long-form path (title + excerpt + permalink +
+		 * link-card embed) for the given post.
+		 *
+		 * Fires only after the length and content guards above pass, so
+		 * callbacks can assume the post has non-empty, fits-in-300 body
+		 * text. Callbacks receive the `WP_Post` so they can branch per
+		 * post type, author, taxonomy, meta, etc.
+		 *
+		 * @param bool     $keep_card Whether to keep the link card. Default false.
+		 * @param \WP_Post $post      The post being evaluated.
+		 */
+		if ( \apply_filters( 'fosse_bsky_link_card_when_post_fits', false, $post ) ) {
+			return $is_short;
+		}
+
+		return true;
+	}
+}

--- a/tests/php/Bsky_Short_Form_FitTest.php
+++ b/tests/php/Bsky_Short_Form_FitTest.php
@@ -8,6 +8,7 @@
 namespace Automattic\Fosse\Tests;
 
 use Automattic\Fosse\Bsky_Short_Form_Fit;
+use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 use WorDBless\BaseTestCase;
 use WP_Post;
@@ -25,17 +26,63 @@ class Bsky_Short_Form_FitTest extends BaseTestCase {
 	 *
 	 * @before
 	 */
+	/**
+	 * Callbacks this test file added to `the_content`, paired with the
+	 * priority they were registered at. Tracked so the after-hook can
+	 * remove each one precisely.
+	 *
+	 * `remove_all_filters( 'the_content' )` is unsafe here because it
+	 * also wipes WordPress core's default chain (wpautop, do_shortcode,
+	 * etc.) for the remainder of the process, which leaks into sibling
+	 * test classes that rely on the default chain.
+	 *
+	 * @var array<int, array{0:callable, 1:int}>
+	 */
+	private array $added_the_content_filters = array();
+
+	/**
+	 * Clean hook state before each test and register the bridge.
+	 *
+	 * @before
+	 */
 	#[Before]
 	public function reset_state(): void {
 		remove_all_filters( 'atmosphere_is_short_form_post' );
 		remove_all_filters( 'fosse_bsky_link_card_when_post_fits' );
-		remove_all_filters( 'the_content' );
 
 		// Memoization cache is per-process; reset it so each test starts
 		// fresh and doesn't see a cached decision from a sibling case.
 		Bsky_Short_Form_Fit::reset_cache_for_testing();
 
 		Bsky_Short_Form_Fit::register();
+	}
+
+	/**
+	 * Remove every `the_content` filter this test file added, by exact
+	 * callback identity + priority. Leaves WordPress core's default
+	 * chain intact.
+	 *
+	 * @after
+	 */
+	#[After]
+	public function remove_added_the_content_filters(): void {
+		foreach ( $this->added_the_content_filters as [ $cb, $priority ] ) {
+			remove_filter( 'the_content', $cb, $priority );
+		}
+		$this->added_the_content_filters = array();
+	}
+
+	/**
+	 * Register a `the_content` callback and stash it so the after-hook
+	 * can remove only what this test file added.
+	 *
+	 * @param callable $cb       Filter callback.
+	 * @param int      $priority Filter priority. Default 10.
+	 * @return void
+	 */
+	private function add_the_content_filter( callable $cb, int $priority = 10 ): void {
+		add_filter( 'the_content', $cb, $priority );
+		$this->added_the_content_filters[] = array( $cb, $priority );
 	}
 
 	/**
@@ -155,8 +202,7 @@ class Bsky_Short_Form_FitTest extends BaseTestCase {
 	 * Atmosphere then truncates.
 	 */
 	public function test_uses_the_content_filter_for_length(): void {
-		add_filter(
-			'the_content',
+		$this->add_the_content_filter(
 			static function ( $content ) {
 				return str_replace( '[expand]', str_repeat( 'y', 400 ), $content );
 			}
@@ -262,8 +308,7 @@ class Bsky_Short_Form_FitTest extends BaseTestCase {
 	 */
 	public function test_memoizes_per_post_id(): void {
 		$count = 0;
-		add_filter(
-			'the_content',
+		$this->add_the_content_filter(
 			static function ( $content ) use ( &$count ) {
 				++$count;
 				return $content;

--- a/tests/php/Bsky_Short_Form_FitTest.php
+++ b/tests/php/Bsky_Short_Form_FitTest.php
@@ -22,11 +22,6 @@ use WP_Post;
 class Bsky_Short_Form_FitTest extends BaseTestCase {
 
 	/**
-	 * Clean hook state before each test and register the bridge.
-	 *
-	 * @before
-	 */
-	/**
 	 * Callbacks this test file added to `the_content`, paired with the
 	 * priority they were registered at. Tracked so the after-hook can
 	 * remove each one precisely.

--- a/tests/php/Bsky_Short_Form_FitTest.php
+++ b/tests/php/Bsky_Short_Form_FitTest.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Tests for the length-based Bluesky short-form bridge.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests;
+
+use Automattic\Fosse\Bsky_Short_Form_Fit;
+use PHPUnit\Framework\Attributes\Before;
+use WorDBless\BaseTestCase;
+use WP_Post;
+
+/**
+ * Verifies the bridge promotes a long-form post to Atmosphere short-form
+ * when the rendered body fits in a single Bluesky record (300 chars),
+ * and that the `fosse_bsky_link_card_when_post_fits` filter is honored
+ * as the per-post / per-site opt-out.
+ */
+class Bsky_Short_Form_FitTest extends BaseTestCase {
+
+	/**
+	 * Clean hook state before each test and register the bridge.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function reset_state(): void {
+		remove_all_filters( 'atmosphere_is_short_form_post' );
+		remove_all_filters( 'fosse_bsky_link_card_when_post_fits' );
+		remove_all_filters( 'the_content' );
+
+		Bsky_Short_Form_Fit::register();
+	}
+
+	/**
+	 * Build a stub WP_Post with the given content. `wp_insert_post` would
+	 * also work but the bridge only touches `post_content` and the
+	 * filter's `WP_Post` type guard — a plain stub keeps tests fast and
+	 * isolates the unit under test from WP's post storage machinery.
+	 *
+	 * @param string $content Raw post content.
+	 * @return WP_Post
+	 */
+	private function make_post( string $content ): WP_Post {
+		return new WP_Post(
+			(object) array(
+				'ID'           => 1,
+				'post_content' => $content,
+			)
+		);
+	}
+
+	/**
+	 * When upstream already decided the post is short-form (post_format
+	 * set, empty title, etc.), the bridge must not re-evaluate — another
+	 * callback in the chain may have set $is_short=true for reasons that
+	 * length doesn't capture. Returning anything other than the input
+	 * here would risk silently flipping the decision back to long-form
+	 * for posts longer than 300 chars.
+	 */
+	public function test_passes_through_when_already_short_form(): void {
+		$this->assertTrue(
+			apply_filters( 'atmosphere_is_short_form_post', true, $this->make_post( str_repeat( 'a', 5000 ) ) ),
+			'A true input must stay true even when the body is way over the Bluesky limit.'
+		);
+	}
+
+	/**
+	 * Defensive guard: if the upstream filter contract ever drifts and
+	 * passes a non-`WP_Post`, the bridge must not crash on
+	 * `$post->post_content`. It should return the input unchanged.
+	 */
+	public function test_passes_through_on_non_wp_post(): void {
+		$this->assertFalse(
+			apply_filters( 'atmosphere_is_short_form_post', false, null )
+		);
+		$this->assertFalse(
+			apply_filters( 'atmosphere_is_short_form_post', false, 42 )
+		);
+		$this->assertFalse(
+			apply_filters( 'atmosphere_is_short_form_post', false, 'not-a-post' )
+		);
+	}
+
+	/**
+	 * Empty post bodies aren't candidates for short-form: forcing
+	 * Atmosphere onto the short-form path would publish a zero-length
+	 * Bluesky post. The long-form path at least carries title + permalink.
+	 */
+	public function test_passes_through_on_empty_body(): void {
+		$this->assertFalse(
+			apply_filters( 'atmosphere_is_short_form_post', false, $this->make_post( '' ) )
+		);
+		$this->assertFalse(
+			apply_filters( 'atmosphere_is_short_form_post', false, $this->make_post( "   \n   \t  " ) ),
+			'Whitespace-only content must count as empty after trim().'
+		);
+	}
+
+	/**
+	 * Core case: a microblog-length post body (well under 300 chars)
+	 * flips the filter to true so Atmosphere takes the short-form path.
+	 */
+	public function test_forces_short_form_when_body_fits(): void {
+		$this->assertTrue(
+			apply_filters( 'atmosphere_is_short_form_post', false, $this->make_post( 'Hello, Bluesky.' ) )
+		);
+	}
+
+	/**
+	 * Boundary: a body that is *exactly* 300 chars should still force
+	 * short-form, because Atmosphere's `build_short_form_text()` will
+	 * publish it verbatim without truncation. The bridge's check uses
+	 * `<=` precisely so the boundary post is the microblog case, not the
+	 * teaser-needs-truncation case.
+	 */
+	public function test_forces_short_form_at_exactly_300_chars(): void {
+		$body = str_repeat( 'x', 300 );
+		$this->assertSame( 300, mb_strlen( $body ) );
+
+		$this->assertTrue(
+			apply_filters( 'atmosphere_is_short_form_post', false, $this->make_post( $body ) )
+		);
+	}
+
+	/**
+	 * Boundary: 301 chars exceeds the limit, so the bridge must defer
+	 * to upstream's long-form decision (the teaser-thread/truncate-link
+	 * strategies exist precisely for the doesn't-fit case).
+	 */
+	public function test_passes_through_at_301_chars(): void {
+		$body = str_repeat( 'x', 301 );
+
+		$this->assertFalse(
+			apply_filters( 'atmosphere_is_short_form_post', false, $this->make_post( $body ) )
+		);
+	}
+
+	/**
+	 * The length measurement uses the post-`the_content` rendered text,
+	 * not the raw `post_content`. A raw body that's short but expands to
+	 * something long (e.g. via a shortcode) must not be misclassified as
+	 * microblog-length — Atmosphere will compose against the expanded
+	 * version too, and we'd otherwise force short-form onto a body that
+	 * Atmosphere then truncates.
+	 */
+	public function test_uses_the_content_filter_for_length(): void {
+		add_filter(
+			'the_content',
+			static function ( $content ) {
+				return str_replace( '[expand]', str_repeat( 'y', 400 ), $content );
+			}
+		);
+
+		$this->assertFalse(
+			apply_filters( 'atmosphere_is_short_form_post', false, $this->make_post( 'Intro [expand] outro.' ) ),
+			'A 21-char raw body that expands to 400+ chars must not be classified as fits-in-300.'
+		);
+	}
+
+	/**
+	 * HTML tags don't count toward the 300-char Bluesky budget — they're
+	 * stripped before publishing. The bridge mirrors that by stripping
+	 * tags before measurement, so a post wrapped in markup that fits in
+	 * 300 chars of visible text still flips to short-form.
+	 */
+	public function test_strips_html_before_measuring(): void {
+		$body = '<p><strong>Short post.</strong></p>';
+
+		$this->assertTrue(
+			apply_filters( 'atmosphere_is_short_form_post', false, $this->make_post( $body ) ),
+			'HTML tags surrounding short visible text must not push the post over the limit.'
+		);
+	}
+
+	/**
+	 * The opt-out filter must be honored when truthy: sites that want
+	 * the long-form-with-card behavior preserved for a given post
+	 * (per type / per author / per meta) can return true and the bridge
+	 * yields. The default (no callbacks) keeps the new short-form path
+	 * active — covered by every other test in this file.
+	 */
+	public function test_override_filter_keeps_long_form_when_truthy(): void {
+		add_filter( 'fosse_bsky_link_card_when_post_fits', '__return_true' );
+
+		$this->assertFalse(
+			apply_filters( 'atmosphere_is_short_form_post', false, $this->make_post( 'Short body.' ) ),
+			'A truthy override must keep Atmosphere on the long-form (link-card) path.'
+		);
+	}
+
+	/**
+	 * The override filter receives the `WP_Post` so callbacks can branch
+	 * per post (post type, author, taxonomy, meta, …). Without this,
+	 * site-wide is the only granularity, which defeats the purpose of an
+	 * override at all.
+	 */
+	public function test_override_filter_receives_post(): void {
+		$received = null;
+		add_filter(
+			'fosse_bsky_link_card_when_post_fits',
+			static function ( $keep, $post ) use ( &$received ) {
+				$received = $post;
+				return $keep;
+			},
+			10,
+			2
+		);
+
+		$post = $this->make_post( 'Short body.' );
+		apply_filters( 'atmosphere_is_short_form_post', false, $post );
+
+		$this->assertSame( $post, $received, 'Override filter must receive the WP_Post being evaluated.' );
+	}
+
+	/**
+	 * Falsy override returns from the filter (the default, `false`, or
+	 * `null`/`0`) must not block the short-form promotion. Anything
+	 * other than a truthy "keep the card" answer should fall through to
+	 * the new behavior.
+	 */
+	public function test_override_filter_falsy_returns_do_not_block(): void {
+		add_filter(
+			'fosse_bsky_link_card_when_post_fits',
+			static function () {
+				return 0;
+			}
+		);
+
+		$this->assertTrue(
+			apply_filters( 'atmosphere_is_short_form_post', false, $this->make_post( 'Short body.' ) )
+		);
+	}
+}

--- a/tests/php/Bsky_Short_Form_FitTest.php
+++ b/tests/php/Bsky_Short_Form_FitTest.php
@@ -31,22 +31,30 @@ class Bsky_Short_Form_FitTest extends BaseTestCase {
 		remove_all_filters( 'fosse_bsky_link_card_when_post_fits' );
 		remove_all_filters( 'the_content' );
 
+		// Memoization cache is per-process; reset it so each test starts
+		// fresh and doesn't see a cached decision from a sibling case.
+		Bsky_Short_Form_Fit::reset_cache_for_testing();
+
 		Bsky_Short_Form_Fit::register();
 	}
 
 	/**
 	 * Build a stub WP_Post with the given content. `wp_insert_post` would
-	 * also work but the bridge only touches `post_content` and the
-	 * filter's `WP_Post` type guard — a plain stub keeps tests fast and
-	 * isolates the unit under test from WP's post storage machinery.
+	 * also work but the bridge only touches `post_content` / `post_title`
+	 * and the filter's `WP_Post` type guard — a plain stub keeps tests
+	 * fast and isolates the unit under test from WP's post storage
+	 * machinery.
 	 *
 	 * @param string $content Raw post content.
+	 * @param string $title   Optional post title; default empty (the
+	 *                        common short-note shape this bridge targets).
 	 * @return WP_Post
 	 */
-	private function make_post( string $content ): WP_Post {
+	private function make_post( string $content, string $title = '' ): WP_Post {
 		return new WP_Post(
 			(object) array(
 				'ID'           => 1,
+				'post_title'   => $title,
 				'post_content' => $content,
 			)
 		);
@@ -213,6 +221,65 @@ class Bsky_Short_Form_FitTest extends BaseTestCase {
 		apply_filters( 'atmosphere_is_short_form_post', false, $post );
 
 		$this->assertSame( $post, $received, 'Override filter must receive the WP_Post being evaluated.' );
+	}
+
+	/**
+	 * A non-empty `post_title` is Atmosphere's long-form signal — the
+	 * link-card composition surfaces the title inside the embed. The
+	 * bridge therefore must NOT flip a titled-short post to short-form,
+	 * or the title silently disappears from Bluesky even though the
+	 * author wrote it. Locks the conflict pinned by the
+	 * `long-form-link-card.spec.ts` e2e test.
+	 */
+	public function test_passes_through_when_post_has_title(): void {
+		$post = $this->make_post( 'Body that easily fits in 300 chars.', 'A short article' );
+
+		$this->assertFalse(
+			apply_filters( 'atmosphere_is_short_form_post', false, $post ),
+			'A titled post must stay on the long-form path even when the body fits — the title would be lost on the short-form path.'
+		);
+	}
+
+	/**
+	 * Whitespace-only titles count as no title. A post that has a stray
+	 * spaces-only `post_title` (e.g. left over from the editor) should
+	 * still take the short-form path — there's no title to drop.
+	 */
+	public function test_treats_whitespace_only_title_as_empty(): void {
+		$post = $this->make_post( 'Body fits in 300 chars.', "  \n\t  " );
+
+		$this->assertTrue(
+			apply_filters( 'atmosphere_is_short_form_post', false, $post )
+		);
+	}
+
+	/**
+	 * The decision is memoized per post id so the filter doesn't re-run
+	 * `apply_filters( 'the_content', ... )` every time
+	 * `atmosphere_is_short_form_post` fires (which can be several times
+	 * per publish — Atmosphere's transformer + publisher + FOSSE's
+	 * metrics resolver all evaluate it).
+	 */
+	public function test_memoizes_per_post_id(): void {
+		$count = 0;
+		add_filter(
+			'the_content',
+			static function ( $content ) use ( &$count ) {
+				++$count;
+				return $content;
+			}
+		);
+
+		$post = $this->make_post( 'Hello, Bluesky.' );
+		apply_filters( 'atmosphere_is_short_form_post', false, $post );
+		apply_filters( 'atmosphere_is_short_form_post', false, $post );
+		apply_filters( 'atmosphere_is_short_form_post', false, $post );
+
+		$this->assertSame(
+			1,
+			$count,
+			'the_content must be applied exactly once per post id across repeated atmosphere_is_short_form_post evaluations.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes DOTCOM-17097.

## Proposed changes

- `src/class-bsky-short-form-fit.php` (new): registers an `atmosphere_is_short_form_post` callback that flips a post to short-form when its rendered body fits inside a single Bluesky record (300 chars). Atmosphere then publishes the body natively — no title prefix, no permalink, no link-card embed.
- `fosse.php`: registers the bridge on `init`, next to `Object_Type::register()` (same posture, same lifecycle).
- New filter `fosse_bsky_link_card_when_post_fits` (default `false`): per-post / per-site escape hatch to keep today's long-form-with-card behavior.
- `tests/php/Bsky_Short_Form_FitTest.php` (new): 11 cases covering the 300-char boundary, the override filter (both polarities + signature), `the_content` expansion (shortcode case), HTML stripping, and the defensive guards (already-short, non-WP_Post, empty body).

## Why

Atmosphere's `is_short_form()` discriminator keys off post *shape* (no title support, empty title, or any non-empty `post_format`), not length. A standard post with a title and no format therefore always takes the long-form path, which by default builds an `app.bsky.embed.external` card. The result on a microblog-length post is a redundant card preview attached to a post whose URL is already in the visible text — see https://bsky.app/profile/bk.cx/post/3mloba4xbmgzd as the motivating example.

This is the "home on the web, federated" thesis in practice: if you write a 50-char post, FOSSE should publish a 50-char post, not a 50-char post with a card preview pointing back to itself.

Keeping the bridge FOSSE-side (rather than upstreaming a default-on change) respects Atmosphere's framing — long-form-with-card is still the right answer for many sites — while letting FOSSE users get the microblog-feels experience.

## Tradeoffs

- Lightly couples to Atmosphere's content pipeline: the bridge runs `apply_filters('the_content', …)` plus `wp_strip_all_tags()` to measure the same body Atmosphere will compose against. If upstream changes how it counts text, FOSSE's measurement could drift a few chars at the boundary. Acceptable for a 300-char heuristic; documented inline.
- Behavior change for existing FOSSE sites: a post that today ships with a card will stop shipping one once its body fits in 300 chars. Default-on with `fosse_bsky_link_card_when_post_fits` as the documented opt-out.

## Testing

- `vendor/bin/phpunit --filter Bsky_Short_Form_Fit` — 11 tests, 15 assertions, green.
- `vendor/bin/phpunit` — full suite, 538 tests, 1250 assertions, green.
- `tools/vendor/bin/phpcs src/class-bsky-short-form-fit.php tests/php/Bsky_Short_Form_FitTest.php fosse.php` — clean.