### PR TITLE
Bump FOSSE version to 0.1.0 for first preview release

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -40,7 +40,7 @@ jobs:
                   if [ "$EVENT_NAME" = "release" ]; then
                       version="${RELEASE_TAG#v}"
                   else
-                      version="0.0.1-dev+${GITHUB_SHA::7}"
+                      version="0.1.0-dev+${GITHUB_SHA::7}"
                   fi
                   echo "FOSSE_VERSION=$version" >> "$GITHUB_ENV"
 

--- a/fosse.php
+++ b/fosse.php
@@ -3,7 +3,7 @@
  * Plugin Name: FOSSE
  * Plugin URI:  https://github.com/Automattic/fosse
  * Description: Social Web
- * Version:     0.0.1
+ * Version:     0.1.0
  * Requires at least: 6.9
  * Tested up to: 7.0
  * Requires PHP: 8.2
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  * `ACTIVITYPUB_PLUGIN_VERSION` / `ATMOSPHERE_VERSION` pattern of the
  * bundled backends. Keep in sync with the `Version:` header above.
  */
-define( 'FOSSE_VERSION', '0.0.1' );
+define( 'FOSSE_VERSION', '0.1.0' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload_packages.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload_packages.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fosse",
-	"version": "0.0.1",
+	"version": "0.1.0",
 	"description": "Social Web for WordPress.",
 	"private": true,
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Summary

- Bumps the `Version:` header and `FOSSE_VERSION` constant in `fosse.php` from `0.0.1` to `0.1.0`.
- Bumps `package.json` version to match.
- Bumps the dev-build placeholder in `.github/workflows/build-zip.yml` so non-release zips read `0.1.0-dev+<sha>`.

Bundled plugin versions (ActivityPub `8.2.1`, Atmosphere `unreleased`) are upstream-owned and unchanged. No docblock since-tags exist in FOSSE yet, so nothing was rewritten.

Preparing for the first "public" preview release.

## Test plan

- [ ] Confirm `FOSSE_VERSION` constant resolves to `0.1.0` after activation.
- [ ] Confirm the Plugins screen shows `0.1.0` next to FOSSE.
- [ ] CI build-zip workflow produces a `0.1.0-dev+<sha>` artifact on non-release runs.