### PR TITLE
Settings: clarify publishing and connection copy

### DIFF
--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -163,7 +163,7 @@ class AP_Provider implements Connection_Provider {
 				<?php if ( $shows_blog ) : ?>
 					<tr>
 						<th scope="row">
-							<label for="fosse-activitypub-blog-identifier"><?php esc_html_e( 'Site Handle', 'fosse' ); ?></label>
+							<label for="fosse-activitypub-blog-identifier"><?php esc_html_e( 'Site handle', 'fosse' ); ?></label>
 						</th>
 						<td>
 							<input
@@ -176,7 +176,7 @@ class AP_Provider implements Connection_Provider {
 								aria-describedby="fosse-activitypub-blog-identifier-desc"
 							/>
 							<p id="fosse-activitypub-blog-identifier-desc" class="description">
-								<?php esc_html_e( 'The username people use to follow your site from the fediverse. Cannot match an existing author login or nicename.', 'fosse' ); ?>
+								<?php esc_html_e( 'The username people use to follow your site in fediverse apps. It cannot match an existing author login or nicename.', 'fosse' ); ?>
 							</p>
 						</td>
 					</tr>
@@ -210,8 +210,8 @@ class AP_Provider implements Connection_Provider {
 			</table>
 
 			<p>
-				<a href="<?php echo esc_url( admin_url( 'options-general.php?page=activitypub' ) ); ?>">
-					<?php esc_html_e( 'Show advanced ActivityPub settings', 'fosse' ); ?>
+				<a class="fosse-settings-secondary-link" href="<?php echo esc_url( admin_url( 'options-general.php?page=activitypub' ) ); ?>">
+					<?php esc_html_e( 'Advanced ActivityPub settings', 'fosse' ); ?>
 				</a>
 			</p>
 		</div>
@@ -278,7 +278,7 @@ class AP_Provider implements Connection_Provider {
 						<td class="fosse-status-card__value"><?php echo esc_html( $mode_label ); ?></td>
 					</tr>
 					<tr>
-						<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Post Types', 'fosse' ); ?></th>
+						<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Content types', 'fosse' ); ?></th>
 						<td class="fosse-status-card__value"><?php echo esc_html( implode( ', ', $post_types ) ); ?></td>
 					</tr>
 					<?php if ( $this->mode_includes_user( $status['actor_mode'] ) && ! empty( $status['user_address'] ) ) : ?>

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -220,7 +220,7 @@ class Bluesky_Provider implements Connection_Provider {
 			<?php settings_errors( 'atmosphere' ); ?>
 
 			<?php if ( ! $status['connected'] ) : ?>
-				<p><?php esc_html_e( 'Connect your Bluesky account so FOSSE can publish new posts there.', 'fosse' ); ?></p>
+				<p><?php esc_html_e( 'Connect a Bluesky account to share eligible WordPress posts there too. You can disconnect it here later.', 'fosse' ); ?></p>
 
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 					<input type="hidden" name="action" value="fosse_connect_bluesky" />
@@ -229,7 +229,7 @@ class Bluesky_Provider implements Connection_Provider {
 					<table class="form-table">
 						<tr>
 							<th scope="row">
-								<label for="fosse_bluesky_handle"><?php esc_html_e( 'Handle', 'fosse' ); ?></label>
+								<label for="fosse_bluesky_handle"><?php esc_html_e( 'Bluesky handle', 'fosse' ); ?></label>
 							</th>
 							<td>
 								<input
@@ -239,7 +239,7 @@ class Bluesky_Provider implements Connection_Provider {
 									id="fosse_bluesky_handle"
 									placeholder="alice.bsky.social"
 								/>
-								<p class="description"><?php esc_html_e( 'Your Bluesky/AT Protocol handle, for example alice.bsky.social or your own domain.', 'fosse' ); ?></p>
+								<p class="description"><?php esc_html_e( 'Enter your Bluesky handle, such as alice.bsky.social. If you use your own domain as your handle, enter that.', 'fosse' ); ?></p>
 								<p class="description fosse-bluesky-signup">
 									<?php
 									echo wp_kses_post(
@@ -259,9 +259,15 @@ class Bluesky_Provider implements Connection_Provider {
 					<?php submit_button( __( 'Connect Bluesky', 'fosse' ) ); ?>
 				</form>
 			<?php else : ?>
+				<p>
+					<strong><?php esc_html_e( 'Connected account', 'fosse' ); ?></strong>
+				</p>
+				<p class="description">
+					<?php esc_html_e( 'FOSSE can share eligible WordPress posts with this Bluesky account.', 'fosse' ); ?>
+				</p>
 				<table class="form-table">
 					<tr>
-						<th scope="row"><?php esc_html_e( 'Handle', 'fosse' ); ?></th>
+						<th scope="row"><?php esc_html_e( 'Bluesky handle', 'fosse' ); ?></th>
 						<td>
 							<strong class="fosse-admin-token fosse-admin-token--handle">
 								<?php
@@ -271,7 +277,7 @@ class Bluesky_Provider implements Connection_Provider {
 						</td>
 					</tr>
 					<tr>
-						<th scope="row"><?php esc_html_e( 'DID', 'fosse' ); ?></th>
+						<th scope="row"><?php esc_html_e( 'Account ID', 'fosse' ); ?></th>
 						<td>
 							<code class="fosse-admin-token fosse-admin-token--did">
 								<?php
@@ -291,7 +297,7 @@ class Bluesky_Provider implements Connection_Provider {
 						</td>
 					</tr>
 					<tr>
-						<th scope="row"><?php esc_html_e( 'Token Health', 'fosse' ); ?></th>
+						<th scope="row"><?php esc_html_e( 'Token health', 'fosse' ); ?></th>
 						<td><?php echo esc_html( $status['token_error'] ? $status['token_error'] : __( 'OK', 'fosse' ) ); ?></td>
 					</tr>
 				</table>
@@ -312,17 +318,20 @@ class Bluesky_Provider implements Connection_Provider {
 					$pending_revert = Bluesky_Domain_Handle::get_pending_revert_handle();
 					if ( '' !== $pending_revert ) :
 						?>
-						<p class="description fosse-domain-handle-revert-note">
-							<?php
-							echo esc_html(
-								sprintf(
-									/* translators: %s: previous Bluesky handle that disconnect will restore (e.g. alice.bsky.social). */
-									__( 'Disconnecting will also restore %s as this account\'s Bluesky handle.', 'fosse' ),
-									$pending_revert
-								)
-							);
-							?>
-						</p>
+						<div class="notice notice-warning inline fosse-domain-handle-revert-note">
+							<p>
+								<strong><?php esc_html_e( 'Disconnect note:', 'fosse' ); ?></strong>
+								<?php
+								echo esc_html(
+									sprintf(
+										/* translators: %s: previous Bluesky handle that disconnect will restore (e.g. alice.bsky.social). */
+										__( 'Disconnecting will also restore %s as this account\'s Bluesky handle.', 'fosse' ),
+										$pending_revert
+									)
+								);
+								?>
+							</p>
+						</div>
 						<?php
 					endif;
 					submit_button( __( 'Disconnect Bluesky', 'fosse' ), 'secondary' );

--- a/src/Admin/templates/setup-page.php
+++ b/src/Admin/templates/setup-page.php
@@ -22,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
 		<p class="fosse-admin-page__eyebrow"><?php esc_html_e( 'Social web', 'fosse' ); ?></p>
 		<h1 class="fosse-admin-page__title"><?php esc_html_e( 'FOSSE Settings', 'fosse' ); ?></h1>
 		<p class="fosse-admin-page__description">
-			<?php esc_html_e( 'Choose which content FOSSE publishes, how your site appears on ActivityPub, and which network accounts are connected.', 'fosse' ); ?>
+			<?php esc_html_e( 'Control which content types FOSSE can share, how people follow your fediverse identity, and which network accounts are connected.', 'fosse' ); ?>
 		</p>
 	</header>
 
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 				echo wp_kses_post(
 					sprintf(
 						/* translators: 1: opening anchor tag to setup wizard, 2: closing anchor tag */
-						__( 'First time here? %1$sRun the setup wizard%2$s to set up social web publishing in a few steps.', 'fosse' ),
+						__( 'Need a guided setup? %1$sRun the setup wizard%2$s to configure social web publishing in a few steps.', 'fosse' ),
 						'<a href="' . esc_url( admin_url( 'admin.php?page=fosse-wizard' ) ) . '">',
 						'</a>'
 					)
@@ -63,21 +63,21 @@ defined( 'ABSPATH' ) || exit;
 				<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $save_nonce ); ?>" />
 
 				<div class="fosse-settings-panel__header">
-					<h2><?php esc_html_e( 'Federation settings', 'fosse' ); ?></h2>
+					<h2><?php esc_html_e( 'Publishing settings', 'fosse' ); ?></h2>
 					<p class="fosse-settings-panel__description">
-						<?php esc_html_e( 'Choose which post types FOSSE publishes and which ActivityPub profile publishes them.', 'fosse' ); ?>
+						<?php esc_html_e( 'Choose the content types FOSSE publishes and the fediverse identity people can follow.', 'fosse' ); ?>
 					</p>
 				</div>
 
 				<div class="fosse-settings-section" id="fosse-section-general">
-					<h3><?php esc_html_e( 'General', 'fosse' ); ?></h3>
+					<h3><?php esc_html_e( 'Content and identity', 'fosse' ); ?></h3>
 
 					<table class="form-table">
 						<tr>
-							<th scope="row"><?php esc_html_e( 'Post Types', 'fosse' ); ?></th>
+							<th scope="row"><?php esc_html_e( 'Content types', 'fosse' ); ?></th>
 							<td>
 								<fieldset class="fosse-settings-choice-grid">
-									<legend class="screen-reader-text"><?php esc_html_e( 'Post Types', 'fosse' ); ?></legend>
+									<legend class="screen-reader-text"><?php esc_html_e( 'Content types', 'fosse' ); ?></legend>
 									<?php foreach ( $all_post_types as $pt ) : ?>
 										<label class="fosse-settings-choice-label">
 											<input
@@ -90,7 +90,7 @@ defined( 'ABSPATH' ) || exit;
 										</label>
 									<?php endforeach; ?>
 									<p class="description">
-										<?php esc_html_e( 'Selected post types can be published to your connected social web providers.', 'fosse' ); ?>
+										<?php esc_html_e( 'Selected content types can be published to your connected social web providers.', 'fosse' ); ?>
 									</p>
 								</fieldset>
 							</td>
@@ -221,7 +221,7 @@ defined( 'ABSPATH' ) || exit;
 			<div class="fosse-settings-panel__header">
 				<h2><?php esc_html_e( 'Connections', 'fosse' ); ?></h2>
 				<p class="fosse-settings-panel__description">
-					<?php esc_html_e( 'Review connection details and connect or disconnect network accounts.', 'fosse' ); ?>
+					<?php esc_html_e( 'Review connected accounts and connect or disconnect the networks FOSSE can publish to.', 'fosse' ); ?>
 				</p>
 			</div>
 

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { resetBlueskyState, setBlueskyState } from './test-helpers';
 
 test.describe( 'Bluesky provider UI', () => {
@@ -24,6 +24,15 @@ test.describe( 'Bluesky provider UI', () => {
 		);
 	} );
 
+	const expectNoCriticalText = async ( page: Page ) => {
+		await expect(
+			page.locator(
+				'text=/Fatal error|Parse error|Uncaught .*Error|critical error/i'
+			)
+		).toHaveCount( 0 );
+		await expect( page.locator( '#error-page' ) ).toHaveCount( 0 );
+	};
+
 	test( 'setup and status pages show Bluesky disconnected by default', async ( {
 		page,
 	} ) => {
@@ -33,6 +42,7 @@ test.describe( 'Bluesky provider UI', () => {
 		} );
 
 		await page.goto( '/wp-admin/admin.php?page=fosse' );
+		await expectNoCriticalText( page );
 
 		const federationSettings = page.locator( '#fosse-federation-settings' );
 		const connections = page.locator( '#fosse-connections' );
@@ -42,7 +52,13 @@ test.describe( 'Bluesky provider UI', () => {
 
 		await expect(
 			federationSettings.getByRole( 'heading', {
-				name: 'Federation settings',
+				name: 'Publishing settings',
+			} )
+		).toBeVisible();
+		await expect( federationSettings ).toContainText( 'Content types' );
+		await expect(
+			federationSettings.getByRole( 'link', {
+				name: 'Advanced ActivityPub settings',
 			} )
 		).toBeVisible();
 		await expect(
@@ -55,7 +71,7 @@ test.describe( 'Bluesky provider UI', () => {
 			connections.locator( '#fosse-provider-activitypub-connection' )
 		).toContainText( 'Connected automatically' );
 		await expect(
-			blueskyConnection.locator( '#fosse_bluesky_handle' )
+			blueskyConnection.getByLabel( 'Bluesky handle' )
 		).toBeVisible();
 		await expect(
 			blueskyConnection.getByRole( 'button', { name: 'Connect Bluesky' } )
@@ -87,6 +103,7 @@ test.describe( 'Bluesky provider UI', () => {
 		} );
 
 		await page.goto( '/wp-admin/admin.php?page=fosse' );
+		await expectNoCriticalText( page );
 
 		const connections = page.locator( '#fosse-connections' );
 		const blueskyConnection = connections.locator(
@@ -98,6 +115,9 @@ test.describe( 'Bluesky provider UI', () => {
 				name: 'Disconnect Bluesky',
 			} )
 		).toBeVisible();
+		await expect( blueskyConnection ).toContainText( 'Connected account' );
+		await expect( blueskyConnection ).toContainText( 'Bluesky handle' );
+		await expect( blueskyConnection ).toContainText( 'Account ID' );
 		await expect( blueskyConnection ).toContainText( 'alice.bsky.social' );
 		await expect( blueskyConnection ).toContainText( 'did:plc:alice123' );
 

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -183,8 +183,8 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * AP's render_setup_section preserves the Site Handle field in
-	 * `blog` mode and the "Show advanced ActivityPub settings" link.
+	 * AP's render_setup_section preserves the Site handle field in
+	 * `blog` mode and the secondary ActivityPub settings link.
 	 */
 	public function test_render_setup_section_renders_blog_mode_fields() {
 		update_option( 'activitypub_actor_mode', 'blog' );
@@ -196,7 +196,8 @@ class AP_ProviderTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
 		$this->assertStringContainsString( 'value="my-site"', $output );
-		$this->assertStringContainsString( 'Show advanced ActivityPub settings', $output );
+		$this->assertStringContainsString( 'Advanced ActivityPub settings', $output );
+		$this->assertStringContainsString( 'fosse-settings-secondary-link', $output );
 	}
 
 	/**
@@ -212,6 +213,7 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'fosse-status-card__table', $output );
 		$this->assertStringContainsString( 'fosse-status-card__label', $output );
 		$this->assertStringContainsString( 'fosse-status-card__value', $output );
+		$this->assertStringContainsString( 'Content types', $output );
 		$this->assertStringNotContainsString( 'Manage ActivityPub settings', $output );
 		$this->assertStringNotContainsString( 'fosse-status-card__manage', $output );
 	}
@@ -790,7 +792,7 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * The Site Handle field renders in `blog` mode with the current saved
+	 * The Site handle field renders in `blog` mode with the current saved
 	 * value pre-filled so site owners can edit it from FOSSE's surface.
 	 */
 	public function test_render_setup_section_shows_site_handle_field_in_blog_mode() {
@@ -803,7 +805,7 @@ class AP_ProviderTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
 		$this->assertStringContainsString( 'value="my-site"', $output );
-		$this->assertStringContainsString( 'Site Handle', $output );
+		$this->assertStringContainsString( 'Site handle', $output );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Rename the Settings publishing panel and content labels so the page distinguishes publishing settings from account connections.
- Align ActivityPub and Bluesky Settings labels with user-facing terms like content types, site handle, Bluesky handle, and connected account.
- Add Settings render/fatal-text e2e coverage and update provider PHP expectations for the revised labels.

## Test plan
- [x] pnpm exec playwright test tests/e2e/bluesky-provider.spec.ts
- [x] composer run-script test-php -- --filter AP_ProviderTest
- [x] composer run-script test-php -- --filter Bluesky_ProviderTest
- [x] pnpm run format:check
- [x] pnpm run lint
- [x] pnpm test
- [x] composer run-script lint-php
- [x] composer run-script test-php
- [x] pnpm run test:e2e
- [x] git diff --check origin/trunk...HEAD