### PR TITLE
chore: resync bundled AP and bump FOSSE to 0.1.1

### DIFF
--- a/bundled/activitypub/activitypub.php
+++ b/bundled/activitypub/activitypub.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActivityPub
  * Plugin URI: https://github.com/Automattic/wordpress-activitypub
  * Description: The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
- * Version: 8.2.1
+ * Version: 8.3.0
  * Author: Matthias Pfefferle & Automattic
  * Author URI: https://automattic.com/
  * License: MIT
@@ -17,7 +17,7 @@
 
 namespace Activitypub;
 
-\define( 'ACTIVITYPUB_PLUGIN_VERSION', '8.2.1' );
+\define( 'ACTIVITYPUB_PLUGIN_VERSION', '8.3.0' );
 
 // Plugin related constants.
 \define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/bundled/activitypub/build/extra-fields/block.json
+++ b/bundled/activitypub/build/extra-fields/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "name": "activitypub/extra-fields",
   "apiVersion": 3,
-  "version": "8.2.1",
+  "version": "8.3.0",
   "title": "Fediverse Extra Fields",
   "category": "widgets",
   "description": "Display extra fields from Fediverse user profiles.",

--- a/bundled/activitypub/build/follow-me/block.json
+++ b/bundled/activitypub/build/follow-me/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "name": "activitypub/follow-me",
   "apiVersion": 3,
-  "version": "8.2.1",
+  "version": "8.3.0",
   "title": "Follow me on the Fediverse",
   "category": "widgets",
   "description": "Display your Fediverse profile so that visitors can follow you.",

--- a/bundled/activitypub/build/followers/block.json
+++ b/bundled/activitypub/build/followers/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "name": "activitypub/followers",
   "apiVersion": 3,
-  "version": "8.2.1",
+  "version": "8.3.0",
   "title": "Fediverse Followers",
   "category": "widgets",
   "description": "Display your followers from the Fediverse on your website.",

--- a/bundled/activitypub/build/following/block.json
+++ b/bundled/activitypub/build/following/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "name": "activitypub/following",
   "apiVersion": 3,
-  "version": "8.2.1",
+  "version": "8.3.0",
   "title": "Fediverse Following",
   "category": "widgets",
   "description": "Display the accounts you follow in the Fediverse on your website.",

--- a/bundled/activitypub/build/reactions/block.json
+++ b/bundled/activitypub/build/reactions/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "name": "activitypub/reactions",
   "apiVersion": 3,
-  "version": "8.2.1",
+  "version": "8.3.0",
   "title": "Fediverse Reactions",
   "category": "widgets",
   "icon": "heart",

--- a/bundled/activitypub/build/remote-reply/block.json
+++ b/bundled/activitypub/build/remote-reply/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "name": "activitypub/remote-reply",
   "apiVersion": 3,
-  "version": "8.2.1",
+  "version": "8.3.0",
   "title": "Reply on the Fediverse",
   "category": "widgets",
   "description": "Allow visitors to reply to your posts from their Fediverse account.",

--- a/bundled/activitypub/build/reply/block.json
+++ b/bundled/activitypub/build/reply/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 3,
   "name": "activitypub/reply",
-  "version": "8.2.1",
+  "version": "8.3.0",
   "title": "Federated Reply",
   "category": "widgets",
   "icon": "admin-comments",

--- a/bundled/activitypub/includes/class-activitypub.php
+++ b/bundled/activitypub/includes/class-activitypub.php
@@ -88,6 +88,7 @@ class Activitypub {
 		Migration::update_comment_counts( 2000 );
 
 		Remote_Posts::delete_all();
+		Tombstone::delete_all();
 		Client::delete_all();
 
 		Options::delete();

--- a/bundled/activitypub/includes/class-migration.php
+++ b/bundled/activitypub/includes/class-migration.php
@@ -34,6 +34,7 @@ class Migration {
 		Scheduler::register_async_batch_callback( 'activitypub_migrate_avatar_to_remote_actors', array( self::class, 'migrate_avatar_to_remote_actors' ) );
 		Scheduler::register_async_batch_callback( 'activitypub_migrate_actor_emoji', array( self::class, 'migrate_actor_emoji' ) );
 		Scheduler::register_async_batch_callback( 'activitypub_backfill_statistics', array( Statistics::class, 'backfill_historical_stats' ) );
+		Scheduler::register_async_batch_callback( 'activitypub_tombstone_migrate', array( self::class, 'migrate_tombstones_to_cpt' ) );
 	}
 
 	/**
@@ -211,6 +212,11 @@ class Migration {
 		if ( \version_compare( $version_from_db, '8.1.0', '<' ) && ! \wp_next_scheduled( 'activitypub_backfill_statistics' ) ) {
 			// Backfill historical statistics data (delay + jitter to avoid load spikes on hosts running many sites).
 			\wp_schedule_single_event( \time() + HOUR_IN_SECONDS + \wp_rand( 0, 6 * HOUR_IN_SECONDS ), 'activitypub_backfill_statistics' );
+		}
+		if ( \version_compare( $version_from_db, '8.3.0', '<' ) ) {
+			if ( ! \wp_next_scheduled( 'activitypub_tombstone_migrate' ) ) {
+				\wp_schedule_single_event( \time() + MINUTE_IN_SECONDS, 'activitypub_tombstone_migrate' );
+			}
 		}
 
 		/*
@@ -1085,6 +1091,119 @@ class Migration {
 		foreach ( $inbox_ids as $post_id ) {
 			\wp_delete_post( $post_id, true );
 		}
+	}
+
+	/**
+	 * Migrate URLs from the legacy `activitypub_tombstone_urls` option into the
+	 * `ap_tombstone` custom post type.
+	 *
+	 * Chunked async migration. Locking and rescheduling is handled by
+	 * Scheduler::async_batch — the callback returns `array( 'batch_size' => N )`
+	 * to request another run, or `null` when the option is fully drained.
+	 *
+	 * Legacy entries are already-normalized strings (no scheme), so we bypass
+	 * URL validation and insert directly via wp_insert_post.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param int $batch_size Optional. Number of URLs to process per call. Default 500.
+	 * @return array|null Args for the next run, or null when migration is complete.
+	 */
+	public static function migrate_tombstones_to_cpt( $batch_size = 500 ) {
+		global $wpdb;
+
+		$urls = \get_option( 'activitypub_tombstone_urls', null );
+
+		if ( null === $urls || ! \is_array( $urls ) || empty( $urls ) ) {
+			\delete_option( 'activitypub_tombstone_urls' );
+			return null;
+		}
+
+		$chunk      = \array_slice( $urls, 0, (int) $batch_size );
+		$remaining  = \array_slice( $urls, (int) $batch_size );
+		$progressed = false;
+
+		foreach ( $chunk as $normalized ) {
+			if ( ! \is_string( $normalized ) || '' === $normalized ) {
+				// Drop garbage entries — counts as progress.
+				$progressed = true;
+				continue;
+			}
+
+			$hash = \md5( $normalized );
+
+			/*
+			 * Light existence check. `get_page_by_path()` would hydrate a
+			 * full `WP_Post` per loop iteration; on a large registry that
+			 * adds up fast. We only need a boolean here.
+			 */
+			$exists = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+				$wpdb->prepare(
+					"SELECT 1 FROM {$wpdb->posts} WHERE post_type = %s AND post_name = %s LIMIT 1",
+					Tombstone::POST_TYPE,
+					$hash
+				)
+			);
+			if ( $exists ) {
+				$progressed = true;
+				continue;
+			}
+
+			/*
+			 * `guid` is intentionally omitted: the legacy option only kept
+			 * the normalized (schemeless) form, so we can't reconstruct the
+			 * original URL. Storing the schemeless string would be mangled
+			 * by `esc_url()`. Leave WordPress to auto-generate the guid
+			 * — it's not used for lookups, only for debugging.
+			 */
+			$result = \wp_insert_post(
+				array(
+					'post_type'   => Tombstone::POST_TYPE,
+					'post_status' => 'publish',
+					'post_name'   => $hash,
+					'post_author' => 0,
+				),
+				true
+			);
+
+			if ( \is_wp_error( $result ) || ! $result ) {
+				/*
+				 * Keep failed inserts in the legacy option so the next batch
+				 * retries them. `Tombstone::exists_local()` still falls back
+				 * to the option, so the tombstone remains discoverable.
+				 */
+				$remaining[] = $normalized;
+			} else {
+				$progressed = true;
+			}
+		}
+
+		if ( empty( $remaining ) ) {
+			\delete_option( 'activitypub_tombstone_urls' );
+			return null;
+		}
+
+		/*
+		 * Disable autoload while we drain. The point of the migration is to
+		 * stop this option from contributing to `alloptions` pressure, so
+		 * flip the flag immediately rather than waiting for the option to
+		 * be fully empty before the relief kicks in.
+		 */
+		\update_option( 'activitypub_tombstone_urls', \array_values( $remaining ), false );
+
+		/*
+		 * If nothing in this batch was drained — every insert errored and
+		 * nothing was already migrated — halt the scheduler so we don't loop
+		 * forever on a persistent failure. The legacy option still backs
+		 * exists_local(), so the data isn't lost; an admin can re-trigger
+		 * the migration via `wp cron event run activitypub_tombstone_migrate`
+		 * after fixing the underlying cause.
+		 */
+		if ( ! $progressed ) {
+			return null;
+		}
+
+		return array( 'batch_size' => (int) $batch_size );
 	}
 
 	/**

--- a/bundled/activitypub/includes/class-post-types.php
+++ b/bundled/activitypub/includes/class-post-types.php
@@ -34,6 +34,7 @@ class Post_Types {
 		\add_action( 'init', array( self::class, 'register_extra_fields_post_types' ), 11 );
 		\add_action( 'init', array( self::class, 'register_activitypub_post_meta' ), 11 );
 		\add_action( 'init', array( self::class, 'register_oauth_post_types' ), 11 );
+		\add_action( 'init', array( self::class, 'register_tombstone_post_type' ), 11 );
 
 		\add_action( 'rest_api_init', array( self::class, 'register_ap_actor_rest_field' ) );
 		\add_action( 'rest_api_init', array( self::class, 'register_ap_post_actor_rest_field' ) );
@@ -557,6 +558,40 @@ class Post_Types {
 				'single'            => false,
 				'description'       => 'User IDs that have active tokens for this client.',
 				'sanitize_callback' => 'absint',
+			)
+		);
+	}
+
+	/**
+	 * Register the ap_tombstone post type.
+	 *
+	 * Stores local tombstone URLs out of the autoloaded options row.
+	 * The post type is fully internal — never queried publicly, never shown in UI.
+	 *
+	 * @since 8.3.0
+	 */
+	public static function register_tombstone_post_type() {
+		\register_post_type(
+			Tombstone::POST_TYPE,
+			array(
+				'labels'              => array(
+					'name'          => \_x( 'Tombstones', 'post_type plural name', 'activitypub' ),
+					'singular_name' => \_x( 'Tombstone', 'post_type single name', 'activitypub' ),
+				),
+				'public'              => false,
+				'publicly_queryable'  => false,
+				'show_ui'             => false,
+				'show_in_menu'        => false,
+				'show_in_nav_menus'   => false,
+				'show_in_admin_bar'   => false,
+				'show_in_rest'        => false,
+				'exclude_from_search' => true,
+				'has_archive'         => false,
+				'rewrite'             => false,
+				'query_var'           => false,
+				'can_export'          => false,
+				'delete_with_user'    => false,
+				'supports'            => array(),
 			)
 		);
 	}

--- a/bundled/activitypub/includes/class-scheduler.php
+++ b/bundled/activitypub/includes/class-scheduler.php
@@ -39,6 +39,7 @@ class Scheduler {
 		'activitypub_outbox_purge'                 => 'daily',
 		'activitypub_inbox_purge'                  => 'daily',
 		'activitypub_ap_post_purge'                => 'daily',
+		'activitypub_tombstone_purge'              => 'daily',
 		'activitypub_sync_blocklist_subscriptions' => 'weekly',
 	);
 
@@ -82,6 +83,7 @@ class Scheduler {
 		\add_action( 'activitypub_outbox_purge', array( self::class, 'purge_outbox' ) );
 		\add_action( 'activitypub_inbox_purge', array( self::class, 'purge_inbox' ) );
 		\add_action( 'activitypub_ap_post_purge', array( self::class, 'purge_ap_posts' ) );
+		\add_action( 'activitypub_tombstone_purge', array( self::class, 'purge_tombstones' ) );
 		\add_action( 'activitypub_inbox_create_item', array( self::class, 'process_inbox_activity' ) );
 		\add_action( 'activitypub_sync_blocklist_subscriptions', array( Blocklist_Subscriptions::class, 'sync_all' ) );
 
@@ -402,6 +404,18 @@ class Scheduler {
 	 */
 	public static function purge_ap_posts() {
 		Remote_Posts::purge( \get_option( 'activitypub_ap_post_purge_days', ACTIVITYPUB_AP_POST_PURGE_DAYS ) );
+	}
+
+	/**
+	 * Daily cron handler that purges expired tombstones.
+	 *
+	 * Retention is non-urgent: large backlogs (e.g. after retention is first enforced)
+	 * drain across multiple daily runs.
+	 *
+	 * @since 8.3.0
+	 */
+	public static function purge_tombstones() {
+		\Activitypub\Tombstone::purge();
 	}
 
 	/**

--- a/bundled/activitypub/includes/class-tombstone.php
+++ b/bundled/activitypub/includes/class-tombstone.php
@@ -31,6 +31,13 @@ class Tombstone {
 	private static $codes = array( 404, 410 );
 
 	/**
+	 * The custom post type used to store local tombstones.
+	 *
+	 * @var string
+	 */
+	const POST_TYPE = 'ap_tombstone';
+
+	/**
 	 * Check if a tombstone exists for the given resource.
 	 *
 	 * This is the main entry point for tombstone detection. It accepts various
@@ -107,17 +114,36 @@ class Tombstone {
 	/**
 	 * Check if a local URL is tombstoned.
 	 *
-	 * Checks against the local tombstone URL registry stored in WordPress options.
-	 * Local URLs are normalized before comparison to ensure consistent matching.
+	 * Matches by the MD5 hash of the normalized URL stored in `post_name`.
+	 * Falls back to the legacy `activitypub_tombstone_urls` option for
+	 * tombstones that have not yet been migrated.
 	 *
 	 * @param string $url The local URL to check for tombstone status.
 	 *
-	 * @return bool True if the local URL is in the tombstone registry, false otherwise.
+	 * @return bool True if the local URL is tombstoned, false otherwise.
 	 */
 	public static function exists_local( $url ) {
-		$urls = get_option( 'activitypub_tombstone_urls', array() );
+		if ( ! \is_string( $url ) || '' === $url ) {
+			return false;
+		}
 
-		return in_array( normalize_url( $url ), $urls, true );
+		$normalized = normalize_url( $url );
+
+		if ( ! empty( self::find_post_ids_by_url( $normalized ) ) ) {
+			return true;
+		}
+
+		/*
+		 * Fallback to the legacy option during migration. Once the option is
+		 * deleted (migration complete), get_option returns false and the
+		 * is_array() guard short-circuits immediately.
+		 */
+		$legacy = \get_option( 'activitypub_tombstone_urls', false );
+		if ( \is_array( $legacy ) && \in_array( $normalized, $legacy, true ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -193,32 +219,90 @@ class Tombstone {
 	}
 
 	/**
+	 * Look up tombstone post IDs by canonical URL.
+	 *
+	 * The MD5 of the normalized URL is unique per URL, so a successful
+	 * `bury()` produces exactly one row and the canonical lookup is enough.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param string $normalized The normalized URL (scheme stripped).
+	 * @return int[] Post IDs (zero or one entry under normal operation).
+	 */
+	private static function find_post_ids_by_url( $normalized ) {
+		global $wpdb;
+
+		/*
+		 * `bury()` is idempotent on the MD5 slug, so a successful insert
+		 * produces exactly one row per URL. `LIMIT 1` matches that invariant
+		 * and keeps the query cheap on the hot `exists_local()` path.
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_name = %s LIMIT 1",
+				self::POST_TYPE,
+				\md5( $normalized )
+			)
+		);
+
+		return \array_map( 'intval', $ids );
+	}
+
+	/**
 	 * Add one or more URLs to the local tombstone registry.
 	 *
 	 * "Buries" URLs by adding them to the local tombstone URL registry.
-	 * URLs are normalized before storage and duplicates are automatically removed.
-	 * This marks the URLs as tombstoned for future local checks.
+	 * URLs are normalized before storage; duplicate calls for the same URL
+	 * are a no-op because the `post_name` slug is the MD5 of the
+	 * normalized URL.
 	 *
 	 * @param string ...$urls The URLs to add to the tombstone registry.
 	 */
 	public static function bury( ...$urls ) {
-		$to_add = array();
-
 		foreach ( $urls as $url ) {
-			if ( \filter_var( $url, \FILTER_VALIDATE_URL ) ) {
-				$to_add[] = normalize_url( $url );
+			if ( ! \filter_var( $url, \FILTER_VALIDATE_URL ) ) {
+				continue;
+			}
+
+			$normalized = normalize_url( $url );
+
+			if ( ! empty( self::find_post_ids_by_url( $normalized ) ) ) {
+				continue;
+			}
+
+			/*
+			 * Store the original URL in `guid` so it is human-readable and
+			 * survives `esc_url()` without scheme mangling. The hash slug
+			 * in `post_name` is what we actually key lookups on.
+			 */
+			$post_id = \wp_insert_post(
+				array(
+					'post_type'   => self::POST_TYPE,
+					'post_status' => 'publish',
+					'post_name'   => \md5( $normalized ),
+					'guid'        => $url,
+					'post_author' => 0,
+				),
+				true
+			);
+
+			if ( \is_wp_error( $post_id ) || ! $post_id ) {
+				/**
+				 * Fires when `bury()` fails to write a tombstone row.
+				 *
+				 * The URL is silently not tombstoned in this case — the
+				 * request path will respond as it would for any other
+				 * non-existent post. Useful as a monitoring hook.
+				 *
+				 * @since 8.3.0
+				 *
+				 * @param string             $normalized The normalized URL that failed to bury.
+				 * @param \WP_Error|int|null $post_id    The `wp_insert_post()` return value.
+				 */
+				\do_action( 'activitypub_tombstone_bury_failed', $normalized, $post_id );
 			}
 		}
-
-		if ( empty( $to_add ) ) {
-			return;
-		}
-
-		$stored_urls = \get_option( 'activitypub_tombstone_urls', array() );
-		$stored_urls = \array_merge( $stored_urls, $to_add );
-		$stored_urls = \array_unique( $stored_urls );
-
-		\update_option( 'activitypub_tombstone_urls', $stored_urls );
 	}
 
 	/**
@@ -231,20 +315,132 @@ class Tombstone {
 	 * @param string ...$urls The URLs to remove from the tombstone registry.
 	 */
 	public static function remove( ...$urls ) {
-		$to_remove = array();
-
+		$normalized_urls = array();
 		foreach ( $urls as $url ) {
 			if ( \filter_var( $url, \FILTER_VALIDATE_URL ) ) {
-				$to_remove[] = normalize_url( $url );
+				$normalized_urls[] = normalize_url( $url );
 			}
 		}
 
-		if ( empty( $to_remove ) ) {
+		if ( empty( $normalized_urls ) ) {
 			return;
 		}
 
-		$stored_urls = \get_option( 'activitypub_tombstone_urls', array() );
-		$stored_urls = \array_diff( $stored_urls, $to_remove );
-		\update_option( 'activitypub_tombstone_urls', $stored_urls );
+		$normalized_urls = \array_values( \array_unique( $normalized_urls ) );
+
+		foreach ( $normalized_urls as $normalized ) {
+			foreach ( self::find_post_ids_by_url( $normalized ) as $post_id ) {
+				\wp_delete_post( $post_id, true );
+			}
+		}
+
+		$legacy = \get_option( 'activitypub_tombstone_urls', false );
+		if ( ! \is_array( $legacy ) ) {
+			return;
+		}
+
+		$filtered = \array_values( \array_diff( $legacy, $normalized_urls ) );
+		if ( \count( $filtered ) === \count( $legacy ) ) {
+			return;
+		}
+
+		if ( empty( $filtered ) ) {
+			\delete_option( 'activitypub_tombstone_urls' );
+		} else {
+			\update_option( 'activitypub_tombstone_urls', $filtered );
+		}
+	}
+
+	/**
+	 * Delete every tombstone post and the legacy option.
+	 *
+	 * Used during plugin uninstall to clean up all local tombstones.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @return int The number of tombstone posts deleted.
+	 */
+	public static function delete_all() {
+		global $wpdb;
+
+		$post_ids = \array_map(
+			'intval',
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s",
+					self::POST_TYPE
+				)
+			)
+		);
+
+		$deleted = 0;
+		foreach ( $post_ids as $post_id ) {
+			if ( \wp_delete_post( $post_id, true ) ) {
+				++$deleted;
+			}
+		}
+
+		\delete_option( 'activitypub_tombstone_urls' );
+
+		return $deleted;
+	}
+
+	/**
+	 * Delete tombstones older than the retention window.
+	 *
+	 * Processes up to `$batch_size` tombstones per call. Retention is
+	 * non-urgent: large backlogs drain across multiple daily runs of the
+	 * `activitypub_tombstone_purge` cron event.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param int $batch_size Max number of tombstones to delete per call.
+	 * @return int The number of tombstones deleted.
+	 */
+	public static function purge( $batch_size = 200 ) {
+		/**
+		 * Filters the retention window for local tombstones, in days.
+		 *
+		 * Set to 0 or a negative value to disable automatic purge.
+		 *
+		 * @since 8.3.0
+		 *
+		 * @param int $days Retention window in days. Default 90.
+		 */
+		$days = (int) \apply_filters( 'activitypub_tombstone_retention_days', 90 );
+
+		if ( $days <= 0 ) {
+			return 0;
+		}
+
+		$cutoff = \gmdate( 'Y-m-d H:i:s', \time() - $days * DAY_IN_SECONDS );
+
+		$ids = \get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => 'publish',
+				'posts_per_page' => (int) $batch_size,
+				'fields'         => 'ids',
+				'orderby'        => 'date',
+				'order'          => 'ASC',
+				'no_found_rows'  => true,
+				'date_query'     => array(
+					array(
+						'column' => 'post_date_gmt',
+						'before' => $cutoff,
+					),
+				),
+			)
+		);
+
+		$deleted = 0;
+		foreach ( $ids as $id ) {
+			if ( \wp_delete_post( (int) $id, true ) ) {
+				++$deleted;
+			}
+		}
+
+		return $deleted;
 	}
 }

--- a/bundled/activitypub/includes/class-webfinger.php
+++ b/bundled/activitypub/includes/class-webfinger.php
@@ -30,7 +30,7 @@ class Webfinger {
 	 *
 	 * The host/local-part pattern follows `ACTIVITYPUB_USERNAME_REGEXP`.
 	 *
-	 * @since unreleased
+	 * @since 8.3.0
 	 *
 	 * @param mixed $value The candidate value.
 	 * @return bool True if the value matches the acct identifier pattern.
@@ -256,7 +256,7 @@ class Webfinger {
 	 * @return string|\WP_Error Error or the Remote-Follow endpoint URI.
 	 */
 	public static function get_remote_follow_endpoint( $uri ) {
-		return self::get_intent_endpoint( $uri, 'http://ostatus.org/schema/1.0/subscribe' );
+		return self::get_intent_endpoint( $uri, 'follow', true );
 	}
 
 	/**
@@ -363,8 +363,24 @@ class Webfinger {
 			);
 		}
 
+		/*
+		 * OStatus subscribe URL (deprecated but still widely supported)
+		 *
+		 * @see https://ostatus.github.io/spec/OStatus%201.0%20Draft%202.html#anchor10
+		 */
 		if ( isset( $links['http://ostatus.org/schema/1.0/subscribe'] ) ) {
 			return $links['http://ostatus.org/schema/1.0/subscribe'];
+		}
+
+		/*
+		 * FEP-3b86 Object Intent — the generic "open this object on my home
+		 * server" link, equivalent to pasting the URL into the home server's
+		 * search box. Useful when no verb-specific intent is advertised.
+		 *
+		 * @see https://codeberg.org/fediverse/fep/src/branch/main/fep/3b86/fep-3b86.md#5-1-object-intent
+		 */
+		if ( isset( $links['https://w3id.org/fep/3b86/object'] ) ) {
+			return $links['https://w3id.org/fep/3b86/object'];
 		}
 
 		// Last-resort: construct a Mastodon-compatible authorize_interaction URL.

--- a/bundled/activitypub/includes/functions-user.php
+++ b/bundled/activitypub/includes/functions-user.php
@@ -147,7 +147,7 @@ function user_can_activitypub( $user_id ) {
  * helper centralizes the "can the current user post / read as the blog?"
  * decision: administrators by default, filterable for integrations.
  *
- * @since unreleased
+ * @since 8.3.0
  *
  * @return bool True if the current user can act as the blog actor.
  */
@@ -163,7 +163,7 @@ function user_can_act_as_blog() {
 	 * and view stats for the blog actor. Always inspect the current user inside
 	 * the callback (`current_user_can()`, role, allowlist) before returning `true`.
 	 *
-	 * @since unreleased
+	 * @since 8.3.0
 	 *
 	 * @param bool $can_act_as_blog Whether the current user can act as the blog actor.
 	 */

--- a/bundled/activitypub/includes/rest/class-server.php
+++ b/bundled/activitypub/includes/rest/class-server.php
@@ -24,6 +24,7 @@ class Server {
 
 		\add_filter( 'rest_post_dispatch', array( self::class, 'filter_output' ), 10, 3 );
 		\add_filter( 'rest_post_dispatch', array( self::class, 'add_cors_headers' ), 10, 3 );
+		\add_filter( 'rest_allowed_cors_headers', array( self::class, 'allow_cors_headers' ), 10, 2 );
 	}
 
 	/**
@@ -184,12 +185,41 @@ class Server {
 		 * REST nonce check, and OAuth Bearer tokens travel in the
 		 * Authorization header — which is permitted via Allow-Headers and
 		 * does not require Allow-Credentials.
+		 *
+		 * Allow-Headers is contributed by core (which already lists `X-WP-Nonce`,
+		 * `Authorization`, `Content-Type`, `Content-Disposition`, and `Content-MD5`)
+		 * and extended for ActivityPub via the `rest_allowed_cors_headers` filter
+		 * in self::allow_cors_headers().
 		 */
 		$response->header( 'Access-Control-Allow-Origin', '*' );
 		$response->header( 'Access-Control-Allow-Methods', 'GET, POST, OPTIONS' );
-		$response->header( 'Access-Control-Allow-Headers', 'Accept, Content-Type, Authorization, Last-Event-ID' );
 
 		return $response;
+	}
+
+	/**
+	 * Extend the CORS Allow-Headers list for ActivityPub REST endpoints.
+	 *
+	 * Adds the headers ActivityPub clients need on top of WordPress core's
+	 * defaults: `Accept` for content negotiation and `Last-Event-ID` for
+	 * Server-Sent Events resume.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param string[]         $allow_headers Headers core currently permits in CORS requests.
+	 * @param \WP_REST_Request $request       The current REST request.
+	 *
+	 * @return string[] The (possibly extended) list of allowed headers.
+	 */
+	public static function allow_cors_headers( $allow_headers, $request ) {
+		$route     = $request->get_route();
+		$namespace = '/' . ACTIVITYPUB_REST_NAMESPACE;
+
+		if ( ! \str_starts_with( $route, $namespace ) || \str_starts_with( $route, $namespace . '/oauth/authorize' ) ) {
+			return $allow_headers;
+		}
+
+		return \array_values( \array_unique( \array_merge( (array) $allow_headers, array( 'Accept', 'Last-Event-ID' ) ) ) );
 	}
 
 	/**
@@ -203,6 +233,6 @@ class Server {
 	public static function send_cors_headers() {
 		\header( 'Access-Control-Allow-Origin: *' );
 		\header( 'Access-Control-Allow-Methods: GET, POST, OPTIONS' );
-		\header( 'Access-Control-Allow-Headers: Accept, Content-Type, Authorization, Last-Event-ID' );
+		\header( 'Access-Control-Allow-Headers: Authorization, X-WP-Nonce, Content-Disposition, Content-MD5, Content-Type, Accept, Last-Event-ID' );
 	}
 }

--- a/bundled/activitypub/readme.txt
+++ b/bundled/activitypub/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, pfefferle, mattwiebe, obenland, akirk, jeherve, mediaf
 Tags: fediverse, activitypub, indieweb, activitystream, social web
 Requires at least: 6.5
 Tested up to: 6.9
-Stable tag: 8.2.1
+Stable tag: 8.3.0
 Requires PHP: 7.4
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -110,6 +110,32 @@ For reasons of data protection, it is not possible to see the followers of other
 5. A Blog-Profile on Mastodon
 
 == Changelog ==
+
+### 8.3.0 - 2026-05-18
+#### Security
+- Block a recently compromised JavaScript dependency from being installed during builds.
+
+#### Added
+- Allow site administrators to post from third-party apps on behalf of the site's blog account.
+- Store content warnings from posts published through third-party ActivityPub apps so they federate correctly.
+
+#### Changed
+- Improve compatibility with newer Fediverse servers by recognizing the FEP-3b86 Object Intent link when resolving remote follow and other intent endpoints.
+- Improve compatibility with newer Fediverse servers by recognizing the standardized FEP-3b86 follow link for remote follows.
+- Refresh bundled scripts to pick up the latest WordPress component updates.
+- Stagger background data processing after plugin updates to reduce server load on hosts running many sites.
+
+#### Fixed
+- Allow third-party apps connected to your site to look up Fediverse users by their handle (like @user@example.com).
+- Fix ActivityPub blocks and widgets failing to load on cross-origin embeds (such as WordPress.com sites) due to a missing nonce header in the CORS allow-list.
+- Fix a JavaScript console error that could appear on pages with the Follow, Reactions, Followers, Following, or Remote Reply blocks.
+- Fix posting an Undo of a Follow through the outbox API failing with a server error or silently leaving the follow in place.
+- Prevent a PHP warning during the monthly statistics backfill when an outbox item disappears between lookup steps.
+- Prevent private outbox items authored by the site account from being visible to logged-out visitors at their permalink URLs.
+- Prevent the site's follower and following lists from being visible to logged-out visitors when the social graph is set to private.
+- Reduce database overhead on sites with many deleted posts by moving the tombstone registry to its own storage.
+- Set a real author on posts created via the blog actor outbox so they no longer appear without a byline.
+- Silence the upcoming WordPress 7.0 deprecation warning about `data-wp-on-async` by switching the plugin's interactive blocks to the new `withSyncEvent()` helper.
 
 ### 8.2.1 - 2026-05-01
 #### Security

--- a/fosse.php
+++ b/fosse.php
@@ -3,7 +3,7 @@
  * Plugin Name: FOSSE
  * Plugin URI:  https://github.com/Automattic/fosse
  * Description: Social Web
- * Version:     0.1.0
+ * Version:     0.1.1
  * Requires at least: 6.9
  * Tested up to: 7.0
  * Requires PHP: 8.2
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  * `ACTIVITYPUB_PLUGIN_VERSION` / `ATMOSPHERE_VERSION` pattern of the
  * bundled backends. Keep in sync with the `Version:` header above.
  */
-define( 'FOSSE_VERSION', '0.1.0' );
+define( 'FOSSE_VERSION', '0.1.1' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload_packages.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload_packages.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fosse",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Social Web for WordPress.",
 	"private": true,
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Summary

- Resyncs `bundled/activitypub` to upstream trunk (`0de6d768`). Brings in tombstone reworks, blog-actor C2S admin/permission fixes, anonymous blog-actor ownership fix, webfinger proxy `Accept` handling, scheduler migration jitter, statistics earliest-date null guard, content-warning storage in the outbox API, the data-wp-on-async deprecation fix, and pinned tanstack-history.
- Atmosphere trunk (`b9b32fe`) had no runtime changes since the last sync — its upstream delta was entirely in paths excluded by `tools/bundled-excludes.txt` (`.agents/`, `.claude/`, `docs/`, `.github/`, `.wordpress-org/`, `AGENTS.md`, `README.md`), so `bundled/atmosphere/` is unchanged this round.
- Bumps `Version:` header and `FOSSE_VERSION` constant in `fosse.php` and `package.json` to `0.1.1`.

## Test plan

- [ ] `composer lint-php` passes (verified locally).
- [ ] Sanity-load FOSSE in a WordPress site and confirm `FOSSE_VERSION === '0.1.1'`.
- [ ] Confirm bundled ActivityPub still registers and federates basic outbox traffic.