### PR TITLE
Build zip: derive version from fosse.php and stamp the runtime constant

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -40,7 +40,14 @@ jobs:
                   if [ "$EVENT_NAME" = "release" ]; then
                       version="${RELEASE_TAG#v}"
                   else
-                      version="0.0.1-dev+${GITHUB_SHA::7}"
+                      # Derive the dev base from fosse.php so future version
+                      # bumps don't need a parallel edit in this workflow.
+                      base=$(awk '/^[[:space:]]*\*[[:space:]]*Version:/ { print $NF; exit }' fosse.php)
+                      if [ -z "$base" ]; then
+                          echo "error: could not extract Version: header from fosse.php" >&2
+                          exit 1
+                      fi
+                      version="${base}-dev+${GITHUB_SHA::7}"
                   fi
                   echo "FOSSE_VERSION=$version" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -37,19 +37,15 @@ jobs:
                   EVENT_NAME: ${{ github.event_name }}
                   RELEASE_TAG: ${{ github.event.release.tag_name }}
               run: |
+                  # Release event: stamp the exact tag (sans optional `v`).
+                  # Anything else (push to trunk, manual dispatch): tell the
+                  # build script to derive its own `<base>-dev+<sha>` from
+                  # fosse.php — keeps version logic in one place.
                   if [ "$EVENT_NAME" = "release" ]; then
-                      version="${RELEASE_TAG#v}"
+                      echo "FOSSE_VERSION=${RELEASE_TAG#v}" >> "$GITHUB_ENV"
                   else
-                      # Derive the dev base from fosse.php so future version
-                      # bumps don't need a parallel edit in this workflow.
-                      base=$(awk '/^[[:space:]]*\*[[:space:]]*Version:/ { print $NF; exit }' fosse.php)
-                      if [ -z "$base" ]; then
-                          echo "error: could not extract Version: header from fosse.php" >&2
-                          exit 1
-                      fi
-                      version="${base}-dev+${GITHUB_SHA::7}"
+                      echo "FOSSE_BUILD_DEV=1" >> "$GITHUB_ENV"
                   fi
-                  echo "FOSSE_VERSION=$version" >> "$GITHUB_ENV"
 
             - name: Build zip
               run: composer run-script build-zip

--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -8,13 +8,18 @@
 # into wp-content/plugins/.
 #
 # Environment:
-#   FOSSE_VERSION  If set, overrides BOTH the `Version:` plugin header
-#                  AND the `define( 'FOSSE_VERSION', '...' )` runtime
-#                  constant in the staged fosse.php (e.g. "0.1.0",
-#                  "0.1.0-dev+abc1234"). The two must stay aligned —
-#                  the constant is what runtime code reads, the header
-#                  is what the WP Plugins screen shows. Leave unset to
-#                  keep whatever is committed in fosse.php.
+#   FOSSE_VERSION    If set, stamps BOTH the `Version:` plugin header
+#                    AND the `define( 'FOSSE_VERSION', '...' )` runtime
+#                    constant in the staged fosse.php (e.g. "0.1.0",
+#                    "0.1.0-dev+abc1234"). The two must stay aligned —
+#                    the constant is what runtime code reads, the header
+#                    is what the WP Plugins screen shows.
+#   FOSSE_BUILD_DEV  If "1" and FOSSE_VERSION is unset, derive a dev
+#                    version "<base>-dev+<sha7>" from the committed
+#                    `Version:` header in fosse.php plus the short HEAD
+#                    SHA (GITHUB_SHA in CI, otherwise `git rev-parse`),
+#                    then stamp via the same path as FOSSE_VERSION.
+#   Neither set:     Leave the staged fosse.php as committed.
 #
 # Usage:
 #   bin/build-zip.sh
@@ -38,6 +43,24 @@ mkdir -p "$STAGE_DIR"
 # how everything else in this script reads from the worktree.
 git -C "$ROOT" archive --format=tar --worktree-attributes HEAD | tar -x -C "$STAGE_DIR"
 
+# Derive a dev-flavored FOSSE_VERSION when the caller asked for one
+# (FOSSE_BUILD_DEV=1) and did not pass an explicit FOSSE_VERSION.
+# The base comes from the committed `Version:` header so future bumps
+# don't need a parallel edit anywhere.
+if [ -z "${FOSSE_VERSION:-}" ] && [ "${FOSSE_BUILD_DEV:-}" = "1" ]; then
+	base=$(awk '/^[[:space:]]*\*[[:space:]]*Version:/ { print $NF; exit }' "$ROOT/fosse.php")
+	if [ -z "$base" ]; then
+		echo "error: could not extract Version: header from $ROOT/fosse.php" >&2
+		exit 1
+	fi
+	sha7="${GITHUB_SHA:0:7}"
+	if [ -z "$sha7" ]; then
+		sha7=$(git -C "$ROOT" rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")
+	fi
+	FOSSE_VERSION="${base}-dev+${sha7}"
+	echo "Derived dev version: $FOSSE_VERSION"
+fi
+
 if [ -n "${FOSSE_VERSION:-}" ]; then
 	# sed -i with a backup suffix is portable across GNU and BSD sed.
 	# Rewrite both the plugin header `Version:` line and the
@@ -48,6 +71,19 @@ if [ -n "${FOSSE_VERSION:-}" ]; then
 		-e "s|(define\([[:space:]]*'FOSSE_VERSION',[[:space:]]*')[^']*(')|\1${FOSSE_VERSION}\2|" \
 		"$STAGE_DIR/fosse.php"
 	rm -f "$STAGE_DIR/fosse.php.bak"
+
+	# Belt-and-braces: assert the sed actually rewrote both spots.
+	# Catches silent no-ops if fosse.php is ever reformatted (e.g.
+	# `define()` split across lines, double-quoted FOSSE_VERSION).
+	header_value=$(awk '/^[[:space:]]*\*[[:space:]]*Version:/ { print $NF; exit }' "$STAGE_DIR/fosse.php")
+	if [ "$header_value" != "$FOSSE_VERSION" ]; then
+		echo "error: Version: header in staged fosse.php is '${header_value}', expected '${FOSSE_VERSION}'" >&2
+		exit 1
+	fi
+	if ! grep -qF "'FOSSE_VERSION', '${FOSSE_VERSION}'" "$STAGE_DIR/fosse.php"; then
+		echo "error: FOSSE_VERSION constant in staged fosse.php did not stamp to '${FOSSE_VERSION}'" >&2
+		exit 1
+	fi
 fi
 
 # Fail fast if composer.lock drifted from composer.json. Otherwise

--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -8,9 +8,13 @@
 # into wp-content/plugins/.
 #
 # Environment:
-#   FOSSE_VERSION  If set, overrides the `Version:` header in the staged
-#                  fosse.php (e.g. "0.1.0", "0.0.1-dev+abc1234"). Leave
-#                  unset to keep whatever is committed in fosse.php.
+#   FOSSE_VERSION  If set, overrides BOTH the `Version:` plugin header
+#                  AND the `define( 'FOSSE_VERSION', '...' )` runtime
+#                  constant in the staged fosse.php (e.g. "0.1.0",
+#                  "0.1.0-dev+abc1234"). The two must stay aligned —
+#                  the constant is what runtime code reads, the header
+#                  is what the WP Plugins screen shows. Leave unset to
+#                  keep whatever is committed in fosse.php.
 #
 # Usage:
 #   bin/build-zip.sh
@@ -36,7 +40,13 @@ git -C "$ROOT" archive --format=tar --worktree-attributes HEAD | tar -x -C "$STA
 
 if [ -n "${FOSSE_VERSION:-}" ]; then
 	# sed -i with a backup suffix is portable across GNU and BSD sed.
-	sed -i.bak -E "s|^([[:space:]]*\*[[:space:]]*Version:[[:space:]]*).+$|\1${FOSSE_VERSION}|" "$STAGE_DIR/fosse.php"
+	# Rewrite both the plugin header `Version:` line and the
+	# `define( 'FOSSE_VERSION', '...' )` constant so the WP Plugins
+	# screen and runtime constant agree.
+	sed -i.bak -E \
+		-e "s|^([[:space:]]*\*[[:space:]]*Version:[[:space:]]*).+$|\1${FOSSE_VERSION}|" \
+		-e "s|(define\([[:space:]]*'FOSSE_VERSION',[[:space:]]*')[^']*(')|\1${FOSSE_VERSION}\2|" \
+		"$STAGE_DIR/fosse.php"
 	rm -f "$STAGE_DIR/fosse.php.bak"
 fi
 


### PR DESCRIPTION
## Summary

Addresses two pieces of Copilot feedback from PR 146 — both about the build-zip pipeline drifting out of sync with future version bumps:

- **`bin/build-zip.sh`** now rewrites BOTH the `Version:` plugin header AND the `define( 'FOSSE_VERSION', '...' )` runtime constant when `FOSSE_VERSION` is set. Previously only the header was stamped, so a trunk artifact would show (for example) `0.1.0-dev+sha` in the WP Plugins screen while the runtime constant remained `0.1.0`, contradicting the "Keep in sync" docblock in `fosse.php`.
- **`.github/workflows/build-zip.yml`** derives the dev base version from the `Version:` header in `fosse.php` via `awk`, instead of the hardcoded `0.1.0-dev+<sha>` literal. Future version bumps no longer need a parallel edit here. Bails loudly if extraction fails so a silent regression can't ship a build stamped only with the dev suffix.

Independent of PR 146 (the actual `0.0.1` → `0.1.0` bump); this PR cleans up the foot-guns the bump exposed.

## Test plan

- [ ] Trigger `Build zip` via `workflow_dispatch` on this branch. Resulting `fosse.zip`'s `fosse.php` shows the same string in both `Version:` and `FOSSE_VERSION`.
- [ ] Confirm the version reads `0.0.1-dev+<sha>` here (since trunk is still on 0.0.1) and would read `0.1.0-dev+<sha>` once PR 146 lands.
- [ ] Cut a dry-run release tag and verify the release-flavored zip stamps both header and constant from the tag.