### PR TITLE
Wizard: prevent lizard theme flash

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -1563,7 +1563,8 @@
 }
 
 /* Hidden wizard style-toggle theme */
-.fosse-wizard.is-lizard-themed {
+.fosse-wizard.is-lizard-themed,
+.has-fosse-wizard-lizard-theme .fosse-wizard {
 	--fosse-ui-surface: #fbfff1;
 	--fosse-ui-surface-muted: #f1f8df;
 	--fosse-ui-border: #cadb9b;
@@ -1586,7 +1587,8 @@
 	isolation: isolate;
 }
 
-.fosse-wizard.is-lizard-themed::before {
+.fosse-wizard.is-lizard-themed::before,
+.has-fosse-wizard-lizard-theme .fosse-wizard::before {
 	position: absolute;
 	z-index: -1;
 	inset: -18px -22px -28px;
@@ -1597,25 +1599,39 @@
 	background: #f8fce8;
 }
 
-.fosse-wizard.is-lizard-themed .fosse-wizard__progress {
+.fosse-wizard.is-lizard-themed .fosse-wizard__progress,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-wizard__progress {
 	background: rgba(251, 255, 241, 0.94);
 	border-color: rgba(120, 152, 58, 0.5);
 }
 
-.fosse-wizard.is-lizard-themed .fosse-wizard__progress-line {
+.fosse-wizard.is-lizard-themed .fosse-wizard__progress-line,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-wizard__progress-line {
 	height: 2px;
 	background: rgba(120, 152, 58, 0.3);
 }
 
-.fosse-wizard.is-lizard-themed .fosse-wizard__progress-line.is-complete {
+.fosse-wizard.is-lizard-themed .fosse-wizard__progress-line.is-complete,
+.has-fosse-wizard-lizard-theme
+	.fosse-wizard
+	.fosse-wizard__progress-line.is-complete {
 	background: rgba(47, 110, 33, 0.75);
 }
 
 .fosse-wizard.is-lizard-themed .fosse-wizard__progress-dot,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-wizard__progress-dot,
 .fosse-wizard.is-lizard-themed
 	.fosse-wizard__progress-step.is-active
 	.fosse-wizard__progress-dot,
+.has-fosse-wizard-lizard-theme
+	.fosse-wizard
+	.fosse-wizard__progress-step.is-active
+	.fosse-wizard__progress-dot,
 .fosse-wizard.is-lizard-themed
+	.fosse-wizard__progress-step.is-complete
+	.fosse-wizard__progress-dot,
+.has-fosse-wizard-lizard-theme
+	.fosse-wizard
 	.fosse-wizard__progress-step.is-complete
 	.fosse-wizard__progress-dot {
 	width: 20px;
@@ -1626,7 +1642,10 @@
 }
 
 /* Theme glyphs: U+1F95A egg, U+1F98E reptile, U+1F43E paw. */
-.fosse-wizard.is-lizard-themed .fosse-wizard__progress-dot::before {
+.fosse-wizard.is-lizard-themed .fosse-wizard__progress-dot::before,
+.has-fosse-wizard-lizard-theme
+	.fosse-wizard
+	.fosse-wizard__progress-dot::before {
 	content: "\1F95A";
 	width: auto;
 	height: auto;
@@ -1639,6 +1658,10 @@
 
 .fosse-wizard.is-lizard-themed
 	.fosse-wizard__progress-step.is-active
+	.fosse-wizard__progress-dot::before,
+.has-fosse-wizard-lizard-theme
+	.fosse-wizard
+	.fosse-wizard__progress-step.is-active
 	.fosse-wizard__progress-dot::before {
 	content: "\1F98E";
 	font-size: 20px;
@@ -1646,21 +1669,31 @@
 
 .fosse-wizard.is-lizard-themed
 	.fosse-wizard__progress-step.is-complete
+	.fosse-wizard__progress-dot::before,
+.has-fosse-wizard-lizard-theme
+	.fosse-wizard
+	.fosse-wizard__progress-step.is-complete
 	.fosse-wizard__progress-dot::before {
 	content: "\1F43E";
 	font-size: 18px;
 }
 
-.fosse-wizard.is-lizard-themed .fosse-complete-icon {
+.fosse-wizard.is-lizard-themed .fosse-complete-icon,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-complete-icon {
 	background: var(--fosse-wizard-accent-icon);
 	box-shadow: 0 0 0 8px rgba(49, 93, 18, 0.08);
 }
 
-.fosse-wizard.is-lizard-themed .fosse-complete-icon .dashicons {
+.fosse-wizard.is-lizard-themed .fosse-complete-icon .dashicons,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-complete-icon .dashicons {
 	font-size: 0;
 }
 
-.fosse-wizard.is-lizard-themed .fosse-complete-icon .dashicons::before {
+.fosse-wizard.is-lizard-themed .fosse-complete-icon .dashicons::before,
+.has-fosse-wizard-lizard-theme
+	.fosse-wizard
+	.fosse-complete-icon
+	.dashicons::before {
 	content: "\1F98E";
 	font-family: initial;
 	font-size: 34px;
@@ -1668,26 +1701,34 @@
 }
 
 .fosse-wizard.is-lizard-themed .fosse-wizard__card,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-wizard__card,
 .fosse-wizard.is-lizard-themed .fosse-destination-card,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-destination-card,
 .fosse-wizard.is-lizard-themed .fosse-mode-card,
-.fosse-wizard.is-lizard-themed .fosse-post-type-item {
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-mode-card,
+.fosse-wizard.is-lizard-themed .fosse-post-type-item,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-post-type-item {
 	box-shadow:
 		0 10px 24px rgba(63, 111, 29, 0.08),
 		inset 0 1px 0 rgba(255, 255, 255, 0.72);
 }
 
-.fosse-wizard.is-lizard-themed .button-primary {
+.fosse-wizard.is-lizard-themed .button-primary,
+.has-fosse-wizard-lizard-theme .fosse-wizard .button-primary {
 	background: var(--fosse-ui-accent);
 	border-color: var(--fosse-wizard-accent-button-border);
 }
 
 .fosse-wizard.is-lizard-themed .button-primary:hover,
-.fosse-wizard.is-lizard-themed .button-primary:focus {
+.has-fosse-wizard-lizard-theme .fosse-wizard .button-primary:hover,
+.fosse-wizard.is-lizard-themed .button-primary:focus,
+.has-fosse-wizard-lizard-theme .fosse-wizard .button-primary:focus {
 	background: var(--fosse-wizard-accent-button-hover);
 	border-color: var(--fosse-wizard-accent-button-hover-border);
 }
 
-.fosse-wizard.is-lizard-themed .fosse-wizard__lizard {
+.fosse-wizard.is-lizard-themed .fosse-wizard__lizard,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-wizard__lizard {
 	background: rgba(63, 111, 29, 0.1);
 	filter: none;
 	opacity: 0.82;

--- a/src/Admin/assets/js/wizard-lizard.js
+++ b/src/Admin/assets/js/wizard-lizard.js
@@ -8,6 +8,7 @@
 ( function () {
 	'use strict';
 
+	const ROOT_THEME_CLASS = 'has-fosse-wizard-lizard-theme';
 	const THEME_CLASS = 'is-lizard-themed';
 	const STORAGE_KEY = 'fosseWizardLizardTheme';
 	const TOGGLE_SELECTOR = '[data-fosse-lizard-toggle]';
@@ -33,10 +34,20 @@
 		}
 	}
 
+	function applyRootTheme( enabled ) {
+		document.documentElement.classList.toggle( ROOT_THEME_CLASS, enabled );
+	}
+
 	function applyTheme( wizard, toggle, enabled ) {
+		applyRootTheme( enabled );
 		wizard.classList.toggle( THEME_CLASS, enabled );
 		toggle.setAttribute( 'aria-pressed', enabled ? 'true' : 'false' );
 	}
+
+	const storedThemeEnabled = readStoredTheme();
+
+	// FOUC guard: this must run synchronously from the head before body paint.
+	applyRootTheme( storedThemeEnabled );
 
 	function init( root ) {
 		const scope = root || document;
@@ -52,7 +63,7 @@
 			return;
 		}
 
-		if ( readStoredTheme() ) {
+		if ( storedThemeEnabled ) {
 			applyTheme( wizard, toggle, true );
 		}
 

--- a/src/Admin/class-menu.php
+++ b/src/Admin/class-menu.php
@@ -262,12 +262,15 @@ class Menu {
 				array( 'in_footer' => true )
 			);
 
+			// Runs synchronously in the head so a stored lizard theme can mark
+			// the root element before the wizard body paints. Do not add a
+			// delayed strategy here; defer/async would reintroduce the flash.
 			wp_enqueue_script(
 				'fosse-wizard-lizard',
 				plugins_url( 'src/Admin/assets/js/wizard-lizard.js', dirname( __DIR__, 2 ) . '/fosse.php' ),
 				array(),
 				filemtime( __DIR__ . '/assets/js/wizard-lizard.js' ),
-				array( 'in_footer' => true )
+				array( 'in_footer' => false )
 			);
 		}
 	}

--- a/tests/js/wizard-lizard.test.js
+++ b/tests/js/wizard-lizard.test.js
@@ -1,4 +1,5 @@
 describe( 'Wizard style toggle', () => {
+	const ROOT_THEME_CLASS = 'has-fosse-wizard-lizard-theme';
 	const STORAGE_KEY = 'fosseWizardLizardTheme';
 
 	function renderWizard() {
@@ -30,6 +31,7 @@ describe( 'Wizard style toggle', () => {
 
 	beforeEach( () => {
 		document.body.innerHTML = '';
+		document.documentElement.classList.remove( ROOT_THEME_CLASS );
 		window.sessionStorage.clear();
 		jest.restoreAllMocks();
 	} );
@@ -59,6 +61,30 @@ describe( 'Wizard style toggle', () => {
 		loadScript();
 
 		const { wizard, toggle } = getElements();
+
+		expect( wizard.classList.contains( 'is-lizard-themed' ) ).toBe( true );
+		expect( toggle.getAttribute( 'aria-pressed' ) ).toBe( 'true' );
+		expect(
+			document.documentElement.classList.contains( ROOT_THEME_CLASS )
+		).toBe( true );
+	} );
+
+	test( 'marks the document before DOMContentLoaded when the stored theme is enabled', () => {
+		window.sessionStorage.setItem( STORAGE_KEY, '1' );
+		loadScript( 'loading' );
+
+		expect(
+			document.documentElement.classList.contains( ROOT_THEME_CLASS )
+		).toBe( true );
+
+		renderWizard();
+
+		const { wizard, toggle } = getElements();
+
+		expect( wizard.classList.contains( 'is-lizard-themed' ) ).toBe( false );
+		expect( toggle.getAttribute( 'aria-pressed' ) ).toBe( 'false' );
+
+		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
 
 		expect( wizard.classList.contains( 'is-lizard-themed' ) ).toBe( true );
 		expect( toggle.getAttribute( 'aria-pressed' ) ).toBe( 'true' );

--- a/tests/php/Admin/MenuTest.php
+++ b/tests/php/Admin/MenuTest.php
@@ -395,6 +395,32 @@ class MenuTest extends BaseTestCase {
 	}
 
 	/**
+	 * The lizard theme script must run from the document head so a stored
+	 * theme can mark the root element before the wizard paints.
+	 */
+	public function test_lizard_theme_script_is_enqueued_in_head_on_wizard_screen(): void {
+		wp_dequeue_script( 'fosse-wizard-lizard' );
+		wp_deregister_script( 'fosse-wizard-lizard' );
+
+		try {
+			Menu::enqueue_assets( 'admin_page_fosse-wizard' );
+
+			$this->assertTrue( wp_script_is( 'fosse-wizard-lizard', 'enqueued' ) );
+			$this->assertFalse(
+				wp_scripts()->get_data( 'fosse-wizard-lizard', 'group' ),
+				'Lizard theme script must stay in the head to prevent a stored-theme flash.'
+			);
+			$this->assertFalse(
+				wp_scripts()->get_data( 'fosse-wizard-lizard', 'strategy' ),
+				'Lizard theme script must execute synchronously; defer/async would reintroduce the flash.'
+			);
+		} finally {
+			wp_dequeue_script( 'fosse-wizard-lizard' );
+			wp_deregister_script( 'fosse-wizard-lizard' );
+		}
+	}
+
+	/**
 	 * Late-stage suppression strips notices that other plugins added
 	 * between `current_screen` and the actual notice hooks (e.g. via
 	 * `admin_head` or `admin_enqueue_scripts`). Mirrors the


### PR DESCRIPTION
## Summary
- Prevent the stored onboarding lizard theme from flashing the default wizard style on reload by applying the root theme marker synchronously in the document head.
- Keep lizard theme CSS in sync with the early root marker and document the no-defer/async contract.
- Add JS and PHP regression coverage for pre-paint theme application and synchronous head enqueueing.

## Test Plan
- [x] pnpm test
- [x] pnpm run format:check
- [x] pnpm run lint
- [x] composer run-script test-php
- [x] composer run-script lint-php
- [x] git diff --check