### PR TITLE
chore: resync bundled AP and Atmosphere to upstream trunk

### DIFF
--- a/bundled/activitypub/includes/class-http.php
+++ b/bundled/activitypub/includes/class-http.php
@@ -261,7 +261,7 @@ class Http {
 
 		$url = object_to_uri( $url_or_object );
 
-		if ( preg_match( '/^@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $url ) ) {
+		if ( Webfinger::is_acct( $url ) ) {
 			$url = Webfinger::resolve( $url );
 		}
 

--- a/bundled/activitypub/includes/class-webfinger.php
+++ b/bundled/activitypub/includes/class-webfinger.php
@@ -20,6 +20,30 @@ use Activitypub\Collection\Remote_Actors;
  */
 class Webfinger {
 	/**
+	 * Check whether a value looks like an `acct` identifier.
+	 *
+	 * Accepts any of:
+	 *
+	 * - `user@host` — bare WebFinger handle.
+	 * - `@user@host` — Mastodon display form with a leading `@`.
+	 * - `acct:user@host` — full RFC 7565 URI form.
+	 *
+	 * The host/local-part pattern follows `ACTIVITYPUB_USERNAME_REGEXP`.
+	 *
+	 * @since unreleased
+	 *
+	 * @param mixed $value The candidate value.
+	 * @return bool True if the value matches the acct identifier pattern.
+	 */
+	public static function is_acct( $value ) {
+		if ( ! \is_string( $value ) || '' === $value ) {
+			return false;
+		}
+
+		return (bool) \preg_match( '/^(?:acct:)?@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $value );
+	}
+
+	/**
 	 * Returns a users WebFinger "resource".
 	 *
 	 * @param int $user_id The WordPress user id.

--- a/bundled/activitypub/includes/collection/class-posts.php
+++ b/bundled/activitypub/includes/collection/class-posts.php
@@ -62,10 +62,16 @@ class Posts {
 
 		$object = $activity['object'] ?? array();
 
-		$object_type = $object['type'] ?? '';
-		$content     = \wp_kses_post( $object['content'] ?? '' );
-		$name        = \sanitize_text_field( $object['name'] ?? '' );
-		$summary     = \wp_kses_post( $object['summary'] ?? '' );
+		$object_type   = $object['type'] ?? '';
+		$content       = \wp_kses_post( $object['content'] ?? '' );
+		$name          = \sanitize_text_field( $object['name'] ?? '' );
+		$summary       = \wp_kses_post( $object['summary'] ?? '' );
+		$plain_summary = \sanitize_text_field( $summary );
+
+		// A summary marked sensitive is a content warning (plain text); otherwise it's a regular excerpt.
+		// Route on the sanitized summary so whitespace-only values don't pollute either field.
+		$content_warning = ! empty( $object['sensitive'] ) && '' !== $plain_summary ? $plain_summary : '';
+		$post_excerpt    = '' === $content_warning && '' !== $plain_summary ? $summary : '';
 
 		// Process content: autop, autolink, hashtags, and convert to blocks.
 		$content = self::prepare_content( $content );
@@ -85,11 +91,12 @@ class Posts {
 			'post_author'  => $post_author,
 			'post_title'   => $title,
 			'post_content' => $content,
-			'post_excerpt' => $summary,
+			'post_excerpt' => $post_excerpt,
 			'post_status'  => ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE === $visibility ? 'private' : 'publish',
 			'post_type'    => 'post',
 			'meta_input'   => array(
 				'activitypub_content_visibility' => $visibility,
+				'activitypub_content_warning'    => $content_warning,
 			),
 		);
 
@@ -121,9 +128,15 @@ class Posts {
 	public static function update( $post, $activity, $visibility = null ) {
 		$object = $activity['object'] ?? array();
 
-		$content = \wp_kses_post( $object['content'] ?? '' );
-		$name    = \sanitize_text_field( $object['name'] ?? '' );
-		$summary = \wp_kses_post( $object['summary'] ?? '' );
+		$content       = \wp_kses_post( $object['content'] ?? '' );
+		$name          = \sanitize_text_field( $object['name'] ?? '' );
+		$summary       = \wp_kses_post( $object['summary'] ?? '' );
+		$plain_summary = \sanitize_text_field( $summary );
+
+		// A summary marked sensitive is a content warning (plain text); otherwise it's a regular excerpt.
+		// Route on the sanitized summary so whitespace-only values don't pollute either field.
+		$content_warning = ! empty( $object['sensitive'] ) && '' !== $plain_summary ? $plain_summary : '';
+		$post_excerpt    = '' === $content_warning && '' !== $plain_summary ? $summary : '';
 
 		// Process content: autop, autolink, hashtags, and convert to blocks.
 		$content = self::prepare_content( $content );
@@ -143,9 +156,10 @@ class Posts {
 			'ID'           => $post->ID,
 			'post_title'   => $title,
 			'post_content' => $content,
-			'post_excerpt' => $summary,
+			'post_excerpt' => $post_excerpt,
 			'meta_input'   => array(
 				'activitypub_content_visibility' => $visibility,
+				'activitypub_content_warning'    => $content_warning,
 			),
 		);
 

--- a/bundled/activitypub/includes/collection/class-remote-actors.php
+++ b/bundled/activitypub/includes/collection/class-remote-actors.php
@@ -283,7 +283,7 @@ class Remote_Actors {
 			return self::fetch_by_uri( $uri_or_acct );
 		}
 
-		if ( preg_match( '/^@?' . ACTIVITYPUB_USERNAME_REGEXP . '$/i', $uri_or_acct ) ) {
+		if ( Webfinger::is_acct( $uri_or_acct ) ) {
 			return self::fetch_by_acct( $uri_or_acct );
 		}
 

--- a/bundled/activitypub/includes/rest/class-proxy-controller.php
+++ b/bundled/activitypub/includes/rest/class-proxy-controller.php
@@ -12,6 +12,7 @@ namespace Activitypub\Rest;
 
 use Activitypub\Collection\Remote_Actors;
 use Activitypub\Http;
+use Activitypub\Webfinger;
 
 use function Activitypub\is_actor;
 
@@ -53,7 +54,7 @@ class Proxy_Controller extends \WP_REST_Controller {
 					'permission_callback' => array( $this, 'verify_authentication' ),
 					'args'                => array(
 						'id' => array(
-							'description'       => 'The URI of the remote ActivityPub object to fetch.',
+							'description'       => 'The remote ActivityPub object to fetch: an HTTPS URL or an acct identifier (`user@host`, `@user@host`, or `acct:user@host`).',
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => array( $this, 'sanitize_url' ),
@@ -75,9 +76,8 @@ class Proxy_Controller extends \WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_stream_permissions_check' ),
 					'args'                => array(
 						'id' => array(
-							'description'       => 'The remote object ID (URI) whose eventStream to proxy.',
+							'description'       => 'The remote actor identifier (URL or WebFinger acct) whose eventStream to proxy.',
 							'type'              => 'string',
-							'format'            => 'uri',
 							'required'          => true,
 							'sanitize_callback' => array( $this, 'sanitize_url' ),
 							'validate_callback' => array( $this, 'validate_url' ),
@@ -89,30 +89,48 @@ class Proxy_Controller extends \WP_REST_Controller {
 	}
 
 	/**
-	 * Sanitizes the URL parameter.
+	 * Sanitize the `id` parameter.
+	 *
+	 * Accepts either an HTTPS URL or an acct identifier (`user@host`,
+	 * `@user@host`, or `acct:user@host`). Acct identifiers are returned
+	 * as-is; URLs are run through `sanitize_url()`. Matches the dual-shape
+	 * contract of `Remote_Actors::fetch_by_various()`.
 	 *
 	 * @see https://developer.wordpress.org/reference/functions/sanitize_url/
 	 *
-	 * @param string $url The urlencoded URL to sanitize.
-	 * @return string The sanitized URL.
+	 * @param string $url The urlencoded URL or acct identifier to sanitize.
+	 * @return string The sanitized value.
 	 */
 	public function sanitize_url( $url ) {
-		// Decode and sanitize the URL.
-		return sanitize_url( urldecode( $url ) );
+		$decoded = \urldecode( $url );
+
+		if ( Webfinger::is_acct( $decoded ) ) {
+			return $decoded;
+		}
+
+		return \sanitize_url( $decoded );
 	}
+
 	/**
-	 * Validate the URL parameter.
+	 * Validate the `id` parameter.
 	 *
-	 * Uses wp_http_validate_url() which blocks local/private IPs and restricts ports.
+	 * Accepts either an HTTPS URL (validated via `wp_http_validate_url()`,
+	 * which blocks local/private IPs and restricts ports) or an acct
+	 * identifier in any of the forms accepted by `Webfinger::is_acct()`:
+	 * `user@host`, `@user@host`, or `acct:user@host`. Matches the
+	 * dual-shape contract of `Remote_Actors::fetch_by_various()`.
 	 *
 	 * @see https://developer.wordpress.org/reference/functions/wp_http_validate_url/
 	 *
-	 * @param string $url The URL to validate.
+	 * @param string $url The URL or acct identifier to validate.
 	 * @return bool True if valid, false otherwise.
 	 */
 	public function validate_url( $url ) {
-		// Decode the url.
-		$decoded_url = urldecode( $url );
+		$decoded_url = \urldecode( $url );
+
+		if ( Webfinger::is_acct( $decoded_url ) ) {
+			return true;
+		}
 
 		// Must be HTTPS.
 		if ( 'https' !== \wp_parse_url( $decoded_url, PHP_URL_SCHEME ) ) {

--- a/bundled/atmosphere/includes/class-reaction-sync.php
+++ b/bundled/atmosphere/includes/class-reaction-sync.php
@@ -414,6 +414,37 @@ class Reaction_Sync {
 			return false;
 		}
 
+		/**
+		 * Filters whether a reply should be synced as a WordPress comment.
+		 *
+		 * Fires after the reply's target post and parent comment have been
+		 * resolved, immediately before any work that depends on the reply
+		 * being kept (author profile resolution, comment row insert,
+		 * comment-meta writes). Return false to skip the insert.
+		 *
+		 * Use case: consumers publishing multi-record threads from their
+		 * own DID may want to skip the round-tripped self-replies that
+		 * `Reaction_Sync` would otherwise ingest as comments. The filter
+		 * is intentionally policy-free upstream so consumers can express
+		 * whatever discriminator fits their publishing strategy.
+		 *
+		 * @param bool  $should         Whether to sync this reply. Default true.
+		 * @param array $notification   Notification or synthesized own-record.
+		 * @param int   $post_id        Resolved local WP post the reply targets.
+		 * @param int   $comment_parent Resolved local parent comment ID, 0 if top-level.
+		 */
+		$should_sync = (bool) \apply_filters(
+			'atmosphere_should_sync_reply',
+			true,
+			$notification,
+			$post_id,
+			$comment_parent
+		);
+
+		if ( ! $should_sync ) {
+			return false;
+		}
+
 		$profile = self::resolve_author( $author['did'] ?? '' );
 
 		return self::insert_reaction( $post_id, 'comment', $text, $comment_parent, $notification, $profile );

--- a/bundled/atmosphere/vendor/composer/installed.php
+++ b/bundled/atmosphere/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'automattic/atmosphere',
         'pretty_version' => 'dev-trunk',
         'version' => 'dev-trunk',
-        'reference' => '06b21d7ecd628915d810481c6b015fecc8757e9e',
+        'reference' => '8ebebbfcc655b714bfbef3569f9a21d68d5893ad',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'automattic/atmosphere' => array(
             'pretty_version' => 'dev-trunk',
             'version' => 'dev-trunk',
-            'reference' => '06b21d7ecd628915d810481c6b015fecc8757e9e',
+            'reference' => '8ebebbfcc655b714bfbef3569f9a21d68d5893ad',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
Refreshes `bundled/activitypub/` and `bundled/atmosphere/` to current upstream trunk via `tools/sync-bundled.sh`.

## Upstream SHAs

- **wordpress-activitypub** trunk → `ddeaa003` (Store content warnings sent through the outbox API)
- **wordpress-atmosphere** trunk → `8ebebbf` (Add `atmosphere_should_sync_reply` filter, [PR 57](https://github.com/Automattic/wordpress-atmosphere/pull/57))

## Notable changes brought in

**Atmosphere:**
- **`atmosphere_should_sync_reply` filter** ([wordpress-atmosphere PR 57](https://github.com/Automattic/wordpress-atmosphere/pull/57)) — fires inside `Reaction_Sync::maybe_sync_reply()` after the target post and parent comment have been resolved, immediately before the comment row insert. Consumers can return false to skip the insert. This is the upstream half of the FOSSE-side `Self_Thread_Comment_Filter` shipping in PR 130; once this resync lands, that branch's bundled-atmosphere shim becomes a no-op against trunk and can be dropped.

**ActivityPub:**
- Outbox content-warning storage.
- WebFinger proxy endpoint accepts handles.
- Smaller fixes across HTTP, posts collection, remote-actors, and proxy controller.

## Sequencing note

Once this merges, PR 130 (suppress own teaser-thread chunks from inbound reaction sync) can drop its bundled-atmosphere shim — the resync brings the same filter natively. The 130 shim diff against trunk should vanish entirely after trunk is merged in.

## Testing

- Resync produced via `tools/sync-bundled.sh`; both upstream checkouts on trunk and verified up-to-date before sync. Atmosphere's `composer.lock` + `vendor/` were scrubbed pre-sync so the production vendor is freshly resolved.
- Bundled atmosphere `Reaction_Sync` diff matches the FOSSE-side shim that PR 130 carried locally.
