### PR TITLE
Tests: use semantic admin locators

### DIFF
--- a/tests/e2e/bluesky-provider.spec.ts
+++ b/tests/e2e/bluesky-provider.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect, type Page } from '@playwright/test';
 import {
 	expectNoHorizontalOverflow,
-	numericCssValue,
+	getProviderStatusCard,
+	numericCssValueFor,
 	resetBlueskyState,
 	resetWizardIfComplete,
 	setBlueskyState,
@@ -52,9 +53,15 @@ test.describe( 'Bluesky provider UI', () => {
 		await page.goto( '/wp-admin/admin.php?page=fosse' );
 		await expectNoCriticalText( page );
 
-		const federationSettings = page.locator( '#fosse-federation-settings' );
-		const connections = page.locator( '#fosse-connections' );
-		const guidedSetup = page.locator( '.fosse-guided-setup' );
+		const federationSettings = page
+			.getByRole( 'heading', { name: 'Publishing settings' } )
+			.locator( 'xpath=ancestor::div[2]' );
+		const connections = page
+			.getByRole( 'heading', { name: 'Connections' } )
+			.locator( 'xpath=ancestor::div[2]' );
+		const guidedSetup = page
+			.getByRole( 'note' )
+			.filter( { hasText: 'Want a guided setup?' } );
 		const blueskyConnection = connections.locator(
 			'#fosse-provider-bluesky'
 		);
@@ -62,36 +69,23 @@ test.describe( 'Bluesky provider UI', () => {
 		await expect( guidedSetup ).toBeVisible();
 		await expect( guidedSetup ).toContainText( 'Want a guided setup?' );
 		await expect( guidedSetup ).toHaveCSS( 'border-left-width', '4px' );
-		const calloutWidth = await page.evaluate( () => {
-			const callout = document.querySelector( '.fosse-guided-setup' );
-			const mainCard = document.querySelector(
-				'#fosse-federation-settings'
-			);
-
-			if ( ! callout || ! mainCard ) {
-				return null;
-			}
-
-			return {
-				calloutWidth: callout.getBoundingClientRect().width,
-				mainCardWidth: mainCard.getBoundingClientRect().width,
-			};
-		} );
-		expect( calloutWidth ).not.toBeNull();
+		const calloutBox = await guidedSetup.boundingBox();
+		const federationSettingsBox = await federationSettings.boundingBox();
+		expect( calloutBox ).not.toBeNull();
+		expect( federationSettingsBox ).not.toBeNull();
 		expect(
-			Math.abs( calloutWidth!.calloutWidth - calloutWidth!.mainCardWidth )
+			Math.abs( calloutBox!.width - federationSettingsBox!.width )
 		).toBeLessThanOrEqual( 1 );
 
-		await expect( federationSettings ).toHaveClass( /fosse-admin-card/ );
 		await expect(
-			federationSettings.locator( '.fosse-field' )
+			federationSettings.getByRole( 'checkbox' )
 		).not.toHaveCount( 0 );
 		await expect(
-			federationSettings.locator( '.fosse-choice-card' )
+			federationSettings.getByRole( 'radio', {
+				name: /Author profiles/,
+			} )
 		).not.toHaveCount( 0 );
-		await expect(
-			page.locator( '.fosse-admin-page .form-table' )
-		).toHaveCount( 0 );
+		await expect( federationSettings.locator( 'table' ) ).toHaveCount( 0 );
 		await expect(
 			federationSettings.getByRole( 'heading', {
 				name: 'Publishing settings',
@@ -109,26 +103,14 @@ test.describe( 'Bluesky provider UI', () => {
 		await expect(
 			page.getByRole( 'link', { name: 'Run the wizard' } )
 		).toHaveAttribute( 'href', /page=fosse-wizard/ );
-		const wizardLinkPlacement = await page.evaluate( () => {
-			const connectionSection =
-				document.querySelector( '#fosse-connections' );
-			const link = document.querySelector(
-				'.fosse-admin-page__footer-action a'
-			);
-
-			if ( ! connectionSection || ! link ) {
-				return null;
-			}
-
-			return {
-				connectionsBottom:
-					connectionSection.getBoundingClientRect().bottom,
-				linkTop: link.getBoundingClientRect().top,
-			};
-		} );
-		expect( wizardLinkPlacement ).not.toBeNull();
-		expect( wizardLinkPlacement!.linkTop ).toBeGreaterThan(
-			wizardLinkPlacement!.connectionsBottom
+		const connectionsBox = await connections.boundingBox();
+		const wizardLink = await page
+			.getByRole( 'link', { name: 'Run the wizard' } )
+			.boundingBox();
+		expect( connectionsBox ).not.toBeNull();
+		expect( wizardLink ).not.toBeNull();
+		expect( wizardLink!.y ).toBeGreaterThan(
+			connectionsBox!.y + connectionsBox!.height
 		);
 		await expect(
 			connections.getByRole( 'heading', { name: 'Connections' } )
@@ -148,9 +130,7 @@ test.describe( 'Bluesky provider UI', () => {
 
 		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
 
-		const blueskyCard = page
-			.locator( '.fosse-status-card' )
-			.filter( { hasText: 'Bluesky' } );
+		const blueskyCard = getProviderStatusCard( page, 'Bluesky' );
 		await expect( blueskyCard ).toContainText( 'Disconnected' );
 		// Auto Publish row was removed alongside the Settings toggle —
 		// the status card no longer surfaces "Enabled" / "Disabled" text
@@ -197,9 +177,7 @@ test.describe( 'Bluesky provider UI', () => {
 
 		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
 
-		const blueskyCard = page
-			.locator( '.fosse-status-card' )
-			.filter( { hasText: 'Bluesky' } );
+		const blueskyCard = getProviderStatusCard( page, 'Bluesky' );
 		await expect( blueskyCard ).toContainText( 'Connected' );
 		await expect( blueskyCard ).toContainText( 'alice.bsky.social' );
 		await expect( blueskyCard ).toContainText( 'did:plc:alice123' );
@@ -230,24 +208,34 @@ test.describe( 'Bluesky provider UI', () => {
 		).toBeVisible();
 
 		expect(
-			await numericCssValue(
-				page,
-				'.fosse-admin-page__title',
+			await numericCssValueFor(
+				page.getByRole( 'heading', { name: 'FOSSE Settings' } ),
 				'letter-spacing'
 			)
 		).toBe( 0 );
 		expect(
-			await numericCssValue(
-				page,
-				'.fosse-field__label',
+			await numericCssValueFor(
+				page
+					.getByText( 'ActivityPub profile', { exact: true } )
+					.first(),
 				'letter-spacing'
 			)
 		).toBe( 0 );
 		expect(
-			await numericCssValue( page, '.fosse-admin-card', 'border-radius' )
+			await numericCssValueFor(
+				page
+					.getByRole( 'heading', { name: 'Publishing settings' } )
+					.locator( 'xpath=ancestor::div[2]' ),
+				'border-radius'
+			)
 		).toBeLessThanOrEqual( 8 );
 		expect(
-			await numericCssValue( page, '.fosse-choice-card', 'border-radius' )
+			await numericCssValueFor(
+				page
+					.getByRole( 'radio', { name: /Author profiles/ } )
+					.locator( 'xpath=..' ),
+				'border-radius'
+			)
 		).toBeLessThanOrEqual( 8 );
 
 		await page.setViewportSize( { width: 390, height: 720 } );

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -306,15 +306,27 @@ test( 'Appearance step swaps the visible address preview when the actor mode cha
 	await expect(
 		page.getByText( 'Your fediverse address:', { exact: true } )
 	).toBeHidden();
+	await expect( page.getByText( 'As you:', { exact: true } ) ).toBeHidden();
+	await expect(
+		page.getByText( 'As your site:', { exact: true } )
+	).toBeHidden();
 	await expect( page.getByLabel( 'Site handle' ) ).toBeVisible();
 
-	// "Both" reveals the actor_blog container instead.
+	// "Both" reveals the actor_blog container and keeps the inline Site
+	// handle row available for the blog actor.
 	await page.getByText( 'Both', { exact: true } ).click();
 
 	await expect( page.getByText( 'As you:', { exact: true } ) ).toBeVisible();
 	await expect(
 		page.getByText( 'As your site:', { exact: true } )
 	).toBeVisible();
+	await expect(
+		page.getByText( 'Your fediverse address:', { exact: true } )
+	).toBeHidden();
+	await expect(
+		page.getByText( 'Site fediverse address:', { exact: true } )
+	).toBeHidden();
+	await expect( page.getByLabel( 'Site handle' ) ).toBeVisible();
 
 	// Returning to "As you" hides the inline site handle row again — it
 	// only applies when the mode publishes from a blog actor.
@@ -323,6 +335,13 @@ test( 'Appearance step swaps the visible address preview when the actor mode cha
 	await expect(
 		page.getByText( 'Your fediverse address:', { exact: true } )
 	).toBeVisible();
+	await expect(
+		page.getByText( 'Site fediverse address:', { exact: true } )
+	).toBeHidden();
+	await expect( page.getByText( 'As you:', { exact: true } ) ).toBeHidden();
+	await expect(
+		page.getByText( 'As your site:', { exact: true } )
+	).toBeHidden();
 	await expect( page.getByLabel( 'Site handle' ) ).toBeHidden();
 } );
 

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -1,16 +1,14 @@
 import { test, expect, type Page } from '@playwright/test';
 import {
 	expectNoHorizontalOverflow,
-	numericCssValue,
+	numericCssValueFor,
 	resetBlueskyState,
 	setBlueskyState,
 } from './test-helpers';
 
 const selectDestination = async ( page: Page, destination: string ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
-	await page
-		.locator( '.fosse-destination-card', { hasText: destination } )
-		.click();
+	await page.getByText( destination, { exact: true } ).click();
 	await page.getByRole( 'button', { name: 'Continue' } ).click();
 	await expect( page ).toHaveURL( /step=appearance/ );
 };
@@ -39,8 +37,8 @@ test( 'Wizard page loads without errors', async ( { page } ) => {
 	await expect( page.locator( '#error-page' ) ).toHaveCount( 0 );
 
 	await expect(
-		page.locator( '.fosse-wizard__title', {
-			hasText: 'Where should your WordPress posts appear?',
+		page.getByRole( 'heading', {
+			name: 'Where should your WordPress posts appear?',
 		} )
 	).toBeVisible();
 } );
@@ -50,44 +48,50 @@ test( 'Wizard shows progress indicator on destination step', async ( {
 } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 
-	await expect( page.locator( '.fosse-wizard__progress' ) ).toBeVisible();
-	await expect(
-		page.locator( '.fosse-wizard__progress-step.is-active', {
-			hasText: 'Destinations',
-		} )
-	).toBeVisible();
+	const progress = page.getByRole( 'list', { name: 'Setup progress' } );
+	await expect( progress ).toBeVisible();
+	await expect( progress.locator( '[aria-current="step"]' ) ).toBeVisible();
+	await expect( progress.locator( '[aria-current="step"]' ) ).toHaveText(
+		'Destinations'
+	);
 } );
 
 test( 'Destination step shows two destination cards', async ( { page } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 
-	await expect( page.locator( '.fosse-wizard__description' ) ).toContainText(
-		'Fediverse apps like Mastodon'
-	);
-	const wizardCard = page.locator( '.fosse-wizard__card.fosse-admin-card' );
-	await expect( wizardCard ).toBeVisible();
 	await expect(
-		wizardCard.locator( '.fosse-card-header .fosse-wizard__title' )
-	).toContainText( 'Where should your WordPress posts appear?' );
-	await expect( wizardCard.locator( '.fosse-card-body' ) ).toBeVisible();
-	await expect(
-		wizardCard.locator( '.fosse-card-footer .fosse-wizard__actions' )
+		page.getByText(
+			/Fediverse sharing is enabled by default.*Fediverse apps like Mastodon/
+		)
 	).toBeVisible();
-	await expect( page.locator( '.fosse-destination-card' ) ).toHaveCount( 2 );
-	await expect( page.locator( '.fosse-choice-card' ) ).toHaveCount( 2 );
 	await expect(
-		page.locator( '.fosse-destination-card', {
-			hasText: 'Fediverse apps like Mastodon',
+		page.getByRole( 'heading', {
+			name: 'Where should your WordPress posts appear?',
+		} )
+	).toContainText( 'Where should your WordPress posts appear?' );
+	await expect(
+		page.getByRole( 'link', { name: 'Skip setup' } )
+	).toBeVisible();
+	await expect(
+		page.getByRole( 'button', { name: 'Continue' } )
+	).toBeVisible();
+	const destinations = page.getByRole( 'group', {
+		name: 'Where to publish',
+	} );
+	await expect( destinations.getByRole( 'radio' ) ).toHaveCount( 2 );
+	await expect(
+		destinations.getByRole( 'radio', {
+			name: /Fediverse apps like Mastodon/,
 		} )
 	).toHaveCount( 2 );
 	await expect(
-		page.locator( '.fosse-destination-card', {
-			hasText: 'Fediverse + Bluesky',
+		destinations.getByRole( 'radio', {
+			name: /Fediverse \+ Bluesky/,
 		} )
 	).toBeVisible();
 	await expect(
-		page.locator( '.fosse-destination-card', {
-			hasText: 'Fediverse only',
+		destinations.getByRole( 'radio', {
+			name: /Fediverse only/,
 		} )
 	).toBeVisible();
 	await expect( page.getByText( 'Mastodon and similar apps' ) ).toHaveCount(
@@ -101,32 +105,25 @@ test( 'Destination step keeps skip and continue actions on one desktop row', asy
 	await page.setViewportSize( { width: 1280, height: 900 } );
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 
-	const metrics = await page.evaluate( () => {
-		const skip = document.querySelector( '.fosse-wizard__skip' );
-		const submit = document.querySelector(
-			'.fosse-wizard__actions input[type="submit"]'
-		);
+	const skipRect = await page
+		.getByRole( 'link', { name: 'Skip setup' } )
+		.boundingBox();
+	const submitRect = await page
+		.getByRole( 'button', { name: 'Continue' } )
+		.boundingBox();
 
-		if ( ! skip || ! submit ) {
-			return null;
-		}
-
-		const skipRect = skip.getBoundingClientRect();
-		const submitRect = submit.getBoundingClientRect();
-
-		return {
-			centerDelta: Math.abs(
-				skipRect.top +
-					skipRect.height / 2 -
-					( submitRect.top + submitRect.height / 2 )
-			),
-			skipBeforeSubmit: skipRect.right <= submitRect.left,
-		};
-	} );
-
-	expect( metrics ).not.toBeNull();
-	expect( metrics!.centerDelta ).toBeLessThanOrEqual( 4 );
-	expect( metrics!.skipBeforeSubmit ).toBe( true );
+	expect( skipRect ).not.toBeNull();
+	expect( submitRect ).not.toBeNull();
+	expect(
+		Math.abs(
+			skipRect!.y +
+				skipRect!.height / 2 -
+				( submitRect!.y + submitRect!.height / 2 )
+		)
+	).toBeLessThanOrEqual( 4 );
+	expect( skipRect!.x + skipRect!.width ).toBeLessThanOrEqual(
+		submitRect!.x
+	);
 } );
 
 test( 'Wizard progress stays compact and keeps step labels available on mobile', async ( {
@@ -139,30 +136,31 @@ test( 'Wizard progress stays compact and keeps step labels available on mobile',
 	await expect(
 		page.getByRole( 'button', { name: 'Continue' } )
 	).toBeVisible();
-	await expect(
-		page.locator(
-			'.fosse-wizard__progress-step.is-active .fosse-wizard__progress-label',
-			{ hasText: 'Destinations' }
-		)
-	).toBeVisible();
+	const progress = page.getByRole( 'list', { name: 'Setup progress' } );
+	await expect( progress.locator( '[aria-current="step"]' ) ).toHaveText(
+		'Destinations'
+	);
 
-	const progressMetrics = await page
-		.locator( '.fosse-wizard__progress' )
-		.evaluate( ( el ) => {
-			const unavailableLabels = Array.from(
-				el.querySelectorAll( '.fosse-wizard__progress-label' )
-			).filter( ( label ) => {
-				const style = window.getComputedStyle( label );
-				return (
-					'hidden' === style.visibility || 'none' === style.display
-				);
-			} ).length;
+	const progressMetrics = await progress.evaluate( ( el ) => {
+		const visibleSteps = Array.from(
+			el.querySelectorAll( 'li:not([aria-hidden="true"])' )
+		);
+		const unavailableLabels = visibleSteps.filter( ( step ) => {
+			const label = Array.from( step.children ).find(
+				( child ) => child.textContent?.trim()
+			);
+			if ( ! label ) {
+				return true;
+			}
+			const style = window.getComputedStyle( label );
+			return 'hidden' === style.visibility || 'none' === style.display;
+		} ).length;
 
-			return {
-				height: ( el as HTMLElement ).offsetHeight,
-				unavailableLabels,
-			};
-		} );
+		return {
+			height: ( el as HTMLElement ).offsetHeight,
+			unavailableLabels,
+		};
+	} );
 
 	expect( progressMetrics.height ).toBeLessThanOrEqual( 48 );
 	expect( progressMetrics.unavailableLabels ).toBe( 0 );
@@ -177,28 +175,41 @@ test( 'Wizard surfaces use restrained visual tokens without page overflow', asyn
 	await expectNoHorizontalOverflow( page );
 
 	expect(
-		await numericCssValue( page, '.fosse-wizard__title', 'letter-spacing' )
-	).toBe( 0 );
-	expect(
-		await numericCssValue(
-			page,
-			'.fosse-destination-card__badge',
+		await numericCssValueFor(
+			page.getByRole( 'heading', {
+				name: 'Where should your WordPress posts appear?',
+			} ),
 			'letter-spacing'
 		)
 	).toBe( 0 );
 	expect(
-		await numericCssValue( page, '.fosse-choice-card', 'border-radius' )
+		await numericCssValueFor(
+			page.getByText( 'Recommended', { exact: true } ),
+			'letter-spacing'
+		)
+	).toBe( 0 );
+	expect(
+		await numericCssValueFor(
+			page
+				.getByRole( 'radio', { name: /Fediverse \+ Bluesky/ } )
+				.locator( 'xpath=..' ),
+			'border-radius'
+		)
 	).toBeLessThanOrEqual( 8 );
 
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=content' );
 	await expectNoHorizontalOverflow( page );
 	expect(
-		await numericCssValue( page, '.fosse-wizard__card', 'border-radius' )
+		await numericCssValueFor(
+			page
+				.getByRole( 'heading', { name: 'What do you want to share?' } )
+				.locator( 'xpath=ancestor::div[3]' ),
+			'border-radius'
+		)
 	).toBeLessThanOrEqual( 8 );
 	expect(
-		await numericCssValue(
-			page,
-			'.fosse-post-types__group-label',
+		await numericCssValueFor(
+			page.getByText( 'Common content types', { exact: true } ),
 			'letter-spacing'
 		)
 	).toBe( 0 );
@@ -217,27 +228,35 @@ test( 'Wizard keeps a centered reading column inside wp-admin content', async ( 
 	await page.setViewportSize( { width: 1103, height: 749 } );
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 
-	const metrics = await page.evaluate( () => {
-		const wpBody = document.querySelector( '#wpbody-content' );
-		const wizard = document.querySelector( '.fosse-wizard' );
+	const metrics = await page
+		.getByRole( 'heading', {
+			name: 'Where should your WordPress posts appear?',
+		} )
+		.evaluate( ( heading ) => {
+			const wpBody = document.querySelector( '#wpbody-content' );
+			let wizard = heading.parentElement;
 
-		if ( ! wpBody || ! wizard ) {
-			return null;
-		}
+			while ( wizard?.parentElement && wizard.parentElement !== wpBody ) {
+				wizard = wizard.parentElement;
+			}
 
-		const wpBodyRect = wpBody.getBoundingClientRect();
-		const wizardRect = wizard.getBoundingClientRect();
+			if ( ! wpBody || ! wizard ) {
+				return null;
+			}
 
-		return {
-			centerDelta: Math.abs(
-				wpBodyRect.left +
-					wpBodyRect.width / 2 -
-					( wizardRect.left + wizardRect.width / 2 )
-			),
-			leftGutter: wizardRect.left - wpBodyRect.left,
-			rightGutter: wpBodyRect.right - wizardRect.right,
-		};
-	} );
+			const wpBodyRect = wpBody.getBoundingClientRect();
+			const wizardRect = wizard.getBoundingClientRect();
+
+			return {
+				centerDelta: Math.abs(
+					wpBodyRect.left +
+						wpBodyRect.width / 2 -
+						( wizardRect.left + wizardRect.width / 2 )
+				),
+				leftGutter: wizardRect.left - wpBodyRect.left,
+				rightGutter: wpBodyRect.right - wizardRect.right,
+			};
+		} );
 
 	expect( metrics ).not.toBeNull();
 	expect( metrics!.centerDelta ).toBeLessThanOrEqual( 1 );
@@ -254,16 +273,18 @@ test( 'Destination selection navigates to identity step', async ( {
 	await page.getByRole( 'button', { name: 'Continue' } ).click();
 	await expect( page ).toHaveURL( /step=appearance/ );
 	await expect(
-		page.locator( '.fosse-wizard__title', {
-			hasText: 'Who should people follow?',
-		} )
+		page.getByRole( 'heading', { name: 'Who should people follow?' } )
 	).toBeVisible();
 } );
 
 test( 'Appearance step has three actor mode cards', async ( { page } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=appearance' );
 
-	await expect( page.locator( '.fosse-mode-card' ) ).toHaveCount( 3 );
+	await expect(
+		page
+			.getByRole( 'group', { name: 'How posts appear' } )
+			.getByRole( 'radio' )
+	).toHaveCount( 3 );
 } );
 
 test( 'Appearance step swaps the visible address preview when the actor mode changes', async ( {
@@ -271,83 +292,38 @@ test( 'Appearance step swaps the visible address preview when the actor mode cha
 } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=appearance' );
 
-	// Three preview containers render server-side, one per mode. JS toggles
-	// `is-hidden` on radio change; only the matching container should be
-	// visible at any given time.
 	await expect(
-		page.locator( '.fosse-address-preview[data-fosse-mode]' )
-	).toHaveCount( 3 );
-	await expect(
-		page.locator( '.fosse-address-preview[data-fosse-mode="actor"]' )
-	).toContainText( 'Your fediverse address:' );
+		page.getByText( 'Your fediverse address:', { exact: true } )
+	).toBeVisible();
 
 	// Selecting "As your site" exposes the blog preview and the inline
 	// Site Handle row, and hides the personal address preview.
-	await page
-		.locator( '.fosse-mode-card', {
-			has: page.locator( '.fosse-mode-card__title', {
-				hasText: /^As your site$/,
-			} ),
-		} )
-		.click();
+	await page.getByText( 'As your site', { exact: true } ).click();
 
 	await expect(
-		page.locator( '.fosse-address-preview[data-fosse-mode="blog"]' )
+		page.getByText( 'Site fediverse address:', { exact: true } )
 	).toBeVisible();
 	await expect(
-		page.locator( '.fosse-address-preview[data-fosse-mode="blog"]' )
-	).toContainText( 'Site fediverse address:' );
-	await expect(
-		page.locator( '.fosse-address-preview[data-fosse-mode="actor"]' )
+		page.getByText( 'Your fediverse address:', { exact: true } )
 	).toBeHidden();
-	await expect(
-		page.locator( '.fosse-address-preview[data-fosse-mode="actor_blog"]' )
-	).toBeHidden();
-	await expect(
-		page.locator( '[data-fosse-when="includes-blog"]' )
-	).toBeVisible();
-	await expect(
-		page.locator( '#fosse-wizard-blog-identifier' )
-	).toBeVisible();
+	await expect( page.getByLabel( 'Site handle' ) ).toBeVisible();
 
 	// "Both" reveals the actor_blog container instead.
-	await page
-		.locator( '.fosse-mode-card', {
-			has: page.locator( '.fosse-mode-card__title', {
-				hasText: /^Both$/,
-			} ),
-		} )
-		.click();
+	await page.getByText( 'Both', { exact: true } ).click();
 
+	await expect( page.getByText( 'As you:', { exact: true } ) ).toBeVisible();
 	await expect(
-		page.locator( '.fosse-address-preview[data-fosse-mode="actor_blog"]' )
-	).toBeVisible();
-	await expect(
-		page.locator( '.fosse-address-preview[data-fosse-mode="blog"]' )
-	).toBeHidden();
-	await expect(
-		page.locator( '[data-fosse-when="includes-blog"]' )
+		page.getByText( 'As your site:', { exact: true } )
 	).toBeVisible();
 
 	// Returning to "As you" hides the inline site handle row again — it
 	// only applies when the mode publishes from a blog actor.
-	await page
-		.locator( '.fosse-mode-card', {
-			has: page.locator( '.fosse-mode-card__title', {
-				hasText: /^As you$/,
-			} ),
-		} )
-		.click();
+	await page.getByText( 'As you', { exact: true } ).click();
 
 	await expect(
-		page.locator( '.fosse-address-preview[data-fosse-mode="actor"]' )
+		page.getByText( 'Your fediverse address:', { exact: true } )
 	).toBeVisible();
-	await expect(
-		page.locator( '.fosse-address-preview[data-fosse-mode="blog"]' )
-	).toBeHidden();
-	await expect(
-		page.locator( '[data-fosse-when="includes-blog"]' )
-	).toBeHidden();
+	await expect( page.getByLabel( 'Site handle' ) ).toBeHidden();
 } );
 
 test( 'Selecting a mode and continuing saves the option', async ( {
@@ -357,14 +333,8 @@ test( 'Selecting a mode and continuing saves the option', async ( {
 
 	// Select "As you" (actor mode). Use exact title match to avoid
 	// substring collision with "As your site".
-	await page
-		.locator( '.fosse-mode-card', {
-			has: page.locator( '.fosse-mode-card__title', {
-				hasText: /^As you$/,
-			} ),
-		} )
-		.click();
-	await page.click( 'input[type="submit"]' );
+	await page.getByText( 'As you', { exact: true } ).click();
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
 
 	await expect( page ).toHaveURL( /step=content/ );
 
@@ -372,7 +342,7 @@ test( 'Selecting a mode and continuing saves the option', async ( {
 	// and checking the radio is still selected.
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=appearance' );
 	await expect(
-		page.locator( '.fosse-mode-card__input[value="actor"]' )
+		page.getByRole( 'radio', { name: /^As you\b/ } )
 	).toBeChecked();
 } );
 
@@ -386,8 +356,8 @@ test( 'Content step saves post types and advances to Bluesky', async ( {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=content' );
 
 	// Posts should be checked by default; check Pages too.
-	await page.locator( '.fosse-post-type-item', { hasText: 'Pages' } ).click();
-	await page.click( 'input[type="submit"]' );
+	await page.getByRole( 'checkbox', { name: 'Pages' } ).check();
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
 
 	await expect( page ).toHaveURL( /step=bluesky/ );
 } );
@@ -396,14 +366,12 @@ test( 'Bluesky step shows connect form', async ( { page } ) => {
 	await openBlueskyStep( page );
 
 	await expect(
-		page.locator( '.fosse-wizard__title', {
-			hasText: 'Connect to Bluesky',
-		} )
+		page.getByRole( 'heading', { name: 'Connect to Bluesky' } )
 	).toBeVisible();
-	await expect( page.locator( '#fosse-bsky-handle' ) ).toBeVisible();
+	await expect( page.getByLabel( 'Bluesky handle' ) ).toBeVisible();
 	await expect(
 		page.getByRole( 'button', { name: 'Connect Bluesky' } )
-	).toHaveClass( /button-primary/ );
+	).toBeVisible();
 	await expect(
 		page.getByRole( 'link', { name: 'Skip Bluesky for now' } )
 	).toBeVisible();
@@ -415,10 +383,9 @@ test( 'Bluesky step (disconnected) shows sign-up help linking to bsky.app', asyn
 } ) => {
 	await openBlueskyStep( page );
 
-	const signupLink = page.locator(
-		'.fosse-bluesky-signup a[href="https://bsky.app/"]'
-	);
+	const signupLink = page.getByRole( 'link', { name: 'Create one' } );
 	await expect( signupLink ).toBeVisible();
+	await expect( signupLink ).toHaveAttribute( 'href', 'https://bsky.app/' );
 	await expect( signupLink ).toHaveAttribute( 'target', '_blank' );
 	await expect( signupLink ).toHaveAttribute( 'rel', /noopener/ );
 } );
@@ -456,22 +423,20 @@ test.describe( 'Bluesky step — connected (post-OAuth completion)', () => {
 		await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
 
 		await expect(
-			page.locator( '.fosse-wizard__title', {
-				hasText: 'Review Bluesky connection',
+			page.getByRole( 'heading', {
+				name: 'Review Bluesky connection',
 			} )
 		).toBeVisible();
 		await expect(
-			page.locator( '.fosse-wizard__description' )
-		).not.toContainText( 'connect later' );
+			page.getByText( /You can connect Bluesky later/ )
+		).toHaveCount( 0 );
 		await expect(
 			page.locator( 'text=/Bluesky is connected/i' )
 		).toHaveCount( 1 );
-		await expect( page.locator( '.fosse-detail-list' ) ).toContainText(
-			'alice.bsky.social'
-		);
-		await expect( page.locator( '.fosse-bluesky-signup' ) ).toHaveCount(
-			0
-		);
+		await expect( page.getByText( 'alice.bsky.social' ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'link', { name: 'Create one' } )
+		).toHaveCount( 0 );
 		await expect(
 			page.getByRole( 'link', { name: 'Finish setup' } )
 		).toBeVisible();
@@ -483,34 +448,22 @@ test( 'Fediverse-only path skips the Bluesky connect step', async ( {
 } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 
-	await page
-		.locator( '.fosse-destination-card', { hasText: 'Fediverse only' } )
-		.click();
+	await page.getByText( 'Fediverse only', { exact: true } ).click();
 	await page.getByRole( 'button', { name: 'Continue' } ).click();
 
 	await expect( page ).toHaveURL( /step=appearance/ );
-	await page
-		.locator( '.fosse-mode-card', {
-			has: page.locator( '.fosse-mode-card__title', {
-				hasText: /^As you$/,
-			} ),
-		} )
-		.click();
-	await page.click( 'input[type="submit"]' );
+	await page.getByText( 'As you', { exact: true } ).click();
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
 
 	await expect( page ).toHaveURL( /step=content/ );
-	await page.click( 'input[type="submit"]' );
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
 
 	await expect( page ).toHaveURL( /step=complete/ );
 	await expect(
-		page.locator( '.fosse-detail-list__term', { hasText: 'Destinations' } )
+		page.locator( 'dt' ).filter( { hasText: /^Destinations$/ } )
 	).toBeVisible();
-	await expect( page.locator( '.fosse-detail-list' ) ).toContainText(
-		'Fediverse only'
-	);
-	await expect( page.locator( '.fosse-detail-list' ) ).toContainText(
-		'Skipped'
-	);
+	await expect( page.getByText( 'Fediverse only' ) ).toBeVisible();
+	await expect( page.getByText( 'Skipped' ) ).toBeVisible();
 } );
 
 test( 'Skip Bluesky for now goes to completion', async ( { page } ) => {
@@ -519,23 +472,24 @@ test( 'Skip Bluesky for now goes to completion', async ( { page } ) => {
 	await page.getByRole( 'link', { name: 'Skip Bluesky for now' } ).click();
 	await expect( page ).toHaveURL( /step=complete/ );
 	await expect(
-		page.locator( '.fosse-wizard__title', {
-			hasText: "You're all set",
-		} )
+		page.getByRole( 'heading', { name: "You're all set!" } )
 	).toBeVisible();
 } );
 
 test( 'Completion step shows summary', async ( { page } ) => {
 	await completeThroughBlueskySkip( page );
 
-	await expect( page.locator( '.fosse-detail-list' ) ).toBeVisible();
 	await expect(
-		page.locator( '.fosse-detail-list__term', { hasText: 'Destinations' } )
+		page.locator( 'dt' ).filter( { hasText: /^Destinations$/ } )
 	).toBeVisible();
-	await expect( page.locator( 'text=Fediverse identity' ) ).toBeVisible();
-	await expect( page.locator( 'text=Content types' ) ).toBeVisible();
 	await expect(
-		page.locator( '.fosse-detail-list__term', { hasText: 'Bluesky' } )
+		page.locator( 'dt' ).filter( { hasText: /^Fediverse identity$/ } )
+	).toBeVisible();
+	await expect(
+		page.locator( 'dt' ).filter( { hasText: /^Content types$/ } )
+	).toBeVisible();
+	await expect(
+		page.locator( 'dt' ).filter( { hasText: /^Bluesky$/ } )
 	).toBeVisible();
 } );
 
@@ -544,12 +498,13 @@ test( 'Completion step exposes "Publish your first Post" CTA to post-new.php', a
 } ) => {
 	await completeThroughBlueskySkip( page );
 
-	const publishCta = page.locator( '.fosse-wizard__cta-publish' );
+	const publishCta = page.getByRole( 'link', {
+		name: 'Publish your first Post',
+	} );
 	await expect( publishCta ).toBeVisible();
 	// Capitalization mirrors the post type's `singular_name` ("Post") so
 	// the assertion matches the PHP-side behavior — see PHPUnit
 	// `test_render_complete_step_renders_publish_cta`.
-	await expect( publishCta ).toContainText( 'Publish your first Post' );
 	await expect( publishCta ).toHaveAttribute( 'href', /post-new\.php$/ );
 } );
 
@@ -558,9 +513,7 @@ test( 'Completion step keeps success header and actions aligned inside the card'
 } ) => {
 	await completeThroughBlueskySkip( page );
 	await expect(
-		page.locator(
-			'.fosse-wizard__complete-card .fosse-wizard__completion-footer .fosse-wizard__cta-publish'
-		)
+		page.getByRole( 'link', { name: 'Publish your first Post' } )
 	).toBeVisible();
 
 	type CompletionMetrics = {
@@ -579,7 +532,6 @@ test( 'Completion step keeps success header and actions aligned inside the card'
 		iconAboveTitle: boolean;
 		iconCenterDelta: number;
 		messageCenterDelta: number;
-		oldTitleRowRemoved: boolean;
 		iconHeight: number;
 		resetBelowCard: boolean;
 		resetOutsideCard: boolean;
@@ -587,93 +539,104 @@ test( 'Completion step keeps success header and actions aligned inside the card'
 		titleTextAlign: string;
 	} | null;
 
-	const metrics = await page.evaluate( (): CompletionMetrics => {
-		const card = document.querySelector( '.fosse-wizard__complete-card' );
-		const header = card?.querySelector( '.fosse-wizard__complete-header' );
-		const message = card?.querySelector(
-			'.fosse-wizard__complete-message'
-		);
-		const icon = card?.querySelector( '.fosse-complete-icon' );
-		const title = card?.querySelector( '.fosse-wizard__title' );
-		const description = card?.querySelector(
-			'.fosse-wizard__complete-message .fosse-wizard__description'
-		);
-		const help = card?.querySelector( '.fosse-wizard__cta-help' );
-		const oldTitleRow = card?.querySelector(
-			'.fosse-wizard__complete-title-row'
-		);
-		const footer = card?.querySelector(
-			'.fosse-wizard__completion-footer'
-		);
-		const cta = card?.querySelector( '.fosse-wizard__cta-publish' );
-		const reset = document.querySelector( '.fosse-wizard__reset' );
+	const metrics = await page
+		.getByRole( 'heading', { name: "You're all set!" } )
+		.evaluate( ( title ): CompletionMetrics => {
+			const message = title.parentElement;
+			const header = message?.parentElement;
+			const card = header?.parentElement;
+			const icon = header?.firstElementChild;
+			const description = Array.from(
+				message?.querySelectorAll( 'p' ) ?? []
+			).find(
+				( paragraph ) =>
+					paragraph.textContent?.includes(
+						'Your sharing setup is ready'
+					)
+			);
+			const help = Array.from(
+				description?.querySelectorAll( 'span' ) ?? []
+			).find(
+				( span ) =>
+					span.textContent?.includes(
+						'Connect Bluesky to share there too.'
+					)
+			);
+			const cta = Array.from( card?.querySelectorAll( 'a' ) ?? [] ).find(
+				( link ) =>
+					link.textContent?.trim() === 'Publish your first Post'
+			);
+			const footer = Array.from( card?.children ?? [] ).find( ( child ) =>
+				child.contains( cta ?? null )
+			);
+			const reset = Array.from( document.querySelectorAll( 'a' ) ).find(
+				( link ) => link.textContent?.trim() === 'Run wizard again'
+			)?.parentElement;
 
-		if (
-			! card ||
-			! header ||
-			! message ||
-			! icon ||
-			! title ||
-			! description ||
-			! help ||
-			! footer ||
-			! cta ||
-			! reset
-		) {
-			return null;
-		}
+			if (
+				! card ||
+				! header ||
+				! message ||
+				! icon ||
+				! description ||
+				! help ||
+				! footer ||
+				! cta ||
+				! reset
+			) {
+				return null;
+			}
 
-		const cardRect = card.getBoundingClientRect();
-		const headerRect = header.getBoundingClientRect();
-		const iconRect = icon.getBoundingClientRect();
-		const messageRect = message.getBoundingClientRect();
-		const titleRect = title.getBoundingClientRect();
-		const descriptionRect = description.getBoundingClientRect();
-		const footerRect = footer.getBoundingClientRect();
-		const ctaRect = cta.getBoundingClientRect();
-		const resetRect = reset.getBoundingClientRect();
+			const cardRect = card.getBoundingClientRect();
+			const headerRect = header.getBoundingClientRect();
+			const iconRect = icon.getBoundingClientRect();
+			const messageRect = message.getBoundingClientRect();
+			const titleRect = title.getBoundingClientRect();
+			const descriptionRect = description.getBoundingClientRect();
+			const footerRect = footer.getBoundingClientRect();
+			const ctaRect = cta.getBoundingClientRect();
+			const resetRect = reset.getBoundingClientRect();
 
-		return {
-			cardBottom: cardRect.bottom,
-			ctaBottom: ctaRect.bottom,
-			ctaInsideFooter: footer.contains( cta ),
-			ctaStartsInFooter: ctaRect.top >= footerRect.top,
-			descriptionContainsSetup:
-				description.textContent?.includes(
-					'Your sharing setup is ready'
-				) ?? false,
-			descriptionContainsReach:
-				description.textContent?.includes(
-					'Your post can reach people'
-				) ?? false,
-			descriptionContainsBluesky:
-				description.textContent?.includes(
-					'Connect Bluesky to share there too.'
-				) ?? false,
-			descriptionTopGap: descriptionRect.top - titleRect.bottom,
-			headerHeight: headerRect.height,
-			helpInsideHeader: header.contains( help ),
-			helpInsideDescription: description.contains( help ),
-			helpOutsideFooter: ! footer.contains( help ),
-			iconAboveTitle: iconRect.bottom <= titleRect.top - 8,
-			iconCenterDelta: Math.abs(
-				iconRect.left +
-					iconRect.width / 2 -
-					( headerRect.left + headerRect.width / 2 )
-			),
-			messageCenterDelta: Math.abs(
-				messageRect.left +
-					messageRect.width / 2 -
-					( headerRect.left + headerRect.width / 2 )
-			),
-			oldTitleRowRemoved: ! oldTitleRow,
-			iconHeight: iconRect.height,
-			resetBelowCard: resetRect.top >= cardRect.bottom + 12,
-			resetOutsideCard: ! card.contains( reset ),
-			descriptionTextAlign: getComputedStyle( description ).textAlign,
-			titleTextAlign: getComputedStyle( title ).textAlign,
-		};
-	} );
+			return {
+				cardBottom: cardRect.bottom,
+				ctaBottom: ctaRect.bottom,
+				ctaInsideFooter: footer.contains( cta ),
+				ctaStartsInFooter: ctaRect.top >= footerRect.top,
+				descriptionContainsSetup:
+					description.textContent?.includes(
+						'Your sharing setup is ready'
+					) ?? false,
+				descriptionContainsReach:
+					description.textContent?.includes(
+						'Your post can reach people'
+					) ?? false,
+				descriptionContainsBluesky:
+					description.textContent?.includes(
+						'Connect Bluesky to share there too.'
+					) ?? false,
+				descriptionTopGap: descriptionRect.top - titleRect.bottom,
+				headerHeight: headerRect.height,
+				helpInsideHeader: header.contains( help ),
+				helpInsideDescription: description.contains( help ),
+				helpOutsideFooter: ! footer.contains( help ),
+				iconAboveTitle: iconRect.bottom <= titleRect.top - 8,
+				iconCenterDelta: Math.abs(
+					iconRect.left +
+						iconRect.width / 2 -
+						( headerRect.left + headerRect.width / 2 )
+				),
+				messageCenterDelta: Math.abs(
+					messageRect.left +
+						messageRect.width / 2 -
+						( headerRect.left + headerRect.width / 2 )
+				),
+				iconHeight: iconRect.height,
+				resetBelowCard: resetRect.top >= cardRect.bottom + 12,
+				resetOutsideCard: ! card.contains( reset ),
+				descriptionTextAlign: getComputedStyle( description ).textAlign,
+				titleTextAlign: getComputedStyle( title ).textAlign,
+			};
+		} );
 
 	expect( metrics ).not.toBeNull();
 	expect( metrics!.ctaInsideFooter ).toBe( true );
@@ -691,7 +654,6 @@ test( 'Completion step keeps success header and actions aligned inside the card'
 	expect( metrics!.iconAboveTitle ).toBe( true );
 	expect( metrics!.iconCenterDelta ).toBeLessThanOrEqual( 2 );
 	expect( metrics!.messageCenterDelta ).toBeLessThanOrEqual( 2 );
-	expect( metrics!.oldTitleRowRemoved ).toBe( true );
 	expect( metrics!.iconHeight ).toBeGreaterThanOrEqual( 52 );
 	expect( metrics!.iconHeight ).toBeLessThanOrEqual( 64 );
 	expect( metrics!.descriptionTextAlign ).toBe( 'center' );
@@ -710,7 +672,7 @@ test( 'Skip setup marks wizard complete and goes to Setup page', async ( {
 } ) => {
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
 
-	await page.click( 'text=Skip setup' );
+	await page.getByRole( 'link', { name: 'Skip setup' } ).click();
 	await expect( page ).toHaveURL( /page=fosse(?!-)/ );
 
 	// Wizard notice should not appear since wizard is now complete.
@@ -718,9 +680,11 @@ test( 'Skip setup marks wizard complete and goes to Setup page', async ( {
 		0
 	);
 
-	await expect( page.locator( '.fosse-guided-setup' ) ).toHaveCount( 0 );
 	await expect(
-		page.locator( '.fosse-admin-page__footer-action a' )
+		page.getByRole( 'note' ).filter( { hasText: 'Want a guided setup?' } )
+	).toHaveCount( 0 );
+	await expect(
+		page.getByRole( 'link', { name: 'Run the wizard' } )
 	).toHaveAttribute( 'href', /page=fosse-wizard/ );
 } );
 

--- a/tests/e2e/status-page.spec.ts
+++ b/tests/e2e/status-page.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect, type Page } from '@playwright/test';
 import {
 	expectNoHorizontalOverflow,
-	numericCssValue,
+	getProviderStatusCard,
+	numericCssValueFor,
 	resetBlueskyState,
 	setBlueskyState,
 } from './test-helpers';
@@ -38,14 +39,10 @@ test.describe( 'Status page polish', () => {
 		} );
 
 	const measureCardOverflow = async ( page: Page ) => {
-		const card = page
-			.locator( '.fosse-status-card' )
-			.filter( { hasText: 'Bluesky' } );
+		const card = getProviderStatusCard( page, 'Bluesky' );
 		await expect( card ).toBeVisible();
 		return card.evaluate( ( el ) => {
-			const detailList = el.querySelector(
-				'.fosse-detail-list'
-			) as HTMLElement | null;
+			const detailList = el.querySelector( 'dl' ) as HTMLElement | null;
 			if ( ! detailList || ! ( el instanceof HTMLElement ) ) {
 				return null;
 			}
@@ -64,31 +61,19 @@ test.describe( 'Status page polish', () => {
 		await seedLongValues( page );
 		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
 
-		const blueskyCard = page
-			.locator( '.fosse-status-card' )
-			.filter( { hasText: 'Bluesky' } );
-
-		// The value pairs should carry the shared detail-list classes the
-		// polish CSS targets, and token wrappers should carry token-shape
-		// modifiers so `overflow-wrap: anywhere` is scoped correctly.
-		await expect(
-			blueskyCard.locator( '.fosse-detail-list' )
-		).toBeVisible();
-		await expect(
-			blueskyCard.locator( '.fosse-detail-list__term' )
-		).not.toHaveCount( 0 );
-		await expect(
-			blueskyCard.locator( '.fosse-detail-list__description' )
-		).not.toHaveCount( 0 );
-		await expect(
-			blueskyCard.locator( '.fosse-token--did' )
-		).toBeVisible();
-		await expect(
-			blueskyCard.locator( '.fosse-token--url' )
-		).toBeVisible();
-		await expect(
-			blueskyCard.locator( '.fosse-token--handle' )
-		).toBeVisible();
+		const blueskyCard = getProviderStatusCard( page, 'Bluesky' );
+		await expect( blueskyCard ).toContainText( 'Handle' );
+		await expect( blueskyCard ).toContainText(
+			'someone.with.an.unreasonably.long.handle.example.org'
+		);
+		await expect( blueskyCard ).toContainText( 'DID' );
+		await expect( blueskyCard ).toContainText(
+			'did:plc:abcdefghijklmnopqrstuvwxyz0123456789longidentifier'
+		);
+		await expect( blueskyCard ).toContainText( 'PDS endpoint' );
+		await expect( blueskyCard ).toContainText(
+			'https://very-long-pds-host-name.example.com/some/deep/nested/path'
+		);
 
 		const overflow = await measureCardOverflow( page );
 
@@ -135,12 +120,10 @@ test.describe( 'Status page polish', () => {
 		} );
 		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
 
-		const activityPubCard = page.locator( '.fosse-status-card' ).filter( {
-			has: page.getByRole( 'heading', { name: 'ActivityPub' } ),
-		} );
+		const activityPubCard = getProviderStatusCard( page, 'ActivityPub' );
 		await expect( activityPubCard ).toHaveCount( 1 );
 
-		const rows = activityPubCard.locator( '.fosse-detail-list__term' );
+		const rows = activityPubCard.locator( 'dt' );
 		const rowCount = await rows.count();
 		expect(
 			rowCount,
@@ -151,12 +134,7 @@ test.describe( 'Status page polish', () => {
 			terms.map( ( label ) => {
 				const value = label.nextElementSibling;
 
-				if (
-					! value ||
-					! value.classList.contains(
-						'fosse-detail-list__description'
-					)
-				) {
+				if ( ! value || 'DD' !== value.tagName ) {
 					return null;
 				}
 
@@ -202,54 +180,55 @@ test.describe( 'Status page polish', () => {
 		await expect(
 			page.getByRole( 'link', { name: 'Run the wizard' } )
 		).toHaveAttribute( 'href', /page=fosse-wizard/ );
-		const wizardLinkPlacement = await page.evaluate( () => {
-			const statusCards = document.querySelector( '.fosse-status-cards' );
-			const link = document.querySelector(
-				'.fosse-admin-page__footer-action a'
-			);
-
-			if ( ! statusCards || ! link ) {
-				return null;
-			}
-
-			return {
-				statusCardsBottom: statusCards.getBoundingClientRect().bottom,
-				linkTop: link.getBoundingClientRect().top,
-			};
-		} );
-		expect( wizardLinkPlacement ).not.toBeNull();
-		expect( wizardLinkPlacement!.linkTop ).toBeGreaterThan(
-			wizardLinkPlacement!.statusCardsBottom
+		const statusCards = await Promise.all(
+			[ 'ActivityPub', 'Bluesky' ].map( async ( provider ) => {
+				const box = await getProviderStatusCard(
+					page,
+					provider
+				).boundingBox();
+				expect( box ).not.toBeNull();
+				return box!;
+			} )
+		);
+		const wizardLink = await page
+			.getByRole( 'link', { name: 'Run the wizard' } )
+			.boundingBox();
+		expect( wizardLink ).not.toBeNull();
+		expect( wizardLink!.y ).toBeGreaterThan(
+			Math.max( ...statusCards.map( ( box ) => box.y + box.height ) )
 		);
 
 		expect(
-			await numericCssValue(
-				page,
-				'.fosse-admin-page__title',
+			await numericCssValueFor(
+				page.getByRole( 'heading', { name: 'FOSSE Status' } ),
 				'letter-spacing'
 			)
 		).toBe( 0 );
 		expect(
-			await numericCssValue(
-				page,
-				'.fosse-status-summary__label',
+			await numericCssValueFor(
+				page.getByText( 'Provider status', { exact: true } ),
 				'letter-spacing'
 			)
 		).toBe( 0 );
 		expect(
-			await numericCssValue(
-				page,
-				'.fosse-status-summary',
+			await numericCssValueFor(
+				page
+					.getByText( 'Provider status', { exact: true } )
+					.locator( 'xpath=ancestor::div[2]' ),
 				'border-radius'
 			)
 		).toBeLessThanOrEqual( 8 );
 		expect(
-			await numericCssValue( page, '.fosse-status-card', 'border-radius' )
+			await numericCssValueFor(
+				getProviderStatusCard( page, 'ActivityPub' ),
+				'border-radius'
+			)
 		).toBeLessThanOrEqual( 8 );
-		await expect( page.locator( '.fosse-status-summary' ) ).toHaveCSS(
-			'background-image',
-			'none'
-		);
+		await expect(
+			page
+				.getByText( 'Provider status', { exact: true } )
+				.locator( 'xpath=ancestor::div[2]' )
+		).toHaveCSS( 'background-image', 'none' );
 
 		await page.setViewportSize( { width: 390, height: 720 } );
 		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
@@ -267,8 +246,8 @@ test.describe( 'Status page polish', () => {
 		await page.goto( '/wp-admin/admin.php?page=fosse-status' );
 
 		await expect(
-			page.locator( '.fosse-status-summary__count' )
-		).toContainText( '1 of 2 providers connected' );
+			page.getByText( '1 of 2 providers connected' )
+		).toBeVisible();
 
 		const manageConnections = page.getByRole( 'link', {
 			name: 'Manage connections',
@@ -279,9 +258,7 @@ test.describe( 'Status page polish', () => {
 			/admin\.php\?page=fosse#fosse-connections$/
 		);
 
-		const blueskyCard = page
-			.locator( '.fosse-status-card' )
-			.filter( { hasText: 'Bluesky' } );
+		const blueskyCard = getProviderStatusCard( page, 'Bluesky' );
 		const openBlueskySettings = blueskyCard.getByRole( 'link', {
 			name: 'Open Bluesky settings',
 		} );

--- a/tests/e2e/test-helpers.ts
+++ b/tests/e2e/test-helpers.ts
@@ -1,4 +1,9 @@
-import { type Browser, expect, type Page } from '@playwright/test';
+import {
+	type Browser,
+	expect,
+	type Locator,
+	type Page,
+} from '@playwright/test';
 
 /**
  * Assert the current document is not wider than the viewport.
@@ -18,27 +23,35 @@ export const expectNoHorizontalOverflow = async ( page: Page ) => {
 };
 
 /**
- * Read a numeric CSS value from the first matching element.
+ * Read a numeric CSS value from a semantic locator.
  *
- * @param {Page}   page     Playwright page.
- * @param {string} selector CSS selector.
- * @param {string} prop     CSS property name.
+ * @param {Locator} locator Playwright locator.
+ * @param {string}  prop    CSS property name.
  * @return {Promise<number>} Parsed CSS value, with `normal` treated as 0.
  */
-export const numericCssValue = async (
-	page: Page,
-	selector: string,
-	prop: string
-) =>
+export const numericCssValueFor = async ( locator: Locator, prop: string ) =>
+	locator.evaluate( readNumericCssValue, prop );
+
+const readNumericCssValue = ( el: Element, property: string ) => {
+	const value = window.getComputedStyle( el ).getPropertyValue( property );
+	return 'normal' === value ? 0 : Number.parseFloat( value );
+};
+
+/**
+ * Return a provider status card by anchoring on the visible provider heading.
+ *
+ * The status-card containers do not have their own accessible names, so this
+ * helper starts from the semantic heading and walks to the card wrapper without
+ * binding the tests to presentation-layer class names.
+ *
+ * @param {Page}   page    Playwright page.
+ * @param {string} heading Visible provider heading text.
+ * @return {Locator} Provider card locator.
+ */
+export const getProviderStatusCard = ( page: Page, heading: string ): Locator =>
 	page
-		.locator( selector )
-		.first()
-		.evaluate( ( el, property ) => {
-			const value = window
-				.getComputedStyle( el )
-				.getPropertyValue( property );
-			return 'normal' === value ? 0 : Number.parseFloat( value );
-		}, prop );
+		.getByRole( 'heading', { name: heading, exact: true } )
+		.locator( 'xpath=ancestor::div[2]' );
 
 /**
  * Seed the Atmosphere connection state via the e2e REST helper.

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -180,7 +180,6 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'ActivityPub', $output );
 		$this->assertStringContainsString( 'Connected automatically', $output );
 		$this->assertStringNotContainsString( '<form', $output );
-		$this->assertStringContainsString( 'fosse-status-badge is-connected', $output );
 	}
 
 	/**
@@ -197,17 +196,16 @@ class AP_ProviderTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
 		$this->assertStringContainsString( 'value="my-site"', $output );
-		$this->assertStringContainsString( 'fosse-field-stack', $output );
-		$this->assertStringContainsString( 'fosse-field', $output );
-		$this->assertStringContainsString( 'fosse-detail-list', $output );
+		$this->assertStringContainsString( 'Site handle', $output );
+		$this->assertStringContainsString( 'Site fediverse address', $output );
 		$this->assertStringContainsString( 'Advanced ActivityPub settings', $output );
-		$this->assertStringContainsString( 'fosse-admin-page__secondary-link', $output );
+		$this->assertStringContainsString( 'options-general.php?page=activitypub', $output );
 		$this->assertStringNotContainsString( 'class="form-table"', $output );
 	}
 
 	/**
-	 * Status card exposes the shared detail-list classes and no longer renders a
-	 * "Manage ActivityPub settings" deep link (issue #74) — the sidebar
+	 * Status card exposes ActivityPub connection details and no longer renders
+	 * a "Manage ActivityPub settings" deep link (issue #74) — the sidebar
 	 * Settings menu entry replaces those per-card links.
 	 */
 	public function test_render_status_card_omits_manage_settings_link() {
@@ -215,16 +213,11 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'fosse-admin-card', $output );
-		$this->assertStringContainsString( 'fosse-card-header', $output );
-		$this->assertStringContainsString( 'fosse-card-body', $output );
-		$this->assertStringContainsString( 'fosse-detail-list', $output );
-		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
-		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
+		$this->assertStringContainsString( '<h2', $output );
+		$this->assertStringContainsString( 'ActivityPub', $output );
 		$this->assertStringContainsString( 'Content types', $output );
 		$this->assertStringNotContainsString( '<table', $output );
 		$this->assertStringNotContainsString( 'Manage ActivityPub settings', $output );
-		$this->assertStringNotContainsString( 'fosse-status-card__manage', $output );
 	}
 
 	// --- save_settings tests ---------------------------------------------------
@@ -884,18 +877,18 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Status card label/value pairs carry the shared detail-list classes the
-	 * polish CSS targets. A renamed class would silently break the column-width
-	 * and wrap rules without surfacing a test failure otherwise.
+	 * Status card renders label/value pairs as a semantic definition list
+	 * rather than the legacy table layout.
 	 */
-	public function test_render_status_card_uses_detail_list_label_value_classes() {
+	public function test_render_status_card_uses_definition_list_label_value_pairs() {
 		ob_start();
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'fosse-detail-list', $output );
-		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
-		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
+		$this->assertStringContainsString( '<dl', $output );
+		$this->assertStringContainsString( '<dt', $output );
+		$this->assertStringContainsString( '<dd', $output );
+		$this->assertStringContainsString( 'ActivityPub profile', $output );
 		$this->assertStringNotContainsString( 'widefat striped', $output );
 	}
 }

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -2687,7 +2687,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'alice.bsky.social', $output );
 		$this->assertIsInt( $note_position );
 		$this->assertIsInt( $button_position );
-		$this->assertLessThan( $button_position, $note_position );
+		$this->assertGreaterThan( $note_position, $button_position );
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -313,10 +313,6 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'id="fosse-provider-bluesky"', $output );
-		$this->assertStringContainsString( 'fosse-connection-section', $output );
-		$this->assertStringContainsString( 'fosse-admin-card', $output );
-		$this->assertStringContainsString( 'fosse-card-header', $output );
-		$this->assertStringContainsString( 'fosse-card-body', $output );
 		$this->assertStringContainsString( '<h3>Bluesky</h3>', $output );
 	}
 
@@ -330,11 +326,10 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'fosse_connect_bluesky', $output );
 		$this->assertStringContainsString( 'bluesky_handle', $output );
-		$this->assertStringContainsString( 'fosse-field', $output );
-		$this->assertStringContainsString( 'fosse-card-footer', $output );
-		$this->assertStringContainsString( 'fosse-action-bar', $output );
+		$this->assertStringContainsString( 'Bluesky handle', $output );
+		$this->assertStringContainsString( 'Connect Bluesky', $output );
+		$this->assertStringContainsString( 'Disconnected', $output );
 		$this->assertStringNotContainsString( 'class="form-table"', $output );
-		$this->assertStringContainsString( 'fosse-status-badge is-disconnected', $output );
 	}
 
 	/**
@@ -357,12 +352,14 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'fosse_disconnect_bluesky', $output );
+		$this->assertStringContainsString( 'Disconnect Bluesky', $output );
+		$this->assertStringContainsString( 'Connected account', $output );
+		$this->assertStringContainsString( 'Bluesky handle', $output );
 		$this->assertStringContainsString( 'alice.bsky.social', $output );
-		$this->assertStringContainsString( 'fosse-detail-list', $output );
-		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
-		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
+		$this->assertStringContainsString( 'Account ID', $output );
+		$this->assertStringContainsString( 'PDS endpoint', $output );
+		$this->assertStringContainsString( 'Token health', $output );
 		$this->assertStringNotContainsString( 'class="form-table"', $output );
-		$this->assertStringContainsString( 'fosse-status-badge is-connected', $output );
 	}
 
 	/**
@@ -411,9 +408,9 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_connection_actions();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'fosse-bluesky-signup', $output );
 		$this->assertStringContainsString( 'https://bsky.app/', $output );
 		$this->assertStringContainsString( 'Need a Bluesky account', $output );
+		$this->assertStringContainsString( 'Create one', $output );
 	}
 
 	/**
@@ -435,8 +432,8 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_connection_actions();
 		$output = ob_get_clean();
 
-		$this->assertStringNotContainsString( 'fosse-bluesky-signup', $output );
 		$this->assertStringNotContainsString( 'https://bsky.app/', $output );
+		$this->assertStringNotContainsString( 'Need a Bluesky account', $output );
 	}
 
 	/**
@@ -535,7 +532,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Reconnect required', $output );
 		$this->assertStringContainsString( '#fosse-provider-bluesky', $output );
 		$this->assertStringContainsString( '<details', $output );
-		$this->assertStringNotContainsString( 'fosse-action-bar', $output );
+		$this->assertSame( 1, substr_count( $output, 'Open Bluesky settings' ) );
 	}
 
 	/**
@@ -557,7 +554,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertMatchesRegularExpression( '/<dd[^>]*class="[^"]*fosse-detail-list__description[^"]*"[^>]*>\s*OK\s*<\/dd>/', $output );
+		$this->assertMatchesRegularExpression( '/<dt[^>]*>\s*Token Health\s*<\/dt>\s*<dd[^>]*>\s*OK\s*<\/dd>/', $output );
 		$this->assertStringNotContainsString( 'Reconnect required', $output );
 		$this->assertStringNotContainsString( '<details', $output );
 	}
@@ -570,8 +567,6 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'fosse-card-footer', $output );
-		$this->assertStringContainsString( 'fosse-action-bar', $output );
 		$this->assertStringContainsString( 'Open Bluesky settings', $output );
 		$this->assertStringContainsString( 'admin.php?page=fosse#fosse-provider-bluesky', $output );
 	}
@@ -595,7 +590,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
 
-		$this->assertStringNotContainsString( 'fosse-action-bar', $output );
+		$this->assertStringNotContainsString( 'Open Bluesky settings', $output );
 	}
 
 	/**
@@ -618,10 +613,6 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		ob_start();
 		$this->provider->render_status_card();
 		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'fosse-detail-list', $output );
-		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
-		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
 
 		$this->assertStringContainsString( 'fosse-token--did', $output );
 		$this->assertStringContainsString( 'fosse-token--handle', $output );
@@ -2212,7 +2203,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'fosse_set_bluesky_domain_handle', $output );
 		$this->assertStringContainsString( 'Use example.com as my Bluesky handle', $output );
 		$this->assertStringContainsString( 'Heads up: replacing your handle is destructive', $output );
-		$this->assertStringContainsString( 'fosse-domain-handle-panel fosse-callout', $output );
+		$this->assertStringContainsString( 'Use your domain as your Bluesky handle', $output );
 	}
 
 	/**
@@ -2688,14 +2679,15 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_connection_actions();
 		$output = ob_get_clean();
 
-		$note_position   = strpos( $output, 'fosse-domain-handle-revert-note' );
-		$footer_position = strpos( $output, 'fosse-card-footer fosse-action-bar' );
+		$decoded         = html_entity_decode( $output, ENT_QUOTES, 'UTF-8' );
+		$note_position   = strpos( $decoded, 'Disconnecting will also restore alice.bsky.social as this account\'s Bluesky handle' );
+		$button_position = strpos( $decoded, 'Disconnect Bluesky' );
 
-		$this->assertStringContainsString( 'Disconnecting will also restore alice.bsky.social as this account\'s Bluesky handle', html_entity_decode( $output, ENT_QUOTES, 'UTF-8' ) );
+		$this->assertStringContainsString( 'Disconnecting will also restore alice.bsky.social as this account\'s Bluesky handle', $decoded );
 		$this->assertStringContainsString( 'alice.bsky.social', $output );
 		$this->assertIsInt( $note_position );
-		$this->assertIsInt( $footer_position );
-		$this->assertLessThan( $footer_position, $note_position );
+		$this->assertIsInt( $button_position );
+		$this->assertLessThan( $button_position, $note_position );
 	}
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -246,8 +246,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 			$output,
 			'Wizard content step should not render a Media (attachment) checkbox.'
 		);
-		$this->assertStringContainsString( 'fosse-choice-card', $output );
-		$this->assertStringContainsString( 'fosse-post-type-item', $output );
+		$this->assertStringContainsString( 'Posts', $output );
+		$this->assertStringContainsString( 'Pages', $output );
 		$this->assertStringNotContainsString( 'form-table', $output );
 	}
 
@@ -668,11 +668,10 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Where should your WordPress posts appear?', $output );
 		$this->assertStringContainsString( 'Fediverse + Bluesky', $output );
-		$this->assertStringContainsString( 'fosse-choice-card', $output );
-		$this->assertStringContainsString( 'fosse-wizard__card fosse-admin-card', $output );
-		$this->assertStringContainsString( 'fosse-card-header', $output );
-		$this->assertStringContainsString( 'fosse-card-body', $output );
-		$this->assertStringContainsString( 'fosse-card-footer', $output );
+		$this->assertStringContainsString( 'Fediverse only', $output );
+		$this->assertStringContainsString( 'name="fosse_onboarding_destination"', $output );
+		$this->assertStringContainsString( 'Skip setup', $output );
+		$this->assertStringContainsString( 'Continue', $output );
 	}
 
 	/**
@@ -697,9 +696,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Who should people follow?', $output );
 		$this->assertStringContainsString( 'Choose the fediverse identity people can follow when FOSSE shares your selected content types.', $output );
-		$this->assertStringContainsString( 'fosse-choice-card', $output );
 		$this->assertMatchesRegularExpression(
-			'/fosse-mode-card__title">As you<.*fosse-mode-card__title">As your site</s',
+			'/As you[\s\S]+As your site/',
 			$output,
 			'The default author-profile option should render before the site-profile option.'
 		);
@@ -1042,10 +1040,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 			'<input type="hidden" name="activitypub_actor_mode" value="' . Actor_Mode_Lock::MODE_BLOG . '"',
 			$output
 		);
-		$this->assertStringNotContainsString( 'class="fosse-mode-cards"', $output );
-		$this->assertStringNotContainsString( 'class="fosse-mode-card__input"', $output );
+		$this->assertStringNotContainsString( 'type="radio"', $output );
 		$this->assertStringContainsString( 'defined through server configuration', $output );
-		$this->assertStringContainsString( 'fosse-wizard__locked-mode', $output );
 	}
 
 	// --- Bluesky step render ---
@@ -1062,10 +1058,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'value="wizard"', $output );
 		$this->assertStringContainsString( 'Connect Bluesky', $output );
 		$this->assertStringContainsString( 'Skip Bluesky for now', $output );
-		$this->assertStringContainsString( 'fosse-bluesky-form', $output );
 		$this->assertStringContainsString( 'Bluesky handle', $output );
 		$this->assertStringContainsString( 'Enter your Bluesky handle, such as yourname.bsky.social. If you use your own domain as your handle, enter that.', $output );
-		$this->assertStringNotContainsString( 'fosse-bluesky-placeholder', $output );
 		$this->assertStringNotContainsString( 'Coming Soon', $output );
 		$this->assertStringNotContainsString( 'Bluesky Handle', $output );
 		$this->assertMatchesRegularExpression( '/<input\b(?=[^>]*\bid="fosse-bsky-handle")(?=[^>]*\bname="bluesky_handle")[^>]*>/i', $output );
@@ -1073,17 +1067,18 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
-	 * The disconnected Bluesky step makes Connect the primary footer action.
+	 * The disconnected Bluesky step points the Connect button at the connect
+	 * form rendered inside the step.
 	 */
-	public function test_render_bluesky_step_disconnected_connect_is_primary_footer_action(): void {
+	public function test_render_bluesky_step_disconnected_connect_targets_connect_form(): void {
 		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_bluesky' );
 
 		$output = $this->render_wizard_step( 'bluesky' );
 
 		$this->assertMatchesRegularExpression(
-			'/<button[^>]*form="fosse-wizard-bluesky-connect-form"[^>]*class="[^"]*button-primary[^"]*"[^>]*>\s*Connect Bluesky\s*<\/button>/i',
+			'/<button[^>]*form="fosse-wizard-bluesky-connect-form"[^>]*>\s*Connect Bluesky\s*<\/button>/i',
 			$output,
-			'Connect Bluesky should be the primary footer action.'
+			'Connect Bluesky should submit the in-step connect form.'
 		);
 		$this->assertStringContainsString( 'Skip Bluesky for now', $output );
 	}
@@ -1398,12 +1393,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertStringContainsString( 'Bluesky', $output );
-		$this->assertStringContainsString( 'fosse-detail-list', $output );
-		$this->assertStringContainsString( 'fosse-detail-list__term', $output );
-		$this->assertStringContainsString( 'fosse-detail-list__description', $output );
+		$this->assertStringContainsString( '<dl', $output );
+		$this->assertStringContainsString( '<dt', $output );
+		$this->assertStringContainsString( '<dd', $output );
 		$this->assertStringContainsString( 'Connected as alice.bsky.social', $output );
 		$this->assertStringNotContainsString( 'Not connected', $output );
-		$this->assertStringNotContainsString( 'class="fosse-summary"', $output );
 	}
 
 	/**
@@ -1435,9 +1429,9 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Fediverse only', $output );
 		$this->assertMatchesRegularExpression(
-			'~<dt class="fosse-detail-list__term">Bluesky</dt>\s*<dd class="fosse-detail-list__description">Connected as alice\.bsky\.social</dd>~',
+			'~<dt[^>]*>Bluesky</dt>\s*<dd[^>]*>Connected as alice\.bsky\.social</dd>~',
 			$output,
-			'Connected Bluesky accounts must not be visually muted even when the saved destination is Fediverse-only.'
+			'Connected Bluesky accounts must be reported even when the saved destination is Fediverse-only.'
 		);
 		$this->assertStringNotContainsString( 'Skipped', $output );
 	}
@@ -1518,8 +1512,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 	public function test_render_bluesky_step_disconnected_shows_signup_link(): void {
 		$output = $this->render_wizard_step( 'bluesky' );
 
-		$this->assertStringContainsString( 'fosse-bluesky-signup', $output );
-		$this->assertSame( 1, substr_count( $output, 'fosse-wizard__hint fosse-bluesky-signup' ) );
+		$this->assertSame( 1, substr_count( $output, 'Need a Bluesky account?' ) );
 		$this->assertStringContainsString( 'https://bsky.app/', $output );
 		$this->assertStringContainsString( 'https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial', $output );
 		$this->assertStringContainsString( 'Need a Bluesky account?', $output );
@@ -1537,7 +1530,6 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$output = $this->render_wizard_step( 'bluesky' );
 
-		$this->assertStringNotContainsString( 'fosse-bluesky-signup', $output );
 		$this->assertStringNotContainsString( 'https://bsky.app/', $output );
 		$this->assertStringNotContainsString( 'Need a Bluesky account', $output );
 	}
@@ -1702,11 +1694,10 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertStringContainsString( 'Publish your first Post', $output );
-		$this->assertStringContainsString( 'fosse-wizard__cta-publish', $output );
 		$this->assertMatchesRegularExpression(
-			'/<a[^>]*href="[^"]*post-new\.php[^"]*"[^>]*class="[^"]*button-primary[^"]*"[^>]*>\s*Publish your first Post/i',
+			'/<a[^>]*href="[^"]*post-new\.php[^"]*"[^>]*>\s*Publish your first Post/i',
 			$output,
-			'The publish CTA must be a button-primary link to post-new.php.'
+			'The publish CTA must link to post-new.php.'
 		);
 	}
 
@@ -1719,13 +1710,8 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$output = $this->render_wizard_step( 'complete' );
 
-		$this->assertStringContainsString( 'fosse-wizard__complete-message', $output );
 		$this->assertStringContainsString( 'Your sharing setup is ready.', $output );
-		$this->assertMatchesRegularExpression(
-			'~<span[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Connect Bluesky to share there too\\.~i',
-			$output,
-			'The completion success copy must describe the selected destinations.'
-		);
+		$this->assertStringContainsString( 'Connect Bluesky to share there too.', $output );
 		$this->assertStringNotContainsString( 'Your post can reach people on Fediverse apps like Mastodon.', $output );
 	}
 
@@ -1740,11 +1726,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$output = $this->render_wizard_step( 'complete' );
 
-		$this->assertMatchesRegularExpression(
-			'~<span[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*Bluesky sharing is ready too\\.~i',
-			$output,
-			'The completion success copy must mention Bluesky when existing settings will publish there.'
-		);
+		$this->assertStringContainsString( 'Bluesky sharing is ready too.', $output );
 		$this->assertStringNotContainsString( 'Your post can reach people on Fediverse apps like Mastodon', $output );
 	}
 
@@ -1760,11 +1742,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$output = $this->render_wizard_step( 'complete' );
 
-		$this->assertMatchesRegularExpression(
-			'~<span[^>]*class="[^"]*fosse-wizard__cta-help[^"]*"[^>]*>[^<]*automatic sharing is off\\.~i',
-			$output,
-			'The completion success copy must explain why a connected account will not receive the next post.'
-		);
+		$this->assertStringContainsString( 'automatic sharing is off.', $output );
 		$this->assertStringNotContainsString( 'Your post can reach people on Fediverse apps like Mastodon', $output );
 	}
 
@@ -1781,7 +1759,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertMatchesRegularExpression(
-			'/<a[^>]*href="[^"]*post-new\.php\?[^"]*post_type=page[^"]*"[^>]*class="[^"]*fosse-wizard__cta-publish[^"]*"/i',
+			'/<a[^>]*href="[^"]*post-new\.php\?[^"]*post_type=page[^"]*"/i',
 			$output,
 			'Publish CTA must deep-link to post-new.php?post_type=page when only page is federated.'
 		);
@@ -1801,7 +1779,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertMatchesRegularExpression(
-			'/<a[^>]*href="[^"]*post-new\.php"[^>]*class="[^"]*fosse-wizard__cta-publish[^"]*"/i',
+			'/<a[^>]*href="[^"]*post-new\.php"[^>]*>/i',
 			$output,
 			'Publish CTA URL must not include post_type=post when post is among the selected types.'
 		);
@@ -1823,7 +1801,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Set up sharing', $output );
 		$this->assertStringNotContainsString( 'Publish your first', $output );
 		$this->assertMatchesRegularExpression(
-			'/<a[^>]*href="[^"]*page=fosse[^"]*"[^>]*class="[^"]*fosse-wizard__cta-publish[^"]*"/i',
+			'/<a[^>]*href="[^"]*page=fosse[^"]*"/i',
 			$output,
 			'Empty post-type list must route the CTA to the FOSSE Setup page.'
 		);

--- a/tests/php/Admin/Setup_PageTest.php
+++ b/tests/php/Admin/Setup_PageTest.php
@@ -493,15 +493,15 @@ class Setup_PageTest extends BaseTestCase {
 	}
 
 	/**
-	 * The first-run wizard prompt should use the FOSSE card/callout visual
-	 * language instead of a generic WordPress info notice.
+	 * The first-run wizard prompt should render as a guided setup note instead
+	 * of a generic WordPress info notice.
 	 */
-	public function test_render_guided_setup_prompt_uses_fosse_callout(): void {
+	public function test_render_guided_setup_prompt_uses_accessible_note(): void {
 		$this->become_admin();
 
 		$output = $this->capture_render();
 
-		$this->assertStringContainsString( 'fosse-guided-setup', $output );
+		$this->assertStringContainsString( 'role="note"', $output );
 		$this->assertStringContainsString( 'Want a guided setup?', $output );
 		$this->assertStringContainsString( 'Run the setup wizard', $output );
 		$this->assertStringNotContainsString( 'Need a guided setup?', $output );
@@ -523,15 +523,13 @@ class Setup_PageTest extends BaseTestCase {
 		$output = $this->capture_render();
 
 		$connections_position = strpos( $output, 'id="fosse-connections"' );
-		$link_position        = strpos( $output, 'fosse-admin-page__footer-action' );
+		$link_position        = strpos( $output, 'Run the wizard' );
 
 		$this->assertIsInt( $connections_position );
 		$this->assertIsInt( $link_position );
 		$this->assertGreaterThan( $connections_position, $link_position );
-		$this->assertStringContainsString( 'fosse-admin-page__footer-action', $output );
-		$this->assertStringContainsString( 'fosse-admin-page__secondary-link', $output );
 		$this->assertStringContainsString( 'Run the wizard', $output );
-		$this->assertStringNotContainsString( 'fosse-guided-setup', $output );
+		$this->assertStringNotContainsString( 'Want a guided setup?', $output );
 		$this->assertStringNotContainsString( 'Run the setup wizard', $output );
 		$this->assertMatchesRegularExpression(
 			'/<a[^>]*href="[^"]*page=fosse-wizard[^"]*"[^>]*>\\s*Run the wizard\\s*<\\/a>/',
@@ -566,11 +564,9 @@ class Setup_PageTest extends BaseTestCase {
 		$this->assertStringContainsString( 'id="fosse-federation-settings"', $output );
 		$this->assertStringContainsString( 'id="fosse-settings-actions"', $output );
 		$this->assertStringContainsString( 'id="fosse-connections"', $output );
-		$this->assertStringContainsString( 'fosse-admin-card', $output );
-		$this->assertStringContainsString( 'fosse-card-header', $output );
-		$this->assertStringContainsString( 'fosse-card-body', $output );
-		$this->assertStringContainsString( 'fosse-card-footer', $output );
-		$this->assertStringContainsString( 'fosse-action-bar', $output );
+		$this->assertStringContainsString( 'Publishing settings', $output );
+		$this->assertStringContainsString( 'Save settings', $output );
+		$this->assertStringContainsString( 'Connections', $output );
 		$this->assertStringContainsString( 'id="fosse-provider-activitypub-connection"', $output );
 
 		$form_position        = strpos( $output, 'id="fosse-settings"' );
@@ -598,9 +594,9 @@ class Setup_PageTest extends BaseTestCase {
 		$output = $this->capture_render();
 
 		$this->assertStringContainsString( 'id="fosse-section-general"', $output );
-		$this->assertStringContainsString( 'fosse-field-stack', $output );
-		$this->assertStringContainsString( 'fosse-field', $output );
-		$this->assertStringContainsString( 'fosse-checkbox-grid', $output );
+		$this->assertStringContainsString( 'Content types', $output );
+		$this->assertStringContainsString( 'Posts', $output );
+		$this->assertStringContainsString( 'ActivityPub profile', $output );
 		$this->assertStringContainsString( 'name="activitypub_support_post_types[]"', $output );
 		$this->assertStringContainsString( 'name="activitypub_actor_mode"', $output );
 		$this->assertStringNotContainsString( 'class="form-table"', $output );
@@ -635,11 +631,11 @@ class Setup_PageTest extends BaseTestCase {
 		$output = $this->capture_render();
 
 		$this->assertStringNotContainsString( 'is-selected', $output );
-		$this->assertStringContainsString( 'fosse-choice-card', $output );
-		$this->assertStringContainsString( 'class="fosse-choice-card__input"', $output );
-		$this->assertStringContainsString( 'class="fosse-choice-card__body"', $output );
+		$this->assertStringContainsString( 'Author profiles', $output );
+		$this->assertStringContainsString( 'Blog profile', $output );
+		$this->assertStringContainsString( 'Both author and blog profiles', $output );
 		$this->assertMatchesRegularExpression(
-			'/id="fosse-activitypub-actor-mode-actor"[\s\S]+?class="fosse-choice-card__body"/',
+			'/<input\b(?=[^>]*\bid="fosse-activitypub-actor-mode-actor")(?=[^>]*\bname="activitypub_actor_mode")(?=[^>]*\bvalue="actor")[^>]*>/',
 			$output
 		);
 	}


### PR DESCRIPTION
## Summary
- Replace admin e2e CSS-class locators with role, label, text, heading, and semantic DOM anchors.
- Add e2e helpers for semantic computed-style checks and provider status cards.
- Update related PHP render assertions to verify behavior, copy, links, forms, and semantic structure instead of presentation classes.

Fixes #151

## Testing
- pnpm run format:check
- pnpm run lint
- composer run-script lint-php
- composer run-script test-php -- --filter 'AP_ProviderTest|Bluesky_ProviderTest|Onboarding_WizardTest|Setup_PageTest'
- pnpm exec playwright test tests/e2e/onboarding-wizard.spec.ts tests/e2e/bluesky-provider.spec.ts tests/e2e/status-page.spec.ts
- git diff --check