### PR TITLE
Admin CSS: normalize visual tokens

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -24,6 +24,9 @@
 	--fosse-admin-warning-soft: #fff7e3;
 	--fosse-admin-text: #1d2327;
 	--fosse-admin-muted: #646970;
+	--fosse-admin-radius: 8px;
+	--fosse-admin-radius-small: 6px;
+	--fosse-admin-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 
 	max-width: 1120px;
 	color: var(--fosse-admin-text);
@@ -38,7 +41,7 @@
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 1.3;
-	letter-spacing: 0.08em;
+	letter-spacing: 0;
 	text-transform: uppercase;
 	color: var(--fosse-admin-muted);
 }
@@ -49,7 +52,7 @@
 	font-size: 32px;
 	font-weight: 600;
 	line-height: 1.18;
-	letter-spacing: -0.01em;
+	letter-spacing: 0;
 	color: var(--fosse-admin-text);
 }
 
@@ -66,7 +69,7 @@
 }
 
 .fosse-admin-page .button {
-	border-radius: 6px;
+	border-radius: var(--fosse-admin-radius-small);
 }
 
 /* Bluesky auto-publish recovery notice form sits above its description
@@ -87,7 +90,7 @@
 	white-space: normal;
 	overflow-wrap: break-word;
 	padding: 2px 5px;
-	border-radius: 5px;
+	border-radius: var(--fosse-admin-radius-small);
 	background: var(--fosse-admin-surface-muted, #f6f7f7);
 	color: var(--fosse-admin-text, #1d2327);
 	box-decoration-break: clone;
@@ -111,14 +114,9 @@
 	margin: 0 0 20px;
 	padding: 18px 20px;
 	border: 1px solid rgba(40, 115, 64, 0.18);
-	border-radius: 14px;
-	background: radial-gradient(
-			circle at right -20px bottom -38px,
-			rgba(40, 115, 64, 0.12),
-			transparent 118px
-		),
-		linear-gradient(135deg, #fff, #f8fcfa);
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+	border-radius: var(--fosse-admin-radius);
+	background: var(--fosse-admin-surface);
+	box-shadow: var(--fosse-admin-shadow);
 }
 
 .fosse-status-summary::before {
@@ -136,12 +134,7 @@
 
 .fosse-status-summary.has-attention {
 	border-color: rgba(138, 98, 0, 0.24);
-	background: radial-gradient(
-			circle at right -20px bottom -38px,
-			rgba(138, 98, 0, 0.12),
-			transparent 118px
-		),
-		linear-gradient(135deg, #fff, #fffaf0);
+	background: var(--fosse-admin-warning-soft);
 }
 
 .fosse-status-summary.has-attention::before {
@@ -169,7 +162,7 @@
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 1.3;
-	letter-spacing: 0.06em;
+	letter-spacing: 0;
 	text-transform: uppercase;
 	color: var(--fosse-admin-muted);
 }
@@ -211,9 +204,9 @@
 	min-width: 0;
 	padding: 20px;
 	border: 1px solid var(--fosse-admin-border);
-	border-radius: 14px;
+	border-radius: var(--fosse-admin-radius);
 	background: var(--fosse-admin-surface);
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+	box-shadow: var(--fosse-admin-shadow);
 }
 
 .fosse-status-card__header {
@@ -314,7 +307,7 @@
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 1.45;
-	letter-spacing: 0.04em;
+	letter-spacing: 0;
 	text-align: left;
 	text-transform: uppercase;
 	white-space: nowrap;
@@ -375,9 +368,9 @@
 	margin: 20px 0;
 	padding: 24px;
 	border: 1px solid var(--fosse-admin-border);
-	border-radius: 14px;
+	border-radius: var(--fosse-admin-radius);
 	background: var(--fosse-admin-surface);
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+	box-shadow: var(--fosse-admin-shadow);
 }
 
 .fosse-settings-panel__header {
@@ -421,7 +414,7 @@
 	font-size: 13px;
 	font-weight: 600;
 	line-height: 1.35;
-	letter-spacing: 0.04em;
+	letter-spacing: 0;
 	text-transform: uppercase;
 	color: var(--fosse-admin-muted);
 }
@@ -463,7 +456,7 @@
 .fosse-admin-page textarea,
 .fosse-admin-page select {
 	border-color: var(--fosse-admin-border-strong);
-	border-radius: 6px;
+	border-radius: var(--fosse-admin-radius-small);
 }
 
 .fosse-settings-choice-grid {
@@ -520,7 +513,7 @@
 	display: block;
 	padding: 14px 16px 14px 41px;
 	border: 1px solid var(--fosse-admin-border-soft);
-	border-radius: 10px;
+	border-radius: var(--fosse-admin-radius);
 	background: var(--fosse-admin-surface);
 	transition:
 		border-color 0.15s ease,
@@ -554,7 +547,7 @@
 	margin-top: 2px;
 	padding: 12px 14px;
 	border: 1px solid var(--fosse-admin-border-soft);
-	border-radius: 10px;
+	border-radius: var(--fosse-admin-radius);
 	background: var(--fosse-admin-surface-muted);
 }
 
@@ -570,8 +563,8 @@
 	margin: 18px 0;
 	padding: 16px;
 	border: 1px solid var(--fosse-admin-border-soft);
-	border-radius: 12px;
-	background: linear-gradient(135deg, #fff, var(--fosse-admin-accent-soft));
+	border-radius: var(--fosse-admin-radius);
+	background: var(--fosse-admin-accent-soft);
 }
 
 .fosse-domain-handle-panel h4 {
@@ -706,6 +699,9 @@
 	--fosse-wizard-muted: #646970;
 	--fosse-wizard-warm: #fff4cf;
 	--fosse-wizard-warm-text: #6f5700;
+	--fosse-wizard-radius: 8px;
+	--fosse-wizard-radius-small: 6px;
+	--fosse-wizard-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 
 	position: relative;
 	max-width: 860px;
@@ -853,7 +849,7 @@
 	font-size: 32px;
 	font-weight: 600;
 	line-height: 1.18;
-	letter-spacing: -0.01em;
+	letter-spacing: 0;
 	text-align: center;
 	color: var(--fosse-wizard-text);
 	margin: 0 auto 20px;
@@ -872,8 +868,8 @@
 .fosse-wizard__card {
 	background: var(--fosse-wizard-surface);
 	border: 1px solid var(--fosse-wizard-border);
-	border-radius: 14px;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+	border-radius: var(--fosse-wizard-radius);
+	box-shadow: var(--fosse-wizard-shadow);
 	padding: 36px;
 	margin-bottom: 0;
 }
@@ -978,7 +974,7 @@
 	min-height: 168px;
 	padding: 20px 22px 22px;
 	border: 1px solid var(--fosse-wizard-border);
-	border-radius: 12px;
+	border-radius: var(--fosse-wizard-radius);
 	background: var(--fosse-wizard-surface);
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.025);
 	cursor: pointer;
@@ -1059,7 +1055,7 @@
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 1.3;
-	letter-spacing: 0.03em;
+	letter-spacing: 0;
 	text-transform: uppercase;
 	color: var(--fosse-wizard-muted);
 }
@@ -1145,7 +1141,7 @@
 	gap: 16px;
 	padding: 18px 22px;
 	border: 1px solid var(--fosse-wizard-border);
-	border-radius: 12px;
+	border-radius: var(--fosse-wizard-radius);
 	cursor: pointer;
 	background: var(--fosse-wizard-surface);
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.025);
@@ -1316,7 +1312,7 @@
 	display: block;
 	font-size: 11px;
 	font-weight: 600;
-	letter-spacing: 0.03em;
+	letter-spacing: 0;
 	text-transform: uppercase;
 	color: var(--fosse-wizard-muted);
 	margin-bottom: 8px;
@@ -1353,7 +1349,7 @@
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 1.3;
-	letter-spacing: 0.03em;
+	letter-spacing: 0;
 	text-transform: uppercase;
 	color: var(--fosse-wizard-muted);
 }
@@ -1417,7 +1413,7 @@
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 1.3;
-	letter-spacing: 0.03em;
+	letter-spacing: 0;
 	text-transform: uppercase;
 	color: var(--fosse-wizard-muted);
 	margin-bottom: 8px;
@@ -1607,15 +1603,8 @@
 	pointer-events: none;
 	content: "";
 	border: 1px solid rgba(137, 168, 75, 0.24);
-	border-radius: 24px;
-	background:
-		radial-gradient(
-				circle at 14px 12px,
-				rgba(49, 93, 18, 0.08) 0 4px,
-				transparent 5px
-			)
-			0 0 / 30px 26px,
-		linear-gradient(135deg, #f8fce8, #fff7ca);
+	border-radius: var(--fosse-wizard-radius);
+	background: #f8fce8;
 }
 
 .fosse-wizard.is-lizard-themed .fosse-wizard__progress {

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, type Page } from '@playwright/test';
-import { resetBlueskyState, setBlueskyState } from './test-helpers';
+import {
+	expectNoHorizontalOverflow,
+	numericCssValue,
+	resetBlueskyState,
+	setBlueskyState,
+} from './test-helpers';
 
 test.describe( 'Bluesky provider UI', () => {
 	// The connected-state test below leaves atmosphere_connection set,
@@ -142,5 +147,62 @@ test.describe( 'Bluesky provider UI', () => {
 		// Auto-publish row was removed from the status card alongside the
 		// Settings toggle.
 		await expect( blueskyCard ).not.toContainText( 'Auto Publish' );
+	} );
+
+	test( 'settings page uses restrained visual tokens without page overflow', async ( {
+		page,
+	} ) => {
+		await setBlueskyState( page, {
+			connected: true,
+			handle: 'someone.with.an.unreasonably.long.handle.example.org',
+			did: 'did:plc:abcdefghijklmnopqrstuvwxyz0123456789longidentifier',
+			pds_endpoint: 'https://bsky.social',
+		} );
+
+		await page.setViewportSize( { width: 1280, height: 720 } );
+		await page.goto( '/wp-admin/admin.php?page=fosse' );
+		await expectNoCriticalText( page );
+		await expectNoHorizontalOverflow( page );
+
+		await expect(
+			page.getByRole( 'button', { name: 'Save settings' } )
+		).toBeVisible();
+
+		expect(
+			await numericCssValue(
+				page,
+				'.fosse-admin-page__title',
+				'letter-spacing'
+			)
+		).toBe( 0 );
+		expect(
+			await numericCssValue(
+				page,
+				'.fosse-settings-section h3',
+				'letter-spacing'
+			)
+		).toBe( 0 );
+		expect(
+			await numericCssValue(
+				page,
+				'.fosse-settings-panel',
+				'border-radius'
+			)
+		).toBeLessThanOrEqual( 8 );
+		expect(
+			await numericCssValue(
+				page,
+				'.fosse-settings-card-option__body',
+				'border-radius'
+			)
+		).toBeLessThanOrEqual( 8 );
+
+		await page.setViewportSize( { width: 390, height: 720 } );
+		await page.goto( '/wp-admin/admin.php?page=fosse' );
+		await expectNoCriticalText( page );
+		await expectNoHorizontalOverflow( page );
+		await expect(
+			page.getByRole( 'button', { name: 'Save settings' } )
+		).toBeVisible();
 	} );
 } );

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, type Page } from '@playwright/test';
-import { resetBlueskyState, setBlueskyState } from './test-helpers';
+import {
+	expectNoHorizontalOverflow,
+	numericCssValue,
+	resetBlueskyState,
+	setBlueskyState,
+} from './test-helpers';
 
 const selectDestination = async ( page: Page, destination: string ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
@@ -19,17 +24,6 @@ const completeThroughBlueskySkip = async ( page: Page ) => {
 	await openBlueskyStep( page );
 	await page.getByRole( 'link', { name: 'Skip Bluesky for now' } ).click();
 	await expect( page ).toHaveURL( /step=complete/ );
-};
-
-const expectNoHorizontalOverflow = async ( page: Page ) => {
-	const overflow = await page.evaluate( () => ( {
-		scrollWidth: document.documentElement.scrollWidth,
-		clientWidth: document.documentElement.clientWidth,
-	} ) );
-
-	expect( overflow.scrollWidth ).toBeLessThanOrEqual(
-		overflow.clientWidth + 1
-	);
 };
 
 test( 'Wizard page loads without errors', async ( { page } ) => {
@@ -125,6 +119,53 @@ test( 'Wizard progress stays compact and keeps step labels available on mobile',
 
 	expect( progressMetrics.height ).toBeLessThanOrEqual( 48 );
 	expect( progressMetrics.unavailableLabels ).toBe( 0 );
+} );
+
+test( 'Wizard surfaces use restrained visual tokens without page overflow', async ( {
+	page,
+} ) => {
+	await page.setViewportSize( { width: 1280, height: 720 } );
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+
+	await expectNoHorizontalOverflow( page );
+
+	expect(
+		await numericCssValue( page, '.fosse-wizard__title', 'letter-spacing' )
+	).toBe( 0 );
+	expect(
+		await numericCssValue(
+			page,
+			'.fosse-destination-card__badge',
+			'letter-spacing'
+		)
+	).toBe( 0 );
+	expect(
+		await numericCssValue(
+			page,
+			'.fosse-destination-card',
+			'border-radius'
+		)
+	).toBeLessThanOrEqual( 8 );
+
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=content' );
+	await expectNoHorizontalOverflow( page );
+	expect(
+		await numericCssValue( page, '.fosse-wizard__card', 'border-radius' )
+	).toBeLessThanOrEqual( 8 );
+	expect(
+		await numericCssValue(
+			page,
+			'.fosse-post-types__group-label',
+			'letter-spacing'
+		)
+	).toBe( 0 );
+
+	await page.setViewportSize( { width: 390, height: 720 } );
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=content' );
+	await expectNoHorizontalOverflow( page );
+	await expect(
+		page.getByRole( 'button', { name: 'Continue' } )
+	).toBeVisible();
 } );
 
 test( 'Destination selection navigates to identity step', async ( {

--- a/tests/e2e/status-page.spec.ts
+++ b/tests/e2e/status-page.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, type Page } from '@playwright/test';
-import { resetBlueskyState, setBlueskyState } from './test-helpers';
+import {
+	expectNoHorizontalOverflow,
+	numericCssValue,
+	resetBlueskyState,
+	setBlueskyState,
+} from './test-helpers';
 
 test.describe( 'Status page polish', () => {
 	// Connected-state writes leak across specs (the wizard's connect step
@@ -109,6 +114,56 @@ test.describe( 'Status page polish', () => {
 		expect( overflow!.tableScroll ).toBeLessThanOrEqual(
 			overflow!.tableClient + 1
 		);
+	} );
+
+	test( 'summary and cards use restrained visual tokens without page overflow', async ( {
+		page,
+	} ) => {
+		await setBlueskyState( page, {
+			connected: false,
+			auto_publish: true,
+		} );
+
+		await page.setViewportSize( { width: 1280, height: 720 } );
+		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
+
+		await expectNoHorizontalOverflow( page );
+		await expect(
+			page.getByRole( 'link', { name: 'Manage connections' } )
+		).toBeVisible();
+
+		expect(
+			await numericCssValue(
+				page,
+				'.fosse-admin-page__title',
+				'letter-spacing'
+			)
+		).toBe( 0 );
+		expect(
+			await numericCssValue(
+				page,
+				'.fosse-status-summary__label',
+				'letter-spacing'
+			)
+		).toBe( 0 );
+		expect(
+			await numericCssValue(
+				page,
+				'.fosse-status-summary',
+				'border-radius'
+			)
+		).toBeLessThanOrEqual( 8 );
+		expect(
+			await numericCssValue( page, '.fosse-status-card', 'border-radius' )
+		).toBeLessThanOrEqual( 8 );
+		await expect( page.locator( '.fosse-status-summary' ) ).toHaveCSS(
+			'background-image',
+			'none'
+		);
+
+		await page.setViewportSize( { width: 390, height: 720 } );
+		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
+		await expectNoHorizontalOverflow( page );
 	} );
 
 	test( 'partial-connected state links to connection management', async ( {

--- a/tests/e2e/test-helpers.ts
+++ b/tests/e2e/test-helpers.ts
@@ -1,6 +1,46 @@
 import { type Browser, expect, type Page } from '@playwright/test';
 
 /**
+ * Assert the current document is not wider than the viewport.
+ *
+ * @param {Page} page Playwright page.
+ * @return {Promise<void>} Resolves when the page has no horizontal overflow.
+ */
+export const expectNoHorizontalOverflow = async ( page: Page ) => {
+	const overflow = await page.evaluate( () => ( {
+		scrollWidth: document.documentElement.scrollWidth,
+		clientWidth: document.documentElement.clientWidth,
+	} ) );
+
+	expect( overflow.scrollWidth ).toBeLessThanOrEqual(
+		overflow.clientWidth + 1
+	);
+};
+
+/**
+ * Read a numeric CSS value from the first matching element.
+ *
+ * @param {Page}   page     Playwright page.
+ * @param {string} selector CSS selector.
+ * @param {string} prop     CSS property name.
+ * @return {Promise<number>} Parsed CSS value, with `normal` treated as 0.
+ */
+export const numericCssValue = async (
+	page: Page,
+	selector: string,
+	prop: string
+) =>
+	page
+		.locator( selector )
+		.first()
+		.evaluate( ( el, property ) => {
+			const value = window
+				.getComputedStyle( el )
+				.getPropertyValue( property );
+			return 'normal' === value ? 0 : Number.parseFloat( value );
+		}, prop );
+
+/**
  * Seed the Atmosphere connection state via the e2e REST helper.
  *
  * The mu-plugin under tests/e2e/mu-plugins/fosse-bsky-capture.php exposes


### PR DESCRIPTION
## Summary

- Normalize FOSSE admin and wizard radius, shadow, and letter-spacing tokens.
- Replace decorative status/settings/wizard backgrounds with restrained WordPress-admin surfaces.
- Add targeted e2e guards for no horizontal overflow, visible primary actions, and visual-token regressions.

## Test plan

- composer run-script lint-php
- composer run-script test-php
- pnpm run format:check
- pnpm run lint
- pnpm test
- pnpm run test:e2e