### PR TITLE
Status: add connection management actions

### DIFF
--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -509,6 +509,14 @@ class Bluesky_Provider implements Connection_Provider {
 					</tr>
 				</tbody>
 			</table>
+
+			<?php if ( ! $status['connected'] && ! $status['token_error'] ) : ?>
+				<p class="fosse-status-card__actions">
+					<a class="button button-secondary" href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-provider-bluesky' ) ); ?>">
+						<?php esc_html_e( 'Open Bluesky settings', 'fosse' ); ?>
+					</a>
+				</p>
+			<?php endif; ?>
 		</div>
 		<?php
 	}

--- a/src/Admin/templates/status-page.php
+++ b/src/Admin/templates/status-page.php
@@ -63,10 +63,10 @@ if ( 0 === $connected_count ) {
 				</p>
 				<p class="fosse-status-summary__description"><?php echo esc_html( $summary_description ); ?></p>
 			</div>
-			<?php if ( empty( $connected ) ) : ?>
+			<?php if ( $connected_count < $available_count ) : ?>
 				<p class="fosse-status-summary__actions">
-					<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=fosse' ) ); ?>">
-						<?php esc_html_e( 'Set up FOSSE', 'fosse' ); ?>
+					<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-connections' ) ); ?>">
+						<?php esc_html_e( 'Manage connections', 'fosse' ); ?>
 					</a>
 				</p>
 			<?php endif; ?>

--- a/tests/e2e/status-page.spec.ts
+++ b/tests/e2e/status-page.spec.ts
@@ -110,4 +110,40 @@ test.describe( 'Status page polish', () => {
 			overflow!.tableClient + 1
 		);
 	} );
+
+	test( 'partial-connected state links to connection management', async ( {
+		page,
+	} ) => {
+		await setBlueskyState( page, {
+			connected: false,
+			auto_publish: true,
+		} );
+
+		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
+
+		await expect(
+			page.locator( '.fosse-status-summary__count' )
+		).toContainText( '1 of 2 providers connected' );
+
+		const manageConnections = page.getByRole( 'link', {
+			name: 'Manage connections',
+		} );
+		await expect( manageConnections ).toBeVisible();
+		await expect( manageConnections ).toHaveAttribute(
+			'href',
+			/admin\.php\?page=fosse#fosse-connections$/
+		);
+
+		const blueskyCard = page
+			.locator( '.fosse-status-card' )
+			.filter( { hasText: 'Bluesky' } );
+		const openBlueskySettings = blueskyCard.getByRole( 'link', {
+			name: 'Open Bluesky settings',
+		} );
+		await expect( openBlueskySettings ).toBeVisible();
+		await expect( openBlueskySettings ).toHaveAttribute(
+			'href',
+			/admin\.php\?page=fosse#fosse-provider-bluesky$/
+		);
+	} );
 } );

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -522,6 +522,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Reconnect required', $output );
 		$this->assertStringContainsString( '#fosse-provider-bluesky', $output );
 		$this->assertStringContainsString( '<details', $output );
+		$this->assertStringNotContainsString( 'fosse-status-card__actions', $output );
 	}
 
 	/**
@@ -549,17 +550,38 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Status card no longer carries a "Manage Bluesky settings" deep link
-	 * (issue #74) — the sidebar Settings menu entry replaces those per-card
-	 * navigation affordances.
+	 * Disconnected status card links directly to Bluesky connection settings.
 	 */
-	public function test_render_status_card_omits_manage_settings_link() {
+	public function test_render_status_card_disconnected_state_links_to_settings() {
 		ob_start();
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringNotContainsString( 'Manage Bluesky settings', $output );
-		$this->assertStringNotContainsString( 'fosse-status-card__manage', $output );
+		$this->assertStringContainsString( 'fosse-status-card__actions', $output );
+		$this->assertStringContainsString( 'Open Bluesky settings', $output );
+		$this->assertStringContainsString( 'admin.php?page=fosse#fosse-provider-bluesky', $output );
+	}
+
+	/**
+	 * Connected healthy status card keeps the settings link out of the card
+	 * action row; token-error recovery still renders inline with token health.
+	 */
+	public function test_render_status_card_connected_state_omits_settings_action_row() {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'fosse-status-card__actions', $output );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Show a Manage connections action on the Status summary whenever not all available providers are connected.
- Add a disconnected Bluesky status-card action that deep-links to the Bluesky settings section.
- Cover the partial-connected Status state in e2e and update Bluesky provider PHP status-card expectations.

## Test plan
- [x] composer run-script test-php -- --filter Bluesky_ProviderTest
- [x] pnpm exec playwright test tests/e2e/status-page.spec.ts
- [x] pnpm run format:check
- [x] pnpm run lint
- [x] composer run-script lint-php
- [x] git diff --check origin/trunk...HEAD

Also run before the review fix:
- [x] pnpm test
- [x] composer run-script test-php
- [x] pnpm run test:e2e