### PR TITLE
Modernize FOSSE admin screens

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -148,30 +148,6 @@
 	margin-bottom: 6px;
 }
 
-/* Shared inline token treatment for long handles, DIDs, AP addresses, and URLs. */
-.fosse-admin-token,
-.fosse-status-card__token {
-	display: inline-block;
-	box-sizing: border-box;
-	max-width: 100%;
-	word-break: normal;
-	white-space: normal;
-	overflow-wrap: break-word;
-	padding: 2px 5px;
-	border-radius: var(--fosse-ui-radius-small);
-	background: var(--fosse-ui-surface-muted, #f6f7f7);
-	color: var(--fosse-ui-text, #1d2327);
-	box-decoration-break: clone;
-	-webkit-box-decoration-break: clone;
-}
-
-.fosse-admin-token--did,
-.fosse-admin-token--url,
-.fosse-status-card__token--did,
-.fosse-status-card__token--url {
-	overflow-wrap: anywhere;
-}
-
 /* Status summary bar */
 .fosse-status-summary {
 	position: relative;
@@ -527,90 +503,6 @@
 .fosse-admin-page select {
 	border-color: var(--fosse-ui-border-strong);
 	border-radius: var(--fosse-ui-radius-small);
-}
-
-.fosse-settings-choice-grid {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 10px 16px;
-	margin: 0;
-}
-
-.fosse-settings-choice-grid .description {
-	flex-basis: 100%;
-	margin: 2px 0 0;
-}
-
-.fosse-settings-choice-label {
-	display: inline-flex;
-	align-items: center;
-	gap: 7px;
-	padding: 0;
-	border: 0;
-	border-radius: 0;
-	background: transparent;
-	font-weight: 400;
-	line-height: 1.2;
-	cursor: pointer;
-}
-
-.fosse-settings-choice-label input {
-	margin: 0;
-}
-
-.fosse-settings-radio-group {
-	display: grid;
-	gap: 10px;
-	max-width: 680px;
-	margin: 0;
-}
-
-.fosse-settings-card-option {
-	position: relative;
-	display: block;
-	cursor: pointer;
-}
-
-.fosse-settings-card-option__input {
-	position: absolute;
-	top: 17px;
-	left: 16px;
-	z-index: 1;
-	margin: 0;
-}
-
-.fosse-settings-card-option__body {
-	display: block;
-	padding: 14px 16px 14px 41px;
-	border: 1px solid var(--fosse-ui-border-soft);
-	border-radius: var(--fosse-ui-radius);
-	background: var(--fosse-ui-surface);
-	transition:
-		border-color 0.15s ease,
-		background-color 0.15s ease,
-		box-shadow 0.15s ease;
-}
-
-.fosse-settings-card-option__input:checked + .fosse-settings-card-option__body {
-	border-color: var(--fosse-ui-accent-soft-border);
-	background: var(--fosse-ui-accent-soft);
-}
-
-.fosse-settings-card-option__input:focus-visible
-	+ .fosse-settings-card-option__body,
-.fosse-settings-card-option:focus-within .fosse-settings-card-option__body {
-	outline: 2px solid var(--fosse-ui-accent);
-	outline-offset: 2px;
-}
-
-.fosse-settings-card-option__label {
-	display: block;
-	font-weight: 600;
-}
-
-.fosse-settings-card-option__body .description {
-	display: block;
-	margin: 7px 0 0;
 }
 
 .fosse-activitypub-actor-mode-note {
@@ -1088,10 +980,6 @@
 
 	.fosse-admin-page .form-table tr + tr td {
 		border-top: 0;
-	}
-
-	.fosse-settings-card-option__body .description {
-		margin-left: 0;
 	}
 
 	.fosse-card-header,
@@ -1976,52 +1864,6 @@
 
 .fosse-wizard__completion-footer {
 	display: block;
-}
-
-/* Summary table */
-.fosse-summary {
-	width: 100%;
-	border-collapse: collapse;
-	margin-bottom: 8px;
-}
-
-.fosse-summary tr {
-	border-bottom: 1px solid var(--fosse-ui-border-faint);
-}
-
-.fosse-summary tr:last-child {
-	border-bottom: none;
-}
-
-.fosse-summary td,
-.fosse-summary th {
-	padding: 14px 0;
-	font-size: 13px;
-	line-height: 1.5;
-}
-
-.fosse-summary__label {
-	color: var(--fosse-ui-muted);
-	width: 40%;
-	/* Reset the bold/centered defaults `<th>` carries so the row label
-	   reads at the same weight as a `<td>` would. The semantic upgrade
-	   to `<th scope="row">` is for assistive tech, not for visual style. */
-	font-weight: normal;
-	text-align: left;
-}
-
-.fosse-summary__value {
-	font-weight: 600;
-	color: var(--fosse-ui-text);
-}
-
-.fosse-summary__value code {
-	overflow-wrap: anywhere;
-}
-
-.fosse-summary__value--muted {
-	color: var(--fosse-ui-muted);
-	font-weight: 400;
 }
 
 /* Reset link */

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -300,82 +300,6 @@
 	color: var(--fosse-admin-danger);
 }
 
-.fosse-status-card__table.widefat {
-	border: 0;
-	background: transparent;
-	box-shadow: none;
-}
-
-.fosse-status-card__table {
-	box-sizing: border-box;
-	width: 100%;
-	max-width: 100%;
-	table-layout: fixed;
-	border-collapse: separate;
-	border-spacing: 0;
-}
-
-.fosse-status-card__table tr {
-	box-sizing: border-box;
-	width: 100%;
-	min-width: 0;
-	/* WP core widefat striped rows win on specificity without !important. */
-	background: transparent !important;
-}
-
-.fosse-status-card__table tr:first-child th,
-.fosse-status-card__table tr:first-child td {
-	padding-top: 0;
-	border-top: 0;
-}
-
-.fosse-status-card__table tr:last-child th,
-.fosse-status-card__table tr:last-child td {
-	padding-bottom: 0;
-}
-
-.fosse-status-card__table th,
-.fosse-status-card__table td {
-	box-sizing: border-box;
-	min-width: 0;
-	padding: 12px 0;
-	border: 0;
-	border-top: 1px solid var(--fosse-ui-border-faint);
-	background: transparent;
-	box-shadow: none;
-	vertical-align: top;
-}
-
-.fosse-status-card__label {
-	width: 38%;
-	padding-right: 18px;
-	font-size: 11px;
-	font-weight: 600;
-	line-height: 1.45;
-	letter-spacing: 0;
-	text-align: left;
-	text-transform: uppercase;
-	white-space: normal;
-	overflow-wrap: break-word;
-	color: var(--fosse-ui-muted);
-}
-
-.fosse-status-card__row--stacked .fosse-status-card__label {
-	white-space: normal;
-}
-
-/* Defense in depth: token wrappers carry their own wrap rules, but if a
-   future cell holds raw user input without going through Status_Formatter,
-   this keeps the value column from inflating the card. */
-.fosse-status-card__value {
-	width: 62%;
-	min-width: 0;
-	font-size: 13px;
-	line-height: 1.5;
-	overflow-wrap: break-word;
-	color: var(--fosse-ui-text);
-}
-
 .fosse-status-card__error {
 	margin-top: 8px;
 }
@@ -519,14 +443,6 @@
 
 .fosse-activitypub-actor-mode-note .description + .description {
 	margin-top: 6px;
-}
-
-.fosse-domain-handle-panel {
-	margin: 18px 0;
-	padding: 16px;
-	border: 1px solid var(--fosse-ui-border-soft);
-	border-radius: var(--fosse-ui-radius);
-	background: var(--fosse-ui-accent-soft);
 }
 
 .fosse-domain-handle-panel h4 {
@@ -938,16 +854,6 @@
 		align-items: flex-start;
 		flex-direction: column;
 		gap: 10px;
-	}
-
-	.fosse-status-card__label {
-		width: 42%;
-		padding-right: 12px;
-		white-space: normal;
-	}
-
-	.fosse-status-card__value {
-		width: 58%;
 	}
 
 	.fosse-admin-page .form-table,
@@ -1860,10 +1766,6 @@
 	height: 30px;
 	color: var(--fosse-ui-success);
 	transform: translateY(1px);
-}
-
-.fosse-wizard__completion-footer {
-	display: block;
 }
 
 /* Reset link */

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -68,8 +68,72 @@
 	color: var(--fosse-ui-muted);
 }
 
+.fosse-admin-page__secondary-action {
+	margin: 8px 0 0;
+	font-size: 13px;
+	line-height: 1.45;
+}
+
+.fosse-admin-page__footer-action {
+	margin: 16px 0 0;
+	font-size: 13px;
+	line-height: 1.45;
+	text-align: center;
+}
+
+.fosse-admin-page__secondary-link {
+	color: var(--fosse-ui-muted);
+	text-decoration: underline;
+	text-decoration-thickness: from-font;
+	text-underline-offset: 2px;
+}
+
+.fosse-admin-page__secondary-link:hover,
+.fosse-admin-page__secondary-link:focus-visible {
+	color: var(--fosse-ui-accent);
+}
+
 .fosse-admin-notice {
 	max-width: 860px;
+}
+
+.fosse-guided-setup {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	box-sizing: border-box;
+	width: 100%;
+	margin: 0 0 20px;
+	padding: 16px 18px;
+	border: 1px solid var(--fosse-ui-border-soft);
+	border-left: 4px solid var(--fosse-ui-accent);
+	border-radius: var(--fosse-ui-radius);
+	background: var(--fosse-ui-surface);
+	box-shadow: var(--fosse-ui-shadow);
+}
+
+.fosse-guided-setup__content {
+	min-width: 0;
+}
+
+.fosse-guided-setup__title {
+	margin: 0;
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1.4;
+	color: var(--fosse-ui-text);
+}
+
+.fosse-guided-setup__description {
+	margin: 3px 0 0;
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--fosse-ui-muted);
+}
+
+.fosse-guided-setup__button {
+	flex: 0 0 auto;
 }
 
 .fosse-admin-page .button {
@@ -599,6 +663,346 @@
 	margin: 0;
 }
 
+/* Shared Gutenberg-like primitives for FOSSE-owned admin screens. */
+.fosse-admin-shell {
+	box-sizing: border-box;
+}
+
+.fosse-admin-card,
+.fosse-status-card.fosse-admin-card,
+.fosse-settings-panel.fosse-admin-card,
+.fosse-connection-section.fosse-admin-card,
+.fosse-status-summary.fosse-admin-card {
+	box-sizing: border-box;
+	min-width: 0;
+	overflow: hidden;
+	padding: 0;
+	border: 1px solid var(--fosse-ui-border);
+	border-radius: var(--fosse-ui-radius);
+	background: var(--fosse-ui-surface);
+	box-shadow: var(--fosse-ui-shadow);
+}
+
+.fosse-card-header,
+.fosse-card-body,
+.fosse-card-footer {
+	box-sizing: border-box;
+	min-width: 0;
+	padding: 20px 24px;
+}
+
+.fosse-card-header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	border-bottom: 1px solid var(--fosse-ui-border-soft);
+}
+
+.fosse-card-header h2,
+.fosse-card-header h3 {
+	margin: 0;
+}
+
+.fosse-card-body > :first-child {
+	margin-top: 0;
+}
+
+.fosse-card-body > :last-child {
+	margin-bottom: 0;
+}
+
+.fosse-card-footer {
+	border-top: 1px solid var(--fosse-ui-border-soft);
+	background: var(--fosse-ui-surface-muted);
+}
+
+.fosse-action-bar {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
+.fosse-action-bar .button,
+.fosse-action-bar p.submit,
+.fosse-card-footer p.submit {
+	margin: 0;
+}
+
+.fosse-field-stack {
+	display: grid;
+	gap: 20px;
+}
+
+.fosse-field {
+	display: grid;
+	grid-template-columns: minmax(140px, 185px) minmax(0, 1fr);
+	gap: 16px 24px;
+	align-items: start;
+	min-width: 0;
+	padding: 18px 0;
+	border-top: 1px solid var(--fosse-ui-border-faint);
+}
+
+.fosse-field:first-child {
+	padding-top: 0;
+	border-top: 0;
+}
+
+.fosse-field:last-child {
+	padding-bottom: 0;
+}
+
+.fosse-field__label {
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 1.45;
+	letter-spacing: 0;
+	color: var(--fosse-ui-text);
+}
+
+.fosse-field__control {
+	min-width: 0;
+}
+
+.fosse-checkbox-grid {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px 16px;
+	min-inline-size: 0;
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.fosse-checkbox-grid .description {
+	flex-basis: 100%;
+	margin: 2px 0 0;
+}
+
+.fosse-checkbox-grid__item {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	line-height: 1.2;
+	cursor: pointer;
+}
+
+.fosse-checkbox-grid__item input {
+	margin: 0;
+}
+
+.fosse-choice-card-group {
+	display: grid;
+	gap: 10px;
+	min-inline-size: 0;
+	max-width: 680px;
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.fosse-choice-card {
+	position: relative;
+	box-sizing: border-box;
+	min-width: 0;
+	border: 1px solid var(--fosse-ui-border);
+	border-radius: var(--fosse-ui-radius);
+	background: var(--fosse-ui-surface);
+	cursor: pointer;
+	transition:
+		border-color 0.15s ease,
+		background-color 0.15s ease,
+		box-shadow 0.15s ease,
+		transform 0.15s ease;
+}
+
+.fosse-choice-card:hover {
+	border-color: var(--fosse-ui-border-strong);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.fosse-choice-card__input {
+	position: absolute;
+	top: 17px;
+	left: 16px;
+	z-index: 1;
+	margin: 0;
+}
+
+.fosse-choice-card__body {
+	display: block;
+	padding: 14px 16px 14px 41px;
+}
+
+.fosse-choice-card__label {
+	display: block;
+	font-weight: 600;
+	line-height: 1.35;
+	color: var(--fosse-ui-text);
+}
+
+.fosse-choice-card__body .description {
+	display: block;
+	margin: 7px 0 0;
+}
+
+.fosse-choice-card:has(.fosse-choice-card__input:checked),
+.fosse-choice-card:has(input:checked) {
+	border-color: var(--fosse-ui-accent-soft-border);
+	background: var(--fosse-ui-accent-soft);
+}
+
+.fosse-choice-card:has(.fosse-choice-card__input:focus-visible),
+.fosse-choice-card:has(input:focus-visible),
+.fosse-choice-card:focus-within {
+	outline: 2px solid var(--fosse-ui-accent);
+	outline-offset: 2px;
+}
+
+.fosse-detail-list {
+	display: grid;
+	grid-template-columns: minmax(120px, 38%) minmax(0, 1fr);
+	width: 100%;
+	min-width: 0;
+	margin: 0;
+	border-top: 1px solid var(--fosse-ui-border-faint);
+}
+
+.fosse-detail-list:first-child {
+	border-top: 0;
+}
+
+.fosse-detail-list__term,
+.fosse-detail-list__description {
+	box-sizing: border-box;
+	min-width: 0;
+	margin: 0;
+	padding: 12px 0;
+	border-bottom: 1px solid var(--fosse-ui-border-faint);
+}
+
+.fosse-detail-list__term {
+	padding-right: 18px;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1.45;
+	letter-spacing: 0;
+	text-transform: uppercase;
+	color: var(--fosse-ui-muted);
+}
+
+.fosse-detail-list__description {
+	font-size: 13px;
+	line-height: 1.5;
+	overflow-wrap: break-word;
+	color: var(--fosse-ui-text);
+}
+
+.fosse-detail-list__description--muted {
+	color: var(--fosse-ui-muted);
+	font-weight: 400;
+}
+
+.fosse-detail-list__term:nth-last-child(2),
+.fosse-detail-list__term:nth-last-child(2) + .fosse-detail-list__description {
+	border-bottom: 0;
+}
+
+.fosse-token,
+.fosse-admin-token,
+.fosse-status-card__token {
+	display: inline-block;
+	box-sizing: border-box;
+	max-width: 100%;
+	padding: 2px 5px;
+	border-radius: var(--fosse-ui-radius-small);
+	background: var(--fosse-ui-surface-muted);
+	color: var(--fosse-ui-text);
+	word-break: normal;
+	white-space: normal;
+	overflow-wrap: break-word;
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+}
+
+.fosse-token--did,
+.fosse-token--url,
+.fosse-admin-token--did,
+.fosse-admin-token--url,
+.fosse-status-card__token--did,
+.fosse-status-card__token--url {
+	overflow-wrap: anywhere;
+}
+
+.fosse-callout {
+	margin: 18px 0;
+	padding: 16px;
+	border: 1px solid var(--fosse-ui-border-soft);
+	border-radius: var(--fosse-ui-radius);
+	background: var(--fosse-ui-surface-muted);
+}
+
+.fosse-callout > :first-child {
+	margin-top: 0;
+}
+
+.fosse-callout > :last-child {
+	margin-bottom: 0;
+}
+
+.fosse-status-summary.fosse-admin-card {
+	display: flex;
+	align-items: stretch;
+	gap: 0;
+	margin: 0 0 20px;
+	background: var(--fosse-ui-surface);
+}
+
+.fosse-status-summary::before {
+	display: none;
+}
+
+.fosse-status-summary.has-attention {
+	border-color: rgba(138, 98, 0, 0.24);
+	background: var(--fosse-ui-surface);
+}
+
+.fosse-status-summary__body.fosse-card-body {
+	flex: 1 1 auto;
+}
+
+.fosse-status-summary__actions.fosse-card-footer {
+	display: flex;
+	align-items: center;
+	flex: 0 0 auto;
+	margin: 0;
+	border-top: 0;
+	border-left: 1px solid var(--fosse-ui-border-soft);
+}
+
+.fosse-connection-section.fosse-admin-card {
+	margin-top: 16px;
+	border-top: 1px solid var(--fosse-ui-border);
+}
+
+.fosse-settings-panel__header.fosse-card-header {
+	margin-bottom: 0;
+}
+
+.fosse-settings-actions.fosse-card-footer {
+	margin-top: 0;
+	padding-top: 20px;
+}
+
+.fosse-card-body .fosse-settings-section {
+	margin-top: 0;
+	padding-top: 0;
+	border-top: 0;
+}
+
 @media (max-width: 782px) {
 	.fosse-admin-page {
 		max-width: none;
@@ -629,6 +1033,13 @@
 	.fosse-settings-panel,
 	.fosse-provider-section {
 		padding: 18px;
+	}
+
+	.fosse-status-card.fosse-admin-card,
+	.fosse-settings-panel.fosse-admin-card,
+	.fosse-connection-section.fosse-admin-card,
+	.fosse-status-summary.fosse-admin-card {
+		padding: 0;
 	}
 
 	.fosse-status-card__header {
@@ -682,6 +1093,65 @@
 	.fosse-settings-card-option__body .description {
 		margin-left: 0;
 	}
+
+	.fosse-card-header,
+	.fosse-card-body,
+	.fosse-card-footer {
+		padding: 18px;
+	}
+
+	.fosse-card-header,
+	.fosse-status-summary.fosse-admin-card,
+	.fosse-status-summary__actions.fosse-card-footer {
+		flex-direction: column;
+	}
+
+	.fosse-guided-setup {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.fosse-guided-setup__button {
+		text-align: center;
+	}
+
+	.fosse-status-summary__actions.fosse-card-footer {
+		align-items: stretch;
+		width: 100%;
+		border-top: 1px solid var(--fosse-ui-border-soft);
+		border-left: 0;
+	}
+
+	.fosse-field,
+	.fosse-detail-list {
+		grid-template-columns: 1fr;
+	}
+
+	.fosse-field {
+		gap: 8px;
+	}
+
+	.fosse-detail-list__term {
+		padding-bottom: 3px;
+		border-bottom: 0;
+	}
+
+	.fosse-detail-list__description {
+		padding-top: 0;
+	}
+}
+
+@media (max-width: 480px) {
+	.fosse-action-bar,
+	.fosse-action-bar .button,
+	.fosse-action-bar input[type="submit"] {
+		width: 100%;
+	}
+
+	.fosse-action-bar {
+		align-items: stretch;
+		flex-direction: column;
+	}
 }
 
 /* =============================================
@@ -694,9 +1164,11 @@
 	--fosse-wizard-warm-text: #6f5700;
 
 	position: relative;
-	max-width: 800px;
+	box-sizing: border-box;
+	width: calc(100% - 112px);
+	max-width: 960px;
 	margin: 0 auto;
-	padding-top: 32px;
+	padding-top: 24px;
 	color: var(--fosse-ui-text);
 }
 
@@ -745,12 +1217,13 @@
 	display: flex;
 	align-items: center;
 	gap: 10px;
-	margin: 0 0 42px;
-	padding: 8px 12px;
+	margin: 0 0 18px;
+	padding: 10px 12px;
 	list-style: none;
-	background: rgba(255, 255, 255, 0.78);
-	border: 1px solid rgba(220, 220, 222, 0.82);
-	border-radius: 999px;
+	background: var(--fosse-ui-surface);
+	border: 1px solid var(--fosse-ui-border);
+	border-radius: var(--fosse-ui-radius);
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.02);
 }
 
 .fosse-wizard__progress-step {
@@ -835,40 +1308,51 @@
 
 /* Title and description */
 .fosse-wizard .fosse-wizard__title {
-	max-width: 650px;
-	font-size: 32px;
+	max-width: none;
+	font-size: 22px;
 	font-weight: 600;
-	line-height: 1.18;
+	line-height: 1.25;
 	letter-spacing: 0;
-	text-align: center;
+	text-align: left;
 	color: var(--fosse-ui-text);
-	margin: 0 auto 20px;
+	margin: 0;
 }
 
 .fosse-wizard .fosse-wizard__description {
-	max-width: 590px;
-	font-size: 15px;
-	line-height: 1.65;
-	text-align: center;
+	max-width: 720px;
+	font-size: 13px;
+	line-height: 1.5;
+	text-align: left;
 	color: var(--fosse-ui-muted);
-	margin: 0 auto 50px;
+	margin: 8px 0 0;
 }
 
 /* Main content card */
 .fosse-wizard__card {
+	overflow: hidden;
+	padding: 0;
 	background: var(--fosse-ui-surface);
 	border: 1px solid var(--fosse-ui-border);
 	border-radius: var(--fosse-ui-radius);
 	box-shadow: var(--fosse-ui-shadow);
-	padding: 36px;
 	margin-bottom: 0;
 }
 
-.fosse-wizard__card:has(.fosse-destination-cards) {
-	padding: 0;
-	background: transparent;
-	border: 0;
-	box-shadow: none;
+.fosse-wizard__card-header {
+	display: block;
+	background: var(--fosse-ui-surface);
+}
+
+.fosse-wizard__card-heading {
+	min-width: 0;
+}
+
+.fosse-wizard__card .fosse-card-body {
+	padding: 24px;
+}
+
+.fosse-wizard__card .fosse-card-footer {
+	padding: 16px 24px;
 }
 
 /* Action bar */
@@ -877,25 +1361,18 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: 16px;
-	margin-top: 32px;
+	margin-top: 0;
 	padding-top: 0;
 }
 
 .fosse-wizard__actions--center {
-	justify-content: center;
+	justify-content: flex-end;
 }
 
 .fosse-wizard__actions-primary {
 	display: flex;
 	align-items: center;
 	gap: 16px;
-}
-
-.fosse-wizard__actions-column {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 10px;
 }
 
 .fosse-wizard__skip {
@@ -954,15 +1431,15 @@
 .fosse-destination-cards {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 18px;
+	gap: 14px;
 }
 
 .fosse-destination-card {
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	min-height: 168px;
-	padding: 20px 22px 22px;
+	min-height: 136px;
+	padding: 18px 20px;
 	border: 1px solid var(--fosse-ui-border);
 	border-radius: var(--fosse-ui-radius);
 	background: var(--fosse-ui-surface);
@@ -1009,15 +1486,15 @@
 	display: flex;
 	align-items: center;
 	gap: 10px;
-	margin-bottom: 16px;
+	margin-bottom: 14px;
 }
 
 .fosse-destination-card__icon {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 34px;
-	height: 34px;
+	width: 30px;
+	height: 30px;
 	border-radius: 50%;
 	background: var(--fosse-wizard-warm);
 	color: var(--fosse-wizard-warm-text);
@@ -1056,8 +1533,8 @@
 }
 
 .fosse-destination-card__title {
-	margin-bottom: 8px;
-	font-size: 18px;
+	margin-bottom: 6px;
+	font-size: 16px;
 	font-weight: 600;
 	line-height: 1.3;
 	color: var(--fosse-ui-text);
@@ -1065,7 +1542,7 @@
 
 .fosse-destination-card__desc {
 	font-size: 13px;
-	line-height: 1.55;
+	line-height: 1.5;
 	color: var(--fosse-ui-muted);
 }
 
@@ -1105,13 +1582,15 @@
 	.fosse-destination-card__check,
 	.fosse-mode-card,
 	.fosse-mode-card__check,
+	.fosse-choice-card,
 	.fosse-post-type-item,
 	.fosse-wizard__lizard {
 		transition: none;
 	}
 
 	.fosse-destination-card:hover,
-	.fosse-mode-card:hover {
+	.fosse-mode-card:hover,
+	.fosse-choice-card:hover {
 		transform: none;
 	}
 }
@@ -1429,45 +1908,74 @@
 }
 
 /* Completion screen */
-.fosse-wizard__complete-header + .fosse-wizard__card {
-	text-align: left;
-}
-
 .fosse-wizard__complete-header {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	justify-content: flex-start;
+	gap: 12px;
+	padding: 22px 32px 20px;
 	text-align: center;
-	margin-bottom: 28px;
 }
 
-/* Keep the Complete step hero copy visually grouped under the success icon. */
 .fosse-wizard__complete-header .fosse-wizard__title,
 .fosse-wizard__complete-header .fosse-wizard__description {
-	max-width: 620px;
+	max-width: none;
+}
+
+.fosse-wizard__complete-message {
+	width: 100%;
+	max-width: 860px;
+	min-width: 0;
+	margin: 0 auto;
+}
+
+.fosse-wizard__complete-message .fosse-wizard__title {
+	margin-top: 0;
+	padding: 0;
+	text-align: center;
+}
+
+.fosse-wizard__complete-message .fosse-wizard__description {
+	margin: 6px 0 0;
+	text-align: center;
+}
+
+.fosse-wizard__complete-message .fosse-wizard__description strong {
+	font-weight: 600;
+	color: var(--fosse-ui-text);
+}
+
+.fosse-wizard__complete-message .fosse-wizard__cta-help {
+	display: inline;
 }
 
 .fosse-complete-icon {
-	width: 64px;
-	height: 64px;
+	width: 56px;
+	height: 56px;
 	border-radius: 50%;
 	background: var(--fosse-ui-success-soft);
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	margin: 0 auto 34px;
-	box-shadow: 0 0 0 8px rgba(22, 138, 74, 0.06);
+	margin: 0 auto;
+	box-shadow: 0 0 0 6px rgba(22, 138, 74, 0.06);
+	flex: 0 0 auto;
 }
 
 .fosse-complete-icon .dashicons {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 32px;
-	width: 32px;
-	height: 32px;
+	font-size: 30px;
+	width: 30px;
+	height: 30px;
 	color: var(--fosse-ui-success);
 	transform: translateY(1px);
+}
+
+.fosse-wizard__completion-footer {
+	display: block;
 }
 
 /* Summary table */
@@ -1519,7 +2027,7 @@
 /* Reset link */
 .fosse-wizard__reset {
 	text-align: center;
-	margin-top: 16px;
+	margin: 14px 0 0;
 	font-size: 12px;
 }
 
@@ -1542,19 +2050,30 @@
 
 /* Completion publish CTA */
 .fosse-wizard__cta-publish {
-	min-width: 240px;
+	min-width: 0;
 }
 
 .fosse-wizard__cta-help {
-	text-align: center;
-	margin: 18px auto 0;
+	text-align: left;
+	margin: 0;
 	font-size: 13px;
 	color: var(--fosse-ui-muted);
-	max-width: 590px;
+	max-width: 720px;
 }
 
-.fosse-wizard__actions--secondary {
-	margin-top: 28px;
+.fosse-wizard__completion-actions {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
+.fosse-wizard__completion-secondary {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
 }
 
 /* Bluesky signup affordance */
@@ -1736,6 +2255,7 @@
 
 @media (max-width: 782px) {
 	.fosse-wizard {
+		width: auto;
 		max-width: none;
 		margin: 0;
 		padding-top: 18px;
@@ -1745,13 +2265,13 @@
 		align-items: center;
 		flex-wrap: nowrap;
 		gap: 6px;
-		margin-bottom: 28px;
+		margin-bottom: 14px;
 		padding: 8px 10px;
-		border-radius: 999px;
+		border-radius: var(--fosse-ui-radius);
 	}
 
 	.fosse-wizard .fosse-wizard__title {
-		font-size: 26px;
+		font-size: 20px;
 	}
 
 	.fosse-wizard__progress-line {
@@ -1788,7 +2308,13 @@
 	}
 
 	.fosse-wizard__card {
-		padding: 24px;
+		padding: 0;
+	}
+
+	.fosse-wizard__card .fosse-card-header,
+	.fosse-wizard__card .fosse-card-body,
+	.fosse-wizard__card .fosse-card-footer {
+		padding: 18px;
 	}
 
 	.fosse-destination-cards {
@@ -1815,6 +2341,8 @@
 
 	.fosse-wizard__actions,
 	.fosse-wizard__actions-primary,
+	.fosse-wizard__completion-actions,
+	.fosse-wizard__completion-secondary,
 	.fosse-bluesky-form__controls {
 		align-items: stretch;
 		flex-direction: column;
@@ -1822,6 +2350,14 @@
 
 	.fosse-wizard__actions {
 		gap: 12px;
+	}
+
+	.fosse-wizard__completion-actions .button {
+		text-align: center;
+	}
+
+	.fosse-wizard__reset {
+		text-align: center;
 	}
 
 	.fosse-wizard__actions .button,

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -800,6 +800,10 @@
 	margin-bottom: 0;
 }
 
+.fosse-status-card__header.fosse-card-header {
+	margin-bottom: 0;
+}
+
 .fosse-settings-actions.fosse-card-footer {
 	margin-top: 0;
 	padding-top: 20px;

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -159,13 +159,11 @@ class AP_Provider implements Connection_Provider {
 		<div class="fosse-settings-section" id="fosse-provider-activitypub">
 			<h3><?php esc_html_e( 'ActivityPub', 'fosse' ); ?></h3>
 
-			<table class="form-table">
+			<div class="fosse-field-stack">
 				<?php if ( $shows_blog ) : ?>
-					<tr>
-						<th scope="row">
-							<label for="fosse-activitypub-blog-identifier"><?php esc_html_e( 'Site handle', 'fosse' ); ?></label>
-						</th>
-						<td>
+					<div class="fosse-field">
+						<label class="fosse-field__label" for="fosse-activitypub-blog-identifier"><?php esc_html_e( 'Site handle', 'fosse' ); ?></label>
+						<div class="fosse-field__control">
 							<input
 								type="text"
 								id="fosse-activitypub-blog-identifier"
@@ -178,38 +176,38 @@ class AP_Provider implements Connection_Provider {
 							<p id="fosse-activitypub-blog-identifier-desc" class="description">
 								<?php esc_html_e( 'The username people use to follow your site in fediverse apps. It cannot match an existing author login or nicename.', 'fosse' ); ?>
 							</p>
-						</td>
-					</tr>
+						</div>
+					</div>
 				<?php endif; ?>
 
-				<?php if ( $shows_user && $user_address ) : ?>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></th>
-						<td>
-							<code class="fosse-admin-token fosse-admin-token--ap-address">
-								<?php
-								echo Status_Formatter::ap_address( '@' . $user_address ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::ap_address() escapes input and returns safe HTML with <wbr>.
-								?>
-							</code>
-						</td>
-					</tr>
-				<?php endif; ?>
+				<?php if ( ( $shows_user && $user_address ) || ( $shows_blog && $blog_address ) ) : ?>
+					<dl class="fosse-detail-list">
+						<?php if ( $shows_user && $user_address ) : ?>
+							<dt class="fosse-detail-list__term"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></dt>
+							<dd class="fosse-detail-list__description">
+								<code class="fosse-token fosse-admin-token fosse-token--ap-address fosse-admin-token--ap-address">
+									<?php
+									echo Status_Formatter::ap_address( '@' . $user_address ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::ap_address() escapes input and returns safe HTML with <wbr>.
+									?>
+								</code>
+							</dd>
+						<?php endif; ?>
 
-				<?php if ( $shows_blog && $blog_address ) : ?>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></th>
-						<td>
-							<code class="fosse-admin-token fosse-admin-token--ap-address">
-								<?php
-								echo Status_Formatter::ap_address( '@' . $blog_address ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::ap_address() escapes input and returns safe HTML with <wbr>.
-								?>
-							</code>
-						</td>
-					</tr>
+						<?php if ( $shows_blog && $blog_address ) : ?>
+							<dt class="fosse-detail-list__term"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></dt>
+							<dd class="fosse-detail-list__description">
+								<code class="fosse-token fosse-admin-token fosse-token--ap-address fosse-admin-token--ap-address">
+									<?php
+									echo Status_Formatter::ap_address( '@' . $blog_address ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::ap_address() escapes input and returns safe HTML with <wbr>.
+									?>
+								</code>
+							</dd>
+						<?php endif; ?>
+					</dl>
 				<?php endif; ?>
-			</table>
+			</div>
 
-			<p>
+			<p class="fosse-action-bar">
 				<a class="fosse-settings-secondary-link" href="<?php echo esc_url( admin_url( 'options-general.php?page=activitypub' ) ); ?>">
 					<?php esc_html_e( 'Advanced ActivityPub settings', 'fosse' ); ?>
 				</a>
@@ -229,14 +227,19 @@ class AP_Provider implements Connection_Provider {
 	 */
 	public function render_connection_actions(): void {
 		?>
-		<div class="fosse-connection-section" id="fosse-provider-activitypub-connection">
-			<h3><?php esc_html_e( 'ActivityPub', 'fosse' ); ?></h3>
-			<p>
-				<strong><?php esc_html_e( 'Connected automatically', 'fosse' ); ?></strong>
-			</p>
-			<p class="description">
-				<?php esc_html_e( 'ActivityPub is active for this site, so no separate connection step is needed.', 'fosse' ); ?>
-			</p>
+		<div class="fosse-connection-section fosse-admin-card" id="fosse-provider-activitypub-connection">
+			<div class="fosse-card-header">
+				<h3><?php esc_html_e( 'ActivityPub', 'fosse' ); ?></h3>
+				<span class="fosse-status-badge is-connected"><?php esc_html_e( 'Connected', 'fosse' ); ?></span>
+			</div>
+			<div class="fosse-card-body">
+				<p>
+					<strong><?php esc_html_e( 'Connected automatically', 'fosse' ); ?></strong>
+				</p>
+				<p class="description">
+					<?php esc_html_e( 'ActivityPub is active for this site, so no separate connection step is needed.', 'fosse' ); ?>
+				</p>
+			</div>
 		</div>
 		<?php
 	}
@@ -259,8 +262,8 @@ class AP_Provider implements Connection_Provider {
 			$status['post_types']
 		);
 		?>
-		<div class="fosse-status-card">
-			<div class="fosse-status-card__header">
+		<div class="fosse-status-card fosse-admin-card">
+			<div class="fosse-status-card__header fosse-card-header">
 				<h2 class="fosse-status-card__title">
 					<span
 						class="fosse-status-indicator <?php echo esc_attr( $status_class ); ?>"
@@ -271,43 +274,35 @@ class AP_Provider implements Connection_Provider {
 				<span class="fosse-status-badge is-<?php echo esc_attr( $status_class ); ?>"><?php echo esc_html( $status_label ); ?></span>
 			</div>
 
-			<table class="widefat striped fosse-status-card__table">
-				<tbody>
-					<tr>
-						<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'ActivityPub profile', 'fosse' ); ?></th>
-						<td class="fosse-status-card__value"><?php echo esc_html( $mode_label ); ?></td>
-					</tr>
-					<tr>
-						<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Content types', 'fosse' ); ?></th>
-						<td class="fosse-status-card__value"><?php echo esc_html( implode( ', ', $post_types ) ); ?></td>
-					</tr>
+			<div class="fosse-card-body">
+				<dl class="fosse-detail-list">
+					<dt class="fosse-detail-list__term"><?php esc_html_e( 'ActivityPub profile', 'fosse' ); ?></dt>
+					<dd class="fosse-detail-list__description"><?php echo esc_html( $mode_label ); ?></dd>
+					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Content types', 'fosse' ); ?></dt>
+					<dd class="fosse-detail-list__description"><?php echo esc_html( implode( ', ', $post_types ) ); ?></dd>
 					<?php if ( $this->mode_includes_user( $status['actor_mode'] ) && ! empty( $status['user_address'] ) ) : ?>
-						<tr class="fosse-status-card__row--stacked">
-							<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></th>
-							<td class="fosse-status-card__value">
-								<code class="fosse-status-card__token fosse-status-card__token--ap-address">
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description">
+								<code class="fosse-token fosse-status-card__token fosse-token--ap-address fosse-status-card__token--ap-address">
 									<?php
 									echo Status_Formatter::ap_address( '@' . $status['user_address'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::ap_address() escapes input and returns safe HTML with <wbr>.
 									?>
 								</code>
-							</td>
-						</tr>
+						</dd>
 					<?php endif; ?>
 					<?php if ( $this->mode_includes_blog( $status['actor_mode'] ) && ! empty( $status['blog_address'] ) ) : ?>
-						<tr class="fosse-status-card__row--stacked">
-							<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></th>
-							<td class="fosse-status-card__value">
-								<code class="fosse-status-card__token fosse-status-card__token--ap-address">
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description">
+								<code class="fosse-token fosse-status-card__token fosse-token--ap-address fosse-status-card__token--ap-address">
 									<?php
 									echo Status_Formatter::ap_address( '@' . $status['blog_address'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::ap_address() escapes input and returns safe HTML with <wbr>.
 									?>
 								</code>
-							</td>
-						</tr>
+						</dd>
 					<?php endif; ?>
 					<?php $this->render_follower_count_row(); ?>
-				</tbody>
-			</table>
+				</dl>
+			</div>
 		</div>
 		<?php
 	}
@@ -619,18 +614,15 @@ class AP_Provider implements Connection_Provider {
 			}
 			$count = \Activitypub\Collection\Followers::count( \Activitypub\Collection\Actors::BLOG_USER_ID );
 			?>
-			<tr>
-				<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Followers', 'fosse' ); ?></th>
-				<td class="fosse-status-card__value"><?php echo esc_html( number_format_i18n( $count ) ); ?></td>
-			</tr>
+			<dt class="fosse-detail-list__term"><?php esc_html_e( 'Followers', 'fosse' ); ?></dt>
+			<dd class="fosse-detail-list__description"><?php echo esc_html( number_format_i18n( $count ) ); ?></dd>
 			<?php
 		} elseif ( 'actor_blog' === $mode && $has_blog_id ) {
 			$user_count = \Activitypub\Collection\Followers::count( get_current_user_id() );
 			$blog_count = \Activitypub\Collection\Followers::count( \Activitypub\Collection\Actors::BLOG_USER_ID );
 			?>
-			<tr>
-				<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Followers', 'fosse' ); ?></th>
-				<td class="fosse-status-card__value">
+			<dt class="fosse-detail-list__term"><?php esc_html_e( 'Followers', 'fosse' ); ?></dt>
+			<dd class="fosse-detail-list__description">
 					<?php
 					printf(
 						/* translators: 1: author follower count, 2: blog follower count */
@@ -639,16 +631,13 @@ class AP_Provider implements Connection_Provider {
 						esc_html( number_format_i18n( $blog_count ) )
 					);
 					?>
-				</td>
-			</tr>
+			</dd>
 			<?php
 		} else {
 			$count = \Activitypub\Collection\Followers::count( get_current_user_id() );
 			?>
-			<tr>
-				<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Your Followers', 'fosse' ); ?></th>
-				<td class="fosse-status-card__value"><?php echo esc_html( number_format_i18n( $count ) ); ?></td>
-			</tr>
+			<dt class="fosse-detail-list__term"><?php esc_html_e( 'Your Followers', 'fosse' ); ?></dt>
+			<dd class="fosse-detail-list__description"><?php echo esc_html( number_format_i18n( $count ) ); ?></dd>
 			<?php
 		}
 	}

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -208,7 +208,7 @@ class AP_Provider implements Connection_Provider {
 			</div>
 
 			<p class="fosse-action-bar">
-				<a class="fosse-settings-secondary-link" href="<?php echo esc_url( admin_url( 'options-general.php?page=activitypub' ) ); ?>">
+				<a class="fosse-admin-page__secondary-link" href="<?php echo esc_url( admin_url( 'options-general.php?page=activitypub' ) ); ?>">
 					<?php esc_html_e( 'Advanced ActivityPub settings', 'fosse' ); ?>
 				</a>
 			</p>

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -214,24 +214,27 @@ class Bluesky_Provider implements Connection_Provider {
 	public function render_connection_actions(): void {
 		$status = $this->get_status();
 		?>
-		<div class="fosse-connection-section" id="fosse-provider-bluesky">
-			<h3><?php esc_html_e( 'Bluesky', 'fosse' ); ?></h3>
+		<div class="fosse-connection-section fosse-admin-card" id="fosse-provider-bluesky">
+			<div class="fosse-card-header">
+				<h3><?php esc_html_e( 'Bluesky', 'fosse' ); ?></h3>
+				<span class="fosse-status-badge is-<?php echo esc_attr( $status['connected'] ? 'connected' : 'disconnected' ); ?>">
+					<?php echo esc_html( $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' ) ); ?>
+				</span>
+			</div>
 
 			<?php settings_errors( 'atmosphere' ); ?>
 
 			<?php if ( ! $status['connected'] ) : ?>
-				<p><?php esc_html_e( 'Connect a Bluesky account to share eligible WordPress posts there too. You can disconnect it here later.', 'fosse' ); ?></p>
-
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 					<input type="hidden" name="action" value="fosse_connect_bluesky" />
 					<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_connect_bluesky' ) ); ?>" />
 
-					<table class="form-table">
-						<tr>
-							<th scope="row">
-								<label for="fosse_bluesky_handle"><?php esc_html_e( 'Bluesky handle', 'fosse' ); ?></label>
-							</th>
-							<td>
+					<div class="fosse-card-body">
+						<p><?php esc_html_e( 'Connect a Bluesky account to share eligible WordPress posts there too. You can disconnect it here later.', 'fosse' ); ?></p>
+
+						<div class="fosse-field">
+							<label class="fosse-field__label" for="fosse_bluesky_handle"><?php esc_html_e( 'Bluesky handle', 'fosse' ); ?></label>
+							<div class="fosse-field__control">
 								<input
 									type="text"
 									class="regular-text"
@@ -252,92 +255,90 @@ class Bluesky_Provider implements Connection_Provider {
 									);
 									?>
 								</p>
-							</td>
-						</tr>
-					</table>
+							</div>
+						</div>
+					</div>
 
-					<?php submit_button( __( 'Connect Bluesky', 'fosse' ) ); ?>
+					<div class="fosse-card-footer fosse-action-bar">
+						<?php submit_button( __( 'Connect Bluesky', 'fosse' ), 'primary', 'submit', false ); ?>
+					</div>
 				</form>
 			<?php else : ?>
-				<p>
-					<strong><?php esc_html_e( 'Connected account', 'fosse' ); ?></strong>
-				</p>
-				<p class="description">
-					<?php esc_html_e( 'FOSSE can share eligible WordPress posts with this Bluesky account.', 'fosse' ); ?>
-				</p>
-				<table class="form-table">
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Bluesky handle', 'fosse' ); ?></th>
-						<td>
-							<strong class="fosse-admin-token fosse-admin-token--handle">
+				<div class="fosse-card-body">
+					<p>
+						<strong><?php esc_html_e( 'Connected account', 'fosse' ); ?></strong>
+					</p>
+					<p class="description">
+						<?php esc_html_e( 'FOSSE can share eligible WordPress posts with this Bluesky account.', 'fosse' ); ?>
+					</p>
+					<dl class="fosse-detail-list">
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Bluesky handle', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description">
+							<strong class="fosse-token fosse-admin-token fosse-token--handle fosse-admin-token--handle">
 								<?php
 								echo Status_Formatter::handle( $status['handle'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::handle() escapes input and returns safe HTML with <wbr>.
 								?>
 							</strong>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Account ID', 'fosse' ); ?></th>
-						<td>
-							<code class="fosse-admin-token fosse-admin-token--did">
+						</dd>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Account ID', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description">
+							<code class="fosse-token fosse-admin-token fosse-token--did fosse-admin-token--did">
 								<?php
 								echo Status_Formatter::did( $status['did'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::did() escapes input and returns safe HTML with <wbr>.
 								?>
 							</code>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'PDS endpoint', 'fosse' ); ?></th>
-						<td>
-							<code class="fosse-admin-token fosse-admin-token--url">
+						</dd>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'PDS endpoint', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description">
+							<code class="fosse-token fosse-admin-token fosse-token--url fosse-admin-token--url">
 								<?php
 								echo Status_Formatter::url( $status['pds_endpoint'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::url() escapes input and returns safe HTML with <wbr>.
 								?>
 							</code>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row"><?php esc_html_e( 'Token health', 'fosse' ); ?></th>
-						<td><?php echo esc_html( $status['token_error'] ? $status['token_error'] : __( 'OK', 'fosse' ) ); ?></td>
-					</tr>
-				</table>
+						</dd>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Token health', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description"><?php echo esc_html( $status['token_error'] ? $status['token_error'] : __( 'OK', 'fosse' ) ); ?></dd>
+					</dl>
 
-				<?php $this->render_domain_handle_panel( $status ); ?>
-
-				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-					<input type="hidden" name="action" value="fosse_disconnect_bluesky" />
-					<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_disconnect_bluesky' ) ); ?>" />
-					<?php
-					// Surface the planned handle-revert so users understand
-					// disconnect isn't just "log me out" when FOSSE previously
-					// changed their Bluesky handle. The disconnect handler
-					// runs the revert before dropping the OAuth token; if the
-					// snapshot belongs to a different DID (reconnect to a
-					// different account) the getter returns '' and the note
-					// is suppressed.
-					$pending_revert = Bluesky_Domain_Handle::get_pending_revert_handle();
-					if ( '' !== $pending_revert ) :
-						?>
-						<div class="notice notice-warning inline fosse-domain-handle-revert-note">
-							<p>
-								<strong><?php esc_html_e( 'Disconnect note:', 'fosse' ); ?></strong>
-								<?php
-								echo esc_html(
-									sprintf(
-										/* translators: %s: previous Bluesky handle that disconnect will restore (e.g. alice.bsky.social). */
-										__( 'Disconnecting will also restore %s as this account\'s Bluesky handle.', 'fosse' ),
-										$pending_revert
-									)
-								);
-								?>
-							</p>
-						</div>
+						<?php $this->render_domain_handle_panel( $status ); ?>
 						<?php
-					endif;
-					submit_button( __( 'Disconnect Bluesky', 'fosse' ), 'secondary' );
-					?>
-				</form>
-			<?php endif; ?>
+						// Surface the planned handle-revert so users understand
+						// disconnect isn't just "log me out" when FOSSE previously
+						// changed their Bluesky handle. The disconnect handler
+						// runs the revert before dropping the OAuth token; if the
+						// snapshot belongs to a different DID (reconnect to a
+						// different account) the getter returns '' and the note
+						// is suppressed.
+						$pending_revert = Bluesky_Domain_Handle::get_pending_revert_handle();
+						if ( '' !== $pending_revert ) :
+							?>
+							<div class="notice notice-warning inline fosse-domain-handle-revert-note">
+								<p>
+									<strong><?php esc_html_e( 'Disconnect note:', 'fosse' ); ?></strong>
+									<?php
+									echo esc_html(
+										sprintf(
+											/* translators: %s: previous Bluesky handle that disconnect will restore (e.g. alice.bsky.social). */
+											__( 'Disconnecting will also restore %s as this account\'s Bluesky handle.', 'fosse' ),
+											$pending_revert
+										)
+									);
+									?>
+								</p>
+							</div>
+							<?php
+						endif;
+						?>
+					</div>
+
+					<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+						<input type="hidden" name="action" value="fosse_disconnect_bluesky" />
+						<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_disconnect_bluesky' ) ); ?>" />
+						<div class="fosse-card-footer fosse-action-bar">
+							<?php submit_button( __( 'Disconnect Bluesky', 'fosse' ), 'secondary', 'submit', false ); ?>
+						</div>
+					</form>
+				<?php endif; ?>
 		</div>
 		<?php
 	}
@@ -369,7 +370,7 @@ class Bluesky_Provider implements Connection_Provider {
 		$target   = Bluesky_Domain_Handle::get_target_handle();
 		$is_drift = Bluesky_Domain_Handle::is_drift( $status );
 		?>
-		<div class="fosse-domain-handle-panel">
+		<div class="fosse-domain-handle-panel fosse-callout">
 			<h4>
 				<?php
 				if ( $is_drift ) {
@@ -415,7 +416,7 @@ class Bluesky_Provider implements Connection_Provider {
 				?>
 			</p>
 			<?php Bluesky_Domain_Handle::render_destructive_warning_notice(); ?>
-			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<form class="fosse-action-bar" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 				<input type="hidden" name="action" value="fosse_set_bluesky_domain_handle" />
 				<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_set_bluesky_domain_handle' ) ); ?>" />
 				<?php
@@ -445,8 +446,8 @@ class Bluesky_Provider implements Connection_Provider {
 		$status_class = $status['connected'] ? 'connected' : 'disconnected';
 		$status_label = $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' );
 		?>
-		<div class="fosse-status-card">
-			<div class="fosse-status-card__header">
+		<div class="fosse-status-card fosse-admin-card">
+			<div class="fosse-status-card__header fosse-card-header">
 				<h2 class="fosse-status-card__title">
 					<span
 						class="fosse-status-indicator <?php echo esc_attr( $status_class ); ?>"
@@ -457,51 +458,42 @@ class Bluesky_Provider implements Connection_Provider {
 				<span class="fosse-status-badge is-<?php echo esc_attr( $status_class ); ?>"><?php echo esc_html( $status_label ); ?></span>
 			</div>
 
-			<table class="widefat striped fosse-status-card__table">
-				<tbody>
-					<tr>
-						<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Connection', 'fosse' ); ?></th>
-						<td class="fosse-status-card__value"><?php echo esc_html( $status_label ); ?></td>
-					</tr>
+			<div class="fosse-card-body">
+				<dl class="fosse-detail-list">
+					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Connection', 'fosse' ); ?></dt>
+					<dd class="fosse-detail-list__description"><?php echo esc_html( $status_label ); ?></dd>
 					<?php if ( $status['handle'] ) : ?>
-						<tr>
-							<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Handle', 'fosse' ); ?></th>
-							<td class="fosse-status-card__value">
-								<strong class="fosse-status-card__token fosse-status-card__token--handle">
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Handle', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description">
+								<strong class="fosse-token fosse-status-card__token fosse-token--handle fosse-status-card__token--handle">
 									<?php
 									echo Status_Formatter::handle( $status['handle'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::handle() escapes input and returns safe HTML with <wbr>.
 									?>
 								</strong>
-							</td>
-						</tr>
+						</dd>
 					<?php endif; ?>
 					<?php if ( $status['did'] ) : ?>
-						<tr>
-							<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'DID', 'fosse' ); ?></th>
-							<td class="fosse-status-card__value">
-								<code class="fosse-status-card__token fosse-status-card__token--did">
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'DID', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description">
+								<code class="fosse-token fosse-status-card__token fosse-token--did fosse-status-card__token--did">
 									<?php
 									echo Status_Formatter::did( $status['did'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::did() escapes input and returns safe HTML with <wbr>.
 									?>
 								</code>
-							</td>
-						</tr>
+						</dd>
 					<?php endif; ?>
 					<?php if ( $status['pds_endpoint'] ) : ?>
-						<tr>
-							<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'PDS endpoint', 'fosse' ); ?></th>
-							<td class="fosse-status-card__value">
-								<code class="fosse-status-card__token fosse-status-card__token--url">
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'PDS endpoint', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description">
+								<code class="fosse-token fosse-status-card__token fosse-token--url fosse-status-card__token--url">
 									<?php
 									echo Status_Formatter::url( $status['pds_endpoint'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::url() escapes input and returns safe HTML with <wbr>.
 									?>
 								</code>
-							</td>
-						</tr>
+						</dd>
 					<?php endif; ?>
-					<tr>
-						<th scope="row" class="fosse-status-card__label"><?php esc_html_e( 'Token Health', 'fosse' ); ?></th>
-						<td class="fosse-status-card__value">
+					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Token Health', 'fosse' ); ?></dt>
+					<dd class="fosse-detail-list__description">
 							<?php if ( $status['token_error'] ) : ?>
 								<strong><?php esc_html_e( 'Reconnect required.', 'fosse' ); ?></strong>
 								<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-provider-bluesky' ) ); ?>">
@@ -514,13 +506,12 @@ class Bluesky_Provider implements Connection_Provider {
 							<?php else : ?>
 								<?php esc_html_e( 'OK', 'fosse' ); ?>
 							<?php endif; ?>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+					</dd>
+				</dl>
+			</div>
 
 			<?php if ( ! $status['connected'] && ! $status['token_error'] ) : ?>
-				<p class="fosse-status-card__actions">
+				<p class="fosse-status-card__actions fosse-card-footer fosse-action-bar">
 					<a class="button button-secondary" href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-provider-bluesky' ) ); ?>">
 						<?php esc_html_e( 'Open Bluesky settings', 'fosse' ); ?>
 					</a>

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -175,7 +175,7 @@ class Onboarding_Wizard {
 		);
 
 		?>
-		<div class="wrap fosse-wizard">
+		<div class="wrap fosse-wizard fosse-admin-shell">
 		<?php
 		self::render_lizard_toggle();
 
@@ -962,6 +962,26 @@ class Onboarding_Wizard {
 	}
 
 	/**
+	 * Render a wizard card header.
+	 *
+	 * @param string $title       Header title.
+	 * @param string $description Header description.
+	 * @return void
+	 */
+	private static function render_step_card_header( string $title, string $description ): void {
+		?>
+		<div class="fosse-card-header fosse-wizard__card-header">
+			<div class="fosse-wizard__card-heading">
+				<h1 class="fosse-wizard__title"><?php echo esc_html( $title ); ?></h1>
+				<p class="fosse-wizard__description">
+					<?php echo esc_html( $description ); ?>
+				</p>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
 	 * Render Step 1: Destinations.
 	 *
 	 * @return void
@@ -989,23 +1009,25 @@ class Onboarding_Wizard {
 			),
 		);
 		?>
-		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Where should your WordPress posts appear?', 'fosse' ); ?></h1>
-		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Fediverse sharing is enabled by default, so people can follow your site from Fediverse apps like Mastodon. You can also connect Bluesky now or set it up later.', 'fosse' ); ?>
-		</p>
-
-		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+		<form class="fosse-wizard__form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 			<input type="hidden" name="action" value="fosse_wizard_save" />
 			<input type="hidden" name="fosse_wizard_step" value="destinations" />
 			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $nonce ); ?>" />
 
-			<div class="fosse-wizard__card">
+			<div class="fosse-wizard__card fosse-admin-card">
+				<?php
+				self::render_step_card_header(
+					__( 'Where should your WordPress posts appear?', 'fosse' ),
+					__( 'Fediverse sharing is enabled by default, so people can follow your site from Fediverse apps like Mastodon. You can also connect Bluesky now or set it up later.', 'fosse' )
+				);
+				?>
+				<div class="fosse-card-body">
 				<fieldset class="fosse-destination-cards">
 					<legend class="screen-reader-text">
 						<?php esc_html_e( 'Where to publish', 'fosse' ); ?>
 					</legend>
 					<?php foreach ( $destinations as $value => $destination ) : ?>
-						<label class="fosse-destination-card <?php echo esc_attr( $destination['class'] ); ?>">
+						<label class="fosse-choice-card fosse-destination-card <?php echo esc_attr( $destination['class'] ); ?>">
 							<input
 								type="radio"
 								name="fosse_onboarding_destination"
@@ -1027,14 +1049,17 @@ class Onboarding_Wizard {
 						</label>
 					<?php endforeach; ?>
 				</fieldset>
-			</div>
+				</div>
 
-			<div class="fosse-wizard__actions fosse-wizard__actions--center">
-				<div class="fosse-wizard__actions-column">
-					<?php submit_button( __( 'Continue', 'fosse' ), 'primary large', 'submit', false ); ?>
-					<a href="<?php echo esc_url( self::get_skip_url() ); ?>" class="fosse-wizard__skip">
-						<?php esc_html_e( 'Skip setup', 'fosse' ); ?>
-					</a>
+				<div class="fosse-card-footer">
+					<div class="fosse-wizard__actions fosse-wizard__actions--center">
+						<div class="fosse-wizard__actions-primary">
+							<a href="<?php echo esc_url( self::get_skip_url() ); ?>" class="fosse-wizard__skip">
+								<?php esc_html_e( 'Skip setup', 'fosse' ); ?>
+							</a>
+							<?php submit_button( __( 'Continue', 'fosse' ), 'primary large', 'submit', false ); ?>
+						</div>
+					</div>
 				</div>
 			</div>
 		</form>
@@ -1118,19 +1143,20 @@ class Onboarding_Wizard {
 		}
 
 		?>
-		<h1 class="fosse-wizard__title"><?php esc_html_e( 'Who should people follow?', 'fosse' ); ?></h1>
-		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Choose the fediverse identity people can follow when FOSSE shares your selected content types.', 'fosse' ); ?>
-		</p>
-
-		<?php settings_errors( 'fosse' ); ?>
-
-		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+		<form class="fosse-wizard__form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 			<input type="hidden" name="action" value="fosse_wizard_save" />
 			<input type="hidden" name="fosse_wizard_step" value="appearance" />
 			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $nonce ); ?>" />
 
-			<div class="fosse-wizard__card">
+			<div class="fosse-wizard__card fosse-admin-card">
+				<?php
+				self::render_step_card_header(
+					__( 'Who should people follow?', 'fosse' ),
+					__( 'Choose the fediverse identity people can follow when FOSSE shares your selected content types.', 'fosse' )
+				);
+				?>
+				<div class="fosse-card-body">
+				<?php settings_errors( 'fosse' ); ?>
 				<?php if ( Actor_Mode_Lock::is_locked() ) : ?>
 					<?php $forced_mode = Actor_Mode_Lock::forced_mode(); ?>
 					<div class="fosse-wizard__locked-mode">
@@ -1151,7 +1177,7 @@ class Onboarding_Wizard {
 							<?php esc_html_e( 'How posts appear', 'fosse' ); ?>
 						</legend>
 						<?php foreach ( $modes as $value => $mode ) : ?>
-							<label class="fosse-mode-card">
+							<label class="fosse-choice-card fosse-mode-card">
 								<input
 									type="radio"
 									name="activitypub_actor_mode"
@@ -1245,17 +1271,20 @@ class Onboarding_Wizard {
 						<?php esc_html_e( 'The username people use to follow your site in fediverse apps. It cannot match an existing author login or nicename.', 'fosse' ); ?>
 					</p>
 				</div>
-			</div>
+				</div>
 
-			<div class="fosse-wizard__actions">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=destinations' ) ); ?>" class="button">
-					&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
-				</a>
-				<div class="fosse-wizard__actions-primary">
-					<a href="<?php echo esc_url( self::get_skip_url() ); ?>" class="fosse-wizard__skip">
-						<?php esc_html_e( 'Skip setup', 'fosse' ); ?>
-					</a>
-					<?php submit_button( __( 'Continue', 'fosse' ), 'primary', 'submit', false ); ?>
+				<div class="fosse-card-footer">
+					<div class="fosse-wizard__actions">
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=destinations' ) ); ?>" class="button">
+							&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
+						</a>
+						<div class="fosse-wizard__actions-primary">
+							<a href="<?php echo esc_url( self::get_skip_url() ); ?>" class="fosse-wizard__skip">
+								<?php esc_html_e( 'Skip setup', 'fosse' ); ?>
+							</a>
+							<?php submit_button( __( 'Continue', 'fosse' ), 'primary', 'submit', false ); ?>
+						</div>
+					</div>
 				</div>
 			</div>
 		</form>
@@ -1278,23 +1307,24 @@ class Onboarding_Wizard {
 		$has_empty_error = isset( $_GET['error'] ) && 'empty_post_types' === $_GET['error'];
 
 		?>
-		<h1 class="fosse-wizard__title"><?php esc_html_e( 'What do you want to share?', 'fosse' ); ?></h1>
-		<p class="fosse-wizard__description">
-			<?php esc_html_e( 'Choose what to share with people who follow your site. You can change this anytime.', 'fosse' ); ?>
-		</p>
-
-		<?php if ( $has_empty_error ) : ?>
-			<div class="notice notice-error inline">
-				<p><?php esc_html_e( 'Pick at least one content type to share.', 'fosse' ); ?></p>
-			</div>
-		<?php endif; ?>
-
-		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+		<form class="fosse-wizard__form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 			<input type="hidden" name="action" value="fosse_wizard_save" />
 			<input type="hidden" name="fosse_wizard_step" value="content" />
 			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $nonce ); ?>" />
 
-			<div class="fosse-wizard__card">
+			<div class="fosse-wizard__card fosse-admin-card">
+				<?php
+				self::render_step_card_header(
+					__( 'What do you want to share?', 'fosse' ),
+					__( 'Choose what to share with people who follow your site. You can change this anytime.', 'fosse' )
+				);
+				?>
+				<div class="fosse-card-body">
+				<?php if ( $has_empty_error ) : ?>
+					<div class="notice notice-error inline">
+						<p><?php esc_html_e( 'Pick at least one content type to share.', 'fosse' ); ?></p>
+					</div>
+				<?php endif; ?>
 				<div class="fosse-post-types">
 					<?php
 					$primary_order = array( 'post', 'page' );
@@ -1325,7 +1355,7 @@ class Onboarding_Wizard {
 						<fieldset class="fosse-post-types__group">
 							<legend class="fosse-post-types__group-label"><?php echo esc_html( $group['label'] ); ?></legend>
 							<?php foreach ( $group['types'] as $pt ) : ?>
-								<label class="fosse-post-type-item">
+								<label class="fosse-choice-card fosse-post-type-item">
 									<input
 										type="checkbox"
 										name="activitypub_support_post_types[]"
@@ -1344,17 +1374,20 @@ class Onboarding_Wizard {
 				<div class="fosse-wizard__hint">
 					<p><?php esc_html_e( 'Only new posts will be shared. Existing content will not be sent to followers.', 'fosse' ); ?></p>
 				</div>
-			</div>
+				</div>
 
-			<div class="fosse-wizard__actions">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=appearance' ) ); ?>" class="button">
-					&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
-				</a>
-				<div class="fosse-wizard__actions-primary">
-					<a href="<?php echo esc_url( self::get_skip_url() ); ?>" class="fosse-wizard__skip">
-						<?php esc_html_e( 'Skip setup', 'fosse' ); ?>
-					</a>
-					<?php submit_button( __( 'Continue', 'fosse' ), 'primary', 'submit', false ); ?>
+				<div class="fosse-card-footer">
+					<div class="fosse-wizard__actions">
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=appearance' ) ); ?>" class="button">
+							&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
+						</a>
+						<div class="fosse-wizard__actions-primary">
+							<a href="<?php echo esc_url( self::get_skip_url() ); ?>" class="fosse-wizard__skip">
+								<?php esc_html_e( 'Skip setup', 'fosse' ); ?>
+							</a>
+							<?php submit_button( __( 'Continue', 'fosse' ), 'primary', 'submit', false ); ?>
+						</div>
+					</div>
 				</div>
 			</div>
 		</form>
@@ -1388,11 +1421,9 @@ class Onboarding_Wizard {
 			? __( 'Review the connected account below before finishing setup.', 'fosse' )
 			: __( 'Connect your Bluesky account to share eligible WordPress posts there too. This is optional, and you can do it later in FOSSE Settings.', 'fosse' );
 		?>
-		<h1 class="fosse-wizard__title"><?php echo esc_html( $title ); ?></h1>
-		<p class="fosse-wizard__description">
-			<?php echo esc_html( $description ); ?>
-		</p>
-
+		<div class="fosse-wizard__card fosse-admin-card">
+			<?php self::render_step_card_header( $title, $description ); ?>
+			<div class="fosse-card-body">
 		<?php
 		// Atmosphere posts a settings_error after every OAuth round-trip — a
 		// "Successfully connected" success notice on the happy path, and an
@@ -1421,7 +1452,6 @@ class Onboarding_Wizard {
 		}
 		?>
 
-		<div class="fosse-wizard__card">
 			<?php if ( ! $status['available'] ) : ?>
 				<div class="notice notice-info inline fosse-wizard__notice">
 					<p>
@@ -1438,32 +1468,24 @@ class Onboarding_Wizard {
 					</p>
 				</div>
 
-				<table class="fosse-summary">
+				<dl class="fosse-detail-list">
 					<?php if ( $status['handle'] ) : ?>
-						<tr>
-							<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Handle', 'fosse' ); ?></th>
-							<td class="fosse-summary__value"><?php echo esc_html( $status['handle'] ); ?></td>
-						</tr>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Handle', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description"><?php echo esc_html( $status['handle'] ); ?></dd>
 					<?php endif; ?>
 					<?php if ( $status['did'] ) : ?>
-						<tr>
-							<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Account ID', 'fosse' ); ?></th>
-							<td class="fosse-summary__value"><code><?php echo esc_html( $status['did'] ); ?></code></td>
-						</tr>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Account ID', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description"><code><?php echo esc_html( $status['did'] ); ?></code></dd>
 					<?php endif; ?>
 					<?php if ( ! empty( $handle_previews['user'] ) ) : ?>
-						<tr>
-							<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></th>
-							<td class="fosse-summary__value"><code><?php echo esc_html( $handle_previews['user'] ); ?></code></td>
-						</tr>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Your fediverse address', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description"><code><?php echo esc_html( $handle_previews['user'] ); ?></code></dd>
 					<?php endif; ?>
 					<?php if ( ! empty( $handle_previews['blog'] ) ) : ?>
-						<tr>
-							<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></th>
-							<td class="fosse-summary__value"><code><?php echo esc_html( $handle_previews['blog'] ); ?></code></td>
-						</tr>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Site fediverse address', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description"><code><?php echo esc_html( $handle_previews['blog'] ); ?></code></dd>
 					<?php endif; ?>
-				</table>
+				</dl>
 
 				<?php
 				// Connected-state confirm button: replace the user's Bluesky
@@ -1575,26 +1597,29 @@ class Onboarding_Wizard {
 					</p>
 				</div>
 			<?php endif; ?>
-		</div>
+			</div>
 
 		<?php $complete_url = wp_nonce_url( admin_url( 'admin-post.php?action=fosse_wizard_complete' ), 'fosse_wizard_complete' ); ?>
-		<div class="fosse-wizard__actions">
-			<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=content' ) ); ?>" class="button">
-				&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
-			</a>
-			<div class="fosse-wizard__actions-primary">
-				<?php if ( $status['available'] && ! $is_connected ) : ?>
-					<a href="<?php echo esc_url( $complete_url ); ?>" class="button">
-						<?php esc_html_e( 'Skip Bluesky for now', 'fosse' ); ?>
+			<div class="fosse-card-footer">
+				<div class="fosse-wizard__actions">
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=content' ) ); ?>" class="button">
+						&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
 					</a>
-					<button type="submit" form="fosse-wizard-bluesky-connect-form" class="button button-primary">
-						<?php esc_html_e( 'Connect Bluesky', 'fosse' ); ?>
-					</button>
-				<?php else : ?>
-					<a href="<?php echo esc_url( $complete_url ); ?>" class="button button-primary">
-						<?php echo esc_html( $is_connected ? __( 'Finish setup', 'fosse' ) : __( 'Skip for now', 'fosse' ) ); ?>
-					</a>
-				<?php endif; ?>
+					<div class="fosse-wizard__actions-primary">
+						<?php if ( $status['available'] && ! $is_connected ) : ?>
+							<a href="<?php echo esc_url( $complete_url ); ?>" class="button">
+								<?php esc_html_e( 'Skip Bluesky for now', 'fosse' ); ?>
+							</a>
+							<button type="submit" form="fosse-wizard-bluesky-connect-form" class="button button-primary">
+								<?php esc_html_e( 'Connect Bluesky', 'fosse' ); ?>
+							</button>
+						<?php else : ?>
+							<a href="<?php echo esc_url( $complete_url ); ?>" class="button button-primary">
+								<?php echo esc_html( $is_connected ? __( 'Finish setup', 'fosse' ) : __( 'Skip for now', 'fosse' ) ); ?>
+							</a>
+						<?php endif; ?>
+					</div>
+				</div>
 			</div>
 		</div>
 		<?php
@@ -1643,26 +1668,41 @@ class Onboarding_Wizard {
 			$bluesky_summary = $includes_bluesky ? __( 'Not connected', 'fosse' ) : __( 'Skipped', 'fosse' );
 		}
 
-		?>
-		<div class="fosse-wizard__complete-header">
-			<div class="fosse-complete-icon">
-				<span class="dashicons dashicons-yes"></span>
-			</div>
-			<h1 class="fosse-wizard__title"><?php esc_html_e( 'You\'re all set!', 'fosse' ); ?></h1>
-			<p class="fosse-wizard__description">
-				<?php esc_html_e( 'Your sharing setup is ready. Review it below, then publish from WordPress when you are ready.', 'fosse' ); ?>
-			</p>
-		</div>
+		$cta = self::resolve_publish_cta( $post_types );
+		if ( $publishes_bluesky ) {
+			$cta_help = __( 'Bluesky sharing is ready too.', 'fosse' );
+		} elseif ( $bluesky['connected'] ) {
+			$cta_help = __( 'Bluesky is connected, but automatic sharing is off.', 'fosse' );
+		} elseif ( $includes_bluesky ) {
+			$cta_help = __( 'Connect Bluesky to share there too.', 'fosse' );
+		} else {
+			$cta_help = '';
+		}
 
-		<div class="fosse-wizard__card">
-			<table class="fosse-summary">
-				<tr>
-					<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Destinations', 'fosse' ); ?></th>
-					<td class="fosse-summary__value"><?php echo esc_html( $destination_label ); ?></td>
-				</tr>
-				<tr>
-					<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Fediverse identity', 'fosse' ); ?></th>
-					<td class="fosse-summary__value">
+		?>
+		<div class="fosse-wizard__card fosse-admin-card fosse-wizard__complete-card">
+			<div class="fosse-card-header fosse-wizard__complete-header">
+				<div class="fosse-complete-icon">
+					<span class="dashicons dashicons-yes"></span>
+				</div>
+				<div class="fosse-wizard__complete-message">
+					<h1 class="fosse-wizard__title"><?php esc_html_e( 'You\'re all set!', 'fosse' ); ?></h1>
+					<p class="fosse-wizard__description">
+						<strong><?php esc_html_e( 'Your sharing setup is ready.', 'fosse' ); ?></strong>
+						<?php esc_html_e( 'Review it below, then publish from WordPress when you are ready.', 'fosse' ); ?>
+						<?php if ( '' !== $cta_help ) : ?>
+							<span class="fosse-wizard__cta-help"><?php echo esc_html( $cta_help ); ?></span>
+						<?php endif; ?>
+					</p>
+				</div>
+			</div>
+
+			<div class="fosse-card-body">
+				<dl class="fosse-detail-list">
+					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Destinations', 'fosse' ); ?></dt>
+					<dd class="fosse-detail-list__description"><?php echo esc_html( $destination_label ); ?></dd>
+					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Fediverse identity', 'fosse' ); ?></dt>
+					<dd class="fosse-detail-list__description">
 						<?php
 						echo wp_kses(
 							$mode_label,
@@ -1672,54 +1712,33 @@ class Onboarding_Wizard {
 							)
 						);
 						?>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Content types', 'fosse' ); ?></th>
-					<td class="fosse-summary__value"><?php echo esc_html( implode( ', ', $type_labels ) ); ?></td>
-				</tr>
-				<tr>
-					<th scope="row" class="fosse-summary__label"><?php esc_html_e( 'Bluesky', 'fosse' ); ?></th>
-					<td class="fosse-summary__value<?php echo $bluesky['connected'] ? '' : ' fosse-summary__value--muted'; ?>"><?php echo esc_html( $bluesky_summary ); ?></td>
-				</tr>
-			</table>
+					</dd>
+					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Content types', 'fosse' ); ?></dt>
+					<dd class="fosse-detail-list__description"><?php echo esc_html( implode( ', ', $type_labels ) ); ?></dd>
+					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Bluesky', 'fosse' ); ?></dt>
+					<dd class="fosse-detail-list__description<?php echo $bluesky['connected'] ? '' : ' fosse-detail-list__description--muted'; ?>"><?php echo esc_html( $bluesky_summary ); ?></dd>
+				</dl>
 
-			<div class="fosse-wizard__hint">
-				<p><?php esc_html_e( 'You can change any of these settings from the FOSSE Settings page at any time.', 'fosse' ); ?></p>
+				<div class="fosse-wizard__hint">
+					<p><?php esc_html_e( 'You can change any of these settings from the FOSSE Settings page at any time.', 'fosse' ); ?></p>
+				</div>
+			</div>
+			<div class="fosse-card-footer fosse-wizard__completion-footer">
+				<div class="fosse-wizard__completion-actions">
+					<div class="fosse-wizard__completion-secondary">
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-status' ) ); ?>" class="button">
+							<?php esc_html_e( 'View Status Dashboard', 'fosse' ); ?>
+						</a>
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse' ) ); ?>" class="button">
+							<?php esc_html_e( 'Go to Settings', 'fosse' ); ?>
+						</a>
+					</div>
+					<a href="<?php echo esc_url( $cta['url'] ); ?>" class="button button-primary fosse-wizard__cta-publish">
+						<?php echo esc_html( $cta['label'] ); ?>
+					</a>
+				</div>
 			</div>
 		</div>
-
-		<?php
-		$cta = self::resolve_publish_cta( $post_types );
-		if ( $publishes_bluesky ) {
-			$cta_help = __( 'Your post can reach people on Fediverse apps like Mastodon and on Bluesky.', 'fosse' );
-		} elseif ( $bluesky['connected'] ) {
-			$cta_help = __( 'Your post can reach people on Fediverse apps like Mastodon. Bluesky is connected, but automatic sharing is off.', 'fosse' );
-		} elseif ( $includes_bluesky ) {
-			$cta_help = __( 'Your post can reach people on Fediverse apps like Mastodon. Connect Bluesky to share there too.', 'fosse' );
-		} else {
-			$cta_help = __( 'Your post can reach people on Fediverse apps like Mastodon.', 'fosse' );
-		}
-		?>
-		<div class="fosse-wizard__actions fosse-wizard__actions--center">
-			<a href="<?php echo esc_url( $cta['url'] ); ?>" class="button button-primary button-hero fosse-wizard__cta-publish">
-				<?php echo esc_html( $cta['label'] ); ?>
-			</a>
-		</div>
-
-		<p class="fosse-wizard__cta-help">
-			<?php echo esc_html( $cta_help ); ?>
-		</p>
-
-		<div class="fosse-wizard__actions fosse-wizard__actions--center fosse-wizard__actions--secondary">
-			<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-status' ) ); ?>" class="button">
-				<?php esc_html_e( 'View Status Dashboard', 'fosse' ); ?>
-			</a>
-			<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse' ) ); ?>" class="button">
-				<?php esc_html_e( 'Go to Settings', 'fosse' ); ?>
-			</a>
-		</div>
-
 		<p class="fosse-wizard__reset">
 			<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=fosse_wizard_reset' ), 'fosse_wizard_reset' ) ); ?>">
 				<?php esc_html_e( 'Run wizard again', 'fosse' ); ?>

--- a/src/Admin/templates/setup-page.php
+++ b/src/Admin/templates/setup-page.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- variables set by Setup_Page::render().
 ?>
-<div class="wrap fosse-admin-page fosse-admin-page--settings">
+<div class="wrap fosse-admin-page fosse-admin-shell fosse-admin-page--settings">
 	<header class="fosse-admin-page__header">
 		<p class="fosse-admin-page__eyebrow"><?php esc_html_e( 'Social web', 'fosse' ); ?></p>
 		<h1 class="fosse-admin-page__title"><?php esc_html_e( 'FOSSE Settings', 'fosse' ); ?></h1>
@@ -29,19 +29,16 @@ defined( 'ABSPATH' ) || exit;
 	<?php settings_errors( 'fosse' ); ?>
 
 	<?php if ( $wizard_incomplete ) : ?>
-		<div class="notice notice-info fosse-admin-notice">
-			<p>
-				<?php
-				echo wp_kses_post(
-					sprintf(
-						/* translators: 1: opening anchor tag to setup wizard, 2: closing anchor tag */
-						__( 'Need a guided setup? %1$sRun the setup wizard%2$s to configure social web publishing in a few steps.', 'fosse' ),
-						'<a href="' . esc_url( admin_url( 'admin.php?page=fosse-wizard' ) ) . '">',
-						'</a>'
-					)
-				);
-				?>
-			</p>
+		<div class="fosse-guided-setup" role="note">
+			<div class="fosse-guided-setup__content">
+				<p class="fosse-guided-setup__title"><?php esc_html_e( 'Want a guided setup?', 'fosse' ); ?></p>
+				<p class="fosse-guided-setup__description">
+					<?php esc_html_e( 'Configure social web publishing in a few steps.', 'fosse' ); ?>
+				</p>
+			</div>
+			<a class="button fosse-guided-setup__button" href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard' ) ); ?>">
+				<?php esc_html_e( 'Run the setup wizard', 'fosse' ); ?>
+			</a>
 		</div>
 	<?php endif; ?>
 
@@ -57,29 +54,30 @@ defined( 'ABSPATH' ) || exit;
 			</p>
 		</div>
 	<?php else : ?>
-		<div class="fosse-settings-panel" id="fosse-federation-settings">
+		<div class="fosse-settings-panel fosse-admin-card" id="fosse-federation-settings">
 			<form id="fosse-settings" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 				<input type="hidden" name="action" value="<?php echo esc_attr( \Automattic\Fosse\Admin\Setup_Page::SAVE_ACTION ); ?>" />
 				<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $save_nonce ); ?>" />
 
-				<div class="fosse-settings-panel__header">
+				<div class="fosse-settings-panel__header fosse-card-header">
 					<h2><?php esc_html_e( 'Publishing settings', 'fosse' ); ?></h2>
 					<p class="fosse-settings-panel__description">
 						<?php esc_html_e( 'Choose the content types FOSSE publishes and the fediverse identity people can follow.', 'fosse' ); ?>
 					</p>
 				</div>
 
-				<div class="fosse-settings-section" id="fosse-section-general">
-					<h3><?php esc_html_e( 'Content and identity', 'fosse' ); ?></h3>
+				<div class="fosse-card-body">
+					<div class="fosse-settings-section" id="fosse-section-general">
+						<h3><?php esc_html_e( 'Content and identity', 'fosse' ); ?></h3>
 
-					<table class="form-table">
-						<tr>
-							<th scope="row"><?php esc_html_e( 'Content types', 'fosse' ); ?></th>
-							<td>
-								<fieldset class="fosse-settings-choice-grid">
+						<div class="fosse-field-stack">
+							<div class="fosse-field">
+								<div class="fosse-field__label" id="fosse-content-types-label"><?php esc_html_e( 'Content types', 'fosse' ); ?></div>
+								<div class="fosse-field__control">
+									<fieldset class="fosse-checkbox-grid" aria-labelledby="fosse-content-types-label">
 									<legend class="screen-reader-text"><?php esc_html_e( 'Content types', 'fosse' ); ?></legend>
 									<?php foreach ( $all_post_types as $pt ) : ?>
-										<label class="fosse-settings-choice-label">
+										<label class="fosse-checkbox-grid__item">
 											<input
 												type="checkbox"
 												name="activitypub_support_post_types[]"
@@ -92,14 +90,14 @@ defined( 'ABSPATH' ) || exit;
 									<p class="description">
 										<?php esc_html_e( 'Selected content types can be published to your connected social web providers.', 'fosse' ); ?>
 									</p>
-								</fieldset>
-							</td>
-						</tr>
+									</fieldset>
+								</div>
+							</div>
 
-						<?php if ( $ap_available ) : ?>
-							<tr>
-								<th scope="row"><?php esc_html_e( 'ActivityPub profile', 'fosse' ); ?></th>
-								<td>
+							<?php if ( $ap_available ) : ?>
+								<div class="fosse-field">
+									<div class="fosse-field__label" id="fosse-activitypub-profile-label"><?php esc_html_e( 'ActivityPub profile', 'fosse' ); ?></div>
+									<div class="fosse-field__control">
 									<?php if ( \Automattic\Fosse\Admin\Actor_Mode_Lock::is_locked() ) : ?>
 										<?php
 										$forced_mode  = \Automattic\Fosse\Admin\Actor_Mode_Lock::forced_mode();
@@ -115,11 +113,11 @@ defined( 'ABSPATH' ) || exit;
 										</p>
 										<input type="hidden" name="activitypub_actor_mode" value="<?php echo esc_attr( $forced_mode ); ?>" />
 									<?php else : ?>
-										<fieldset class="fosse-settings-radio-group">
+										<fieldset class="fosse-choice-card-group" aria-labelledby="fosse-activitypub-profile-label">
 											<legend class="screen-reader-text"><?php esc_html_e( 'ActivityPub profile', 'fosse' ); ?></legend>
-											<label class="fosse-settings-card-option">
+											<label class="fosse-choice-card">
 												<input
-													class="fosse-settings-card-option__input"
+													class="fosse-choice-card__input"
 													type="radio"
 													id="fosse-activitypub-actor-mode-actor"
 													name="activitypub_actor_mode"
@@ -127,8 +125,8 @@ defined( 'ABSPATH' ) || exit;
 													aria-describedby="fosse-activitypub-actor-mode-actor-desc fosse-activitypub-actor-mode-note"
 													<?php checked( 'actor', $actor_mode ); ?>
 												/>
-												<span class="fosse-settings-card-option__body">
-													<span class="fosse-settings-card-option__label">
+												<span class="fosse-choice-card__body">
+													<span class="fosse-choice-card__label">
 														<?php esc_html_e( 'Author profiles', 'fosse' ); ?>
 													</span>
 													<span id="fosse-activitypub-actor-mode-actor-desc" class="description">
@@ -136,9 +134,9 @@ defined( 'ABSPATH' ) || exit;
 													</span>
 												</span>
 											</label>
-											<label class="fosse-settings-card-option">
+											<label class="fosse-choice-card">
 												<input
-													class="fosse-settings-card-option__input"
+													class="fosse-choice-card__input"
 													type="radio"
 													id="fosse-activitypub-actor-mode-blog"
 													name="activitypub_actor_mode"
@@ -146,8 +144,8 @@ defined( 'ABSPATH' ) || exit;
 													aria-describedby="fosse-activitypub-actor-mode-blog-desc fosse-activitypub-actor-mode-note"
 													<?php checked( 'blog', $actor_mode ); ?>
 												/>
-												<span class="fosse-settings-card-option__body">
-													<span class="fosse-settings-card-option__label">
+												<span class="fosse-choice-card__body">
+													<span class="fosse-choice-card__label">
 														<?php esc_html_e( 'Blog profile', 'fosse' ); ?>
 													</span>
 													<span id="fosse-activitypub-actor-mode-blog-desc" class="description">
@@ -155,9 +153,9 @@ defined( 'ABSPATH' ) || exit;
 													</span>
 												</span>
 											</label>
-											<label class="fosse-settings-card-option">
+											<label class="fosse-choice-card">
 												<input
-													class="fosse-settings-card-option__input"
+													class="fosse-choice-card__input"
 													type="radio"
 													id="fosse-activitypub-actor-mode-actor-blog"
 													name="activitypub_actor_mode"
@@ -165,8 +163,8 @@ defined( 'ABSPATH' ) || exit;
 													aria-describedby="fosse-activitypub-actor-mode-actor-blog-desc fosse-activitypub-actor-mode-note"
 													<?php checked( 'actor_blog', $actor_mode ); ?>
 												/>
-												<span class="fosse-settings-card-option__body">
-													<span class="fosse-settings-card-option__label">
+												<span class="fosse-choice-card__body">
+													<span class="fosse-choice-card__label">
 														<?php esc_html_e( 'Both author and blog profiles', 'fosse' ); ?>
 													</span>
 													<span id="fosse-activitypub-actor-mode-actor-blog-desc" class="description">
@@ -197,43 +195,52 @@ defined( 'ABSPATH' ) || exit;
 											</div>
 										</fieldset>
 									<?php endif; ?>
-								</td>
-							</tr>
-						<?php endif; ?>
-					</table>
+									</div>
+								</div>
+							<?php endif; ?>
+						</div>
+					</div>
+
+					<?php
+					foreach ( $providers as $provider ) {
+						if ( $provider->is_available() ) {
+							$provider->render_setup_section();
+						}
+					}
+					?>
 				</div>
 
-				<?php
-				foreach ( $providers as $provider ) {
-					if ( $provider->is_available() ) {
-						$provider->render_setup_section();
-					}
-				}
-				?>
-
-				<div class="fosse-settings-actions" id="fosse-settings-actions">
+				<div class="fosse-settings-actions fosse-card-footer fosse-action-bar" id="fosse-settings-actions">
 					<?php submit_button( __( 'Save settings', 'fosse' ), 'primary', 'submit', false ); ?>
 				</div>
 			</form>
 		</div>
 
-		<div class="fosse-settings-panel" id="fosse-connections">
-			<div class="fosse-settings-panel__header">
+		<div class="fosse-settings-panel fosse-admin-card" id="fosse-connections">
+			<div class="fosse-settings-panel__header fosse-card-header">
 				<h2><?php esc_html_e( 'Connections', 'fosse' ); ?></h2>
 				<p class="fosse-settings-panel__description">
 					<?php esc_html_e( 'Review connected accounts and connect or disconnect the networks FOSSE can publish to.', 'fosse' ); ?>
 				</p>
 			</div>
 
-			<?php
-			foreach ( $providers as $provider ) {
-				if ( $provider->is_available() ) {
-					$provider->render_connection_actions();
+			<div class="fosse-card-body">
+				<?php
+				foreach ( $providers as $provider ) {
+					if ( $provider->is_available() ) {
+						$provider->render_connection_actions();
+					}
 				}
-			}
-			?>
+				?>
+			</div>
 		</div>
 	<?php endif; ?>
+
+	<p class="fosse-admin-page__footer-action">
+		<a class="fosse-admin-page__secondary-link" href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard' ) ); ?>">
+			<?php esc_html_e( 'Run the wizard', 'fosse' ); ?>
+		</a>
+	</p>
 </div>
 <?php
 // phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/src/Admin/templates/status-page.php
+++ b/src/Admin/templates/status-page.php
@@ -38,7 +38,7 @@ if ( 0 === $connected_count ) {
 	$summary_description = __( 'All available providers are connected and ready to publish.', 'fosse' );
 }
 ?>
-<div class="wrap fosse-admin-page fosse-admin-page--status">
+<div class="wrap fosse-admin-page fosse-admin-shell fosse-admin-page--status">
 	<header class="fosse-admin-page__header">
 		<p class="fosse-admin-page__eyebrow"><?php esc_html_e( 'Social web', 'fosse' ); ?></p>
 		<h1 class="fosse-admin-page__title"><?php esc_html_e( 'FOSSE Status', 'fosse' ); ?></h1>
@@ -48,8 +48,8 @@ if ( 0 === $connected_count ) {
 	</header>
 
 	<?php if ( ! empty( $available ) ) : ?>
-		<div class="fosse-status-summary<?php echo esc_attr( $connected_count < $available_count ? ' has-attention' : '' ); ?>">
-			<div class="fosse-status-summary__body">
+		<div class="fosse-status-summary fosse-admin-card<?php echo esc_attr( $connected_count < $available_count ? ' has-attention' : '' ); ?>">
+			<div class="fosse-status-summary__body fosse-card-body">
 				<p class="fosse-status-summary__label"><?php esc_html_e( 'Provider status', 'fosse' ); ?></p>
 				<p class="fosse-status-summary__count">
 					<?php
@@ -64,7 +64,7 @@ if ( 0 === $connected_count ) {
 				<p class="fosse-status-summary__description"><?php echo esc_html( $summary_description ); ?></p>
 			</div>
 			<?php if ( $connected_count < $available_count ) : ?>
-				<p class="fosse-status-summary__actions">
+				<p class="fosse-status-summary__actions fosse-card-footer fosse-action-bar">
 					<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=fosse#fosse-connections' ) ); ?>">
 						<?php esc_html_e( 'Manage connections', 'fosse' ); ?>
 					</a>
@@ -91,4 +91,10 @@ if ( 0 === $connected_count ) {
 			</p>
 		</div>
 	<?php endif; ?>
+
+	<p class="fosse-admin-page__footer-action">
+		<a class="fosse-admin-page__secondary-link" href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard' ) ); ?>">
+			<?php esc_html_e( 'Run the wizard', 'fosse' ); ?>
+		</a>
+	</p>
 </div>

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -38,6 +38,18 @@ test.describe( 'Bluesky provider UI', () => {
 		await expect( page.locator( '#error-page' ) ).toHaveCount( 0 );
 	};
 
+	const resetWizardIfComplete = async ( page: Page ) => {
+		await page.goto(
+			'/wp-admin/admin.php?page=fosse-wizard&step=complete'
+		);
+		const reset = page.getByRole( 'link', { name: 'Run wizard again' } );
+
+		if ( await reset.count() ) {
+			await reset.click();
+			await expect( page ).toHaveURL( /page=fosse-wizard/ );
+		}
+	};
+
 	test( 'setup and status pages show Bluesky disconnected by default', async ( {
 		page,
 	} ) => {
@@ -45,16 +57,55 @@ test.describe( 'Bluesky provider UI', () => {
 			connected: false,
 			auto_publish: true,
 		} );
+		await resetWizardIfComplete( page );
 
 		await page.goto( '/wp-admin/admin.php?page=fosse' );
 		await expectNoCriticalText( page );
 
 		const federationSettings = page.locator( '#fosse-federation-settings' );
 		const connections = page.locator( '#fosse-connections' );
+		const guidedSetup = page.locator( '.fosse-guided-setup' );
 		const blueskyConnection = connections.locator(
 			'#fosse-provider-bluesky'
 		);
 
+		await expect( guidedSetup ).toBeVisible();
+		await expect( guidedSetup ).toContainText( 'Want a guided setup?' );
+		await expect( guidedSetup ).toHaveCSS( 'border-left-width', '4px' );
+		await expect( guidedSetup ).toHaveCSS(
+			'border-left-color',
+			'rgb(56, 88, 233)'
+		);
+		const calloutWidth = await page.evaluate( () => {
+			const callout = document.querySelector( '.fosse-guided-setup' );
+			const mainCard = document.querySelector(
+				'#fosse-federation-settings'
+			);
+
+			if ( ! callout || ! mainCard ) {
+				return null;
+			}
+
+			return {
+				calloutWidth: callout.getBoundingClientRect().width,
+				mainCardWidth: mainCard.getBoundingClientRect().width,
+			};
+		} );
+		expect( calloutWidth ).not.toBeNull();
+		expect(
+			Math.abs( calloutWidth!.calloutWidth - calloutWidth!.mainCardWidth )
+		).toBeLessThanOrEqual( 1 );
+
+		await expect( federationSettings ).toHaveClass( /fosse-admin-card/ );
+		await expect(
+			federationSettings.locator( '.fosse-field' )
+		).not.toHaveCount( 0 );
+		await expect(
+			federationSettings.locator( '.fosse-choice-card' )
+		).not.toHaveCount( 0 );
+		await expect(
+			page.locator( '.fosse-admin-page .form-table' )
+		).toHaveCount( 0 );
 		await expect(
 			federationSettings.getByRole( 'heading', {
 				name: 'Publishing settings',
@@ -69,6 +120,30 @@ test.describe( 'Bluesky provider UI', () => {
 		await expect(
 			federationSettings.getByRole( 'button', { name: 'Save settings' } )
 		).toBeVisible();
+		await expect(
+			page.getByRole( 'link', { name: 'Run the wizard' } )
+		).toHaveAttribute( 'href', /page=fosse-wizard/ );
+		const wizardLinkPlacement = await page.evaluate( () => {
+			const connectionSection =
+				document.querySelector( '#fosse-connections' );
+			const link = document.querySelector(
+				'.fosse-admin-page__footer-action a'
+			);
+
+			if ( ! connectionSection || ! link ) {
+				return null;
+			}
+
+			return {
+				connectionsBottom:
+					connectionSection.getBoundingClientRect().bottom,
+				linkTop: link.getBoundingClientRect().top,
+			};
+		} );
+		expect( wizardLinkPlacement ).not.toBeNull();
+		expect( wizardLinkPlacement!.linkTop ).toBeGreaterThan(
+			wizardLinkPlacement!.connectionsBottom
+		);
 		await expect(
 			connections.getByRole( 'heading', { name: 'Connections' } )
 		).toBeVisible();
@@ -178,23 +253,15 @@ test.describe( 'Bluesky provider UI', () => {
 		expect(
 			await numericCssValue(
 				page,
-				'.fosse-settings-section h3',
+				'.fosse-field__label',
 				'letter-spacing'
 			)
 		).toBe( 0 );
 		expect(
-			await numericCssValue(
-				page,
-				'.fosse-settings-panel',
-				'border-radius'
-			)
+			await numericCssValue( page, '.fosse-admin-card', 'border-radius' )
 		).toBeLessThanOrEqual( 8 );
 		expect(
-			await numericCssValue(
-				page,
-				'.fosse-settings-card-option__body',
-				'border-radius'
-			)
+			await numericCssValue( page, '.fosse-choice-card', 'border-radius' )
 		).toBeLessThanOrEqual( 8 );
 
 		await page.setViewportSize( { width: 390, height: 720 } );

--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -3,6 +3,7 @@ import {
 	expectNoHorizontalOverflow,
 	numericCssValue,
 	resetBlueskyState,
+	resetWizardIfComplete,
 	setBlueskyState,
 } from './test-helpers';
 
@@ -38,18 +39,6 @@ test.describe( 'Bluesky provider UI', () => {
 		await expect( page.locator( '#error-page' ) ).toHaveCount( 0 );
 	};
 
-	const resetWizardIfComplete = async ( page: Page ) => {
-		await page.goto(
-			'/wp-admin/admin.php?page=fosse-wizard&step=complete'
-		);
-		const reset = page.getByRole( 'link', { name: 'Run wizard again' } );
-
-		if ( await reset.count() ) {
-			await reset.click();
-			await expect( page ).toHaveURL( /page=fosse-wizard/ );
-		}
-	};
-
 	test( 'setup and status pages show Bluesky disconnected by default', async ( {
 		page,
 	} ) => {
@@ -59,6 +48,7 @@ test.describe( 'Bluesky provider UI', () => {
 		} );
 		await resetWizardIfComplete( page );
 
+		await page.setViewportSize( { width: 1280, height: 720 } );
 		await page.goto( '/wp-admin/admin.php?page=fosse' );
 		await expectNoCriticalText( page );
 
@@ -72,10 +62,6 @@ test.describe( 'Bluesky provider UI', () => {
 		await expect( guidedSetup ).toBeVisible();
 		await expect( guidedSetup ).toContainText( 'Want a guided setup?' );
 		await expect( guidedSetup ).toHaveCSS( 'border-left-width', '4px' );
-		await expect( guidedSetup ).toHaveCSS(
-			'border-left-color',
-			'rgb(56, 88, 233)'
-		);
 		const calloutWidth = await page.evaluate( () => {
 			const callout = document.querySelector( '.fosse-guided-setup' );
 			const mainCard = document.querySelector(

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -64,7 +64,17 @@ test( 'Destination step shows two destination cards', async ( { page } ) => {
 	await expect( page.locator( '.fosse-wizard__description' ) ).toContainText(
 		'Fediverse apps like Mastodon'
 	);
+	const wizardCard = page.locator( '.fosse-wizard__card.fosse-admin-card' );
+	await expect( wizardCard ).toBeVisible();
+	await expect(
+		wizardCard.locator( '.fosse-card-header .fosse-wizard__title' )
+	).toContainText( 'Where should your WordPress posts appear?' );
+	await expect( wizardCard.locator( '.fosse-card-body' ) ).toBeVisible();
+	await expect(
+		wizardCard.locator( '.fosse-card-footer .fosse-wizard__actions' )
+	).toBeVisible();
 	await expect( page.locator( '.fosse-destination-card' ) ).toHaveCount( 2 );
+	await expect( page.locator( '.fosse-choice-card' ) ).toHaveCount( 2 );
 	await expect(
 		page.locator( '.fosse-destination-card', {
 			hasText: 'Fediverse apps like Mastodon',
@@ -83,6 +93,40 @@ test( 'Destination step shows two destination cards', async ( { page } ) => {
 	await expect( page.getByText( 'Mastodon and similar apps' ) ).toHaveCount(
 		0
 	);
+} );
+
+test( 'Destination step keeps skip and continue actions on one desktop row', async ( {
+	page,
+} ) => {
+	await page.setViewportSize( { width: 1280, height: 900 } );
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+
+	const metrics = await page.evaluate( () => {
+		const skip = document.querySelector( '.fosse-wizard__skip' );
+		const submit = document.querySelector(
+			'.fosse-wizard__actions input[type="submit"]'
+		);
+
+		if ( ! skip || ! submit ) {
+			return null;
+		}
+
+		const skipRect = skip.getBoundingClientRect();
+		const submitRect = submit.getBoundingClientRect();
+
+		return {
+			centerDelta: Math.abs(
+				skipRect.top +
+					skipRect.height / 2 -
+					( submitRect.top + submitRect.height / 2 )
+			),
+			skipBeforeSubmit: skipRect.right <= submitRect.left,
+		};
+	} );
+
+	expect( metrics ).not.toBeNull();
+	expect( metrics!.centerDelta ).toBeLessThanOrEqual( 4 );
+	expect( metrics!.skipBeforeSubmit ).toBe( true );
 } );
 
 test( 'Wizard progress stays compact and keeps step labels available on mobile', async ( {
@@ -143,11 +187,7 @@ test( 'Wizard surfaces use restrained visual tokens without page overflow', asyn
 		)
 	).toBe( 0 );
 	expect(
-		await numericCssValue(
-			page,
-			'.fosse-destination-card',
-			'border-radius'
-		)
+		await numericCssValue( page, '.fosse-choice-card', 'border-radius' )
 	).toBeLessThanOrEqual( 8 );
 
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=content' );
@@ -426,7 +466,7 @@ test.describe( 'Bluesky step — connected (post-OAuth completion)', () => {
 		await expect(
 			page.locator( 'text=/Bluesky is connected/i' )
 		).toHaveCount( 1 );
-		await expect( page.locator( '.fosse-summary' ) ).toContainText(
+		await expect( page.locator( '.fosse-detail-list' ) ).toContainText(
 			'alice.bsky.social'
 		);
 		await expect( page.locator( '.fosse-bluesky-signup' ) ).toHaveCount(
@@ -463,12 +503,14 @@ test( 'Fediverse-only path skips the Bluesky connect step', async ( {
 
 	await expect( page ).toHaveURL( /step=complete/ );
 	await expect(
-		page.locator( '.fosse-summary__label', { hasText: 'Destinations' } )
+		page.locator( '.fosse-detail-list__term', { hasText: 'Destinations' } )
 	).toBeVisible();
-	await expect( page.locator( '.fosse-summary' ) ).toContainText(
+	await expect( page.locator( '.fosse-detail-list' ) ).toContainText(
 		'Fediverse only'
 	);
-	await expect( page.locator( '.fosse-summary' ) ).toContainText( 'Skipped' );
+	await expect( page.locator( '.fosse-detail-list' ) ).toContainText(
+		'Skipped'
+	);
 } );
 
 test( 'Skip Bluesky for now goes to completion', async ( { page } ) => {
@@ -486,14 +528,14 @@ test( 'Skip Bluesky for now goes to completion', async ( { page } ) => {
 test( 'Completion step shows summary', async ( { page } ) => {
 	await completeThroughBlueskySkip( page );
 
-	await expect( page.locator( '.fosse-summary' ) ).toBeVisible();
+	await expect( page.locator( '.fosse-detail-list' ) ).toBeVisible();
 	await expect(
-		page.locator( '.fosse-summary__label', { hasText: 'Destinations' } )
+		page.locator( '.fosse-detail-list__term', { hasText: 'Destinations' } )
 	).toBeVisible();
 	await expect( page.locator( 'text=Fediverse identity' ) ).toBeVisible();
 	await expect( page.locator( 'text=Content types' ) ).toBeVisible();
 	await expect(
-		page.locator( '.fosse-summary__label', { hasText: 'Bluesky' } )
+		page.locator( '.fosse-detail-list__term', { hasText: 'Bluesky' } )
 	).toBeVisible();
 } );
 
@@ -509,6 +551,129 @@ test( 'Completion step exposes "Publish your first Post" CTA to post-new.php', a
 	// `test_render_complete_step_renders_publish_cta`.
 	await expect( publishCta ).toContainText( 'Publish your first Post' );
 	await expect( publishCta ).toHaveAttribute( 'href', /post-new\.php$/ );
+} );
+
+test( 'Completion step keeps success header and actions aligned inside the card', async ( {
+	page,
+} ) => {
+	await completeThroughBlueskySkip( page );
+	await expect(
+		page.locator(
+			'.fosse-wizard__complete-card .fosse-wizard__completion-footer .fosse-wizard__cta-publish'
+		)
+	).toBeVisible();
+
+	const metrics = await page.evaluate( () => {
+		const card = document.querySelector( '.fosse-wizard__complete-card' );
+		const header = card?.querySelector( '.fosse-wizard__complete-header' );
+		const message = card?.querySelector(
+			'.fosse-wizard__complete-message'
+		);
+		const icon = card?.querySelector( '.fosse-complete-icon' );
+		const title = card?.querySelector( '.fosse-wizard__title' );
+		const description = card?.querySelector(
+			'.fosse-wizard__complete-message .fosse-wizard__description'
+		);
+		const help = card?.querySelector( '.fosse-wizard__cta-help' );
+		const oldTitleRow = card?.querySelector(
+			'.fosse-wizard__complete-title-row'
+		);
+		const footer = card?.querySelector(
+			'.fosse-wizard__completion-footer'
+		);
+		const cta = card?.querySelector( '.fosse-wizard__cta-publish' );
+		const reset = document.querySelector( '.fosse-wizard__reset' );
+
+		if (
+			! card ||
+			! header ||
+			! message ||
+			! icon ||
+			! title ||
+			! description ||
+			! help ||
+			! footer ||
+			! cta ||
+			! reset
+		) {
+			return null;
+		}
+
+		const cardRect = card.getBoundingClientRect();
+		const headerRect = header.getBoundingClientRect();
+		const iconRect = icon.getBoundingClientRect();
+		const messageRect = message.getBoundingClientRect();
+		const titleRect = title.getBoundingClientRect();
+		const descriptionRect = description.getBoundingClientRect();
+		const footerRect = footer.getBoundingClientRect();
+		const ctaRect = cta.getBoundingClientRect();
+		const resetRect = reset.getBoundingClientRect();
+
+		return {
+			cardBottom: cardRect.bottom,
+			ctaBottom: ctaRect.bottom,
+			ctaInsideFooter: footer.contains( cta ),
+			ctaStartsInFooter: ctaRect.top >= footerRect.top,
+			descriptionContainsSetup:
+				description.textContent?.includes(
+					'Your sharing setup is ready'
+				) ?? false,
+			descriptionContainsReach:
+				description.textContent?.includes(
+					'Your post can reach people'
+				) ?? false,
+			descriptionContainsBluesky:
+				description.textContent?.includes(
+					'Connect Bluesky to share there too.'
+				) ?? false,
+			descriptionTopGap: descriptionRect.top - titleRect.bottom,
+			headerHeight: headerRect.height,
+			helpInsideHeader: header.contains( help ),
+			helpInsideDescription: description.contains( help ),
+			helpOutsideFooter: ! footer.contains( help ),
+			iconAboveTitle: iconRect.bottom <= titleRect.top - 8,
+			iconCenterDelta: Math.abs(
+				iconRect.left +
+					iconRect.width / 2 -
+					( headerRect.left + headerRect.width / 2 )
+			),
+			messageCenterDelta: Math.abs(
+				messageRect.left +
+					messageRect.width / 2 -
+					( headerRect.left + headerRect.width / 2 )
+			),
+			oldTitleRowRemoved: ! oldTitleRow,
+			iconHeight: iconRect.height,
+			resetBelowCard: resetRect.top >= cardRect.bottom + 12,
+			resetOutsideCard: ! card.contains( reset ),
+			descriptionTextAlign: getComputedStyle( description ).textAlign,
+			titleTextAlign: getComputedStyle( title ).textAlign,
+		};
+	} );
+
+	expect( metrics ).not.toBeNull();
+	expect( metrics!.ctaInsideFooter ).toBe( true );
+	expect( metrics!.ctaStartsInFooter ).toBe( true );
+	expect( metrics!.ctaBottom ).toBeLessThanOrEqual( metrics!.cardBottom + 1 );
+	expect( metrics!.descriptionContainsSetup ).toBe( true );
+	expect( metrics!.descriptionContainsReach ).toBe( false );
+	expect( metrics!.descriptionContainsBluesky ).toBe( true );
+	expect( metrics!.descriptionTopGap ).toBeGreaterThanOrEqual( 6 );
+	expect( metrics!.descriptionTopGap ).toBeLessThanOrEqual( 14 );
+	expect( metrics!.headerHeight ).toBeLessThanOrEqual( 210 );
+	expect( metrics!.helpInsideHeader ).toBe( true );
+	expect( metrics!.helpInsideDescription ).toBe( true );
+	expect( metrics!.helpOutsideFooter ).toBe( true );
+	expect( metrics!.iconAboveTitle ).toBe( true );
+	expect( metrics!.iconCenterDelta ).toBeLessThanOrEqual( 2 );
+	expect( metrics!.messageCenterDelta ).toBeLessThanOrEqual( 2 );
+	expect( metrics!.oldTitleRowRemoved ).toBe( true );
+	expect( metrics!.iconHeight ).toBeGreaterThanOrEqual( 52 );
+	expect( metrics!.iconHeight ).toBeLessThanOrEqual( 64 );
+	expect( metrics!.descriptionTextAlign ).toBe( 'center' );
+	expect( metrics!.titleTextAlign ).toBe( 'center' );
+	expect( metrics!.resetOutsideCard ).toBe( true );
+	expect( metrics!.resetBelowCard ).toBe( true );
 } );
 
 // Activation-redirect coverage lives in PHPUnit (MenuTest). The E2E

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -563,7 +563,31 @@ test( 'Completion step keeps success header and actions aligned inside the card'
 		)
 	).toBeVisible();
 
-	const metrics = await page.evaluate( () => {
+	type CompletionMetrics = {
+		cardBottom: number;
+		ctaBottom: number;
+		ctaInsideFooter: boolean;
+		ctaStartsInFooter: boolean;
+		descriptionContainsSetup: boolean;
+		descriptionContainsReach: boolean;
+		descriptionContainsBluesky: boolean;
+		descriptionTopGap: number;
+		headerHeight: number;
+		helpInsideHeader: boolean;
+		helpInsideDescription: boolean;
+		helpOutsideFooter: boolean;
+		iconAboveTitle: boolean;
+		iconCenterDelta: number;
+		messageCenterDelta: number;
+		oldTitleRowRemoved: boolean;
+		iconHeight: number;
+		resetBelowCard: boolean;
+		resetOutsideCard: boolean;
+		descriptionTextAlign: string;
+		titleTextAlign: string;
+	} | null;
+
+	const metrics = await page.evaluate( (): CompletionMetrics => {
 		const card = document.querySelector( '.fosse-wizard__complete-card' );
 		const header = card?.querySelector( '.fosse-wizard__complete-header' );
 		const message = card?.querySelector(

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -717,6 +717,11 @@ test( 'Skip setup marks wizard complete and goes to Setup page', async ( {
 	await expect( page.locator( 'text=Run the setup wizard' ) ).toHaveCount(
 		0
 	);
+
+	await expect( page.locator( '.fosse-guided-setup' ) ).toHaveCount( 0 );
+	await expect(
+		page.locator( '.fosse-admin-page__footer-action a' )
+	).toHaveAttribute( 'href', /page=fosse-wizard/ );
 } );
 
 test( 'Wizard is not visible in the admin sidebar menu', async ( { page } ) => {

--- a/tests/e2e/status-page.spec.ts
+++ b/tests/e2e/status-page.spec.ts
@@ -43,17 +43,17 @@ test.describe( 'Status page polish', () => {
 			.filter( { hasText: 'Bluesky' } );
 		await expect( card ).toBeVisible();
 		return card.evaluate( ( el ) => {
-			const table = el.querySelector(
-				'.fosse-status-card__table'
+			const detailList = el.querySelector(
+				'.fosse-detail-list'
 			) as HTMLElement | null;
-			if ( ! table || ! ( el instanceof HTMLElement ) ) {
+			if ( ! detailList || ! ( el instanceof HTMLElement ) ) {
 				return null;
 			}
 			return {
 				cardScroll: el.scrollWidth,
 				cardClient: el.clientWidth,
-				tableScroll: table.scrollWidth,
-				tableClient: table.clientWidth,
+				detailListScroll: detailList.scrollWidth,
+				detailListClient: detailList.clientWidth,
 			};
 		} );
 	};
@@ -68,17 +68,26 @@ test.describe( 'Status page polish', () => {
 			.locator( '.fosse-status-card' )
 			.filter( { hasText: 'Bluesky' } );
 
-		// The value cells should carry the BEM classes the polish CSS
-		// targets, and the token wrappers should carry the token-shape
-		// modifier so `overflow-wrap: anywhere` is scoped correctly.
+		// The value pairs should carry the shared detail-list classes the
+		// polish CSS targets, and token wrappers should carry token-shape
+		// modifiers so `overflow-wrap: anywhere` is scoped correctly.
 		await expect(
-			blueskyCard.locator( '.fosse-status-card__token--did' )
+			blueskyCard.locator( '.fosse-detail-list' )
 		).toBeVisible();
 		await expect(
-			blueskyCard.locator( '.fosse-status-card__token--url' )
+			blueskyCard.locator( '.fosse-detail-list__term' )
+		).not.toHaveCount( 0 );
+		await expect(
+			blueskyCard.locator( '.fosse-detail-list__description' )
+		).not.toHaveCount( 0 );
+		await expect(
+			blueskyCard.locator( '.fosse-token--did' )
 		).toBeVisible();
 		await expect(
-			blueskyCard.locator( '.fosse-status-card__token--handle' )
+			blueskyCard.locator( '.fosse-token--url' )
+		).toBeVisible();
+		await expect(
+			blueskyCard.locator( '.fosse-token--handle' )
 		).toBeVisible();
 
 		const overflow = await measureCardOverflow( page );
@@ -88,8 +97,8 @@ test.describe( 'Status page polish', () => {
 		expect( overflow!.cardScroll ).toBeLessThanOrEqual(
 			overflow!.cardClient + 1
 		);
-		expect( overflow!.tableScroll ).toBeLessThanOrEqual(
-			overflow!.tableClient + 1
+		expect( overflow!.detailListScroll ).toBeLessThanOrEqual(
+			overflow!.detailListClient + 1
 		);
 	} );
 
@@ -111,8 +120,8 @@ test.describe( 'Status page polish', () => {
 		expect( overflow!.cardScroll ).toBeLessThanOrEqual(
 			overflow!.cardClient + 1
 		);
-		expect( overflow!.tableScroll ).toBeLessThanOrEqual(
-			overflow!.tableClient + 1
+		expect( overflow!.detailListScroll ).toBeLessThanOrEqual(
+			overflow!.detailListClient + 1
 		);
 	} );
 
@@ -131,19 +140,23 @@ test.describe( 'Status page polish', () => {
 		} );
 		await expect( activityPubCard ).toHaveCount( 1 );
 
-		const rows = activityPubCard.locator( '.fosse-status-card__table tr' );
+		const rows = activityPubCard.locator( '.fosse-detail-list__term' );
 		const rowCount = await rows.count();
 		expect(
 			rowCount,
 			'ActivityPub status rows should be present'
 		).toBeGreaterThan( 0 );
 
-		const rowGaps = await rows.evaluateAll( ( statusRows ) =>
-			statusRows.map( ( row ) => {
-				const label = row.querySelector( '.fosse-status-card__label' );
-				const value = row.querySelector( '.fosse-status-card__value' );
+		const rowGaps = await rows.evaluateAll( ( terms ) =>
+			terms.map( ( label ) => {
+				const value = label.nextElementSibling;
 
-				if ( ! label || ! value ) {
+				if (
+					! value ||
+					! value.classList.contains(
+						'fosse-detail-list__description'
+					)
+				) {
 					return null;
 				}
 
@@ -186,6 +199,28 @@ test.describe( 'Status page polish', () => {
 		await expect(
 			page.getByRole( 'link', { name: 'Manage connections' } )
 		).toBeVisible();
+		await expect(
+			page.getByRole( 'link', { name: 'Run the wizard' } )
+		).toHaveAttribute( 'href', /page=fosse-wizard/ );
+		const wizardLinkPlacement = await page.evaluate( () => {
+			const statusCards = document.querySelector( '.fosse-status-cards' );
+			const link = document.querySelector(
+				'.fosse-admin-page__footer-action a'
+			);
+
+			if ( ! statusCards || ! link ) {
+				return null;
+			}
+
+			return {
+				statusCardsBottom: statusCards.getBoundingClientRect().bottom,
+				linkTop: link.getBoundingClientRect().top,
+			};
+		} );
+		expect( wizardLinkPlacement ).not.toBeNull();
+		expect( wizardLinkPlacement!.linkTop ).toBeGreaterThan(
+			wizardLinkPlacement!.statusCardsBottom
+		);
 
 		expect(
 			await numericCssValue(

--- a/tests/e2e/test-helpers.ts
+++ b/tests/e2e/test-helpers.ts
@@ -115,3 +115,15 @@ export const resetBlueskyState = async (
 		await page.close();
 	}
 };
+
+export const resetWizardIfComplete = async ( page: Page ) => {
+	await page.goto(
+		'/wp-admin/admin.php?page=fosse-wizard&step=complete'
+	);
+	const reset = page.getByRole( 'link', { name: 'Run wizard again' } );
+
+	if ( await reset.count() ) {
+		await reset.click();
+		await expect( page ).toHaveURL( /page=fosse-wizard/ );
+	}
+};

--- a/tests/e2e/test-helpers.ts
+++ b/tests/e2e/test-helpers.ts
@@ -116,13 +116,28 @@ export const resetBlueskyState = async (
 	}
 };
 
-export const resetWizardIfComplete = async ( page: Page ) => {
-	await page.goto(
-		'/wp-admin/admin.php?page=fosse-wizard&step=complete'
-	);
+/**
+ * Reset the FOSSE onboarding wizard back to the destinations step when it is
+ * currently in the completed state.
+ *
+ * Navigates to the wizard's complete step and clicks the "Run wizard again"
+ * link if it is present. Acts as a no-op when the wizard is not complete (the
+ * link will not be rendered). The provided `page` must already hold a
+ * logged-in wp-admin session.
+ *
+ * @param {Page} page Playwright page already authenticated against wp-admin.
+ * @return {Promise<void>} Resolves once the reset (or no-op) completes.
+ */
+export const resetWizardIfComplete = async ( page: Page ): Promise< void > => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=complete' );
 	const reset = page.getByRole( 'link', { name: 'Run wizard again' } );
 
-	if ( await reset.count() ) {
+	const isComplete = await reset
+		.waitFor( { state: 'attached', timeout: 2000 } )
+		.then( () => true )
+		.catch( () => false );
+
+	if ( isComplete ) {
 		await reset.click();
 		await expect( page ).toHaveURL( /page=fosse-wizard/ );
 	}

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -180,6 +180,7 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'ActivityPub', $output );
 		$this->assertStringContainsString( 'Connected automatically', $output );
 		$this->assertStringNotContainsString( '<form', $output );
+		$this->assertStringContainsString( 'fosse-status-badge is-connected', $output );
 	}
 
 	/**
@@ -200,7 +201,7 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'fosse-field', $output );
 		$this->assertStringContainsString( 'fosse-detail-list', $output );
 		$this->assertStringContainsString( 'Advanced ActivityPub settings', $output );
-		$this->assertStringContainsString( 'fosse-settings-secondary-link', $output );
+		$this->assertStringContainsString( 'fosse-admin-page__secondary-link', $output );
 		$this->assertStringNotContainsString( 'class="form-table"', $output );
 	}
 

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -196,12 +196,16 @@ class AP_ProviderTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
 		$this->assertStringContainsString( 'value="my-site"', $output );
+		$this->assertStringContainsString( 'fosse-field-stack', $output );
+		$this->assertStringContainsString( 'fosse-field', $output );
+		$this->assertStringContainsString( 'fosse-detail-list', $output );
 		$this->assertStringContainsString( 'Advanced ActivityPub settings', $output );
 		$this->assertStringContainsString( 'fosse-settings-secondary-link', $output );
+		$this->assertStringNotContainsString( 'class="form-table"', $output );
 	}
 
 	/**
-	 * Status card exposes the BEM table classes and no longer renders a
+	 * Status card exposes the shared detail-list classes and no longer renders a
 	 * "Manage ActivityPub settings" deep link (issue #74) — the sidebar
 	 * Settings menu entry replaces those per-card links.
 	 */
@@ -210,10 +214,14 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'fosse-status-card__table', $output );
-		$this->assertStringContainsString( 'fosse-status-card__label', $output );
-		$this->assertStringContainsString( 'fosse-status-card__value', $output );
+		$this->assertStringContainsString( 'fosse-admin-card', $output );
+		$this->assertStringContainsString( 'fosse-card-header', $output );
+		$this->assertStringContainsString( 'fosse-card-body', $output );
+		$this->assertStringContainsString( 'fosse-detail-list', $output );
+		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
+		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
 		$this->assertStringContainsString( 'Content types', $output );
+		$this->assertStringNotContainsString( '<table', $output );
 		$this->assertStringNotContainsString( 'Manage ActivityPub settings', $output );
 		$this->assertStringNotContainsString( 'fosse-status-card__manage', $output );
 	}
@@ -875,17 +883,18 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Status card label/value cells carry the BEM classes the polish CSS
-	 * targets. A renamed class would silently break the column-width and
-	 * wrap rules without surfacing a test failure otherwise.
+	 * Status card label/value pairs carry the shared detail-list classes the
+	 * polish CSS targets. A renamed class would silently break the column-width
+	 * and wrap rules without surfacing a test failure otherwise.
 	 */
-	public function test_render_status_card_uses_bem_label_value_classes() {
+	public function test_render_status_card_uses_detail_list_label_value_classes() {
 		ob_start();
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'fosse-status-card__table', $output );
-		$this->assertStringContainsString( 'fosse-status-card__label', $output );
-		$this->assertStringContainsString( 'fosse-status-card__value', $output );
+		$this->assertStringContainsString( 'fosse-detail-list', $output );
+		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
+		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
+		$this->assertStringNotContainsString( 'widefat striped', $output );
 	}
 }

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -313,7 +313,10 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'id="fosse-provider-bluesky"', $output );
-		$this->assertStringContainsString( 'class="fosse-connection-section"', $output );
+		$this->assertStringContainsString( 'fosse-connection-section', $output );
+		$this->assertStringContainsString( 'fosse-admin-card', $output );
+		$this->assertStringContainsString( 'fosse-card-header', $output );
+		$this->assertStringContainsString( 'fosse-card-body', $output );
 		$this->assertStringContainsString( '<h3>Bluesky</h3>', $output );
 	}
 
@@ -327,6 +330,10 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'fosse_connect_bluesky', $output );
 		$this->assertStringContainsString( 'bluesky_handle', $output );
+		$this->assertStringContainsString( 'fosse-field', $output );
+		$this->assertStringContainsString( 'fosse-card-footer', $output );
+		$this->assertStringContainsString( 'fosse-action-bar', $output );
+		$this->assertStringNotContainsString( 'class="form-table"', $output );
 	}
 
 	/**
@@ -350,6 +357,10 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'fosse_disconnect_bluesky', $output );
 		$this->assertStringContainsString( 'alice.bsky.social', $output );
+		$this->assertStringContainsString( 'fosse-detail-list', $output );
+		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
+		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
+		$this->assertStringNotContainsString( 'class="form-table"', $output );
 	}
 
 	/**
@@ -522,7 +533,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Reconnect required', $output );
 		$this->assertStringContainsString( '#fosse-provider-bluesky', $output );
 		$this->assertStringContainsString( '<details', $output );
-		$this->assertStringNotContainsString( 'fosse-status-card__actions', $output );
+		$this->assertStringNotContainsString( 'fosse-action-bar', $output );
 	}
 
 	/**
@@ -544,7 +555,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertMatchesRegularExpression( '/<td[^>]*>\s*OK\s*<\/td>/', $output );
+		$this->assertMatchesRegularExpression( '/<dd[^>]*class="[^"]*fosse-detail-list__description[^"]*"[^>]*>\s*OK\s*<\/dd>/', $output );
 		$this->assertStringNotContainsString( 'Reconnect required', $output );
 		$this->assertStringNotContainsString( '<details', $output );
 	}
@@ -557,7 +568,8 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'fosse-status-card__actions', $output );
+		$this->assertStringContainsString( 'fosse-card-footer', $output );
+		$this->assertStringContainsString( 'fosse-action-bar', $output );
 		$this->assertStringContainsString( 'Open Bluesky settings', $output );
 		$this->assertStringContainsString( 'admin.php?page=fosse#fosse-provider-bluesky', $output );
 	}
@@ -581,7 +593,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringNotContainsString( 'fosse-status-card__actions', $output );
+		$this->assertStringNotContainsString( 'fosse-action-bar', $output );
 	}
 
 	/**
@@ -605,13 +617,14 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'fosse-status-card__table', $output );
-		$this->assertStringContainsString( 'fosse-status-card__label', $output );
-		$this->assertStringContainsString( 'fosse-status-card__value', $output );
+		$this->assertStringContainsString( 'fosse-detail-list', $output );
+		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
+		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
 
-		$this->assertStringContainsString( 'fosse-status-card__token--did', $output );
-		$this->assertStringContainsString( 'fosse-status-card__token--handle', $output );
-		$this->assertStringContainsString( 'fosse-status-card__token--url', $output );
+		$this->assertStringContainsString( 'fosse-token--did', $output );
+		$this->assertStringContainsString( 'fosse-token--handle', $output );
+		$this->assertStringContainsString( 'fosse-token--url', $output );
+		$this->assertStringNotContainsString( 'widefat striped', $output );
 
 		// DID renders with <wbr> after each `:` separator.
 		$this->assertStringContainsString( 'did:<wbr>plc:<wbr>longidentifier', $output );
@@ -2672,8 +2685,14 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_connection_actions();
 		$output = ob_get_clean();
 
+		$note_position   = strpos( $output, 'fosse-domain-handle-revert-note' );
+		$footer_position = strpos( $output, 'fosse-card-footer fosse-action-bar' );
+
 		$this->assertStringContainsString( 'Disconnecting will also restore alice.bsky.social as this account\'s Bluesky handle', html_entity_decode( $output, ENT_QUOTES, 'UTF-8' ) );
 		$this->assertStringContainsString( 'alice.bsky.social', $output );
+		$this->assertIsInt( $note_position );
+		$this->assertIsInt( $footer_position );
+		$this->assertLessThan( $footer_position, $note_position );
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -334,6 +334,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'fosse-card-footer', $output );
 		$this->assertStringContainsString( 'fosse-action-bar', $output );
 		$this->assertStringNotContainsString( 'class="form-table"', $output );
+		$this->assertStringContainsString( 'fosse-status-badge is-disconnected', $output );
 	}
 
 	/**
@@ -361,6 +362,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
 		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
 		$this->assertStringNotContainsString( 'class="form-table"', $output );
+		$this->assertStringContainsString( 'fosse-status-badge is-connected', $output );
 	}
 
 	/**
@@ -2210,6 +2212,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'fosse_set_bluesky_domain_handle', $output );
 		$this->assertStringContainsString( 'Use example.com as my Bluesky handle', $output );
 		$this->assertStringContainsString( 'Heads up: replacing your handle is destructive', $output );
+		$this->assertStringContainsString( 'fosse-domain-handle-panel fosse-callout', $output );
 	}
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -246,6 +246,9 @@ class Onboarding_WizardTest extends BaseTestCase {
 			$output,
 			'Wizard content step should not render a Media (attachment) checkbox.'
 		);
+		$this->assertStringContainsString( 'fosse-choice-card', $output );
+		$this->assertStringContainsString( 'fosse-post-type-item', $output );
+		$this->assertStringNotContainsString( 'form-table', $output );
 	}
 
 	/**
@@ -1062,6 +1065,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'fosse-bluesky-form', $output );
 		$this->assertStringContainsString( 'Bluesky handle', $output );
 		$this->assertStringContainsString( 'Enter your Bluesky handle, such as yourname.bsky.social. If you use your own domain as your handle, enter that.', $output );
+		$this->assertStringContainsString( 'class="fosse-wizard__form"', $output );
 		$this->assertStringNotContainsString( 'fosse-bluesky-placeholder', $output );
 		$this->assertStringNotContainsString( 'Coming Soon', $output );
 		$this->assertStringNotContainsString( 'Bluesky Handle', $output );

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1065,7 +1065,6 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'fosse-bluesky-form', $output );
 		$this->assertStringContainsString( 'Bluesky handle', $output );
 		$this->assertStringContainsString( 'Enter your Bluesky handle, such as yourname.bsky.social. If you use your own domain as your handle, enter that.', $output );
-		$this->assertStringContainsString( 'class="fosse-wizard__form"', $output );
 		$this->assertStringNotContainsString( 'fosse-bluesky-placeholder', $output );
 		$this->assertStringNotContainsString( 'Coming Soon', $output );
 		$this->assertStringNotContainsString( 'Bluesky Handle', $output );

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -665,6 +665,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
 		$this->assertStringContainsString( 'Fediverse + Bluesky', $output );
+		$this->assertStringContainsString( 'fosse-choice-card', $output );
+		$this->assertStringContainsString( 'fosse-wizard__card fosse-admin-card', $output );
+		$this->assertStringContainsString( 'fosse-card-header', $output );
+		$this->assertStringContainsString( 'fosse-card-body', $output );
+		$this->assertStringContainsString( 'fosse-card-footer', $output );
 	}
 
 	/**
@@ -689,6 +694,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Who should people follow?', $output );
 		$this->assertStringContainsString( 'Choose the fediverse identity people can follow when FOSSE shares your selected content types.', $output );
+		$this->assertStringContainsString( 'fosse-choice-card', $output );
 		$this->assertMatchesRegularExpression(
 			'/fosse-mode-card__title">As you<.*fosse-mode-card__title">As your site</s',
 			$output,
@@ -1389,8 +1395,12 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertStringContainsString( 'Bluesky', $output );
+		$this->assertStringContainsString( 'fosse-detail-list', $output );
+		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
+		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
 		$this->assertStringContainsString( 'Connected as alice.bsky.social', $output );
 		$this->assertStringNotContainsString( 'Not connected', $output );
+		$this->assertStringNotContainsString( 'class="fosse-summary"', $output );
 	}
 
 	/**
@@ -1422,7 +1432,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Fediverse only', $output );
 		$this->assertMatchesRegularExpression(
-			'~<th scope="row" class="fosse-summary__label">Bluesky</th>\s*<td class="fosse-summary__value">Connected as alice\.bsky\.social</td>~',
+			'~<dt class="fosse-detail-list__term">Bluesky</dt>\s*<dd class="fosse-detail-list__description">Connected as alice\.bsky\.social</dd>~',
 			$output,
 			'Connected Bluesky accounts must not be visually muted even when the saved destination is Fediverse-only.'
 		);
@@ -1706,11 +1716,14 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$output = $this->render_wizard_step( 'complete' );
 
+		$this->assertStringContainsString( 'fosse-wizard__complete-message', $output );
+		$this->assertStringContainsString( 'Your sharing setup is ready.', $output );
 		$this->assertMatchesRegularExpression(
-			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Fediverse apps like Mastodon.*Connect Bluesky~i',
+			'~<span[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Connect Bluesky to share there too\\.~i',
 			$output,
-			'The publish CTA helper copy must describe the selected destinations.'
+			'The completion success copy must describe the selected destinations.'
 		);
+		$this->assertStringNotContainsString( 'Your post can reach people on Fediverse apps like Mastodon.', $output );
 	}
 
 	/**
@@ -1725,10 +1738,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertMatchesRegularExpression(
-			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Fediverse apps like Mastodon and on Bluesky\\.~i',
+			'~<span[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Bluesky sharing is ready too\\.~i',
 			$output,
-			'The publish CTA helper copy must mention Bluesky when existing settings will publish there.'
+			'The completion success copy must mention Bluesky when existing settings will publish there.'
 		);
+		$this->assertStringNotContainsString( 'Your post can reach people on Fediverse apps like Mastodon', $output );
 	}
 
 	/**
@@ -1744,11 +1758,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertMatchesRegularExpression(
-			'~<p[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*automatic sharing is off\\.~i',
+			'~<span[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*automatic sharing is off\\.~i',
 			$output,
-			'The publish CTA helper copy must explain why a connected account will not receive the next post.'
+			'The completion success copy must explain why a connected account will not receive the next post.'
 		);
-		$this->assertStringNotContainsString( 'Fediverse apps like Mastodon and on Bluesky.', $output );
+		$this->assertStringNotContainsString( 'Your post can reach people on Fediverse apps like Mastodon', $output );
 	}
 
 	/**

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -12,6 +12,7 @@ use Automattic\Fosse\Admin\Actor_Mode_Lock;
 use Automattic\Fosse\Admin\AP_Provider;
 use Automattic\Fosse\Admin\Bluesky_Provider;
 use Automattic\Fosse\Admin\Connection_Provider_Registry;
+use Automattic\Fosse\Admin\Onboarding_Wizard;
 use Automattic\Fosse\Admin\Setup_Page;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
@@ -48,6 +49,7 @@ class Setup_PageTest extends BaseTestCase {
 		delete_option( 'activitypub_blog_identifier' );
 		delete_option( 'atmosphere_connection' );
 		delete_option( 'atmosphere_auto_publish' );
+		delete_option( Onboarding_Wizard::COMPLETED_OPTION );
 
 		global $wp_settings_errors;
 		$wp_settings_errors = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- reset core settings-error storage for test isolation.
@@ -491,6 +493,53 @@ class Setup_PageTest extends BaseTestCase {
 	}
 
 	/**
+	 * The first-run wizard prompt should use the FOSSE card/callout visual
+	 * language instead of a generic WordPress info notice.
+	 */
+	public function test_render_guided_setup_prompt_uses_fosse_callout(): void {
+		$this->become_admin();
+
+		$output = $this->capture_render();
+
+		$this->assertStringContainsString( 'fosse-guided-setup', $output );
+		$this->assertStringContainsString( 'Want a guided setup?', $output );
+		$this->assertStringContainsString( 'Run the setup wizard', $output );
+		$this->assertStringNotContainsString( 'Need a guided setup?', $output );
+		$this->assertStringNotContainsString( 'notice notice-info fosse-admin-notice', $output );
+		$this->assertMatchesRegularExpression(
+			'/<a[^>]*class="[^"]*button[^"]*"[^>]*href="[^"]*page=fosse-wizard[^"]*"[^>]*>\\s*Run the setup wizard\\s*<\\/a>/',
+			$output
+		);
+	}
+
+	/**
+	 * The Settings page keeps a low-emphasis path back to the hidden wizard
+	 * even when the first-run notice is no longer shown.
+	 */
+	public function test_render_exposes_subtle_wizard_link(): void {
+		$this->become_admin();
+		update_option( Onboarding_Wizard::COMPLETED_OPTION, 1, false );
+
+		$output = $this->capture_render();
+
+		$connections_position = strpos( $output, 'id="fosse-connections"' );
+		$link_position        = strpos( $output, 'fosse-admin-page__footer-action' );
+
+		$this->assertIsInt( $connections_position );
+		$this->assertIsInt( $link_position );
+		$this->assertGreaterThan( $connections_position, $link_position );
+		$this->assertStringContainsString( 'fosse-admin-page__footer-action', $output );
+		$this->assertStringContainsString( 'fosse-admin-page__secondary-link', $output );
+		$this->assertStringContainsString( 'Run the wizard', $output );
+		$this->assertStringNotContainsString( 'fosse-guided-setup', $output );
+		$this->assertStringNotContainsString( 'Run the setup wizard', $output );
+		$this->assertMatchesRegularExpression(
+			'/<a[^>]*href="[^"]*page=fosse-wizard[^"]*"[^>]*>\\s*Run the wizard\\s*<\\/a>/',
+			$output
+		);
+	}
+
+	/**
 	 * The unified Settings form posts to admin-post.php with the canonical
 	 * action and a fresh nonce.
 	 */
@@ -517,6 +566,11 @@ class Setup_PageTest extends BaseTestCase {
 		$this->assertStringContainsString( 'id="fosse-federation-settings"', $output );
 		$this->assertStringContainsString( 'id="fosse-settings-actions"', $output );
 		$this->assertStringContainsString( 'id="fosse-connections"', $output );
+		$this->assertStringContainsString( 'fosse-admin-card', $output );
+		$this->assertStringContainsString( 'fosse-card-header', $output );
+		$this->assertStringContainsString( 'fosse-card-body', $output );
+		$this->assertStringContainsString( 'fosse-card-footer', $output );
+		$this->assertStringContainsString( 'fosse-action-bar', $output );
 		$this->assertStringContainsString( 'id="fosse-provider-activitypub-connection"', $output );
 
 		$form_position        = strpos( $output, 'id="fosse-settings"' );
@@ -544,8 +598,12 @@ class Setup_PageTest extends BaseTestCase {
 		$output = $this->capture_render();
 
 		$this->assertStringContainsString( 'id="fosse-section-general"', $output );
+		$this->assertStringContainsString( 'fosse-field-stack', $output );
+		$this->assertStringContainsString( 'fosse-field', $output );
+		$this->assertStringContainsString( 'fosse-checkbox-grid', $output );
 		$this->assertStringContainsString( 'name="activitypub_support_post_types[]"', $output );
 		$this->assertStringContainsString( 'name="activitypub_actor_mode"', $output );
+		$this->assertStringNotContainsString( 'class="form-table"', $output );
 	}
 
 	/**
@@ -577,10 +635,11 @@ class Setup_PageTest extends BaseTestCase {
 		$output = $this->capture_render();
 
 		$this->assertStringNotContainsString( 'is-selected', $output );
-		$this->assertStringContainsString( 'class="fosse-settings-card-option__input"', $output );
-		$this->assertStringContainsString( 'class="fosse-settings-card-option__body"', $output );
+		$this->assertStringContainsString( 'fosse-choice-card', $output );
+		$this->assertStringContainsString( 'class="fosse-choice-card__input"', $output );
+		$this->assertStringContainsString( 'class="fosse-choice-card__body"', $output );
 		$this->assertMatchesRegularExpression(
-			'/id="fosse-activitypub-actor-mode-actor"[\s\S]+?class="fosse-settings-card-option__body"/',
+			'/id="fosse-activitypub-actor-mode-actor"[\s\S]+?class="fosse-choice-card__body"/',
 			$output
 		);
 	}


### PR DESCRIPTION
## Summary

- Adds no-build Gutenberg-like primitives for FOSSE admin cards, fields, badges, detail lists, callouts, actions, and wizard surfaces.
- Modernizes Settings, Status, ActivityPub, Bluesky, and onboarding wizard markup while preserving existing actions, input names, nonces, and fragment targets.
- Updates PHP/e2e markup contracts and refreshes the wizard screenshot.

## Testing

- composer run-script test-php
- composer run-script lint-php
- pnpm test
- pnpm run lint
- pnpm run format:check
- pnpm run test:e2e