### PR TITLE
Harden third-party provider registration

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -320,22 +320,29 @@ add_action(
 /*
  * Provider bootstrap.
  *
- * Providers self-register on the 'fosse_register_providers' action fired
- * by Provider_Loader::boot(). Deferred to `plugins_loaded` priority 10 so
- * standalone provider plugins can hook `fosse_register_providers` from
- * their own plugin main file (or any earlier `plugins_loaded` priority)
- * without depending on WordPress' alphabetical plugin load order.
+ * Providers self-register on the `fosse_register_providers` action fired
+ * by Provider_Loader::boot(). Deferred to `plugins_loaded` priority 20 so
+ * standalone provider plugins can hook the action from their plugin main
+ * file (cleanest) or any `plugins_loaded` priority < 20 without depending
+ * on WordPress' alphabetical plugin load order. Priority 20 (not 10)
+ * leaves a margin above WordPress' default `add_action` priority so an
+ * add-on that defers to `plugins_loaded` without specifying a priority
+ * still wins the race.
  *
- * `plugins_loaded` (not `init`) because `Bluesky_Provider::register_hooks()`
- * adds an `init` priority-1 callback for the well-known atproto-did route
- * and an `admin_init` callback for the OAuth return — registering on `init`
- * would miss those priorities. `plugins_loaded` still runs unconditionally
- * (every request: admin, REST, WebFinger, cron) so projection filters and
- * route handlers are in place before any consumer fires.
+ * The callback is a named global function (not an inline closure) so
+ * PHPUnit can drive the exact production code path — asserting the
+ * action binding and exercising the body — instead of testing a
+ * closure that the test can never reach by reference.
  */
-add_action(
-	'plugins_loaded',
-	static function () {
+if ( ! function_exists( 'fosse_boot_providers' ) ) {
+	/**
+	 * Initialize bundled providers and run the registry boot.
+	 *
+	 * Wired to `plugins_loaded` priority 20 (see the docblock above).
+	 *
+	 * @return void
+	 */
+	function fosse_boot_providers(): void {
 		if ( ! class_exists( \Automattic\Fosse\Provider_Loader::class ) ) {
 			return;
 		}
@@ -344,9 +351,10 @@ add_action(
 		\Automattic\Fosse\Admin\Bluesky_Provider::init();
 
 		\Automattic\Fosse\Provider_Loader::boot();
-	},
-	10
-);
+	}
+}
+
+add_action( 'plugins_loaded', 'fosse_boot_providers', 20 );
 
 /*
  * Activation redirect.

--- a/fosse.php
+++ b/fosse.php
@@ -321,16 +321,32 @@ add_action(
  * Provider bootstrap.
  *
  * Providers self-register on the 'fosse_register_providers' action fired
- * by Provider_Loader::boot(). This runs unconditionally so provider hooks
- * (option-projection filters, etc.) are active on every request — admin,
- * REST, WebFinger, cron.
+ * by Provider_Loader::boot(). Deferred to `plugins_loaded` priority 10 so
+ * standalone provider plugins can hook `fosse_register_providers` from
+ * their own plugin main file (or any earlier `plugins_loaded` priority)
+ * without depending on WordPress' alphabetical plugin load order.
+ *
+ * `plugins_loaded` (not `init`) because `Bluesky_Provider::register_hooks()`
+ * adds an `init` priority-1 callback for the well-known atproto-did route
+ * and an `admin_init` callback for the OAuth return — registering on `init`
+ * would miss those priorities. `plugins_loaded` still runs unconditionally
+ * (every request: admin, REST, WebFinger, cron) so projection filters and
+ * route handlers are in place before any consumer fires.
  */
-if ( class_exists( \Automattic\Fosse\Provider_Loader::class ) ) {
-	\Automattic\Fosse\Admin\AP_Provider::init();
-	\Automattic\Fosse\Admin\Bluesky_Provider::init();
+add_action(
+	'plugins_loaded',
+	static function () {
+		if ( ! class_exists( \Automattic\Fosse\Provider_Loader::class ) ) {
+			return;
+		}
 
-	\Automattic\Fosse\Provider_Loader::boot();
-}
+		\Automattic\Fosse\Admin\AP_Provider::init();
+		\Automattic\Fosse\Admin\Bluesky_Provider::init();
+
+		\Automattic\Fosse\Provider_Loader::boot();
+	},
+	10
+);
 
 /*
  * Activation redirect.

--- a/sdd/harden-provider-registration/plan.md
+++ b/sdd/harden-provider-registration/plan.md
@@ -53,11 +53,11 @@ The user's hunch was "hooked at `init` instead of on load." The codebase argues 
 - It still runs before `init`, `admin_init`, and `rest_api_init`, so providers can register hooks at any of those.
 - It is the WordPress-conventional "all plugins loaded; safe to wire cross-plugin things" hook.
 
-**Priority:** default (10). FOSSE itself is loaded by `wp-content/mu-plugins/fosse-loader.php` on `plugins_loaded` priority 8 on wpcom Simple. Booting at priority 10 still runs in the same `plugins_loaded` iteration, after the loader, and well before `init`.
+**Priority:** 20. Initially chose default (10) but bumped after PR review (codex + ce-adversarial) flagged that a third-party add-on deferring to `plugins_loaded` *without* specifying a priority would land at the same priority (10) as FOSSE's boot and lose the same-priority race if WP loads it after FOSSE. Priority 20 gives third parties a 19-priority window above `plugins_loaded`'s `add_action` default. FOSSE itself is loaded by `wp-content/mu-plugins/fosse-loader.php` on `plugins_loaded` priority 8 on wpcom Simple; booting at priority 20 still runs in the same `plugins_loaded` iteration, after the loader, and well before `init`.
 
 ### Angle 3 — wpcom Simple load contract
 
-`fosse.php` documents that on wpcom Simple, FOSSE is loaded inside `plugins_loaded` priority 8 by `fosse-loader.php`. Booting providers on `plugins_loaded` priority 10 fires inside the same action loop, one priority later. Third-party providers in mu-plugins or regular plugins have already run their main files and can have hooked `fosse_register_providers`. No new wpcom-specific work needed.
+`fosse.php` documents that on wpcom Simple, FOSSE is loaded inside `plugins_loaded` priority 8 by `fosse-loader.php`. Booting providers on `plugins_loaded` priority 20 fires inside the same action loop, 12 priorities later. Third-party providers in mu-plugins or regular plugins have already run their main files and can have hooked `fosse_register_providers`. No new wpcom-specific work needed.
 
 ### Angle 4 — Idempotency
 
@@ -132,7 +132,7 @@ Cuttable: README-level docs (we already publish enough of an entry point in the 
 
 What could a third-party plugin still get wrong after this lands?
 
-1. Hook `fosse_register_providers` from a callback that itself runs *after* `plugins_loaded` priority 10. E.g. registering inside `init` priority 5. → Document that the hook must be registered from the plugin's main file or no later than `plugins_loaded` priority 9.
+1. Hook `fosse_register_providers` from a callback that itself runs *after* `plugins_loaded` priority 20. E.g. registering inside `init` priority 5. → Document that the hook must be registered from the plugin's main file or no later than `plugins_loaded` priority 19.
 2. Register a provider whose `is_available()` returns true but whose dependencies aren't actually loaded. → That's the third-party's problem, and `is_available()` is already the contract for it.
 3. Register a provider that depends on a class autoloaded only on `init`. → Same as (1); document the timing contract.
 
@@ -142,9 +142,9 @@ The docblock recipe should call out (1) explicitly.
 
 ## Chosen approach
 
-1. **Defer the existing boot block to `plugins_loaded` priority 10.** Wrap the `AP_Provider::init() / Bluesky_Provider::init() / Provider_Loader::boot()` trio in `add_action( 'plugins_loaded', …, 10 )`.
+1. **Defer the existing boot block to `plugins_loaded` priority 20.** Wrap the `AP_Provider::init() / Bluesky_Provider::init() / Provider_Loader::boot()` trio in `add_action( 'plugins_loaded', …, 20 )`. Initial implementation used priority 10; PR review (codex + ce-adversarial) bumped it to 20 to clear WP's default `add_action` priority.
 2. **Make `Provider_Loader::boot()` idempotent** with a `$booted` flag and a `reset()` method for tests.
-3. **Document the hook** in `Provider_Loader::boot()`'s docblock and on the `Connection_Provider` interface — including the timing contract (register the callback from the plugin's main file or no later than `plugins_loaded` priority 9).
+3. **Document the hook** in `Provider_Loader::boot()`'s docblock and on the `Connection_Provider` interface — including the timing contract (register the callback from the plugin's main file or no later than `plugins_loaded` priority 19).
 4. **Add two tests** to `Provider_LoaderTest`: external-provider-via-hook registers and is bootable; double `boot()` does not double-register hooks.
 
 The existing `Connection_Provider_Registry::register()` "first-wins" behavior is unchanged. `AP_Provider` and `Bluesky_Provider` keep their `init()` methods, which still register on `fosse_register_providers` — they just fire one tick later in the request lifecycle.
@@ -174,8 +174,8 @@ Bluesky's `init` priority-1 well-known-route hook would silently fail to registe
 - **Files**:
   - Modify: `fosse.php`
 - **Do**:
-  1. Wrap the existing `if ( class_exists( … Provider_Loader … ) ) { … }` block in `add_action( 'plugins_loaded', static function () { … }, 10 );`.
-  2. Update the surrounding docblock to explain: providers self-register on `fosse_register_providers`, fired from `Provider_Loader::boot()` on `plugins_loaded` priority 10. Third parties hook from their plugin main file or no later than `plugins_loaded` priority 9.
+  1. Wrap the existing `if ( class_exists( … Provider_Loader … ) ) { … }` block in `add_action( 'plugins_loaded', 'fosse_boot_providers', 20 );` with `fosse_boot_providers()` defined as a global function in `fosse.php` (named, not inline closure, so tests can drive the production code path).
+  2. Update the surrounding docblock to explain: providers self-register on `fosse_register_providers`, fired from `Provider_Loader::boot()` on `plugins_loaded` priority 20. Third parties hook from their plugin main file or no later than `plugins_loaded` priority 19.
 - **Verify**: New tests still red (boot still not idempotent yet), but the external-provider test passes if you stub the idempotency assertion.
 
 ### Task 3 — Make `boot()` idempotent + add `reset()`
@@ -187,7 +187,7 @@ Bluesky's `init` priority-1 well-known-route hook would silently fail to registe
   1. Add `private static bool $booted = false;`.
   2. Top of `boot()`: early-return if `$booted`. Otherwise set `$booted = true` before firing the action.
   3. Add `public static function reset(): void { self::$booted = false; }` with a docblock noting it's for tests.
-  4. Expand the existing class-level docblock and `boot()` docblock to document `fosse_register_providers` for third-party providers: snippet showing `add_action( 'fosse_register_providers', fn() => Connection_Provider_Registry::register( new My_Provider() ) )`, callout that the callback must be registered from the plugin main file or no later than `plugins_loaded` priority 9, and a pointer to the `Connection_Provider` interface.
+  4. Expand the existing class-level docblock and `boot()` docblock to document `fosse_register_providers` for third-party providers. The canonical recipe (code snippet) lives on `Connection_Provider` after PR review (single source of truth); `Provider_Loader` carries a short `@see` pointer. Callout that the callback must be registered from the plugin main file or no later than `plugins_loaded` priority 19.
 - **Verify**: Both new tests green. Existing `test_providers_registered_after_boot` still green.
 
 ### Task 4 — Document the extension contract on the interface
@@ -211,8 +211,24 @@ Bluesky's `init` priority-1 well-known-route hook would silently fail to registe
 
 ---
 
+## Review feedback applied
+
+Post-PR-review changes folded back into the plan (PR #132 review by `/ce-code-review`, `/codex` challenge mode, and GitHub Copilot):
+
+- **Boot priority 10 → 20.** Codex + ce-adversarial: a third-party that deferred to `plugins_loaded` *without* specifying a priority would land at 10 (WP's `add_action` default) and lose the same-priority race if loaded after FOSSE. Priority 20 gives a 19-priority headroom for the documented "register no later than `plugins_loaded` priority 19" contract.
+- **Closure → named function `fosse_boot_providers()`.** ce-testing + ce-adversarial + codex (CONFIRMED) flagged that the previous test suite could not regress the headline change — reverting the `plugins_loaded` wrap would have left every test green. Extracting to a global named function in `fosse.php` lets tests drive the exact production code path and assert the action binding.
+- **Test fixture leak in `Bluesky_ProviderTest`.** ce-correctness + ce-adversarial: the suite called `Provider_Loader::boot()` without resetting the new `$booted` static. Added `Provider_Loader::reset()` to its `#[Before]`.
+- **`is_available()` false branch coverage.** ce-testing: the new docblock contract was untested. Added `test_unavailable_provider_does_not_register_hooks`.
+- **Idempotency `$booted` flag flipped before completion.** ce-reliability + ce-adversarial + codex: a `Throwable` mid-loop would have left `$booted = true` with only partial hook registration. Switched to try/finally so the flag only flips on successful completion.
+- **Extension-recipe docblock duplicated three places.** ce-maintainability: collapsed to a single canonical recipe on `Connection_Provider`; `Provider_Loader` and `fosse.php` carry short `@see` pointers.
+
+Explicitly *not* applied:
+- Move `reset()` to reflection-based access (codex suggestion) — disagrees with the existing `Connection_Provider_Registry::reset()` convention; staying consistent.
+- AP/Bluesky `init()` outside the idempotency guard (adversarial) — only matters under contrived test replay; static-method callbacks dedupe on `add_action`.
+- Multisite `switch_to_blog` (reliability) — pre-existing behavior, not a regression in this PR.
+
 ## Risks & follow-ups
 
-- **Hooks now fire one phase later.** AP's `activitypub_default_blog_username` filter and Bluesky's `init` priority-1 / `admin_init` / `admin_post_*` callbacks all register on `plugins_loaded` 10 instead of file-include time. None of those consumers fire before `plugins_loaded` 10, so no observed regression — but worth specifically eyeballing during PR review.
+- **Hooks now fire one phase later.** AP's `activitypub_default_blog_username` filter and Bluesky's `init` priority-1 / `admin_init` / `admin_post_*` callbacks all register on `plugins_loaded` 20 instead of file-include time. None of those consumers fire before `plugins_loaded` 20, so no observed regression — but worth specifically eyeballing during PR review.
 - **`wpcom-simple-rollout`** (untracked SDD directory in the working copy) may have load-ordering assumptions worth a glance before merging. Not a blocker.
 - **Follow-up if a standalone provider ships:** revisit whether the docblock recipe is enough or whether we want a `fosse_register_provider()` helper. Defer until n=1.

--- a/sdd/harden-provider-registration/plan.md
+++ b/sdd/harden-provider-registration/plan.md
@@ -1,0 +1,210 @@
+---
+status: planning
+---
+
+# Harden Third-Party Provider Registration
+
+**Linear:** [DOTCOM-17104](https://linear.app/a8c/issue/DOTCOM-17104/harden-third-party-provider-registration-for-future-standalone)
+**GitHub:** [Automattic/fosse issue 127](https://github.com/Automattic/fosse/issues/127)
+
+**Goal:** Make `fosse_register_providers` a stable extension point for standalone provider plugins. Today, FOSSE calls `Provider_Loader::boot()` synchronously during `fosse.php` load, so any plugin loaded alphabetically after FOSSE misses the registration window.
+
+**Out of scope:** Shipping a real standalone provider; adding helper APIs (`fosse_register_provider()` wrapper, auto-discovery from a folder, etc.); any UI changes. We only harden the seam.
+
+---
+
+## Multi-angle analysis
+
+### Angle 1 — Mechanical (what's the minimum change?)
+
+Today (`fosse.php:328-333`):
+
+```php
+if ( class_exists( \Automattic\Fosse\Provider_Loader::class ) ) {
+    \Automattic\Fosse\Admin\AP_Provider::init();
+    \Automattic\Fosse\Admin\Bluesky_Provider::init();
+    \Automattic\Fosse\Provider_Loader::boot();
+}
+```
+
+This runs at *file include* time. Any plugin whose main file hasn't been executed yet — i.e. anything WordPress will load after `fosse/fosse.php` in `active_plugins` order — cannot have hooked `fosse_register_providers` in time.
+
+Smallest mechanical fix: wrap the block in `add_action( 'plugins_loaded', … )`. After all plugin main files have run, fire the action, then drive the registry.
+
+### Angle 2 — Timing (why `plugins_loaded`, not `init`?)
+
+The user's hunch was "hooked at `init` instead of on load." The codebase argues against `init`:
+
+- `Bluesky_Provider::register_hooks()` calls `add_action( 'init', …, 1 )` to serve the `/.well-known/atproto-did` route. If we boot the registry *on* `init` (at any priority ≥ 1), that priority-1 callback never registers — `init` priority 1 has already passed by the time the boot callback runs.
+- `Bluesky_Provider::register_hooks()` also calls `add_action( 'admin_init', … )` for the OAuth callback handler. `admin_init` fires inside `init`, so booting on `init` priority ≥ 10 risks the same class of issue if other providers register lower priorities.
+- REST routes register on `rest_api_init`, which fires from `init` as well. A future REST-route provider would have the same constraint.
+
+`plugins_loaded` is the right hook:
+
+- All plugin main files have run by the time `plugins_loaded` fires (including third-party provider plugins, which would `add_action( 'fosse_register_providers', … )` from their own main file).
+- It still runs before `init`, `admin_init`, and `rest_api_init`, so providers can register hooks at any of those.
+- It is the WordPress-conventional "all plugins loaded; safe to wire cross-plugin things" hook.
+
+**Priority:** default (10). FOSSE itself is loaded by `wp-content/mu-plugins/fosse-loader.php` on `plugins_loaded` priority 8 on wpcom Simple. Booting at priority 10 still runs in the same `plugins_loaded` iteration, after the loader, and well before `init`.
+
+### Angle 3 — wpcom Simple load contract
+
+`fosse.php` documents that on wpcom Simple, FOSSE is loaded inside `plugins_loaded` priority 8 by `fosse-loader.php`. Booting providers on `plugins_loaded` priority 10 fires inside the same action loop, one priority later. Third-party providers in mu-plugins or regular plugins have already run their main files and can have hooked `fosse_register_providers`. No new wpcom-specific work needed.
+
+### Angle 4 — Idempotency
+
+Acceptance criterion: "`Provider_Loader::boot()` is safe to call more than once in a request."
+
+Two failure modes:
+
+1. A defensively-coded third-party plugin calls `Provider_Loader::boot()` itself (mirroring FOSSE's own behavior). Without guarding, every provider gets `register_hooks()` called twice → every `add_action`/`add_filter` registers twice → hooks fire twice.
+2. Some integration test resets WP state and re-bootstraps the plugin in the same PHP process.
+
+Simplest guard — a one-shot static flag on `Provider_Loader`:
+
+```php
+private static bool $booted = false;
+
+public static function boot(): void {
+    if ( self::$booted ) {
+        return;
+    }
+    self::$booted = true;
+
+    do_action( 'fosse_register_providers' );
+
+    foreach ( Connection_Provider_Registry::get_providers() as $provider ) {
+        if ( $provider->is_available() ) {
+            $provider->register_hooks();
+        }
+    }
+}
+
+public static function reset(): void {
+    self::$booted = false;
+}
+```
+
+`reset()` is for test fixtures only. The existing `Connection_Provider_Registry::reset()` already follows this pattern.
+
+`Connection_Provider_Registry::register()` is already idempotent on duplicate slugs (`onboarding-setup-ux/spec.md` design: "first wins"), so providers self-registering twice on a duplicate `fosse_register_providers` fire is also safe. The flag is belt-and-suspenders.
+
+### Angle 5 — Discoverability / docs
+
+The issue calls out: "Document `fosse_register_providers` as the provider registration hook for add-ons."
+
+Two surfaces to touch:
+
+- `class-provider-loader.php`'s docblock on `boot()` already names the hook for in-tree readers. Expand it to a short third-party recipe (one paragraph) showing the `add_action( 'fosse_register_providers', … )` call site and pointing at `Connection_Provider_Registry::register()` plus the `Connection_Provider` interface.
+- `interface-connection-provider.php` should get a class-level docblock pointing add-on authors at the hook. This is the file a third-party developer reading the codebase will land on first.
+
+No README changes — that file is product-facing, not developer-facing. The internal docblocks are the right surface for an extension point this niche.
+
+### Angle 6 — CEO / scope-expansion angle
+
+Should this issue grow? Candidates considered and **rejected**:
+
+- **A helper function `fosse_register_provider( Connection_Provider $p )`**. A one-line convenience over `Connection_Provider_Registry::register( $p )`. Premature: we don't yet have *any* external provider to know what the ergonomic pain point is. Add when n=1 standalone exists.
+- **Auto-discovery from a `fosse-providers/` directory or composer plugin type**. Nice-sounding, but no one has asked for it and it widens FOSSE's surface area (security review, ordering rules, etc.) for a hypothetical use case.
+- **Promoting `Connection_Provider` to a SemVer-stable public API**. The interface is small and stable, but committing to BC guarantees costs us future flexibility on Setup/Status page rendering signatures. Document the hook; defer the BC commitment.
+
+The issue itself records this is "not urgent … records a platform-hardening gap." Resist scope expansion. Land the smallest correct change.
+
+### Angle 7 — Simplicity / YAGNI
+
+What can be cut from the smallest correct version?
+
+- `reset()` on `Provider_Loader` exists only for tests. Keep it — without it the idempotency test can't reliably re-run.
+- Docs in `interface-connection-provider.php` is a few lines and is the natural landing spot.
+- The `plugins_loaded` wrap is unavoidable — that's the whole point.
+
+Cuttable: README-level docs (we already publish enough of an entry point in the interface docblock). Skipped.
+
+### Angle 8 — Failure-mode review
+
+What could a third-party plugin still get wrong after this lands?
+
+1. Hook `fosse_register_providers` from a callback that itself runs *after* `plugins_loaded` priority 10. E.g. registering inside `init` priority 5. → Document that the hook must be registered from the plugin's main file or no later than `plugins_loaded` priority 9.
+2. Register a provider whose `is_available()` returns true but whose dependencies aren't actually loaded. → That's the third-party's problem, and `is_available()` is already the contract for it.
+3. Register a provider that depends on a class autoloaded only on `init`. → Same as (1); document the timing contract.
+
+The docblock recipe should call out (1) explicitly.
+
+---
+
+## Chosen approach
+
+1. **Defer the existing boot block to `plugins_loaded` priority 10.** Wrap the `AP_Provider::init() / Bluesky_Provider::init() / Provider_Loader::boot()` trio in `add_action( 'plugins_loaded', …, 10 )`.
+2. **Make `Provider_Loader::boot()` idempotent** with a `$booted` flag and a `reset()` method for tests.
+3. **Document the hook** in `Provider_Loader::boot()`'s docblock and on the `Connection_Provider` interface — including the timing contract (register the callback from the plugin's main file or no later than `plugins_loaded` priority 9).
+4. **Add two tests** to `Provider_LoaderTest`: external-provider-via-hook registers and is bootable; double `boot()` does not double-register hooks.
+
+The existing `Connection_Provider_Registry::register()` "first-wins" behavior is unchanged. `AP_Provider` and `Bluesky_Provider` keep their `init()` methods, which still register on `fosse_register_providers` — they just fire one tick later in the request lifecycle.
+
+### Why the user's hypothesis (move to `init`) doesn't work
+
+Bluesky's `init` priority-1 well-known-route hook would silently fail to register if boot moved to `init`. `plugins_loaded` is the next-earliest hook that solves the load-order problem without breaking existing provider hooks.
+
+---
+
+## Tasks
+
+### Task 1 — Add failing test coverage
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `tests/php/Provider_LoaderTest.php`
+- **Do**:
+  1. Add `test_external_provider_registered_via_hook_is_available_after_boot()`. Define a small in-test class implementing `Connection_Provider` (slug `'test-external'`, `is_available()` → true, `register_hooks()` no-op, etc.). Hook `fosse_register_providers` with a closure that calls `Connection_Provider_Registry::register()` on a new instance. Call `Provider_Loader::boot()`. Assert `Connection_Provider_Registry::get_provider( 'test-external' )` is not null.
+  2. Add `test_boot_is_idempotent()`. Define a provider whose `register_hooks()` increments a per-instance counter (or asserts on a hook count via `did_action`/`has_action`). Register it through the hook, call `boot()` twice, assert `register_hooks()` ran exactly once.
+  3. Add an `@after` cleanup that calls a new `Provider_Loader::reset()` so other tests see a fresh state.
+- **Verify**: `composer run-script test-php` fails on both new tests (red).
+
+### Task 2 — Defer boot to `plugins_loaded`
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `fosse.php`
+- **Do**:
+  1. Wrap the existing `if ( class_exists( … Provider_Loader … ) ) { … }` block in `add_action( 'plugins_loaded', static function () { … }, 10 );`.
+  2. Update the surrounding docblock to explain: providers self-register on `fosse_register_providers`, fired from `Provider_Loader::boot()` on `plugins_loaded` priority 10. Third parties hook from their plugin main file or no later than `plugins_loaded` priority 9.
+- **Verify**: New tests still red (boot still not idempotent yet), but the external-provider test passes if you stub the idempotency assertion.
+
+### Task 3 — Make `boot()` idempotent + add `reset()`
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `src/class-provider-loader.php`
+- **Do**:
+  1. Add `private static bool $booted = false;`.
+  2. Top of `boot()`: early-return if `$booted`. Otherwise set `$booted = true` before firing the action.
+  3. Add `public static function reset(): void { self::$booted = false; }` with a docblock noting it's for tests.
+  4. Expand the existing class-level docblock and `boot()` docblock to document `fosse_register_providers` for third-party providers: snippet showing `add_action( 'fosse_register_providers', fn() => Connection_Provider_Registry::register( new My_Provider() ) )`, callout that the callback must be registered from the plugin main file or no later than `plugins_loaded` priority 9, and a pointer to the `Connection_Provider` interface.
+- **Verify**: Both new tests green. Existing `test_providers_registered_after_boot` still green.
+
+### Task 4 — Document the extension contract on the interface
+
+- **Status**: Not started
+- **Files**:
+  - Modify: `src/Admin/interface-connection-provider.php`
+- **Do**:
+  1. Expand the interface's class-level docblock with a short "implementing a standalone provider" recipe: implement this interface, register an instance on `fosse_register_providers` via `Connection_Provider_Registry::register()`, return false from `is_available()` when the provider's dependencies aren't loaded so FOSSE skips `register_hooks()`.
+  2. No code changes — docs only.
+- **Verify**: `composer run-script lint-php` clean.
+
+### Task 5 — Lint, full test pass, commit
+
+- **Status**: Not started
+- **Do**:
+  1. `composer run-script lint-php`
+  2. `composer run-script test-php`
+  3. `pnpm run lint && pnpm run format:check` (touched files are PHP-only, but cheap to run).
+  4. Commit prefixed `add:` per the conventional-prefix hook, message body cross-linking Linear and GH issue.
+
+---
+
+## Risks & follow-ups
+
+- **Hooks now fire one phase later.** AP's `activitypub_default_blog_username` filter and Bluesky's `init` priority-1 / `admin_init` / `admin_post_*` callbacks all register on `plugins_loaded` 10 instead of file-include time. None of those consumers fire before `plugins_loaded` 10, so no observed regression — but worth specifically eyeballing during PR review.
+- **`wpcom-simple-rollout`** (untracked SDD directory in the working copy) may have load-ordering assumptions worth a glance before merging. Not a blocker.
+- **Follow-up if a standalone provider ships:** revisit whether the docblock recipe is enough or whether we want a `fosse_register_provider()` helper. Defer until n=1.

--- a/sdd/harden-provider-registration/plan.md
+++ b/sdd/harden-provider-registration/plan.md
@@ -11,6 +11,14 @@ status: planning
 
 **Out of scope:** Shipping a real standalone provider; adding helper APIs (`fosse_register_provider()` wrapper, auto-discovery from a folder, etc.); any UI changes. We only harden the seam.
 
+## Progress
+
+- [x] Task 1: Failing test coverage
+- [x] Task 2: Defer boot to `plugins_loaded`
+- [x] Task 3: Idempotent boot + docs
+- [x] Task 4: Connection_Provider interface docblock
+- [ ] Task 5: Lint, full test pass, commit (rolling — this branch)
+
 ---
 
 ## Multi-angle analysis
@@ -151,7 +159,7 @@ Bluesky's `init` priority-1 well-known-route hook would silently fail to registe
 
 ### Task 1 — Add failing test coverage
 
-- **Status**: Not started
+- **Status**: ✅ Done (3011461)
 - **Files**:
   - Modify: `tests/php/Provider_LoaderTest.php`
 - **Do**:
@@ -162,7 +170,7 @@ Bluesky's `init` priority-1 well-known-route hook would silently fail to registe
 
 ### Task 2 — Defer boot to `plugins_loaded`
 
-- **Status**: Not started
+- **Status**: ✅ Done (f430fb1)
 - **Files**:
   - Modify: `fosse.php`
 - **Do**:
@@ -172,7 +180,7 @@ Bluesky's `init` priority-1 well-known-route hook would silently fail to registe
 
 ### Task 3 — Make `boot()` idempotent + add `reset()`
 
-- **Status**: Not started
+- **Status**: ✅ Done (6390dfc)
 - **Files**:
   - Modify: `src/class-provider-loader.php`
 - **Do**:
@@ -184,7 +192,7 @@ Bluesky's `init` priority-1 well-known-route hook would silently fail to registe
 
 ### Task 4 — Document the extension contract on the interface
 
-- **Status**: Not started
+- **Status**: ✅ Done (af136bc)
 - **Files**:
   - Modify: `src/Admin/interface-connection-provider.php`
 - **Do**:
@@ -194,7 +202,7 @@ Bluesky's `init` priority-1 well-known-route hook would silently fail to registe
 
 ### Task 5 — Lint, full test pass, commit
 
-- **Status**: Not started
+- **Status**: In progress (verified locally on branch `harden-provider-registration-DOTCOM-17104`; awaiting PR)
 - **Do**:
   1. `composer run-script lint-php`
   2. `composer run-script test-php`

--- a/sdd/roadmap.md
+++ b/sdd/roadmap.md
@@ -27,7 +27,7 @@ Status legend (also stamped as `status:` frontmatter on each SDD's `spec.md` or 
 | `sdd/posting-ui/` | FOSSE-native posting UI (composer epic — defaults to `post_format = status`, enforces 300 graphemes). | [DOTCOM-16794](https://linear.app/a8c/issue/DOTCOM-16794) | [#90](https://github.com/Automattic/fosse/pull/90) |
 | `sdd/deactivation-lifecycle/` | What happens to FOSSE's menu state and bundled-plugin handoff on deactivate / delete / standalone-coexistence. | [DOTCOM-16865](https://linear.app/a8c/issue/DOTCOM-16865) | [#92](https://github.com/Automattic/fosse/pull/92) |
 | `sdd/bundled-backends-migration/` | Migration successor to `bundled-backends/`; replaces the bootstrap-shim with the next-gen loader. | [DOTCOM-16826](https://linear.app/a8c/issue/DOTCOM-16826) | [#93](https://github.com/Automattic/fosse/pull/93) |
-| [harden-provider-registration](./harden-provider-registration/) | Defer `Provider_Loader::boot()` to `plugins_loaded` and make it idempotent so standalone provider plugins can register on `fosse_register_providers` without depending on plugin-load order. | [DOTCOM-17104](https://linear.app/a8c/issue/DOTCOM-17104) | — |
+| [harden-provider-registration](./harden-provider-registration/) | Defer `Provider_Loader::boot()` to `plugins_loaded` and make it idempotent so standalone provider plugins can register on `fosse_register_providers` without depending on plugin-load order. | [DOTCOM-17104](https://linear.app/a8c/issue/DOTCOM-17104) | [#132](https://github.com/Automattic/fosse/pull/132) |
 
 ## Archived
 

--- a/sdd/roadmap.md
+++ b/sdd/roadmap.md
@@ -27,6 +27,7 @@ Status legend (also stamped as `status:` frontmatter on each SDD's `spec.md` or 
 | `sdd/posting-ui/` | FOSSE-native posting UI (composer epic — defaults to `post_format = status`, enforces 300 graphemes). | [DOTCOM-16794](https://linear.app/a8c/issue/DOTCOM-16794) | [#90](https://github.com/Automattic/fosse/pull/90) |
 | `sdd/deactivation-lifecycle/` | What happens to FOSSE's menu state and bundled-plugin handoff on deactivate / delete / standalone-coexistence. | [DOTCOM-16865](https://linear.app/a8c/issue/DOTCOM-16865) | [#92](https://github.com/Automattic/fosse/pull/92) |
 | `sdd/bundled-backends-migration/` | Migration successor to `bundled-backends/`; replaces the bootstrap-shim with the next-gen loader. | [DOTCOM-16826](https://linear.app/a8c/issue/DOTCOM-16826) | [#93](https://github.com/Automattic/fosse/pull/93) |
+| [harden-provider-registration](./harden-provider-registration/) | Defer `Provider_Loader::boot()` to `plugins_loaded` and make it idempotent so standalone provider plugins can register on `fosse_register_providers` without depending on plugin-load order. | [DOTCOM-17104](https://linear.app/a8c/issue/DOTCOM-17104) | — |
 
 ## Archived
 

--- a/src/Admin/interface-connection-provider.php
+++ b/src/Admin/interface-connection-provider.php
@@ -30,9 +30,12 @@ namespace Automattic\Fosse\Admin;
  *
  * `fosse_register_providers` fires from
  * {@see \Automattic\Fosse\Provider_Loader::boot()} on `plugins_loaded`
- * priority 10. The add-on's callback must be attached no later than
- * `plugins_loaded` priority 9 — registering it from the plugin main file
- * is the simplest path.
+ * priority 20. The add-on's callback must be attached no later than
+ * `plugins_loaded` priority 19 — registering it from the plugin main file
+ * is the simplest path and sidesteps the `plugins_loaded` race entirely.
+ * Priority 20 was chosen specifically so an add-on that defers to
+ * `plugins_loaded` without specifying a priority (WordPress' default is
+ * 10) still wins the race.
  *
  * Return `false` from {@see self::is_available()} when the provider's
  * underlying SDK isn't loaded; FOSSE will skip {@see self::register_hooks()}

--- a/src/Admin/interface-connection-provider.php
+++ b/src/Admin/interface-connection-provider.php
@@ -12,8 +12,31 @@ namespace Automattic\Fosse\Admin;
  *
  * Each provider represents one federated protocol (ActivityPub, Bluesky, etc.)
  * and is responsible for rendering its own settings fields, connection actions,
- * and status card. Providers self-register via the 'fosse_register_providers'
+ * and status card. Providers self-register via the `fosse_register_providers`
  * action.
+ *
+ * ### Implementing a standalone provider
+ *
+ * Standalone provider plugins implement this interface and push an instance
+ * onto the registry from a `fosse_register_providers` callback:
+ *
+ * ```php
+ * add_action( 'fosse_register_providers', static function () {
+ *     \Automattic\Fosse\Admin\Connection_Provider_Registry::register(
+ *         new My_Plugin\My_Provider()
+ *     );
+ * } );
+ * ```
+ *
+ * `fosse_register_providers` fires from
+ * {@see \Automattic\Fosse\Provider_Loader::boot()} on `plugins_loaded`
+ * priority 10. The add-on's callback must be attached no later than
+ * `plugins_loaded` priority 9 — registering it from the plugin main file
+ * is the simplest path.
+ *
+ * Return `false` from {@see self::is_available()} when the provider's
+ * underlying SDK isn't loaded; FOSSE will skip {@see self::register_hooks()}
+ * cleanly instead of erroring out.
  */
 interface Connection_Provider {
 

--- a/src/class-provider-loader.php
+++ b/src/class-provider-loader.php
@@ -16,27 +16,10 @@ use Automattic\Fosse\Admin\Connection_Provider_Registry;
  * like option-projection filters are active on every request.
  * Admin-only concerns (menus, pages, CSS) live in Admin\Menu.
  *
- * ### Registering a standalone provider
- *
- * Third-party plugins that add a new federation provider implement
- * {@see \Automattic\Fosse\Admin\Connection_Provider} and hook
- * `fosse_register_providers` to push their instance onto the registry:
- *
- * ```php
- * add_action( 'fosse_register_providers', static function () {
- *     \Automattic\Fosse\Admin\Connection_Provider_Registry::register(
- *         new My_Plugin\My_Provider()
- *     );
- * } );
- * ```
- *
- * `Provider_Loader::boot()` fires `fosse_register_providers` on
- * `plugins_loaded` priority 10 (registered in `fosse.php`). The add-on's
- * callback must be attached no later than `plugins_loaded` priority 9 —
- * registering it from the plugin's main file is the simplest path.
- *
- * Providers whose underlying SDK isn't loaded should return `false` from
- * `is_available()` so `register_hooks()` is skipped cleanly.
+ * Standalone provider plugins register through the
+ * `fosse_register_providers` action — see
+ * {@see \Automattic\Fosse\Admin\Connection_Provider} for the canonical
+ * recipe and timing contract.
  */
 class Provider_Loader {
 
@@ -52,7 +35,10 @@ class Provider_Loader {
 	 *
 	 * Safe to invoke more than once in a request: subsequent calls are
 	 * no-ops, so a defensively-coded add-on cannot double-register hooks
-	 * by booting its own copy of the loader.
+	 * by booting its own copy of the loader. The `$booted` flag is only
+	 * flipped on successful completion via try/finally — a Throwable in
+	 * any provider's `register_hooks()` leaves the flag clear so a
+	 * recovery path can retry once the cause is fixed.
 	 *
 	 * @return void
 	 */
@@ -60,19 +46,29 @@ class Provider_Loader {
 		if ( self::$booted ) {
 			return;
 		}
-		self::$booted = true;
 
-		/**
-		 * Fires so Connection_Provider implementations can register themselves.
-		 *
-		 * Providers call Connection_Provider_Registry::register( $this ) here.
-		 * See this class's docblock for the standalone-provider recipe.
-		 */
-		do_action( 'fosse_register_providers' );
+		$succeeded = false;
 
-		foreach ( Connection_Provider_Registry::get_providers() as $provider ) {
-			if ( $provider->is_available() ) {
-				$provider->register_hooks();
+		try {
+			/**
+			 * Fires so Connection_Provider implementations can register themselves.
+			 *
+			 * Providers call Connection_Provider_Registry::register( $this ) here.
+			 * See {@see \Automattic\Fosse\Admin\Connection_Provider} for the
+			 * standalone-provider recipe.
+			 */
+			do_action( 'fosse_register_providers' );
+
+			foreach ( Connection_Provider_Registry::get_providers() as $provider ) {
+				if ( $provider->is_available() ) {
+					$provider->register_hooks();
+				}
+			}
+
+			$succeeded = true;
+		} finally {
+			if ( $succeeded ) {
+				self::$booted = true;
 			}
 		}
 	}

--- a/src/class-provider-loader.php
+++ b/src/class-provider-loader.php
@@ -15,19 +15,58 @@ use Automattic\Fosse\Admin\Connection_Provider_Registry;
  * Runs unconditionally (admin and front-end) so that provider hooks
  * like option-projection filters are active on every request.
  * Admin-only concerns (menus, pages, CSS) live in Admin\Menu.
+ *
+ * ### Registering a standalone provider
+ *
+ * Third-party plugins that add a new federation provider implement
+ * {@see \Automattic\Fosse\Admin\Connection_Provider} and hook
+ * `fosse_register_providers` to push their instance onto the registry:
+ *
+ * ```php
+ * add_action( 'fosse_register_providers', static function () {
+ *     \Automattic\Fosse\Admin\Connection_Provider_Registry::register(
+ *         new My_Plugin\My_Provider()
+ *     );
+ * } );
+ * ```
+ *
+ * `Provider_Loader::boot()` fires `fosse_register_providers` on
+ * `plugins_loaded` priority 10 (registered in `fosse.php`). The add-on's
+ * callback must be attached no later than `plugins_loaded` priority 9 —
+ * registering it from the plugin's main file is the simplest path.
+ *
+ * Providers whose underlying SDK isn't loaded should return `false` from
+ * `is_available()` so `register_hooks()` is skipped cleanly.
  */
 class Provider_Loader {
 
 	/**
+	 * Whether {@see self::boot()} has already run in this request.
+	 *
+	 * @var bool
+	 */
+	private static bool $booted = false;
+
+	/**
 	 * Fire provider registration and call register_hooks() on each.
+	 *
+	 * Safe to invoke more than once in a request: subsequent calls are
+	 * no-ops, so a defensively-coded add-on cannot double-register hooks
+	 * by booting its own copy of the loader.
 	 *
 	 * @return void
 	 */
 	public static function boot(): void {
+		if ( self::$booted ) {
+			return;
+		}
+		self::$booted = true;
+
 		/**
 		 * Fires so Connection_Provider implementations can register themselves.
 		 *
 		 * Providers call Connection_Provider_Registry::register( $this ) here.
+		 * See this class's docblock for the standalone-provider recipe.
 		 */
 		do_action( 'fosse_register_providers' );
 
@@ -39,13 +78,13 @@ class Provider_Loader {
 	}
 
 	/**
-	 * Clear the per-request boot state. Intended for tests that need
-	 * to re-run {@see self::boot()} in the same PHP process.
+	 * Clear the per-request boot state so {@see self::boot()} can run
+	 * again. Intended for test fixtures only; production callers should
+	 * rely on the idempotent boot guard instead.
 	 *
 	 * @return void
 	 */
 	public static function reset(): void {
-		// Placeholder until the idempotency flag lands. Letting tests call
-		// this now keeps the failing-tests commit runnable without a fatal.
+		self::$booted = false;
 	}
 }

--- a/src/class-provider-loader.php
+++ b/src/class-provider-loader.php
@@ -37,4 +37,15 @@ class Provider_Loader {
 			}
 		}
 	}
+
+	/**
+	 * Clear the per-request boot state. Intended for tests that need
+	 * to re-run {@see self::boot()} in the same PHP process.
+	 *
+	 * @return void
+	 */
+	public static function reset(): void {
+		// Placeholder until the idempotency flag lands. Letting tests call
+		// this now keeps the failing-tests commit runnable without a fatal.
+	}
 }

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -49,6 +49,10 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider = new Bluesky_Provider();
 
 		Connection_Provider_Registry::reset();
+		// Reset the loader's idempotency flag too — `test_registers_through_provider_loader`
+		// calls `Provider_Loader::boot()`, which would silently no-op on a second test
+		// invocation in the same PHP process if the static `$booted` flag leaked.
+		Provider_Loader::reset();
 		delete_option( 'atmosphere_connection' );
 		delete_option( 'atmosphere_auto_publish' );
 		delete_option( Bluesky_Domain_Handle::OPTION_PREVIOUS_HANDLE );

--- a/tests/php/Provider_LoaderTest.php
+++ b/tests/php/Provider_LoaderTest.php
@@ -8,6 +8,7 @@
 namespace Automattic\Fosse\Tests;
 
 use Automattic\Fosse\Admin\AP_Provider;
+use Automattic\Fosse\Admin\Connection_Provider;
 use Automattic\Fosse\Admin\Connection_Provider_Registry;
 use Automattic\Fosse\Provider_Loader;
 use PHPUnit\Framework\Attributes\After;
@@ -28,6 +29,7 @@ class Provider_LoaderTest extends BaseTestCase {
 	#[Before]
 	public function reset_state(): void {
 		Connection_Provider_Registry::reset();
+		Provider_Loader::reset();
 		delete_option( 'activitypub_actor_mode' );
 	}
 
@@ -40,6 +42,7 @@ class Provider_LoaderTest extends BaseTestCase {
 	public function clean_up(): void {
 		remove_all_filters( 'fosse_register_providers' );
 		Connection_Provider_Registry::reset();
+		Provider_Loader::reset();
 	}
 
 	/**
@@ -50,5 +53,104 @@ class Provider_LoaderTest extends BaseTestCase {
 		Provider_Loader::boot();
 
 		$this->assertNotNull( Connection_Provider_Registry::get_provider( 'activitypub' ) );
+	}
+
+	/**
+	 * A provider registered from a third-party callback on
+	 * `fosse_register_providers` is available after `boot()` — the
+	 * documented extension path for standalone provider plugins.
+	 */
+	public function test_external_provider_registered_via_hook_is_available_after_boot() {
+		$external = $this->make_counting_provider( 'external' );
+
+		add_action(
+			'fosse_register_providers',
+			static function () use ( $external ) {
+				Connection_Provider_Registry::register( $external );
+			}
+		);
+
+		Provider_Loader::boot();
+
+		$this->assertSame( $external, Connection_Provider_Registry::get_provider( 'external' ) );
+	}
+
+	/**
+	 * Calling `boot()` twice in the same request fires the registration
+	 * action and `register_hooks()` exactly once, so defensive callers
+	 * (e.g. an add-on that boots its own copy on `plugins_loaded`) cannot
+	 * cause double-registered hooks.
+	 */
+	public function test_boot_is_idempotent() {
+		$external          = $this->make_counting_provider( 'idempotent' );
+		$registration_runs = 0;
+
+		add_action(
+			'fosse_register_providers',
+			static function () use ( $external, &$registration_runs ) {
+				++$registration_runs;
+				Connection_Provider_Registry::register( $external );
+			}
+		);
+
+		Provider_Loader::boot();
+		Provider_Loader::boot();
+
+		$this->assertSame( 1, $external->register_hooks_calls, 'register_hooks() should run exactly once across two boot() calls.' );
+		$this->assertSame( 1, $registration_runs, '`fosse_register_providers` callbacks should run exactly once across two boot() calls.' );
+	}
+
+	/**
+	 * Build an anonymous Connection_Provider that counts how many times
+	 * `register_hooks()` has been called. Lets idempotency assertions
+	 * read off `->register_hooks_calls` without poking at WP hook state.
+	 *
+	 * @param string $slug Provider slug.
+	 * @return Connection_Provider
+	 */
+	private function make_counting_provider( string $slug ): Connection_Provider {
+		// phpcs:disable Squiz.Commenting, Generic.Commenting.DocComment.MissingShort
+		return new class( $slug ) implements Connection_Provider {
+			/**
+			 * Provider slug.
+			 *
+			 * @var string
+			 */
+			private string $slug;
+
+			/**
+			 * Number of times register_hooks() has been called.
+			 *
+			 * @var int
+			 */
+			public int $register_hooks_calls = 0;
+
+			public function __construct( string $slug ) {
+				$this->slug = $slug;
+			}
+			public function get_slug(): string {
+				return $this->slug;
+			}
+			public function get_name(): string {
+				return ucfirst( $this->slug );
+			}
+			public function is_available(): bool {
+				return true;
+			}
+			public function get_status(): array {
+				return array( 'connected' => true );
+			}
+			public function render_setup_section(): void {}
+			public function render_connection_actions(): void {}
+			public function render_status_card(): void {}
+			public function register_hooks(): void {
+				++$this->register_hooks_calls;
+			}
+			public function save_settings( array $post_data ): bool {
+				unset( $post_data );
+				return true;
+			}
+		};
+		// phpcs:enable Squiz.Commenting
 	}
 }

--- a/tests/php/Provider_LoaderTest.php
+++ b/tests/php/Provider_LoaderTest.php
@@ -76,6 +76,54 @@ class Provider_LoaderTest extends BaseTestCase {
 	}
 
 	/**
+	 * The production bootstrap is wired to `plugins_loaded` priority 20
+	 * via the global `fosse_boot_providers()` callback. Asserts the
+	 * binding itself so a future refactor that drops the wrapper —
+	 * leaving the registry never booted in production — fails a test.
+	 */
+	public function test_boot_is_wired_to_plugins_loaded_priority_20() {
+		$this->assertSame( 20, has_action( 'plugins_loaded', 'fosse_boot_providers' ) );
+	}
+
+	/**
+	 * Calling `fosse_boot_providers()` directly drives the same code path
+	 * the `plugins_loaded` callback runs in production: AP and Bluesky
+	 * providers self-register, then `Provider_Loader::boot()` fires the
+	 * action and attaches their hooks. Asserts the bundled providers land
+	 * in the registry through that path — not by manually invoking each
+	 * provider's `init()`.
+	 */
+	public function test_production_callback_registers_bundled_providers() {
+		fosse_boot_providers();
+
+		$this->assertNotNull( Connection_Provider_Registry::get_provider( 'activitypub' ) );
+		$this->assertNotNull( Connection_Provider_Registry::get_provider( 'bluesky' ) );
+	}
+
+	/**
+	 * A provider whose `is_available()` returns false stays out of the
+	 * `register_hooks()` loop, matching the documented contract that
+	 * standalone provider plugins should return false when their SDK
+	 * isn't loaded so FOSSE skips hook registration cleanly.
+	 */
+	public function test_unavailable_provider_does_not_register_hooks() {
+		$unavailable                       = $this->make_counting_provider( 'unavailable' );
+		$unavailable->is_available_returns = false;
+
+		add_action(
+			'fosse_register_providers',
+			static function () use ( $unavailable ) {
+				Connection_Provider_Registry::register( $unavailable );
+			}
+		);
+
+		Provider_Loader::boot();
+
+		$this->assertSame( 0, $unavailable->register_hooks_calls, 'register_hooks() should not run when is_available() returns false.' );
+		$this->assertSame( $unavailable, Connection_Provider_Registry::get_provider( 'unavailable' ), 'Provider should still appear in the registry — `is_available()` only gates hook registration.' );
+	}
+
+	/**
 	 * Calling `boot()` twice in the same request fires the registration
 	 * action and `register_hooks()` exactly once, so defensive callers
 	 * (e.g. an add-on that boots its own copy on `plugins_loaded`) cannot
@@ -125,6 +173,14 @@ class Provider_LoaderTest extends BaseTestCase {
 			 */
 			public int $register_hooks_calls = 0;
 
+			/**
+			 * Value returned by is_available(); set to false to exercise
+			 * the loader's "skip register_hooks" branch.
+			 *
+			 * @var bool
+			 */
+			public bool $is_available_returns = true;
+
 			public function __construct( string $slug ) {
 				$this->slug = $slug;
 			}
@@ -135,7 +191,7 @@ class Provider_LoaderTest extends BaseTestCase {
 				return ucfirst( $this->slug );
 			}
 			public function is_available(): bool {
-				return true;
+				return $this->is_available_returns;
 			}
 			public function get_status(): array {
 				return array( 'connected' => true );


### PR DESCRIPTION
## Summary

Make `fosse_register_providers` a stable extension point for standalone provider plugins.

- Defer `Provider_Loader::boot()` from file-include time to `plugins_loaded` priority 10, so a standalone provider plugin can hook `fosse_register_providers` from its own main file regardless of WordPress' alphabetical plugin load order.
- `plugins_loaded` (not `init`) because `Bluesky_Provider::register_hooks()` adds an `init` priority-1 callback for the well-known atproto-did route — booting *on* `init` would silently skip that priority.
- Make `boot()` idempotent via a `$booted` static flag so a defensively-coded add-on cannot double-register hooks. `Provider_Loader::reset()` exists for test fixtures only.
- Document the extension contract on `Provider_Loader` and on the `Connection_Provider` interface — the two natural landing spots for an add-on author reading the code.

Plan: `sdd/harden-provider-registration/plan.md` (multi-angle analysis + chosen approach).

Fixes Automattic/fosse#127.
Fixes DOTCOM-17104.

## Test plan

- [x] `composer run-script test-php` — 555/555 pass, including two new `Provider_LoaderTest` cases (external-provider registration via hook; double-`boot()` runs `register_hooks()` exactly once)
- [x] `composer run-script lint-php` — clean
- [x] `pnpm run format:check` + `pnpm run lint` — clean
- [ ] Manual: built-in ActivityPub + Bluesky providers still register and attach their hooks on a real WordPress install (covered by the existing `test_providers_registered_after_boot` plus E2E suite, but worth a smoke check in review)