### PR TITLE
Wizard: tighten onboarding copy and mobile progress

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -1722,10 +1722,12 @@
 	}
 
 	.fosse-wizard__progress {
-		align-items: flex-start;
-		flex-wrap: wrap;
-		gap: 8px 12px;
-		border-radius: 14px;
+		align-items: center;
+		flex-wrap: nowrap;
+		gap: 6px;
+		margin-bottom: 28px;
+		padding: 8px 10px;
+		border-radius: 999px;
 	}
 
 	.fosse-wizard .fosse-wizard__title {
@@ -1733,7 +1735,36 @@
 	}
 
 	.fosse-wizard__progress-line {
-		display: none;
+		display: block;
+		flex: 1 1 10px;
+		min-width: 8px;
+	}
+
+	.fosse-wizard__progress-step {
+		position: relative;
+		flex: 0 0 auto;
+		gap: 0;
+	}
+
+	.fosse-wizard__progress-step:not(.is-active) .fosse-wizard__progress-label {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		clip-path: inset(50%);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	.fosse-wizard__progress-step.is-active .fosse-wizard__progress-label {
+		max-width: 118px;
+		margin-left: 6px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.fosse-wizard__card {

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -698,7 +698,7 @@ class Onboarding_Wizard {
 	}
 
 	/**
-	 * Format the "People follow" summary value for the completion step.
+	 * Format the fediverse identity summary value for the completion step.
 	 *
 	 * Embeds the resolved fediverse handle(s) so users see the actual
 	 * identity they just stood up rather than just the bare host. Falls
@@ -978,20 +978,20 @@ class Onboarding_Wizard {
 				'icon'  => 'dashicons-star-filled',
 				'badge' => __( 'Recommended', 'fosse' ),
 				'title' => __( 'Fediverse + Bluesky', 'fosse' ),
-				'desc'  => __( 'Let people follow your site from apps like Mastodon, and share eligible posts to Bluesky.', 'fosse' ),
+				'desc'  => __( 'Let people follow your site from Fediverse apps like Mastodon, and share eligible posts to Bluesky.', 'fosse' ),
 			),
 			self::DESTINATION_FEDIVERSE_ONLY    => array(
 				'class' => 'fosse-destination-card--fediverse-only',
 				'icon'  => 'dashicons-networking',
 				'badge' => __( 'Simple setup', 'fosse' ),
 				'title' => __( 'Fediverse only', 'fosse' ),
-				'desc'  => __( 'Let people follow your site from apps like Mastodon. You can connect Bluesky later.', 'fosse' ),
+				'desc'  => __( 'Let people follow your site from Fediverse apps like Mastodon. You can connect Bluesky later.', 'fosse' ),
 			),
 		);
 		?>
 		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Where should your WordPress posts appear?', 'fosse' ); ?></h1>
 		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Fediverse sharing is enabled by default, so people can follow your site from Mastodon and similar apps. You can also connect Bluesky now or set it up later.', 'fosse' ); ?>
+			<?php esc_html_e( 'Fediverse sharing is enabled by default, so people can follow your site from Fediverse apps like Mastodon. You can also connect Bluesky now or set it up later.', 'fosse' ); ?>
 		</p>
 
 		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
@@ -1058,7 +1058,10 @@ class Onboarding_Wizard {
 			$current_mode = Actor_Mode_Lock::forced_mode();
 		}
 		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
-		$nonce     = wp_create_nonce( 'fosse_wizard' );
+		if ( in_array( $site_host, array( 'localhost', '127.0.0.1', '::1', '0.0.0.0' ), true ) ) {
+			$site_host = '';
+		}
+		$nonce = wp_create_nonce( 'fosse_wizard' );
 
 		$modes = array(
 			'actor'      => array(
@@ -1117,7 +1120,7 @@ class Onboarding_Wizard {
 		?>
 		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Who should people follow?', 'fosse' ); ?></h1>
 		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Choose how your site appears in social apps. This controls the name people see when your posts are shared.', 'fosse' ); ?>
+			<?php esc_html_e( 'Choose the fediverse identity people can follow when FOSSE shares your selected content types.', 'fosse' ); ?>
 		</p>
 
 		<?php settings_errors( 'fosse' ); ?>
@@ -1210,10 +1213,10 @@ class Onboarding_Wizard {
 								</div>
 							<?php endif; ?>
 						<?php elseif ( 'actor' === $preview_mode && '' !== $user_handle ) : ?>
-							<span class="fosse-address-preview__label"><?php esc_html_e( 'Your follow address:', 'fosse' ); ?></span>
+							<span class="fosse-address-preview__label"><?php esc_html_e( 'Your fediverse address:', 'fosse' ); ?></span>
 							<code class="fosse-address-preview__address"><?php echo esc_html( $user_handle ); ?></code>
 						<?php elseif ( 'blog' === $preview_mode && '' !== $blog_handle ) : ?>
-							<span class="fosse-address-preview__label"><?php esc_html_e( 'Site follow address:', 'fosse' ); ?></span>
+							<span class="fosse-address-preview__label"><?php esc_html_e( 'Site fediverse address:', 'fosse' ); ?></span>
 							<code class="fosse-address-preview__address"><?php echo esc_html( $blog_handle ); ?></code>
 						<?php endif; ?>
 					</div>
@@ -1239,7 +1242,7 @@ class Onboarding_Wizard {
 						aria-describedby="fosse-wizard-blog-identifier-desc"
 					/>
 					<p id="fosse-wizard-blog-identifier-desc" class="description">
-						<?php esc_html_e( 'The username people use to follow your site. It cannot match an existing author username.', 'fosse' ); ?>
+						<?php esc_html_e( 'The username people use to follow your site in fediverse apps. It cannot match an existing author login or nicename.', 'fosse' ); ?>
 					</p>
 				</div>
 			</div>
@@ -1378,11 +1381,11 @@ class Onboarding_Wizard {
 		$is_connected = (bool) $status['connected'];
 
 		$title = $is_connected
-			? __( 'Bluesky is connected', 'fosse' )
+			? __( 'Review Bluesky connection', 'fosse' )
 			: __( 'Connect to Bluesky', 'fosse' );
 
 		$description = $is_connected
-			? __( 'Bluesky is connected. Review the details below before finishing setup.', 'fosse' )
+			? __( 'Review the connected account below before finishing setup.', 'fosse' )
 			: __( 'Connect your Bluesky account to share eligible WordPress posts there too. This is optional, and you can do it later in FOSSE Settings.', 'fosse' );
 		?>
 		<h1 class="fosse-wizard__title"><?php echo esc_html( $title ); ?></h1>
@@ -1450,13 +1453,13 @@ class Onboarding_Wizard {
 					<?php endif; ?>
 					<?php if ( ! empty( $handle_previews['user'] ) ) : ?>
 						<tr>
-							<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Your follow address', 'fosse' ); ?></th>
+							<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></th>
 							<td class="fosse-summary__value"><code><?php echo esc_html( $handle_previews['user'] ); ?></code></td>
 						</tr>
 					<?php endif; ?>
 					<?php if ( ! empty( $handle_previews['blog'] ) ) : ?>
 						<tr>
-							<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Site follow address', 'fosse' ); ?></th>
+							<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></th>
 							<td class="fosse-summary__value"><code><?php echo esc_html( $handle_previews['blog'] ); ?></code></td>
 						</tr>
 					<?php endif; ?>
@@ -1658,7 +1661,7 @@ class Onboarding_Wizard {
 					<td class="fosse-summary__value"><?php echo esc_html( $destination_label ); ?></td>
 				</tr>
 				<tr>
-					<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'People follow', 'fosse' ); ?></th>
+					<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Fediverse identity', 'fosse' ); ?></th>
 					<td class="fosse-summary__value">
 						<?php
 						echo wp_kses(
@@ -1672,7 +1675,7 @@ class Onboarding_Wizard {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Content shared', 'fosse' ); ?></th>
+					<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Content types', 'fosse' ); ?></th>
 					<td class="fosse-summary__value"><?php echo esc_html( implode( ', ', $type_labels ) ); ?></td>
 				</tr>
 				<tr>

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -21,6 +21,17 @@ const completeThroughBlueskySkip = async ( page: Page ) => {
 	await expect( page ).toHaveURL( /step=complete/ );
 };
 
+const expectNoHorizontalOverflow = async ( page: Page ) => {
+	const overflow = await page.evaluate( () => ( {
+		scrollWidth: document.documentElement.scrollWidth,
+		clientWidth: document.documentElement.clientWidth,
+	} ) );
+
+	expect( overflow.scrollWidth ).toBeLessThanOrEqual(
+		overflow.clientWidth + 1
+	);
+};
+
 test( 'Wizard page loads without errors', async ( { page } ) => {
 	const response = await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 	expect( response?.status() ).toBeLessThan( 400 );
@@ -53,7 +64,15 @@ test( 'Wizard shows progress indicator on destination step', async ( {
 test( 'Destination step shows two destination cards', async ( { page } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 
+	await expect( page.locator( '.fosse-wizard__description' ) ).toContainText(
+		'Fediverse apps like Mastodon'
+	);
 	await expect( page.locator( '.fosse-destination-card' ) ).toHaveCount( 2 );
+	await expect(
+		page.locator( '.fosse-destination-card', {
+			hasText: 'Fediverse apps like Mastodon',
+		} )
+	).toHaveCount( 2 );
 	await expect(
 		page.locator( '.fosse-destination-card', {
 			hasText: 'Fediverse + Bluesky',
@@ -64,6 +83,48 @@ test( 'Destination step shows two destination cards', async ( { page } ) => {
 			hasText: 'Fediverse only',
 		} )
 	).toBeVisible();
+	await expect( page.getByText( 'Mastodon and similar apps' ) ).toHaveCount(
+		0
+	);
+} );
+
+test( 'Wizard progress stays compact and keeps step labels available on mobile', async ( {
+	page,
+} ) => {
+	await page.setViewportSize( { width: 390, height: 720 } );
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+
+	await expectNoHorizontalOverflow( page );
+	await expect(
+		page.getByRole( 'button', { name: 'Continue' } )
+	).toBeVisible();
+	await expect(
+		page.locator(
+			'.fosse-wizard__progress-step.is-active .fosse-wizard__progress-label',
+			{ hasText: 'Destinations' }
+		)
+	).toBeVisible();
+
+	const progressMetrics = await page
+		.locator( '.fosse-wizard__progress' )
+		.evaluate( ( el ) => {
+			const unavailableLabels = Array.from(
+				el.querySelectorAll( '.fosse-wizard__progress-label' )
+			).filter( ( label ) => {
+				const style = window.getComputedStyle( label );
+				return (
+					'hidden' === style.visibility || 'none' === style.display
+				);
+			} ).length;
+
+			return {
+				height: ( el as HTMLElement ).offsetHeight,
+				unavailableLabels,
+			};
+		} );
+
+	expect( progressMetrics.height ).toBeLessThanOrEqual( 48 );
+	expect( progressMetrics.unavailableLabels ).toBe( 0 );
 } );
 
 test( 'Destination selection navigates to identity step', async ( {
@@ -97,6 +158,9 @@ test( 'Appearance step swaps the visible address preview when the actor mode cha
 	await expect(
 		page.locator( '.fosse-address-preview[data-fosse-mode]' )
 	).toHaveCount( 3 );
+	await expect(
+		page.locator( '.fosse-address-preview[data-fosse-mode="actor"]' )
+	).toContainText( 'Your fediverse address:' );
 
 	// Selecting "As your site" exposes the blog preview and the inline
 	// Site Handle row, and hides the personal address preview.
@@ -111,6 +175,9 @@ test( 'Appearance step swaps the visible address preview when the actor mode cha
 	await expect(
 		page.locator( '.fosse-address-preview[data-fosse-mode="blog"]' )
 	).toBeVisible();
+	await expect(
+		page.locator( '.fosse-address-preview[data-fosse-mode="blog"]' )
+	).toContainText( 'Site fediverse address:' );
 	await expect(
 		page.locator( '.fosse-address-preview[data-fosse-mode="actor"]' )
 	).toBeHidden();
@@ -271,12 +338,15 @@ test.describe( 'Bluesky step — connected (post-OAuth completion)', () => {
 
 		await expect(
 			page.locator( '.fosse-wizard__title', {
-				hasText: 'Bluesky is connected',
+				hasText: 'Review Bluesky connection',
 			} )
 		).toBeVisible();
 		await expect(
 			page.locator( '.fosse-wizard__description' )
 		).not.toContainText( 'connect later' );
+		await expect(
+			page.locator( 'text=/Bluesky is connected/i' )
+		).toHaveCount( 1 );
 		await expect( page.locator( '.fosse-summary' ) ).toContainText(
 			'alice.bsky.social'
 		);
@@ -341,8 +411,8 @@ test( 'Completion step shows summary', async ( { page } ) => {
 	await expect(
 		page.locator( '.fosse-summary__label', { hasText: 'Destinations' } )
 	).toBeVisible();
-	await expect( page.locator( 'text=People follow' ) ).toBeVisible();
-	await expect( page.locator( 'text=Content shared' ) ).toBeVisible();
+	await expect( page.locator( 'text=Fediverse identity' ) ).toBeVisible();
+	await expect( page.locator( 'text=Content types' ) ).toBeVisible();
 	await expect(
 		page.locator( '.fosse-summary__label', { hasText: 'Bluesky' } )
 	).toBeVisible();

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -641,11 +641,13 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( '' );
 
 		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
-		$this->assertStringContainsString( 'Fediverse sharing is enabled by default, so people can follow your site from Mastodon and similar apps. You can also connect Bluesky now or set it up later.', $output );
+		$this->assertStringContainsString( 'Fediverse sharing is enabled by default, so people can follow your site from Fediverse apps like Mastodon. You can also connect Bluesky now or set it up later.', $output );
 		$this->assertStringContainsString( 'Fediverse + Bluesky', $output );
 		$this->assertStringContainsString( 'Fediverse only', $output );
 		$this->assertStringContainsString( 'Simple setup', $output );
-		$this->assertStringContainsString( 'Let people follow your site from apps like Mastodon. You can connect Bluesky later.', $output );
+		$this->assertSame( 3, substr_count( $output, 'Fediverse apps like Mastodon' ) );
+		$this->assertStringContainsString( 'Let people follow your site from Fediverse apps like Mastodon. You can connect Bluesky later.', $output );
+		$this->assertStringNotContainsString( 'Mastodon and similar apps', $output );
 		$this->assertStringContainsString( 'name="fosse_onboarding_destination"', $output );
 		$this->assertStringContainsString( 'data-fosse-lizard-toggle', $output );
 		$this->assertStringContainsString( 'aria-label="Toggle wizard theme"', $output );
@@ -686,11 +688,33 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'appearance' );
 
 		$this->assertStringContainsString( 'Who should people follow?', $output );
+		$this->assertStringContainsString( 'Choose the fediverse identity people can follow when FOSSE shares your selected content types.', $output );
 		$this->assertMatchesRegularExpression(
 			'/fosse-mode-card__title">As you<.*fosse-mode-card__title">As your site</s',
 			$output,
 			'The default author-profile option should render before the site-profile option.'
 		);
+	}
+
+	/**
+	 * Local preview URLs should not make localhost read like a product identity.
+	 */
+	public function test_identity_step_uses_generic_site_copy_for_localhost_preview(): void {
+		$old_home    = get_option( 'home' );
+		$old_siteurl = get_option( 'siteurl' );
+
+		update_option( 'home', 'http://localhost:9400' );
+		update_option( 'siteurl', 'http://localhost:9400' );
+
+		try {
+			$output = $this->render_wizard_step( 'appearance' );
+		} finally {
+			update_option( 'home', $old_home );
+			update_option( 'siteurl', $old_siteurl );
+		}
+
+		$this->assertStringContainsString( 'People follow your site, and posts show your site name. Best for blogs and publications.', $output );
+		$this->assertStringNotContainsString( 'People follow <strong>localhost</strong>', $output );
 	}
 
 	// --- Appearance step render ---
@@ -728,6 +752,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 			$output,
 			'Expected an actor_blog-mode preview container.'
 		);
+		$this->assertStringContainsString( 'Your fediverse address:', $output );
+		$this->assertStringContainsString( 'Site fediverse address:', $output );
 	}
 
 	/**
@@ -1207,7 +1233,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$output = $this->render_wizard_step( 'bluesky' );
 
-		$this->assertStringContainsString( 'Bluesky is connected', $output );
+		$this->assertStringContainsString( 'Review Bluesky connection', $output );
+		$this->assertSame( 1, substr_count( $output, 'Bluesky is connected' ) );
 		$this->assertStringContainsString( 'alice.bsky.social', $output );
 		$this->assertStringContainsString( 'did:plc:alice123', $output );
 		$this->assertStringContainsString( 'Finish setup', $output );
@@ -1376,6 +1403,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertStringContainsString( 'Destinations', $output );
+		$this->assertStringContainsString( 'Fediverse identity', $output );
+		$this->assertStringContainsString( 'Content types', $output );
 		$this->assertStringContainsString( 'Fediverse only', $output );
 		$this->assertStringContainsString( 'Skipped', $output );
 	}
@@ -1567,7 +1596,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringNotContainsString( 'connect later', $output );
 		$this->assertStringNotContainsString( 'This step is optional', $output );
 		$this->assertStringContainsString( 'Bluesky is connected', $output );
-		$this->assertStringContainsString( 'Review the details below', $output );
+		$this->assertStringContainsString( 'Review the connected account below', $output );
 	}
 
 	/**
@@ -1587,7 +1616,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 			remove_filter( 'activitypub_user_can_activitypub', '__return_true' );
 		}
 
-		$this->assertStringContainsString( 'Your follow address', $output );
+		$this->assertStringContainsString( 'Your fediverse address', $output );
 		$this->assertMatchesRegularExpression( '/<code>@[^<]+@[^<]+<\/code>/', $output );
 	}
 
@@ -1599,8 +1628,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 	public function test_render_bluesky_step_disconnected_omits_fediverse_identity(): void {
 		$output = $this->render_wizard_step( 'bluesky' );
 
-		$this->assertStringNotContainsString( 'Your follow address', $output );
-		$this->assertStringNotContainsString( 'Site follow address', $output );
+		$this->assertStringNotContainsString( 'Your fediverse address', $output );
+		$this->assertStringNotContainsString( 'Site fediverse address', $output );
 	}
 
 	// --- Publish CTA on completion step (#63) ---


### PR DESCRIPTION
## Summary
- align wizard copy with Settings/Status terms for fediverse identity, content types, and fediverse addresses
- reduce repeated connected Bluesky confirmation copy while keeping the in-card success state
- make the wizard progress indicator compact at mobile widths without hiding step labels from assistive tech

## Testing
- pnpm run format:check
- pnpm run lint
- composer run-script lint-php
- pnpm test
- composer run-script test-php
- pnpm run test:e2e