### PR TITLE
Photo-post detection + ActivityPub federation shape

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
+		"ext-dom": "*",
 		"automattic/jetpack-autoloader": "*"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "99cdf0493a0b85a1291846afe792affa",
+    "content-hash": "c6cf8acc77b532d5997411fe9f3a64e8",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -2153,7 +2153,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2"
+        "php": ">=8.2",
+        "ext-dom": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/fosse.php
+++ b/fosse.php
@@ -190,6 +190,28 @@ add_action(
 );
 
 /*
+ * Photo-post detection + AP federation-shape projector.
+ *
+ * Detects when a WP post is shaped like a photo post (post format
+ * `image`/`gallery`, or block content that boils down to "image
+ * block + optional caption paragraph," or a featured image with
+ * minimal body) and forces the outbound ActivityPub envelope into
+ * the shape Pixelfed and other IG-style photo clients render
+ * natively — `type: Note` with caption-only content and dimensionally
+ * complete image attachments. See `DOTCOM-17143`. Same registration
+ * posture as the bridges above.
+ */
+add_action(
+	'init',
+	static function () {
+		if ( ! class_exists( \Automattic\Fosse\Photo_Post::class ) ) {
+			return;
+		}
+		\Automattic\Fosse\Photo_Post::register();
+	}
+);
+
+/*
  * Cross-network post-type projector.
  *
  * Feeds ActivityPub's stored `activitypub_support_post_types` option into

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -148,18 +148,23 @@ class Photo_Post {
 		// Reject obviously-unsupported input BEFORE handing off to
 		// `get_post()`. The core helper falls back to
 		// `$GLOBALS['post']` whenever its argument is empty — which
-		// includes `null`, `0`, `false`, and `''` — so calling it
-		// with those values during template rendering would silently
-		// resolve to the current loop post instead of returning the
-		// "no post" answer the discriminator's contract promises.
+		// includes `null`, `0`, `'0'`, `false`, and `''` — so calling
+		// it with those values during template rendering would
+		// silently resolve to the current loop post instead of
+		// returning the "no post" answer the discriminator's
+		// contract promises. The numeric branch also rejects zero
+		// since `is_numeric(0)` and `is_numeric('0')` are both true
+		// but `get_post(0)` triggers the same fallback.
 		if ( null === $post || false === $post || '' === $post ) {
 			return false;
 		}
-		if ( ! \is_numeric( $post ) && ! ( $post instanceof WP_Post ) ) {
+		if ( $post instanceof WP_Post ) {
+			$resolved = $post;
+		} elseif ( \is_numeric( $post ) && (int) $post > 0 ) {
+			$resolved = \get_post( (int) $post );
+		} else {
 			return false;
 		}
-
-		$resolved = \get_post( $post );
 		if ( ! $resolved instanceof WP_Post ) {
 			return false;
 		}
@@ -274,9 +279,17 @@ class Photo_Post {
 			return false;
 		}
 
-		$image_count     = 0;
-		$paragraph_count = 0;
-		$other_count     = 0;
+		$image_count              = 0;
+		$paragraph_count          = 0;
+		$other_count              = 0;
+		$unresolvable_image_count = 0;
+		// Flattened count of individual images that would actually
+		// federate as attachments. `image_count` counts image-like
+		// BLOCKS for Rule 2's shape check ("exactly one image-like
+		// block"), but `total_image_count` counts gallery children
+		// individually so the `max_image_attachments` cap can be
+		// compared against what bundled AP will really emit.
+		$total_image_count = 0;
 
 		foreach ( $blocks as $block ) {
 			$name = $block['blockName'] ?? null;
@@ -340,8 +353,10 @@ class Photo_Post {
 				// the external URL stays in the body.
 				if ( self::block_resolves_locally( $block, $post ) ) {
 					++$image_count;
+					$total_image_count += self::count_resolvable_images( $block, $post );
 				} else {
 					++$other_count;
+					++$unresolvable_image_count;
 				}
 				continue;
 			}
@@ -360,18 +375,45 @@ class Photo_Post {
 			++$other_count;
 		}
 
+		// Bundled AP caps attachment lists at
+		// `activitypub_max_image_attachments` (default 4). When the
+		// body carries more resolvable images than the cap, photo
+		// treatment would strip every image figure but only ship
+		// `cap` attachments — the overflow images vanish from the
+		// federated post. Falling back to article behavior keeps
+		// every figure inline AND still emits the first `cap`
+		// images as supplementary attachments, so receivers never
+		// see fewer images than the body declares.
+		// Effective attachment count: resolvable images in the body
+		// PLUS the featured image when set (bundled AP unshifts the
+		// thumbnail into the media list before walking blocks).
+		// `core/post-featured-image` in the body is already counted
+		// via `count_resolvable_images`, so don't double-count when
+		// the user includes both the block and a separate thumbnail.
+		$effective_image_count = $total_image_count;
+		if ( $has_thumbnail ) {
+			++$effective_image_count;
+		}
+
+		$max_attachments = self::get_max_image_attachments( $post );
+		if ( $max_attachments > 0 && $effective_image_count > $max_attachments ) {
+			return false;
+		}
+
 		// Rule 1: explicit Image / Gallery post format. Fires only
 		// when the body has SOME federatable image source — a
-		// resolvable image-like block OR a live featured image.
-		// A bare post-format hint isn't enough: without
-		// federatable content, photo treatment would strip the
-		// image markup (if any) and bundled AP would emit zero
-		// attachments, leaving a Note with no photo. The thumbnail
-		// or block-image presence guarantees the receiver actually
-		// gets an image. Bypasses the `other_count > 0` gate so
-		// users who explicitly opt in via post format aren't held
-		// to Rule 2/3's strict body-shape constraints.
-		if ( $has_format && ( $image_count > 0 || $has_thumbnail ) ) {
+		// resolvable image-like block OR a live featured image —
+		// AND no unresolvable image blocks. The latter gate is
+		// important: `filter_content()` strips every
+		// `wp-block-image` / `wp-block-gallery` /
+		// `wp-block-post-featured-image` figure regardless of
+		// resolvability, so allowing an unresolvable inline image
+		// block to coexist with a thumbnail-only Rule 1 trigger
+		// would silently drop that inline image from the federated
+		// post. Other "other_count" content (headings, lists,
+		// paragraphs the user wrote) is preserved by the stripper
+		// and so still allowed under the Rule 1 bypass.
+		if ( $has_format && ( $image_count > 0 || $has_thumbnail ) && 0 === $unresolvable_image_count ) {
 			return true;
 		}
 
@@ -390,6 +432,33 @@ class Photo_Post {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Resolve the effective `activitypub_max_image_attachments` cap
+	 * for a post. Mirrors bundled AP's read order
+	 * (`bundled/activitypub/includes/transformer/class-post.php`
+	 * `get_attachment()`): per-post meta → site option → upstream
+	 * constant default, then run through the
+	 * `activitypub_max_image_attachments` filter. Returning 0
+	 * means attachments are disabled entirely.
+	 *
+	 * @param \WP_Post $post The post being evaluated.
+	 * @return int The effective attachment cap.
+	 */
+	private static function get_max_image_attachments( WP_Post $post ): int {
+		$meta = \get_post_meta( $post->ID, 'activitypub_max_image_attachments', true );
+		if ( false === $meta || '' === $meta ) {
+			$default = \defined( 'ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS' ) ? ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS : 4;
+			$max     = \get_option( 'activitypub_max_image_attachments', $default );
+		} else {
+			$max = $meta;
+		}
+
+		/** This filter is documented in bundled/activitypub/includes/transformer/class-post.php */
+		$max = \apply_filters( 'activitypub_max_image_attachments', (int) $max );
+
+		return (int) $max;
 	}
 
 	/**
@@ -485,6 +554,46 @@ class Photo_Post {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Flattened count of individual resolvable images an image-like
+	 * block would contribute as AP attachments. For `core/image` and
+	 * `core/post-featured-image` that's 1; for `core/gallery` it's
+	 * the count of resolvable inner `core/image` children. Used for
+	 * the `activitypub_max_image_attachments` cap check — that cap
+	 * operates on individual images, not on image-bearing blocks.
+	 *
+	 * @param array<string, mixed> $block The parsed block.
+	 * @param \WP_Post             $post  The post being evaluated.
+	 * @return int Count of resolvable images contributed by the block.
+	 */
+	private static function count_resolvable_images( array $block, WP_Post $post ): int {
+		$name = $block['blockName'] ?? '';
+
+		if ( 'core/post-featured-image' === $name ) {
+			return self::has_image_thumbnail( $post ) ? 1 : 0;
+		}
+
+		if ( 'core/image' === $name ) {
+			$id = (int) ( $block['attrs']['id'] ?? 0 );
+			return $id > 0 && \wp_attachment_is_image( $id ) ? 1 : 0;
+		}
+
+		if ( 'core/gallery' === $name ) {
+			$count        = 0;
+			$inner_blocks = $block['innerBlocks'] ?? array();
+			if ( \is_array( $inner_blocks ) ) {
+				foreach ( $inner_blocks as $sub_block ) {
+					if ( \is_array( $sub_block ) ) {
+						$count += self::count_resolvable_images( $sub_block, $post );
+					}
+				}
+			}
+			return $count;
+		}
+
+		return 0;
 	}
 
 	/**

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -290,6 +290,13 @@ class Photo_Post {
 		// individually so the `max_image_attachments` cap can be
 		// compared against what bundled AP will really emit.
 		$total_image_count = 0;
+		// True when a `core/post-featured-image` block is present in
+		// the body. Bundled AP unshifts the post thumbnail into the
+		// media list AND extracts the featured-image block via
+		// `get_block_attachments`, then dedupes by id — both resolve
+		// to the same attachment. Tracking this lets the cap check
+		// avoid double-counting one image as two.
+		$has_featured_image_block = false;
 
 		foreach ( $blocks as $block ) {
 			$name = $block['blockName'] ?? null;
@@ -315,6 +322,16 @@ class Photo_Post {
 				}
 				if ( \preg_match( '#<(?:img|figure|h[1-6]|ul|ol|li|table|blockquote|pre|hr)\b#i', $inner_html ) ) {
 					++$other_count;
+					// Inline `<img>` / `<figure>` in freeform content
+					// gets stripped by `filter_content()`'s orphan-img
+					// pass and figure-class walker, but bundled AP
+					// can't extract it (no `attrs.id`) — same cascade
+					// as an unresolvable `core/image` block. Bump the
+					// gate so Rule 1's format bypass treats this as
+					// disqualifying.
+					if ( \preg_match( '#<(?:img|figure)\b#i', $inner_html ) ) {
+						++$unresolvable_image_count;
+					}
 					continue;
 				}
 
@@ -354,6 +371,9 @@ class Photo_Post {
 				if ( self::block_resolves_locally( $block, $post ) ) {
 					++$image_count;
 					$total_image_count += self::count_resolvable_images( $block, $post );
+					if ( 'core/post-featured-image' === $name ) {
+						$has_featured_image_block = true;
+					}
 				} else {
 					++$other_count;
 					++$unresolvable_image_count;
@@ -387,16 +407,28 @@ class Photo_Post {
 		// Effective attachment count: resolvable images in the body
 		// PLUS the featured image when set (bundled AP unshifts the
 		// thumbnail into the media list before walking blocks).
-		// `core/post-featured-image` in the body is already counted
-		// via `count_resolvable_images`, so don't double-count when
-		// the user includes both the block and a separate thumbnail.
+		// Skip the thumbnail bump when a `core/post-featured-image`
+		// block is already in the body — that block resolves to the
+		// same attachment id, and bundled AP dedupes by id before
+		// emitting attachments. Counting it twice would over-report
+		// against the cap and reject otherwise-valid single-photo
+		// posts when the cap is set tight (e.g., 1).
 		$effective_image_count = $total_image_count;
-		if ( $has_thumbnail ) {
+		if ( $has_thumbnail && ! $has_featured_image_block ) {
 			++$effective_image_count;
 		}
 
+		// Bundled AP supports disabling attachments entirely via
+		// `activitypub_max_image_attachments = 0`. Photo treatment
+		// makes no sense in that mode — the content stripper would
+		// remove every image figure while AP emits zero attachments,
+		// leaving a caption-only Note with no image. Reject before
+		// any rule fires.
 		$max_attachments = self::get_max_image_attachments( $post );
-		if ( $max_attachments > 0 && $effective_image_count > $max_attachments ) {
+		if ( $max_attachments <= 0 ) {
+			return false;
+		}
+		if ( $effective_image_count > $max_attachments ) {
 			return false;
 		}
 

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -235,16 +235,24 @@ class Photo_Post {
 		// block parser, which returns a single blank-blockName block
 		// for empty content and would otherwise classify it as not a
 		// photo post.
-		// `$post->post_content` round-trips through WP's storage layer
-		// with kses-applied slashes intact ("\"id\":42") — fine for
-		// rendering, but `parse_blocks()` then deserializes block
-		// attributes as `null` because the embedded JSON is malformed.
-		// Unslashing here gives the block parser the same view of the
-		// post as the editor sees, so attribute-driven checks
-		// (`block_resolves_locally()` reads `attrs.id`) work
-		// consistently across stored, autosaved, and revisioned
-		// content.
-		$content = (string) \wp_unslash( $post->post_content );
+		// Parse the post body the same way bundled AP's
+		// `get_block_attachments()` does — directly off
+		// `$post->post_content` without unslashing. Deliberately:
+		// for non-admin authors (Contributors, multisite Authors
+		// lacking `unfiltered_html`), `wp_filter_post_kses` slashes
+		// block-attribute JSON in storage, so `parse_blocks()`
+		// returns `null` attrs. A detector that unslashed before
+		// parsing would find `attrs.id`, classify the post as
+		// photo, and force `Note` — but bundled AP would then
+		// extract zero attachments from the still-slashed
+		// post_content, leaving a caption-only Note with no image.
+		// Matching the view AP's extractor uses guarantees the
+		// two stay in sync: when AP can't surface an image, FOSSE
+		// doesn't either, and the post federates as an article
+		// with its image markup intact in the body. Restoring
+		// photo treatment for slashed content is upstream work in
+		// bundled AP.
+		$content = (string) $post->post_content;
 
 		if ( $has_thumbnail && '' === \trim( $content ) ) {
 			return true;
@@ -351,9 +359,15 @@ class Photo_Post {
 	 * attachment is dropped silently downstream rather than blocking
 	 * federation).
 	 *
-	 * For `core/gallery`: any positive id in the top-level `ids`
-	 * attribute counts; for WP 5.9+ block-nested galleries, recurse
-	 * into `innerBlocks`.
+	 * For `core/gallery`: only WP 5.9+ block-nested galleries
+	 * (innerBlocks containing `core/image` children) count.
+	 * Legacy galleries with a top-level `attrs.ids` array are NOT
+	 * recognized — bundled AP's `get_media_from_blocks()` does not
+	 * extract from `core/gallery` `attrs.ids` either (only
+	 * `jetpack/slideshow` / `jetpack/tiled-gallery` and inner
+	 * `core/image` blocks), so detecting on `ids` here would
+	 * misclassify the post as photo while AP emits no
+	 * attachment.
 	 *
 	 * For `core/post-featured-image`: defer to `has_image_thumbnail`,
 	 * which validates the thumbnail attachment still exists.
@@ -374,17 +388,12 @@ class Photo_Post {
 		}
 
 		if ( 'core/gallery' === $name ) {
-			$ids = $block['attrs']['ids'] ?? array();
-			if ( \is_array( $ids ) ) {
-				foreach ( $ids as $id ) {
-					if ( (int) $id > 0 ) {
-						return true;
-					}
-				}
-			}
 			// WP 5.9+ galleries wrap individual `core/image` blocks
-			// in `innerBlocks` rather than listing ids on the
-			// gallery itself.
+			// in `innerBlocks`. Bundled AP recurses into innerBlocks
+			// for any block type, so any federatable image in the
+			// gallery's children is enough to classify here too.
+			// Legacy galleries (top-level `attrs.ids`) are
+			// intentionally NOT recognized — see class docblock.
 			$inner_blocks = $block['innerBlocks'] ?? array();
 			if ( \is_array( $inner_blocks ) ) {
 				foreach ( $inner_blocks as $sub_block ) {

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -120,39 +120,9 @@ class Photo_Post {
 	 * @return void
 	 */
 	public static function register(): void {
-		\add_action( 'after_setup_theme', array( self::class, 'register_post_format_support' ), 99 );
 		\add_filter( 'activitypub_post_object_type', array( self::class, 'filter_object_type' ), 10, 2 );
 		\add_filter( 'activitypub_the_content', array( self::class, 'filter_content' ), 10, 2 );
 		\add_filter( 'activitypub_attachment', array( self::class, 'filter_attachment_dimensions' ), 10, 2 );
-	}
-
-	/**
-	 * Ensure the `post` post type supports post formats so
-	 * `get_post_format()` doesn't short-circuit before consulting the
-	 * `post_format` taxonomy term — Rule 1 of `detect()` depends on
-	 * that term being readable. Block themes increasingly skip
-	 * `add_theme_support( 'post-formats', … )` in their setup, which
-	 * silently disables `get_post_format()` even when the term is set.
-	 *
-	 * Runs at `after_setup_theme` priority 99 so the active theme has
-	 * already had its chance to declare any post-type / theme support
-	 * of its own. `add_post_type_support` is idempotent and additive —
-	 * registering it here on top of a theme that already declared it
-	 * is a no-op.
-	 *
-	 * Intentionally narrow: we register the *post-type* support flag
-	 * that `get_post_format()` checks, but do NOT call
-	 * `add_theme_support( 'post-formats', [...] )` to populate the
-	 * Gutenberg format picker's dropdown. Doing so would either
-	 * overwrite the theme's curated list or require a brittle merge.
-	 * The federation-shape contract only needs the term to be
-	 * readable; surfacing format UI for users on opinionated themes
-	 * is a separate UX concern.
-	 *
-	 * @return void
-	 */
-	public static function register_post_format_support(): void {
-		\add_post_type_support( 'post', 'post-formats' );
 	}
 
 	/**
@@ -258,7 +228,7 @@ class Photo_Post {
 			return true;
 		}
 
-		$has_thumbnail = \has_post_thumbnail( $post );
+		$has_thumbnail = self::has_image_thumbnail( $post );
 
 		// Empty body + featured image = "Set thumbnail, hit publish"
 		// flow (Rule 3 with zero paragraphs). Catch this before the
@@ -336,6 +306,29 @@ class Photo_Post {
 	}
 
 	/**
+	 * True when the post has a Featured Image that still resolves to a
+	 * live image attachment. `has_post_thumbnail()` only checks for a
+	 * non-zero `_thumbnail_id` postmeta — the meta survives deletion of
+	 * the underlying attachment, so it can be true for a featured image
+	 * whose file is gone. Rule 3 would then classify the post as a
+	 * photo post and force `Note` shape, but bundled AP's
+	 * `transform_attachment` silently drops the broken attachment,
+	 * leaving the user with a Note that says "look at my photo" but has
+	 * no photo. Falling back to article behavior is the less surprising
+	 * degradation.
+	 *
+	 * @param \WP_Post $post The post being evaluated.
+	 * @return bool True when the featured image attachment exists and is an image.
+	 */
+	private static function has_image_thumbnail( WP_Post $post ): bool {
+		$thumbnail_id = (int) \get_post_thumbnail_id( $post );
+		if ( $thumbnail_id <= 0 ) {
+			return false;
+		}
+		return (bool) \wp_attachment_is_image( $thumbnail_id );
+	}
+
+	/**
 	 * Force `type: "Note"` for photo posts. Hooked on
 	 * `activitypub_post_object_type`.
 	 *
@@ -374,11 +367,17 @@ class Photo_Post {
 	 * full `the_content` chain — blocks are already expanded to HTML.
 	 * Image blocks render with stable wrapper classes
 	 * (`wp-block-image`, `wp-block-gallery`,
-	 * `wp-block-post-featured-image`), so a class-anchored regex pass
-	 * is enough to remove them along with any nested `<img>` /
-	 * `<figcaption>`. After stripping, we also drop standalone `<img>`
-	 * tags as a defensive measure and clean up empty paragraph
-	 * wrappers left behind by the editor.
+	 * `wp-block-post-featured-image`), so a DOM walk that removes
+	 * any matching `<figure>` plus its descendants handles nested
+	 * gallery markup (gallery wraps individual image figures)
+	 * without leaving orphan closing tags — the failure mode of a
+	 * naive `.*?</figure>` regex on the same input.
+	 *
+	 * After the figure pass we also drop standalone `<img>` tags (a
+	 * defensive measure for classic-editor inline images, or
+	 * themes/plugins that wrap images differently) and clean up
+	 * paragraph shells the editor leaves behind once their only
+	 * child was the image we just removed.
 	 *
 	 * Why strip at all: Pixelfed accepts HTML in `content` and would
 	 * happily render the figure markup inline, but the photo-grid
@@ -402,23 +401,99 @@ class Photo_Post {
 			return $content;
 		}
 
-		// Drop the entire figure wrapper produced by core image-like blocks,
-		// including any nested <img> / <figcaption>.
-		$content = (string) \preg_replace(
-			'#<figure\b[^>]*class="[^"]*\bwp-block-(?:image|gallery|post-featured-image)\b[^"]*"[^>]*>.*?</figure>#is',
-			'',
-			$content
-		);
+		if ( '' === \trim( $content ) ) {
+			return $content;
+		}
 
-		// Defensive: strip any orphan <img> that survived (classic-editor
-		// inline images, or themes/plugins that wrap images differently).
-		$content = (string) \preg_replace( '#<img\b[^>]*>#is', '', $content );
+		return self::strip_image_block_markup( $content );
+	}
 
-		// Clean up empty paragraph shells the editor leaves behind once the
-		// only child was the image we just removed.
-		$content = (string) \preg_replace( '#<p\b[^>]*>\s*</p>#is', '', $content );
+	/**
+	 * DOM-walk pass that removes image-block figures, orphan `<img>`,
+	 * and empty paragraph shells from rendered HTML. Returns the
+	 * input unchanged if parsing fails — better to ship the caption
+	 * alongside the image markup than to drop the content entirely on
+	 * a parser hiccup.
+	 *
+	 * @param string $content Rendered HTML.
+	 * @return string Content with image-block markup removed.
+	 */
+	private static function strip_image_block_markup( string $content ): string {
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- The DOM API exposes camelCase properties (parentNode, childNodes); these are upstream PHP names, not ones we control.
+		$doc                      = new \DOMDocument();
+		$previous_internal_errors = \libxml_use_internal_errors( true );
 
-		return \trim( $content );
+		// Wrap with a UTF-8 hint so libxml doesn't mangle non-ASCII
+		// captions, and with a <body> so we have a single root to
+		// serialize children from. LIBXML_HTML_NOIMPLIED stops
+		// libxml from wrapping the input in an <html>/<body> shell
+		// of its own.
+		$wrapped = '<?xml encoding="UTF-8"?><body>' . $content . '</body>';
+		$loaded  = $doc->loadHTML( $wrapped, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+
+		\libxml_clear_errors();
+		\libxml_use_internal_errors( $previous_internal_errors );
+
+		if ( ! $loaded ) {
+			return $content;
+		}
+
+		$xpath = new \DOMXPath( $doc );
+
+		// Match figures whose class list contains any of the image-like
+		// block tokens. `concat(' ', normalize-space(@class), ' ')` is
+		// the XPath idiom for whole-token matching — it sidesteps the
+		// "wp-block-image-rounded" false-match a plain `contains()`
+		// would hit.
+		$figure_query = '//figure['
+			. 'contains(concat(" ", normalize-space(@class), " "), " wp-block-image ") or '
+			. 'contains(concat(" ", normalize-space(@class), " "), " wp-block-gallery ") or '
+			. 'contains(concat(" ", normalize-space(@class), " "), " wp-block-post-featured-image ")'
+			. ']';
+
+		$figures = $xpath->query( $figure_query );
+		if ( $figures instanceof \DOMNodeList ) {
+			foreach ( \iterator_to_array( $figures ) as $figure ) {
+				if ( $figure->parentNode ) {
+					$figure->parentNode->removeChild( $figure );
+				}
+			}
+		}
+
+		// Drop any orphan <img> that survived (classic-editor inline
+		// images, or themes that wrap images outside <figure>).
+		$imgs = $doc->getElementsByTagName( 'img' );
+		foreach ( \iterator_to_array( $imgs ) as $img ) {
+			if ( $img->parentNode ) {
+				$img->parentNode->removeChild( $img );
+			}
+		}
+
+		// Empty paragraph shells left behind by the editor.
+		$empty_paragraphs = $xpath->query( '//p[not(normalize-space())]' );
+		if ( $empty_paragraphs instanceof \DOMNodeList ) {
+			foreach ( \iterator_to_array( $empty_paragraphs ) as $paragraph ) {
+				if ( $paragraph->parentNode ) {
+					$paragraph->parentNode->removeChild( $paragraph );
+				}
+			}
+		}
+
+		$body = $doc->getElementsByTagName( 'body' )->item( 0 );
+		if ( null === $body ) {
+			return $content;
+		}
+
+		$result = '';
+		foreach ( $body->childNodes as $child ) {
+			$serialized = $doc->saveHTML( $child );
+			if ( false !== $serialized ) {
+				$result .= $serialized;
+			}
+		}
+
+		return \trim( $result );
+		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	}
 
 	/**
@@ -432,16 +507,34 @@ class Photo_Post {
 	 * already emits them for video/audio. Adding them for images
 	 * closes a gap without changing any other behavior.
 	 *
-	 * The bundled transformer shapes images like
-	 * `{type:"Image", url, mediaType, name?, exifData?}` — we add
-	 * `width` / `height` from `wp_get_attachment_metadata()` when
-	 * present and skip silently when missing (e.g. external images
-	 * with no local attachment ID, or attachments whose metadata
-	 * hasn't been generated yet).
+	 * Dimensions must match the URL bundled AP emitted, not the
+	 * original attachment's metadata. Bundled AP defaults to the
+	 * `large` derivative for image URLs
+	 * (`wp_get_attachment_image_src( $id, 'large' )`), so populating
+	 * `width`/`height` from `wp_get_attachment_metadata()` on a 4000-pixel
+	 * original yields values that don't describe the linked 1024-pixel
+	 * file — Pixelfed enforces dimensions server-side against the
+	 * delivered bytes and rejects the mismatch. We resolve dimensions
+	 * in three passes:
+	 *
+	 *   1. WP's resized-image filename suffix (`-WIDTHxHEIGHT.ext`).
+	 *      Stable across core, Photon, and most CDN rewrites that
+	 *      preserve the source filename.
+	 *   2. The attachment's registered intermediate sizes (`sizes[]`
+	 *      from `wp_get_attachment_metadata`), matching by filename
+	 *      against the URL.
+	 *   3. The attachment's original (full-size) metadata, used only
+	 *      when neither suffix nor any intermediate size matches the
+	 *      URL — i.e. the URL points at the original file.
+	 *
+	 * Zero / negative values are dropped rather than emitted: a
+	 * width-0 image attachment is one Pixelfed will reject in
+	 * `verifyAttachments` anyway, and Mastodon falls back to a
+	 * sensible default when the keys are absent.
 	 *
 	 * @param array $attachment The AP attachment array.
 	 * @param mixed $id         The WP attachment ID being transformed.
-	 * @return array The attachment with width/height when available.
+	 * @return array The attachment with width/height when resolvable.
 	 */
 	public static function filter_attachment_dimensions( $attachment, $id ): array {
 		if ( ! \is_array( $attachment ) ) {
@@ -456,23 +549,83 @@ class Photo_Post {
 			return $attachment;
 		}
 
-		if ( ! \is_numeric( $id ) ) {
+		$url = (string) ( $attachment['url'] ?? '' );
+		if ( '' === $url ) {
 			return $attachment;
+		}
+
+		$dims = self::dimensions_for_url( $url, $id );
+		if ( null === $dims ) {
+			return $attachment;
+		}
+
+		$attachment['width']  = $dims[0];
+		$attachment['height'] = $dims[1];
+
+		return $attachment;
+	}
+
+	/**
+	 * Resolve dimensions for an image URL. Returns `[width, height]`
+	 * when both are positive integers, or `null` when the URL can't
+	 * be confidently matched to a known size.
+	 *
+	 * @param string $url The image URL bundled AP emitted.
+	 * @param mixed  $id  The WP attachment ID, if known.
+	 * @return array{0:int, 1:int}|null
+	 */
+	private static function dimensions_for_url( string $url, $id ): ?array {
+		// Pass 1: filename suffix. WP names resized derivatives
+		// `<base>-<W>x<H>.<ext>`; the suffix survives most CDN
+		// URL rewrites that keep the source basename intact.
+		if ( \preg_match( '/-(\d+)x(\d+)\.(?:jpe?g|png|gif|webp|avif)(?:$|[\?\#])/i', $url, $matches ) ) {
+			$width  = (int) $matches[1];
+			$height = (int) $matches[2];
+			if ( $width > 0 && $height > 0 ) {
+				return array( $width, $height );
+			}
+		}
+
+		if ( ! \is_numeric( $id ) ) {
+			return null;
 		}
 
 		$meta = \wp_get_attachment_metadata( (int) $id );
 		if ( ! \is_array( $meta ) ) {
-			return $attachment;
+			return null;
 		}
 
-		if ( ! isset( $meta['width'] ) || ! isset( $meta['height'] ) ) {
-			return $attachment;
+		// Pass 2: registered intermediate sizes. `sizes[name].file` is
+		// the basename of the resized file; matching it against the
+		// URL handles renamed derivatives that don't carry the
+		// `-WxH` suffix (e.g. some custom-size registrations).
+		if ( ! empty( $meta['sizes'] ) && \is_array( $meta['sizes'] ) ) {
+			foreach ( $meta['sizes'] as $size_data ) {
+				if ( ! \is_array( $size_data ) ) {
+					continue;
+				}
+				$file   = (string) ( $size_data['file'] ?? '' );
+				$width  = (int) ( $size_data['width'] ?? 0 );
+				$height = (int) ( $size_data['height'] ?? 0 );
+				if ( '' === $file || $width <= 0 || $height <= 0 ) {
+					continue;
+				}
+				if ( \str_contains( $url, $file ) ) {
+					return array( $width, $height );
+				}
+			}
 		}
 
-		$attachment['width']  = (int) $meta['width'];
-		$attachment['height'] = (int) $meta['height'];
+		// Pass 3: full-size original. Reached when neither the
+		// filename suffix nor any registered intermediate matches —
+		// the URL most likely points at the original upload.
+		$width  = (int) ( $meta['width'] ?? 0 );
+		$height = (int) ( $meta['height'] ?? 0 );
+		if ( $width > 0 && $height > 0 ) {
+			return array( $width, $height );
+		}
 
-		return $attachment;
+		return null;
 	}
 
 	/**

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -272,15 +272,28 @@ class Photo_Post {
 
 			// `parse_blocks()` emits a null-blockName entry for any
 			// freeform / classic content sandwiched between blocks
-			// (or for a post that's entirely classic content). Treat
-			// whitespace-only freeform as ignorable; substantive
-			// freeform counts as "other" content that disqualifies.
+			// (or for a post that's entirely classic content). The
+			// mobile WP-app and classic-editor "set featured image,
+			// type a one-line caption" flow lands here as a single
+			// freeform block whose innerHTML is just `<p>Caption.</p>`
+			// (no block-comment wrappers). Rule 3 explicitly targets
+			// this shape, so we mirror the paragraph-block heuristic:
+			// if the freeform body strips to plain text wrapped at
+			// most in `<p>` / `<br>` (no figures, images, headings,
+			// lists, tables — the structural tags that signal an
+			// article body), count it as one paragraph. Otherwise
+			// treat as "other" content that disqualifies.
 			if ( null === $name ) {
-				$inner = \trim( $block['innerHTML'] ?? '' );
-				if ( '' === $inner ) {
+				$inner_html = $block['innerHTML'] ?? '';
+				$inner_text = \trim( \wp_strip_all_tags( $inner_html ) );
+				if ( '' === $inner_text ) {
 					continue;
 				}
-				++$other_count;
+				if ( \preg_match( '#<(?:img|figure|h[1-6]|ul|ol|li|table|blockquote|pre|hr)\b#i', $inner_html ) ) {
+					++$other_count;
+					continue;
+				}
+				++$paragraph_count;
 				continue;
 			}
 
@@ -389,20 +402,41 @@ class Photo_Post {
 
 		if ( 'core/gallery' === $name ) {
 			// WP 5.9+ galleries wrap individual `core/image` blocks
-			// in `innerBlocks`. Bundled AP recurses into innerBlocks
-			// for any block type, so any federatable image in the
-			// gallery's children is enough to classify here too.
-			// Legacy galleries (top-level `attrs.ids`) are
-			// intentionally NOT recognized — see class docblock.
+			// in `innerBlocks`. Legacy galleries (top-level
+			// `attrs.ids`) are intentionally NOT recognized — see
+			// class docblock.
+			//
+			// Require EVERY image-like child to resolve, not just
+			// one: if a gallery mixes local and external images,
+			// declaring it a photo post would strip the entire
+			// gallery from content while bundled AP only emits
+			// attachments for the local-id children — the external
+			// images would silently disappear from the federated
+			// post. Falling back to article behavior keeps every
+			// figure intact in the body where receivers can render
+			// the externally-hosted images inline. Children that
+			// aren't image-like (paragraph captions, spacers
+			// occasionally found inside galleries) are ignored.
 			$inner_blocks = $block['innerBlocks'] ?? array();
-			if ( \is_array( $inner_blocks ) ) {
-				foreach ( $inner_blocks as $sub_block ) {
-					if ( \is_array( $sub_block ) && self::block_resolves_locally( $sub_block, $post ) ) {
-						return true;
-					}
+			if ( ! \is_array( $inner_blocks ) || empty( $inner_blocks ) ) {
+				return false;
+			}
+
+			$has_image = false;
+			foreach ( $inner_blocks as $sub_block ) {
+				if ( ! \is_array( $sub_block ) ) {
+					continue;
+				}
+				$sub_name = $sub_block['blockName'] ?? '';
+				if ( ! \in_array( $sub_name, self::IMAGE_LIKE_BLOCKS, true ) ) {
+					continue;
+				}
+				$has_image = true;
+				if ( ! self::block_resolves_locally( $sub_block, $post ) ) {
+					return false;
 				}
 			}
-			return false;
+			return $has_image;
 		}
 
 		return false;
@@ -702,10 +736,15 @@ class Photo_Post {
 		// Pass 3 (external-URL fallback): filename suffix `-WxH.ext`.
 		// WP names resized derivatives that way and the suffix
 		// survives most CDN rewrites that keep the source basename
-		// intact. This is the only resolution path for external
+		// intact. Match against the URL's path component only —
+		// matching against the full URL would pick up a `-WxH.ext`
+		// fragment in a query string (e.g. a redirect / tracker
+		// param `?next=photo-1024x768.jpg`), emitting dimensions
+		// that describe a different image than the one actually
+		// linked. This is the only resolution path for external
 		// images (no local attachment id), so we treat it as
 		// best-effort rather than authoritative.
-		if ( \preg_match( '/-(\d+)x(\d+)\.(?:jpe?g|png|gif|webp|avif|heic|heif|tiff?)(?:$|[\?\#])/i', $url, $matches ) ) {
+		if ( '' !== $path && \preg_match( '/-(\d+)x(\d+)\.(?:jpe?g|png|gif|webp|avif|heic|heif|tiff?)$/i', $path, $matches ) ) {
 			$width  = (int) $matches[1];
 			$height = (int) $matches[2];
 			if ( $width > 0 && $height > 0 ) {

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -219,14 +219,31 @@ class Photo_Post {
 	 *
 	 * Returns true when any of:
 	 *
-	 *   1. The post format is `image` or `gallery`.
+	 *   1. The post format is `image` or `gallery` AND the body
+	 *      carries a federatable image source (a resolvable
+	 *      image-like block OR a live featured image) AND no
+	 *      unresolvable image markup. Post format alone is not
+	 *      enough — bare format would force `Note` even when
+	 *      bundled AP can't emit any attachment, leaving a
+	 *      caption-only Note with no photo.
 	 *   2. The block content boils down to "one image-like block,
 	 *      optionally followed by a single paragraph block,"
 	 *      ignoring purely structural blocks (spacer, separator).
-	 *   3. The post has a featured image and the body has at most
-	 *      one paragraph block (so "set featured image, type one
-	 *      sentence, hit publish" works without the user having to
-	 *      know about Post Formats).
+	 *      The image-like block must resolve to a local attachment
+	 *      (`wp_attachment_is_image`); external-URL image blocks
+	 *      don't qualify.
+	 *   3. The post has a featured image (validated via
+	 *      `wp_attachment_is_image`, not just postmeta) and the body
+	 *      has at most one paragraph block — so "set featured image,
+	 *      type one sentence, hit publish" works without the user
+	 *      having to know about Post Formats.
+	 *
+	 * All three rules also enforce the
+	 * `activitypub_max_image_attachments` cap. When the body
+	 * carries more images than bundled AP will emit, detection
+	 * falls through to article behavior so the overflow stays
+	 * inline. A cap of 0 (attachments disabled) rejects photo
+	 * treatment entirely.
 	 *
 	 * Rule 2 is the catch-most-cases path for users who don't use
 	 * Post Formats at all (modern block-editor flow). Rule 3 handles
@@ -777,9 +794,30 @@ class Photo_Post {
 		$figures = $xpath->query( $figure_query );
 		if ( $figures instanceof \DOMNodeList ) {
 			foreach ( \iterator_to_array( $figures ) as $figure ) {
-				if ( $figure->parentNode ) {
-					$figure->parentNode->removeChild( $figure );
+				if ( ! $figure->parentNode ) {
+					continue;
 				}
+
+				// Image-block figures often nest a `<figcaption>`
+				// that carries the user's caption text — losing it
+				// when we strip the figure would mangle the user's
+				// intent (Pixelfed and Mastodon both render figcaption
+				// content alongside attached media). Lift each non-
+				// empty figcaption out as a `<p>` in the figure's
+				// place before removing the wrapper so the caption
+				// survives stripping.
+				$figcaptions = $figure->getElementsByTagName( 'figcaption' );
+				foreach ( \iterator_to_array( $figcaptions ) as $figcaption ) {
+					$caption_text = \trim( (string) $figcaption->textContent );
+					if ( '' === $caption_text ) {
+						continue;
+					}
+					$paragraph = $doc->createElement( 'p' );
+					$paragraph->appendChild( $doc->createTextNode( $caption_text ) );
+					$figure->parentNode->insertBefore( $paragraph, $figure );
+				}
+
+				$figure->parentNode->removeChild( $figure );
 			}
 		}
 

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -331,29 +331,6 @@ class Photo_Post {
 	}
 
 	/**
-	 * True when the post has a Featured Image that still resolves to a
-	 * live image attachment. `has_post_thumbnail()` only checks for a
-	 * non-zero `_thumbnail_id` postmeta — the meta survives deletion of
-	 * the underlying attachment, so it can be true for a featured image
-	 * whose file is gone. Rule 3 would then classify the post as a
-	 * photo post and force `Note` shape, but bundled AP's
-	 * `transform_attachment` silently drops the broken attachment,
-	 * leaving the user with a Note that says "look at my photo" but has
-	 * no photo. Falling back to article behavior is the less surprising
-	 * degradation.
-	 *
-	 * @param \WP_Post $post The post being evaluated.
-	 * @return bool True when the featured image attachment exists and is an image.
-	 */
-	private static function has_image_thumbnail( WP_Post $post ): bool {
-		$thumbnail_id = (int) \get_post_thumbnail_id( $post );
-		if ( $thumbnail_id <= 0 ) {
-			return false;
-		}
-		return (bool) \wp_attachment_is_image( $thumbnail_id );
-	}
-
-	/**
 	 * True when an image-like block resolves to local content bundled
 	 * AP can federate as an `attachment[]` entry.
 	 *
@@ -420,6 +397,29 @@ class Photo_Post {
 		}
 
 		return false;
+	}
+
+	/**
+	 * True when the post has a Featured Image that still resolves to a
+	 * live image attachment. `has_post_thumbnail()` only checks for a
+	 * non-zero `_thumbnail_id` postmeta — the meta survives deletion of
+	 * the underlying attachment, so it can be true for a featured image
+	 * whose file is gone. Rule 3 would then classify the post as a
+	 * photo post and force `Note` shape, but bundled AP's
+	 * `transform_attachment` silently drops the broken attachment,
+	 * leaving the user with a Note that says "look at my photo" but has
+	 * no photo. Falling back to article behavior is the less surprising
+	 * degradation.
+	 *
+	 * @param \WP_Post $post The post being evaluated.
+	 * @return bool True when the featured image attachment exists and is an image.
+	 */
+	private static function has_image_thumbnail( WP_Post $post ): bool {
+		$thumbnail_id = (int) \get_post_thumbnail_id( $post );
+		if ( $thumbnail_id <= 0 ) {
+			return false;
+		}
+		return (bool) \wp_attachment_is_image( $thumbnail_id );
 	}
 
 	/**
@@ -669,10 +669,34 @@ class Photo_Post {
 	 * @return array{0:int, 1:int}|null
 	 */
 	private static function dimensions_for_url( string $url, $id ): ?array {
-		// Pass 1: filename suffix. WP names resized derivatives
-		// `<base>-<W>x<H>.<ext>`; the suffix survives most CDN
-		// URL rewrites that keep the source basename intact.
-		if ( \preg_match( '/-(\d+)x(\d+)\.(?:jpe?g|png|gif|webp|avif)(?:$|[\?\#])/i', $url, $matches ) ) {
+		$parsed = \wp_parse_url( $url );
+		$path   = (string) ( $parsed['path'] ?? '' );
+
+		// When we have a local attachment id, prefer metadata-driven
+		// resolution. Metadata describes the actual files on disk; the
+		// filename-suffix regex (below) is a heuristic that misfires
+		// when a user-uploaded original happens to be named
+		// `photo-1024x683.jpg` while its actual bytes are some other
+		// size. Falling through to Pass 3 (URL-suffix parsing) for
+		// local attachments only when metadata can't resolve keeps
+		// authoritative numbers winning over inference.
+		if ( \is_numeric( $id ) && (int) $id > 0 ) {
+			$meta = \wp_get_attachment_metadata( (int) $id );
+			if ( \is_array( $meta ) ) {
+				$dims = self::dimensions_from_metadata( $meta, $path );
+				if ( null !== $dims ) {
+					return $dims;
+				}
+			}
+		}
+
+		// Pass 3 (external-URL fallback): filename suffix `-WxH.ext`.
+		// WP names resized derivatives that way and the suffix
+		// survives most CDN rewrites that keep the source basename
+		// intact. This is the only resolution path for external
+		// images (no local attachment id), so we treat it as
+		// best-effort rather than authoritative.
+		if ( \preg_match( '/-(\d+)x(\d+)\.(?:jpe?g|png|gif|webp|avif|heic|heif|tiff?)(?:$|[\?\#])/i', $url, $matches ) ) {
 			$width  = (int) $matches[1];
 			$height = (int) $matches[2];
 			if ( $width > 0 && $height > 0 ) {
@@ -680,19 +704,35 @@ class Photo_Post {
 			}
 		}
 
-		if ( ! \is_numeric( $id ) ) {
+		return null;
+	}
+
+	/**
+	 * Resolve dimensions from an attachment's stored metadata when the
+	 * URL path matches a registered file. Returns `[width, height]` or
+	 * `null` when no size's filename appears in the URL path.
+	 *
+	 * Pass A walks the registered intermediate sizes (`sizes[name].file`
+	 * is the basename of each resized derivative); Pass B falls back
+	 * to the full-size original (`meta['file']` is the relative path
+	 * from `wp-content/uploads/`). Both passes anchor the basename
+	 * with a leading `/` so a URL like `/uploads/some-photo.jpg`
+	 * doesn't accidentally match a registered file named `photo.jpg`
+	 * — important on sites that disable the year/month upload subdir
+	 * option, where `meta['file']` is a bare basename.
+	 *
+	 * @param array<string, mixed> $meta The attachment metadata.
+	 * @param string               $path The URL's path component (no query/fragment).
+	 * @return array{0:int, 1:int}|null
+	 */
+	private static function dimensions_from_metadata( array $meta, string $path ): ?array {
+		if ( '' === $path ) {
 			return null;
 		}
 
-		$meta = \wp_get_attachment_metadata( (int) $id );
-		if ( ! \is_array( $meta ) ) {
-			return null;
-		}
-
-		// Pass 2: registered intermediate sizes. `sizes[name].file` is
-		// the basename of the resized file; matching it against the
-		// URL handles renamed derivatives that don't carry the
-		// `-WxH` suffix (e.g. some custom-size registrations).
+		// Pass A: registered intermediate sizes. Each entry's
+		// `file` is just the basename, so we anchor with a slash
+		// to require a directory boundary before the match.
 		if ( ! empty( $meta['sizes'] ) && \is_array( $meta['sizes'] ) ) {
 			foreach ( $meta['sizes'] as $size_data ) {
 				if ( ! \is_array( $size_data ) ) {
@@ -704,30 +744,18 @@ class Photo_Post {
 				if ( '' === $file || $width <= 0 || $height <= 0 ) {
 					continue;
 				}
-				if ( \str_contains( $url, $file ) ) {
+				if ( \str_ends_with( $path, '/' . \ltrim( $file, '/' ) ) ) {
 					return array( $width, $height );
 				}
 			}
 		}
 
-		// Pass 3: full-size original. Reached when neither the
-		// filename suffix nor any registered intermediate matches.
-		// Confirm the URL actually points at `$meta['file']` before
-		// falling back — otherwise a CDN rewrite that preserves the
-		// basename, or an `activitypub_get_image` callback that
-		// substitutes a derivative URL without the size suffix, would
-		// reintroduce the original/derivative dimension mismatch this
-		// helper exists to prevent. Match against the URL's path
-		// component only so query strings / fragments don't fool the
-		// `str_ends_with` check.
+		// Pass B: full-size original. `meta['file']` is the
+		// relative path under uploads (e.g. `2026/05/photo.jpg`),
+		// but on sites with year/month folders disabled it's a
+		// bare basename — anchor with `/` either way.
 		$file = (string) ( $meta['file'] ?? '' );
-		if ( '' === $file ) {
-			return null;
-		}
-
-		$parsed = \wp_parse_url( $url );
-		$path   = (string) ( $parsed['path'] ?? '' );
-		if ( '' === $path || ! \str_ends_with( $path, $file ) ) {
+		if ( '' === $file || ! \str_ends_with( $path, '/' . \ltrim( $file, '/' ) ) ) {
 			return null;
 		}
 

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -293,6 +293,21 @@ class Photo_Post {
 					++$other_count;
 					continue;
 				}
+
+				// Count substantive `<p>` paragraphs to catch the
+				// `<p>Line 1.</p><p>Line 2.</p>` shape — multiple
+				// paragraphs are article content, not a single
+				// caption. Drop empty `<p></p>` shells first so
+				// editor padding doesn't inflate the count.
+				$cleaned = (string) \preg_replace( '#<p\b[^>]*>\s*</p>#i', '', $inner_html );
+				$opens   = \preg_match_all( '#<p\b#i', $cleaned );
+
+				// Zero `<p>` tags means a wrapper-less freeform
+				// line — still one logical paragraph for Rule 3.
+				if ( ( $opens > 0 ? (int) $opens : 1 ) > 1 ) {
+					++$other_count;
+					continue;
+				}
 				++$paragraph_count;
 				continue;
 			}
@@ -366,11 +381,14 @@ class Photo_Post {
 	 * external URL intact in the body so receivers can still render
 	 * it inline.
 	 *
-	 * For `core/image`: presence of a positive `id` attribute is
-	 * enough — we intentionally do NOT verify the attachment still
-	 * exists, mirroring bundled AP's own posture (a deleted-but-id'd
-	 * attachment is dropped silently downstream rather than blocking
-	 * federation).
+	 * For `core/image`: the `id` attribute must point at an
+	 * attachment that still resolves to an image
+	 * (`wp_attachment_is_image()`). Without this guard a
+	 * deleted-but-id'd attachment would slip through detection and
+	 * force `Note` shape, but bundled AP's `transform_attachment()`
+	 * would drop the broken attachment silently — caption-only Note
+	 * with no image. Mirrors the `has_image_thumbnail` posture for
+	 * Rule 3.
 	 *
 	 * For `core/gallery`: only WP 5.9+ block-nested galleries
 	 * (innerBlocks containing `core/image` children) count.
@@ -397,7 +415,8 @@ class Photo_Post {
 		}
 
 		if ( 'core/image' === $name ) {
-			return (int) ( $block['attrs']['id'] ?? 0 ) > 0;
+			$id = (int) ( $block['attrs']['id'] ?? 0 );
+			return $id > 0 && (bool) \wp_attachment_is_image( $id );
 		}
 
 		if ( 'core/gallery' === $name ) {

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -237,11 +237,8 @@ class Photo_Post {
 	 * @return bool True if the post matches one of the built-in rules.
 	 */
 	private static function detect( WP_Post $post ): bool {
-		$format = \get_post_format( $post );
-		if ( 'image' === $format || 'gallery' === $format ) {
-			return true;
-		}
-
+		$format        = \get_post_format( $post );
+		$has_format    = 'image' === $format || 'gallery' === $format;
 		$has_thumbnail = self::has_image_thumbnail( $post );
 
 		// Empty body + featured image = "Set thumbnail, hit publish"
@@ -361,6 +358,21 @@ class Photo_Post {
 			}
 
 			++$other_count;
+		}
+
+		// Rule 1: explicit Image / Gallery post format. Fires only
+		// when the body has SOME federatable image source — a
+		// resolvable image-like block OR a live featured image.
+		// A bare post-format hint isn't enough: without
+		// federatable content, photo treatment would strip the
+		// image markup (if any) and bundled AP would emit zero
+		// attachments, leaving a Note with no photo. The thumbnail
+		// or block-image presence guarantees the receiver actually
+		// gets an image. Bypasses the `other_count > 0` gate so
+		// users who explicitly opt in via post format aren't held
+		// to Rule 2/3's strict body-shape constraints.
+		if ( $has_format && ( $image_count > 0 || $has_thumbnail ) ) {
+			return true;
 		}
 
 		if ( $other_count > 0 ) {

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -235,11 +235,22 @@ class Photo_Post {
 		// block parser, which returns a single blank-blockName block
 		// for empty content and would otherwise classify it as not a
 		// photo post.
-		if ( $has_thumbnail && '' === \trim( (string) $post->post_content ) ) {
+		// `$post->post_content` round-trips through WP's storage layer
+		// with kses-applied slashes intact ("\"id\":42") — fine for
+		// rendering, but `parse_blocks()` then deserializes block
+		// attributes as `null` because the embedded JSON is malformed.
+		// Unslashing here gives the block parser the same view of the
+		// post as the editor sees, so attribute-driven checks
+		// (`block_resolves_locally()` reads `attrs.id`) work
+		// consistently across stored, autosaved, and revisioned
+		// content.
+		$content = (string) \wp_unslash( $post->post_content );
+
+		if ( $has_thumbnail && '' === \trim( $content ) ) {
 			return true;
 		}
 
-		$blocks = \parse_blocks( $post->post_content );
+		$blocks = \parse_blocks( $content );
 		if ( empty( $blocks ) ) {
 			return false;
 		}
@@ -270,7 +281,21 @@ class Photo_Post {
 			}
 
 			if ( \in_array( $name, self::IMAGE_LIKE_BLOCKS, true ) ) {
-				++$image_count;
+				// Image-like blocks only count toward photo-post
+				// detection when they resolve to local content
+				// bundled AP can actually federate. An image block
+				// with an external URL (no `id` attribute) would
+				// have its markup stripped by `filter_content()` but
+				// produce no attachment in the AP envelope — the
+				// receiver sees a caption-only Note with no photo.
+				// Treat unresolvable image blocks as "other" content
+				// so detection falls through to article behavior and
+				// the external URL stays in the body.
+				if ( self::block_resolves_locally( $block, $post ) ) {
+					++$image_count;
+				} else {
+					++$other_count;
+				}
 				continue;
 			}
 
@@ -326,6 +351,75 @@ class Photo_Post {
 			return false;
 		}
 		return (bool) \wp_attachment_is_image( $thumbnail_id );
+	}
+
+	/**
+	 * True when an image-like block resolves to local content bundled
+	 * AP can federate as an `attachment[]` entry.
+	 *
+	 * Block-shape detection without this gate would classify a
+	 * `core/image` block carrying an external URL as a photo-post
+	 * trigger, but bundled AP's attachment extraction (see
+	 * `bundled/activitypub/includes/transformer/class-post.php::get_block_attachments`)
+	 * only emits items with a resolvable local attachment id. The
+	 * federated Note would then have its image markup stripped by
+	 * `filter_content()` AND carry no attachment — the user loses the
+	 * image entirely. Falling back to article behavior keeps the
+	 * external URL intact in the body so receivers can still render
+	 * it inline.
+	 *
+	 * For `core/image`: presence of a positive `id` attribute is
+	 * enough — we intentionally do NOT verify the attachment still
+	 * exists, mirroring bundled AP's own posture (a deleted-but-id'd
+	 * attachment is dropped silently downstream rather than blocking
+	 * federation).
+	 *
+	 * For `core/gallery`: any positive id in the top-level `ids`
+	 * attribute counts; for WP 5.9+ block-nested galleries, recurse
+	 * into `innerBlocks`.
+	 *
+	 * For `core/post-featured-image`: defer to `has_image_thumbnail`,
+	 * which validates the thumbnail attachment still exists.
+	 *
+	 * @param array<string, mixed> $block The parsed block.
+	 * @param \WP_Post             $post  The post being evaluated.
+	 * @return bool True when the block contributes a federatable image.
+	 */
+	private static function block_resolves_locally( array $block, WP_Post $post ): bool {
+		$name = $block['blockName'] ?? '';
+
+		if ( 'core/post-featured-image' === $name ) {
+			return self::has_image_thumbnail( $post );
+		}
+
+		if ( 'core/image' === $name ) {
+			return (int) ( $block['attrs']['id'] ?? 0 ) > 0;
+		}
+
+		if ( 'core/gallery' === $name ) {
+			$ids = $block['attrs']['ids'] ?? array();
+			if ( \is_array( $ids ) ) {
+				foreach ( $ids as $id ) {
+					if ( (int) $id > 0 ) {
+						return true;
+					}
+				}
+			}
+			// WP 5.9+ galleries wrap individual `core/image` blocks
+			// in `innerBlocks` rather than listing ids on the
+			// gallery itself.
+			$inner_blocks = $block['innerBlocks'] ?? array();
+			if ( \is_array( $inner_blocks ) ) {
+				foreach ( $inner_blocks as $sub_block ) {
+					if ( \is_array( $sub_block ) && self::block_resolves_locally( $sub_block, $post ) ) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		return false;
 	}
 
 	/**
@@ -617,8 +711,26 @@ class Photo_Post {
 		}
 
 		// Pass 3: full-size original. Reached when neither the
-		// filename suffix nor any registered intermediate matches —
-		// the URL most likely points at the original upload.
+		// filename suffix nor any registered intermediate matches.
+		// Confirm the URL actually points at `$meta['file']` before
+		// falling back — otherwise a CDN rewrite that preserves the
+		// basename, or an `activitypub_get_image` callback that
+		// substitutes a derivative URL without the size suffix, would
+		// reintroduce the original/derivative dimension mismatch this
+		// helper exists to prevent. Match against the URL's path
+		// component only so query strings / fragments don't fool the
+		// `str_ends_with` check.
+		$file = (string) ( $meta['file'] ?? '' );
+		if ( '' === $file ) {
+			return null;
+		}
+
+		$parsed = \wp_parse_url( $url );
+		$path   = (string) ( $parsed['path'] ?? '' );
+		if ( '' === $path || ! \str_ends_with( $path, $file ) ) {
+			return null;
+		}
+
 		$width  = (int) ( $meta['width'] ?? 0 );
 		$height = (int) ( $meta['height'] ?? 0 );
 		if ( $width > 0 && $height > 0 ) {

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -145,6 +145,20 @@ class Photo_Post {
 	 * @return bool True if the post should federate as a photo post.
 	 */
 	public static function is_photo_post( $post ): bool {
+		// Reject obviously-unsupported input BEFORE handing off to
+		// `get_post()`. The core helper falls back to
+		// `$GLOBALS['post']` whenever its argument is empty — which
+		// includes `null`, `0`, `false`, and `''` — so calling it
+		// with those values during template rendering would silently
+		// resolve to the current loop post instead of returning the
+		// "no post" answer the discriminator's contract promises.
+		if ( null === $post || false === $post || '' === $post ) {
+			return false;
+		}
+		if ( ! \is_numeric( $post ) && ! ( $post instanceof WP_Post ) ) {
+			return false;
+		}
+
 		$resolved = \get_post( $post );
 		if ( ! $resolved instanceof WP_Post ) {
 			return false;

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -1,0 +1,491 @@
+<?php
+/**
+ * Photo-post detection + ActivityPub federation-shape projector.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse;
+
+use WP_Post;
+
+/**
+ * Detects "this WordPress post is a photo post" and projects the
+ * detection onto ActivityPub's transformer filters so the outbound
+ * activity matches what Pixelfed (and IG-style photo clients) render
+ * natively in a photo grid.
+ *
+ * External AP consumers (Pixelfed, Mastodon, Misskey, …) have no
+ * visibility into WordPress internals — CPTs, taxonomies, block
+ * structure — so the photo-shape decision has to be made on the WP
+ * side and projected onto the AP envelope. Pixelfed's "this is a
+ * photo" gate is purely "does the Note have valid image attachments?"
+ * (`pixelfed/app/Util/ActivityPub/Helpers.php::verifyAttachments`),
+ * and the IG-feel rendering wants `type: Note` with a caption-only
+ * `content` plus dimensionally-complete `attachment[]` entries.
+ *
+ * Detection (`is_photo_post()`) fires in three stages so callers can
+ * intervene at either boundary:
+ *
+ *   1. `fosse_pre_is_photo_post` short-circuit. Return a non-null
+ *      bool to hardwire the decision before any block parsing
+ *      happens (the recipe for sites that maintain a custom photo
+ *      CPT — they already know what's a photo and don't need FOSSE
+ *      to look at blocks).
+ *   2. Built-in detection: post format `image`/`gallery`, or block
+ *      content shaped like "one image-like block plus at most one
+ *      paragraph," or a featured image with an otherwise empty
+ *      body. Title presence is intentionally not a disqualifier —
+ *      "headline + photo + caption" is a common photo-post shape.
+ *   3. `fosse_is_photo_post` final filter. Mutate or downgrade the
+ *      detection result.
+ *
+ * When the discriminator returns true, the AP-side hooks fire:
+ *
+ *   - `activitypub_post_object_type` → force `Note` (Pixelfed only
+ *     renders Notes in photo timelines; Articles drop into the
+ *     long-form reader path).
+ *   - `activitypub_the_content` → strip the image / gallery /
+ *     featured-image block markup so the body is caption-only.
+ *     Pixelfed accepts HTML in `content`, but the photo-grid feel
+ *     wants a short caption, not an article that happens to lead
+ *     with an image.
+ *   - `activitypub_attachment` → add `width`/`height` to every
+ *     image attachment from `wp_get_attachment_metadata()`. Fires
+ *     unconditionally (not gated on `is_photo_post()`): dimensions
+ *     are universally useful — Mastodon uses them for layout,
+ *     Pixelfed enforces them in `verifyAttachments`, and bundled AP
+ *     already emits them for video/audio. Closing the gap for
+ *     images here is a strict superset.
+ *
+ * Out of scope (separate tickets):
+ *   - `blurhash`: needs a PHP encoder dep + background job at
+ *     upload time, can't run synchronously on the federation hot
+ *     path.
+ *   - AT-protocol `app.bsky.embed.images`: Atmosphere today only
+ *     emits `app.bsky.embed.external` link cards. Switching photo
+ *     posts to native image embeds is its own project (uploadBlob,
+ *     blob caching, 4-image cap with overflow strategy).
+ *   - `sensitive` / `summary` (content warnings): needs UX decision
+ *     on the source of truth — taxonomy, postmeta, or per-network.
+ */
+class Photo_Post {
+
+	/**
+	 * Block names that count as image-like content for the body-shape
+	 * detector. `core/post-featured-image` is included because the
+	 * Featured Image block resolves to the post thumbnail and federates
+	 * the same way as a `core/image` — from Pixelfed's point of view
+	 * they're indistinguishable.
+	 *
+	 * @var array<int, string>
+	 */
+	private const IMAGE_LIKE_BLOCKS = array(
+		'core/image',
+		'core/gallery',
+		'core/post-featured-image',
+	);
+
+	/**
+	 * Block names that don't count as substantive content when deciding
+	 * "is the body just image + caption?". Used to ignore structural
+	 * filler so a post with `<image><spacer><paragraph>` still detects
+	 * the same as `<image><paragraph>`.
+	 *
+	 * @var array<int, string>
+	 */
+	private const IGNORABLE_BLOCKS = array(
+		'core/spacer',
+		'core/separator',
+	);
+
+	/**
+	 * Per-request memo of `is_photo_post()` results.
+	 *
+	 * Detection runs `parse_blocks()` against the post body and can be
+	 * called from several hooks during a single federation pass (object
+	 * type, content stripping, attachment dimension enrichment). Keyed
+	 * by post ID; cleared between requests because the cache lives on a
+	 * static.
+	 *
+	 * @var array<int, bool>
+	 */
+	private static array $decision_cache = array();
+
+	/**
+	 * Register the AP transformer hooks. Safe to call more than once
+	 * per request — WordPress dedupes identical callable-as-array
+	 * registrations.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		\add_action( 'after_setup_theme', array( self::class, 'register_post_format_support' ), 99 );
+		\add_filter( 'activitypub_post_object_type', array( self::class, 'filter_object_type' ), 10, 2 );
+		\add_filter( 'activitypub_the_content', array( self::class, 'filter_content' ), 10, 2 );
+		\add_filter( 'activitypub_attachment', array( self::class, 'filter_attachment_dimensions' ), 10, 2 );
+	}
+
+	/**
+	 * Ensure the `post` post type supports post formats so
+	 * `get_post_format()` doesn't short-circuit before consulting the
+	 * `post_format` taxonomy term — Rule 1 of `detect()` depends on
+	 * that term being readable. Block themes increasingly skip
+	 * `add_theme_support( 'post-formats', … )` in their setup, which
+	 * silently disables `get_post_format()` even when the term is set.
+	 *
+	 * Runs at `after_setup_theme` priority 99 so the active theme has
+	 * already had its chance to declare any post-type / theme support
+	 * of its own. `add_post_type_support` is idempotent and additive —
+	 * registering it here on top of a theme that already declared it
+	 * is a no-op.
+	 *
+	 * Intentionally narrow: we register the *post-type* support flag
+	 * that `get_post_format()` checks, but do NOT call
+	 * `add_theme_support( 'post-formats', [...] )` to populate the
+	 * Gutenberg format picker's dropdown. Doing so would either
+	 * overwrite the theme's curated list or require a brittle merge.
+	 * The federation-shape contract only needs the term to be
+	 * readable; surfacing format UI for users on opinionated themes
+	 * is a separate UX concern.
+	 *
+	 * @return void
+	 */
+	public static function register_post_format_support(): void {
+		\add_post_type_support( 'post', 'post-formats' );
+	}
+
+	/**
+	 * Discriminator: should this WP post federate as a photo post?
+	 *
+	 * Short-circuit order:
+	 *
+	 *   1. Resolve `$post` to a WP_Post; return false on failure
+	 *      (defensive — any non-post input is treated as not-a-photo,
+	 *      so a stray hook call can't flip the AP envelope).
+	 *   2. Apply `fosse_pre_is_photo_post`. A callback returning a
+	 *      bool wins outright; null means "no opinion, run detection."
+	 *   3. Run the built-in detector (`detect()`).
+	 *   4. Apply `fosse_is_photo_post` to the detected value so
+	 *      callers can downgrade or upgrade after the fact.
+	 *
+	 * Memoized per post id — see {@see self::$decision_cache} for why.
+	 *
+	 * @param int|WP_Post $post Post ID or `WP_Post`.
+	 * @return bool True if the post should federate as a photo post.
+	 */
+	public static function is_photo_post( $post ): bool {
+		$resolved = \get_post( $post );
+		if ( ! $resolved instanceof WP_Post ) {
+			return false;
+		}
+
+		if ( isset( self::$decision_cache[ $resolved->ID ] ) ) {
+			return self::$decision_cache[ $resolved->ID ];
+		}
+
+		/**
+		 * Hardwire the photo-post decision before built-in detection runs.
+		 *
+		 * Return a bool to short-circuit (`true` to force photo-post
+		 * treatment, `false` to suppress it). Return `null` (the
+		 * default) to let `Photo_Post::detect()` run the post-format
+		 * and block-shape checks. Use this when the site has its own
+		 * authoritative signal — e.g. a custom photo CPT, a taxonomy
+		 * term, or postmeta set by a composer — that's faster and
+		 * more reliable than block introspection.
+		 *
+		 * @param bool|null $short_circuit Hardwired decision, or null to defer.
+		 * @param \WP_Post  $post          The post being evaluated.
+		 */
+		$pre = \apply_filters( 'fosse_pre_is_photo_post', null, $resolved );
+		if ( null !== $pre ) {
+			$result = (bool) $pre;
+		} else {
+			$result = self::detect( $resolved );
+		}
+
+		/**
+		 * Filter the final photo-post decision after built-in detection.
+		 *
+		 * Fires after `fosse_pre_is_photo_post` and any built-in
+		 * detection. Use this to override a detected positive (e.g.
+		 * exclude posts in a specific taxonomy term from being
+		 * treated as photo posts) or to upgrade an undetected case
+		 * (e.g. a CPT whose body happens to be a custom block FOSSE
+		 * doesn't recognize as image-like).
+		 *
+		 * @param bool     $is_photo Whether the post is a photo post.
+		 * @param \WP_Post $post     The post being evaluated.
+		 */
+		$result = (bool) \apply_filters( 'fosse_is_photo_post', $result, $resolved );
+
+		self::$decision_cache[ $resolved->ID ] = $result;
+		return $result;
+	}
+
+	/**
+	 * Built-in photo-post detection. Runs after the pre-filter
+	 * short-circuit declines to answer.
+	 *
+	 * Returns true when any of:
+	 *
+	 *   1. The post format is `image` or `gallery`.
+	 *   2. The block content boils down to "one image-like block,
+	 *      optionally followed by a single paragraph block,"
+	 *      ignoring purely structural blocks (spacer, separator).
+	 *   3. The post has a featured image and the body has at most
+	 *      one paragraph block (so "set featured image, type one
+	 *      sentence, hit publish" works without the user having to
+	 *      know about Post Formats).
+	 *
+	 * Rule 2 is the catch-most-cases path for users who don't use
+	 * Post Formats at all (modern block-editor flow). Rule 3 handles
+	 * the classic-editor / mobile-app flow where the featured image
+	 * is the photo and the body is the caption.
+	 *
+	 * Title presence is intentionally not a disqualifier — a post
+	 * shaped like "Headline. Big photo. One-line caption." is still
+	 * a photo post; the user explicitly requested this on
+	 * `DOTCOM-17143`.
+	 *
+	 * @param \WP_Post $post The post being evaluated.
+	 * @return bool True if the post matches one of the built-in rules.
+	 */
+	private static function detect( WP_Post $post ): bool {
+		$format = \get_post_format( $post );
+		if ( 'image' === $format || 'gallery' === $format ) {
+			return true;
+		}
+
+		$has_thumbnail = \has_post_thumbnail( $post );
+
+		// Empty body + featured image = "Set thumbnail, hit publish"
+		// flow (Rule 3 with zero paragraphs). Catch this before the
+		// block parser, which returns a single blank-blockName block
+		// for empty content and would otherwise classify it as not a
+		// photo post.
+		if ( $has_thumbnail && '' === \trim( (string) $post->post_content ) ) {
+			return true;
+		}
+
+		$blocks = \parse_blocks( $post->post_content );
+		if ( empty( $blocks ) ) {
+			return false;
+		}
+
+		$image_count     = 0;
+		$paragraph_count = 0;
+		$other_count     = 0;
+
+		foreach ( $blocks as $block ) {
+			$name = $block['blockName'] ?? null;
+
+			// `parse_blocks()` emits a null-blockName entry for any
+			// freeform / classic content sandwiched between blocks
+			// (or for a post that's entirely classic content). Treat
+			// whitespace-only freeform as ignorable; substantive
+			// freeform counts as "other" content that disqualifies.
+			if ( null === $name ) {
+				$inner = \trim( $block['innerHTML'] ?? '' );
+				if ( '' === $inner ) {
+					continue;
+				}
+				++$other_count;
+				continue;
+			}
+
+			if ( \in_array( $name, self::IGNORABLE_BLOCKS, true ) ) {
+				continue;
+			}
+
+			if ( \in_array( $name, self::IMAGE_LIKE_BLOCKS, true ) ) {
+				++$image_count;
+				continue;
+			}
+
+			if ( 'core/paragraph' === $name ) {
+				// An empty paragraph block ("<p></p>") is structural
+				// padding from the editor, not a real caption.
+				$inner = \trim( \wp_strip_all_tags( $block['innerHTML'] ?? '' ) );
+				if ( '' === $inner ) {
+					continue;
+				}
+				++$paragraph_count;
+				continue;
+			}
+
+			++$other_count;
+		}
+
+		if ( $other_count > 0 ) {
+			return false;
+		}
+
+		// Rule 2: exactly one image-like block, at most one caption paragraph.
+		if ( 1 === $image_count && $paragraph_count <= 1 ) {
+			return true;
+		}
+
+		// Rule 3: featured image + body = at most one paragraph.
+		if ( $has_thumbnail && 0 === $image_count && $paragraph_count <= 1 ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Force `type: "Note"` for photo posts. Hooked on
+	 * `activitypub_post_object_type`.
+	 *
+	 * Pixelfed renders only Notes in its photo timeline; an Article
+	 * lands in the long-form reader path regardless of how
+	 * dimensionally-complete its attachments are. Mastodon treats
+	 * Notes-with-attachments as native toots with media. Forcing
+	 * `Note` is therefore the single highest-leverage change for
+	 * photo-feel rendering across the AP ecosystem.
+	 *
+	 * Pass-through for non-photo posts so this filter is a no-op on
+	 * everything else (Article / Page choices owned by bundled AP's
+	 * own `get_type()` logic remain authoritative).
+	 *
+	 * @param string $object_type The AP-computed object type.
+	 * @param mixed  $post        The post being transformed.
+	 * @return string `Note` for photo posts, otherwise pass-through.
+	 */
+	public static function filter_object_type( $object_type, $post ): string {
+		if ( ! $post instanceof WP_Post ) {
+			return (string) $object_type;
+		}
+
+		if ( ! self::is_photo_post( $post ) ) {
+			return (string) $object_type;
+		}
+
+		return 'Note';
+	}
+
+	/**
+	 * Strip image-block markup from the rendered AP content for photo
+	 * posts. Hooked on `activitypub_the_content`.
+	 *
+	 * By the time this filter fires, the body has been through the
+	 * full `the_content` chain — blocks are already expanded to HTML.
+	 * Image blocks render with stable wrapper classes
+	 * (`wp-block-image`, `wp-block-gallery`,
+	 * `wp-block-post-featured-image`), so a class-anchored regex pass
+	 * is enough to remove them along with any nested `<img>` /
+	 * `<figcaption>`. After stripping, we also drop standalone `<img>`
+	 * tags as a defensive measure and clean up empty paragraph
+	 * wrappers left behind by the editor.
+	 *
+	 * Why strip at all: Pixelfed accepts HTML in `content` and would
+	 * happily render the figure markup inline, but the photo-grid
+	 * feel wants a short caption next to the attachment, not an
+	 * article that opens with an image and then duplicates that image
+	 * via `attachment[]`. Stripping leaves the caption (paragraph
+	 * text, headings, etc.) intact for downstream rendering.
+	 *
+	 * @param string $content The rendered AP content.
+	 * @param mixed  $post    The post being transformed.
+	 * @return string Content with image-block markup removed when the post is a photo post.
+	 */
+	public static function filter_content( $content, $post ): string {
+		$content = (string) $content;
+
+		if ( ! $post instanceof WP_Post ) {
+			return $content;
+		}
+
+		if ( ! self::is_photo_post( $post ) ) {
+			return $content;
+		}
+
+		// Drop the entire figure wrapper produced by core image-like blocks,
+		// including any nested <img> / <figcaption>.
+		$content = (string) \preg_replace(
+			'#<figure\b[^>]*class="[^"]*\bwp-block-(?:image|gallery|post-featured-image)\b[^"]*"[^>]*>.*?</figure>#is',
+			'',
+			$content
+		);
+
+		// Defensive: strip any orphan <img> that survived (classic-editor
+		// inline images, or themes/plugins that wrap images differently).
+		$content = (string) \preg_replace( '#<img\b[^>]*>#is', '', $content );
+
+		// Clean up empty paragraph shells the editor leaves behind once the
+		// only child was the image we just removed.
+		$content = (string) \preg_replace( '#<p\b[^>]*>\s*</p>#is', '', $content );
+
+		return \trim( $content );
+	}
+
+	/**
+	 * Add `width` / `height` to image attachments. Hooked on
+	 * `activitypub_attachment`.
+	 *
+	 * Fires unconditionally (NOT gated on `is_photo_post()`) — image
+	 * dimensions are useful to every AP receiver: Mastodon uses them
+	 * for media-grid layout, Pixelfed enforces them in
+	 * `verifyAttachments` (1–5000 pixels per side), and bundled AP
+	 * already emits them for video/audio. Adding them for images
+	 * closes a gap without changing any other behavior.
+	 *
+	 * The bundled transformer shapes images like
+	 * `{type:"Image", url, mediaType, name?, exifData?}` — we add
+	 * `width` / `height` from `wp_get_attachment_metadata()` when
+	 * present and skip silently when missing (e.g. external images
+	 * with no local attachment ID, or attachments whose metadata
+	 * hasn't been generated yet).
+	 *
+	 * @param array $attachment The AP attachment array.
+	 * @param mixed $id         The WP attachment ID being transformed.
+	 * @return array The attachment with width/height when available.
+	 */
+	public static function filter_attachment_dimensions( $attachment, $id ): array {
+		if ( ! \is_array( $attachment ) ) {
+			return array();
+		}
+
+		if ( 'Image' !== ( $attachment['type'] ?? null ) ) {
+			return $attachment;
+		}
+
+		if ( isset( $attachment['width'] ) && isset( $attachment['height'] ) ) {
+			return $attachment;
+		}
+
+		if ( ! \is_numeric( $id ) ) {
+			return $attachment;
+		}
+
+		$meta = \wp_get_attachment_metadata( (int) $id );
+		if ( ! \is_array( $meta ) ) {
+			return $attachment;
+		}
+
+		if ( ! isset( $meta['width'] ) || ! isset( $meta['height'] ) ) {
+			return $attachment;
+		}
+
+		$attachment['width']  = (int) $meta['width'];
+		$attachment['height'] = (int) $meta['height'];
+
+		return $attachment;
+	}
+
+	/**
+	 * Clear the per-request decision cache.
+	 *
+	 * Test-only entry point — production never needs to invalidate
+	 * mid-request because the cache key is the post id and the post's
+	 * shape (post format, content, featured image) is stable across
+	 * a single federation pass. Public so test setUp can call it.
+	 *
+	 * @return void
+	 */
+	public static function reset_cache_for_testing(): void {
+		self::$decision_cache = array();
+	}
+}

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -295,6 +295,11 @@ class Photo_PostTest extends BaseTestCase {
 		$this->assertFalse( Photo_Post::is_photo_post( 999999 ) );
 		$this->assertFalse( Photo_Post::is_photo_post( false ) );
 		$this->assertFalse( Photo_Post::is_photo_post( '' ) );
+		// `0` / `'0'` are `is_numeric()`-true but `get_post(0)`
+		// also resolves to the global `$post`. Must short-circuit
+		// on the integer-zero path too.
+		$this->assertFalse( Photo_Post::is_photo_post( 0 ) );
+		$this->assertFalse( Photo_Post::is_photo_post( '0' ) );
 	}
 
 	/**
@@ -318,6 +323,8 @@ class Photo_PostTest extends BaseTestCase {
 			$this->assertFalse( Photo_Post::is_photo_post( null ) );
 			$this->assertFalse( Photo_Post::is_photo_post( false ) );
 			$this->assertFalse( Photo_Post::is_photo_post( '' ) );
+			$this->assertFalse( Photo_Post::is_photo_post( 0 ) );
+			$this->assertFalse( Photo_Post::is_photo_post( '0' ) );
 		} finally {
 			if ( null === $previous_global ) {
 				unset( $GLOBALS['post'] );
@@ -497,6 +504,93 @@ class Photo_PostTest extends BaseTestCase {
 		$post     = $this->make_post( $external, '', 'image' );
 
 		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Rule 1 must NOT fire when a Featured Image is set AND the
+	 * body carries an unresolvable image block — the content
+	 * filter strips every `wp-block-image` figure regardless of
+	 * resolvability, so allowing this combination would silently
+	 * drop the external inline image from the federated post even
+	 * though the thumbnail anchors the photo classification.
+	 * Falling back to article behavior keeps the inline figure
+	 * intact for receivers.
+	 */
+	public function test_image_format_with_thumbnail_plus_external_inline_does_not_detect(): void {
+		$external = '<!-- wp:image --><figure class="wp-block-image"><img src="https://elsewhere.test/inline.jpg"/></figure><!-- /wp:image -->';
+		$post     = $this->make_post( $external, '', 'image', 1 );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Bundled AP caps attachments at
+	 * `activitypub_max_image_attachments` (default 4). A
+	 * gallery / multi-image post that exceeds the cap must NOT
+	 * detect as a photo — the content stripper would remove every
+	 * image figure but only N would ship as attachments, losing
+	 * the overflow. Falling through to article behavior keeps
+	 * every figure inline AND still emits the first N attachments
+	 * as supplements.
+	 */
+	public function test_image_count_exceeding_max_attachments_does_not_detect(): void {
+		// Lower the cap to 1 so a two-image gallery exceeds it
+		// without needing five real attachments. Using a filter
+		// keeps the test environment minimal.
+		add_filter(
+			'activitypub_max_image_attachments',
+			static function () {
+				return 1;
+			}
+		);
+
+		$two_image_gallery = $this->resolve_image_placeholders(
+			'<!-- wp:gallery -->'
+			. '<figure class="wp-block-gallery">'
+			. '<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":PHOTO_ID_ALT} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '</figure>'
+			. '<!-- /wp:gallery -->'
+		);
+		$post              = $this->make_post( $two_image_gallery );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Sanity: the cap-comparison helper honors per-post meta over
+	 * the site option. A meta override of 10 must let a 2-image
+	 * gallery sail through even when a hypothetical site-level
+	 * cap would block it.
+	 */
+	public function test_image_count_with_per_post_cap_override_detects(): void {
+		$two_image_gallery = $this->resolve_image_placeholders(
+			'<!-- wp:gallery -->'
+			. '<figure class="wp-block-gallery">'
+			. '<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":PHOTO_ID_ALT} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '</figure>'
+			. '<!-- /wp:gallery -->'
+		);
+		$post              = $this->make_post( $two_image_gallery );
+		update_post_meta( $post->ID, 'activitypub_max_image_attachments', 10 );
+
+		// Force the same low site-level cap as the previous test
+		// to prove per-post meta wins. The post-meta read happens
+		// before the filter so the meta value bypasses the
+		// site-wide constraint.
+		add_filter(
+			'activitypub_max_image_attachments',
+			static function ( $value ) {
+				return $value; // pass through whatever resolved
+			}
+		);
+
+		// Bust the per-post cache so detection re-evaluates after
+		// the meta update.
+		Photo_Post::reset_cache_for_testing();
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
 	}
 
 	// ---------------------------------------------------------------

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -299,9 +299,14 @@ class Photo_PostTest extends BaseTestCase {
 	 * @return array<string, array{0:string, 1:bool}>
 	 */
 	public static function block_shape_cases(): array {
+		// Block fixtures use `id` / `ids` attributes that signal a
+		// local attachment to `Photo_Post::block_resolves_locally`.
+		// External-URL image blocks (no `id`) and post-featured-image
+		// blocks (which require a real thumbnail) are exercised in
+		// dedicated test methods below — the data provider is static
+		// and cannot wire up per-case thumbnail state.
 		$image     = '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img src="https://example.test/a.jpg" alt=""/></figure><!-- /wp:image -->';
-		$gallery   = '<!-- wp:gallery --><figure class="wp-block-gallery"></figure><!-- /wp:gallery -->';
-		$featured  = '<!-- wp:post-featured-image /-->';
+		$gallery   = '<!-- wp:gallery {"ids":[42,43]} --><figure class="wp-block-gallery"></figure><!-- /wp:gallery -->';
 		$paragraph = '<!-- wp:paragraph --><p>caption text</p><!-- /wp:paragraph -->';
 		$heading   = '<!-- wp:heading --><h2>headline</h2><!-- /wp:heading -->';
 		$spacer    = '<!-- wp:spacer --><div class="wp-block-spacer"></div><!-- /wp:spacer -->';
@@ -309,20 +314,18 @@ class Photo_PostTest extends BaseTestCase {
 		$empty_p   = '<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->';
 
 		return array(
-			'image only'                     => array( $image, true ),
-			'image plus single paragraph'    => array( $image . $paragraph, true ),
-			'image plus two paragraphs'      => array( $image . $paragraph . $paragraph, false ),
-			'paragraph only'                 => array( $paragraph, false ),
-			'gallery only'                   => array( $gallery, true ),
-			'gallery plus paragraph'         => array( $gallery . $paragraph, true ),
-			'featured image block only'      => array( $featured, true ),
-			'featured image block plus para' => array( $featured . $paragraph, true ),
-			'image plus heading'             => array( $image . $heading, false ),
-			'two images'                     => array( $image . $image, false ),
-			'image plus empty paragraph'     => array( $image . $empty_p, true ),
-			'image plus spacer plus para'    => array( $image . $spacer . $paragraph, true ),
-			'image plus separator'           => array( $image . $separator, true ),
-			'empty content'                  => array( '', false ),
+			'image only'                  => array( $image, true ),
+			'image plus single paragraph' => array( $image . $paragraph, true ),
+			'image plus two paragraphs'   => array( $image . $paragraph . $paragraph, false ),
+			'paragraph only'              => array( $paragraph, false ),
+			'gallery only'                => array( $gallery, true ),
+			'gallery plus paragraph'      => array( $gallery . $paragraph, true ),
+			'image plus heading'          => array( $image . $heading, false ),
+			'two images'                  => array( $image . $image, false ),
+			'image plus empty paragraph'  => array( $image . $empty_p, true ),
+			'image plus spacer plus para' => array( $image . $spacer . $paragraph, true ),
+			'image plus separator'        => array( $image . $separator, true ),
+			'empty content'               => array( '', false ),
 		);
 	}
 
@@ -336,7 +339,7 @@ class Photo_PostTest extends BaseTestCase {
 	 * Caption." to still count.
 	 */
 	public function test_title_does_not_suppress_detection(): void {
-		$image = '<!-- wp:image --><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure><!-- /wp:image -->';
+		$image = '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure><!-- /wp:image -->';
 		$post  = $this->make_post( $image, 'My Photo Title' );
 
 		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
@@ -551,6 +554,7 @@ class Photo_PostTest extends BaseTestCase {
 		wp_update_attachment_metadata(
 			$attachment_id,
 			array(
+				'file'   => 'a.jpg',
 				'width'  => 2048,
 				'height' => 1365,
 			)
@@ -864,5 +868,136 @@ class Photo_PostTest extends BaseTestCase {
 		$post = $this->make_post( '', '', '', -1 );
 
 		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	// ---------------------------------------------------------------
+	// Detection: image block must resolve to local attachment.
+	// ---------------------------------------------------------------
+
+	/**
+	 * A `core/image` block carrying an external URL has no `id`
+	 * attribute. Bundled AP's attachment extraction skips it, so
+	 * forcing photo-post treatment would strip the markup from
+	 * content AND ship no attachment — caption-only Note with no
+	 * image. Treat as not-a-photo so the external URL stays in the
+	 * body for receivers to render inline.
+	 */
+	public function test_external_url_image_block_does_not_detect(): void {
+		$external_image = '<!-- wp:image --><figure class="wp-block-image"><img src="https://elsewhere.test/foo.jpg"/></figure><!-- /wp:image -->';
+		$post           = $this->make_post( $external_image );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * A WP 5.9+ gallery wraps individual `core/image` blocks in its
+	 * `innerBlocks` rather than listing ids on the gallery itself.
+	 * The resolver must recurse into innerBlocks so block-nested
+	 * galleries still detect.
+	 */
+	public function test_gallery_with_inner_image_blocks_detects(): void {
+		$nested_gallery = '<!-- wp:gallery -->'
+			. '<figure class="wp-block-gallery">'
+			. '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":43} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '</figure>'
+			. '<!-- /wp:gallery -->';
+		$post           = $this->make_post( $nested_gallery );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * A gallery with neither `ids` attribute nor block-nested images
+	 * has no federatable content. Same degradation as the external-URL
+	 * image case: classify as not-a-photo.
+	 */
+	public function test_empty_gallery_does_not_detect(): void {
+		$empty_gallery = '<!-- wp:gallery --><figure class="wp-block-gallery"></figure><!-- /wp:gallery -->';
+		$post          = $this->make_post( $empty_gallery );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	// ---------------------------------------------------------------
+	// Detection: post-featured-image block requires a real thumbnail.
+	// ---------------------------------------------------------------
+
+	/**
+	 * `core/post-featured-image` block with a real Featured Image set
+	 * federates the same way as Rule 3's empty-body case — count it
+	 * as a photo post when there's a thumbnail to actually emit.
+	 */
+	public function test_featured_image_block_with_thumbnail_detects(): void {
+		$featured = '<!-- wp:post-featured-image /-->';
+		$post     = $this->make_post( $featured, '', '', 1 );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Same block plus a caption paragraph also detects. Matches the
+	 * "headline + photo + caption" shape the discriminator targets.
+	 */
+	public function test_featured_image_block_plus_paragraph_with_thumbnail_detects(): void {
+		$featured  = '<!-- wp:post-featured-image /-->';
+		$paragraph = '<!-- wp:paragraph --><p>caption</p><!-- /wp:paragraph -->';
+		$post      = $this->make_post( $featured . $paragraph, '', '', 1 );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * The block in the body without a real Featured Image set on the
+	 * post resolves to nothing federation-side — classify as not a
+	 * photo post so detection falls through to article behavior.
+	 */
+	public function test_featured_image_block_without_thumbnail_does_not_detect(): void {
+		$featured = '<!-- wp:post-featured-image /-->';
+		$post     = $this->make_post( $featured );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	// ---------------------------------------------------------------
+	// AP hook: dimensions full-size fallback only fires on real path.
+	// ---------------------------------------------------------------
+
+	/**
+	 * The full-size fallback is now gated on the URL ending with
+	 * `meta['file']`. A CDN URL that preserves the basename but
+	 * doesn't include the upload subpath must NOT inherit the
+	 * recorded original dimensions — Pixelfed would then enforce the
+	 * mismatch and reject the post. Verify by setting up metadata for
+	 * a "/2026/05/original.jpg" file but passing a URL that ends in
+	 * just "/original.jpg".
+	 */
+	public function test_attachment_filter_skips_full_size_when_path_mismatches(): void {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		wp_update_attachment_metadata(
+			$attachment_id,
+			array(
+				'file'   => '2026/05/original.jpg',
+				'width'  => 4000,
+				'height' => 3000,
+			)
+		);
+
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://cdn.example.test/cached/original.jpg',
+			'mediaType' => 'image/jpeg',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, $attachment_id );
+
+		$this->assertArrayNotHasKey( 'width', $out );
+		$this->assertArrayNotHasKey( 'height', $out );
 	}
 }

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -964,6 +964,132 @@ class Photo_PostTest extends BaseTestCase {
 	// ---------------------------------------------------------------
 
 	/**
+	 * Pass 2 (registered intermediate sizes) was the dimension-
+	 * resolution path the round-1 fix added but no test exercised.
+	 * Custom-named derivatives (sizes registered without the standard
+	 * `-WxH` naming convention) only resolve through `sizes[]` lookup.
+	 * Set up metadata with a custom-named size, pass a URL ending in
+	 * that filename, and assert the matching dimensions come back.
+	 */
+	public function test_attachment_filter_uses_metadata_sizes_match(): void {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		wp_update_attachment_metadata(
+			$attachment_id,
+			array(
+				'file'  => '2026/05/photo.jpg',
+				'sizes' => array(
+					'hero' => array(
+						'file'   => 'photo-hero.jpg',
+						'width'  => 1200,
+						'height' => 800,
+					),
+				),
+			)
+		);
+
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://example.test/wp-content/uploads/2026/05/photo-hero.jpg',
+			'mediaType' => 'image/jpeg',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, $attachment_id );
+
+		$this->assertSame( 1200, $out['width'] );
+		$this->assertSame( 800, $out['height'] );
+	}
+
+	/**
+	 * The full-size fallback's `str_ends_with` check anchors on a
+	 * leading `/` so a bare-basename `meta['file']` (sites that
+	 * disable year/month upload subdirs in Settings → Media) doesn't
+	 * collide with URLs that end in the basename as a suffix.
+	 * Without the anchor, `/wp-content/uploads/some-photo.jpg` ends
+	 * with `photo.jpg` and would inherit the wrong attachment's
+	 * dimensions.
+	 */
+	public function test_attachment_filter_skips_full_size_on_basename_collision(): void {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		wp_update_attachment_metadata(
+			$attachment_id,
+			array(
+				'file'   => 'photo.jpg',
+				'width'  => 4000,
+				'height' => 3000,
+			)
+		);
+
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://example.test/wp-content/uploads/some-photo.jpg',
+			'mediaType' => 'image/jpeg',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, $attachment_id );
+
+		$this->assertArrayNotHasKey( 'width', $out );
+		$this->assertArrayNotHasKey( 'height', $out );
+	}
+
+	/**
+	 * HEIC, HEIF, and TIFF derivatives carry the same `-WIDTHxHEIGHT`
+	 * filename suffix as JPEG / PNG / WebP / AVIF. Mastodon now
+	 * accepts HEIC server-side, and Pixelfed enforces dimensions for
+	 * all image types — the suffix regex must cover the modern format
+	 * set or HEIC posts will ship without dimensions and (where the
+	 * receiver enforces them) get rejected.
+	 *
+	 * @param string $url      Image URL with a HEIC/HEIF/TIFF derivative suffix.
+	 * @param int    $expected_width Expected width parsed from the suffix.
+	 * @param int    $expected_height Expected height parsed from the suffix.
+	 *
+	 * @dataProvider modern_image_format_cases
+	 */
+	#[DataProvider( 'modern_image_format_cases' )]
+	public function test_attachment_filter_extracts_modern_format_dimensions(
+		string $url,
+		int $expected_width,
+		int $expected_height
+	): void {
+		$input = array(
+			'type'      => 'Image',
+			'url'       => $url,
+			'mediaType' => 'image/jpeg',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, 0 );
+
+		$this->assertSame( $expected_width, $out['width'] );
+		$this->assertSame( $expected_height, $out['height'] );
+	}
+
+	/**
+	 * Data provider for `test_attachment_filter_extracts_modern_format_dimensions`.
+	 *
+	 * @return array<string, array{0:string, 1:int, 2:int}>
+	 */
+	public static function modern_image_format_cases(): array {
+		return array(
+			'heic' => array( 'https://example.test/photo-1024x683.heic', 1024, 683 ),
+			'heif' => array( 'https://example.test/photo-800x600.heif', 800, 600 ),
+			'tif'  => array( 'https://example.test/photo-2000x1500.tif', 2000, 1500 ),
+			'tiff' => array( 'https://example.test/photo-4096x4096.tiff', 4096, 4096 ),
+		);
+	}
+
+	/**
 	 * The full-size fallback is now gated on the URL ending with
 	 * `meta['file']`. A CDN URL that preserves the basename but
 	 * doesn't include the upload subpath must NOT inherit the
@@ -999,5 +1125,49 @@ class Photo_PostTest extends BaseTestCase {
 
 		$this->assertArrayNotHasKey( 'width', $out );
 		$this->assertArrayNotHasKey( 'height', $out );
+	}
+
+	// ---------------------------------------------------------------
+	// Detection: wp_unslash regression + gallery innerBlocks edge case.
+	// ---------------------------------------------------------------
+
+	/**
+	 * `wp_filter_post_kses` slashes block-attribute JSON in
+	 * post_content for users without `unfiltered_html` (Contributors,
+	 * multisite Authors). Without the `wp_unslash()` call in
+	 * `Photo_Post::detect()`, `parse_blocks()` deserializes attrs as
+	 * `null` from the slashed JSON and `block_resolves_locally()`
+	 * misses the `id` — the post then falls through to article shape
+	 * even though it's a legitimate photo post.
+	 *
+	 * This test mutates the stored `post_content` to the slashed form
+	 * a non-admin author would produce and asserts detection still
+	 * fires. Without `wp_unslash`, the assertion fails.
+	 */
+	public function test_detection_handles_slashed_block_attributes(): void {
+		$slashed_body = \addslashes( '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure><!-- /wp:image -->' );
+		$post         = $this->make_post( $slashed_body );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * A WP 5.9+ gallery whose `innerBlocks` are all external-URL
+	 * image blocks (no `id` attribute) has no federatable content —
+	 * `block_resolves_locally` recurses through innerBlocks but every
+	 * sub-block fails the `id > 0` check. Result: gallery is treated
+	 * as "other" content, detection falls through to article
+	 * behavior, and the external URLs stay in the body.
+	 */
+	public function test_gallery_with_only_external_inner_image_blocks_does_not_detect(): void {
+		$external_gallery = '<!-- wp:gallery -->'
+			. '<figure class="wp-block-gallery">'
+			. '<!-- wp:image --><figure class="wp-block-image"><img src="https://elsewhere.test/a.jpg"/></figure><!-- /wp:image -->'
+			. '<!-- wp:image --><figure class="wp-block-image"><img src="https://elsewhere.test/b.jpg"/></figure><!-- /wp:image -->'
+			. '</figure>'
+			. '<!-- /wp:gallery -->';
+		$post             = $this->make_post( $external_gallery );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
 	}
 }

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -1231,6 +1231,41 @@ class Photo_PostTest extends BaseTestCase {
 	}
 
 	/**
+	 * `<figcaption>` inside an image/gallery figure carries the
+	 * user's caption text. Dropping the figure wrapper without
+	 * preserving the figcaption would mangle the user's intent —
+	 * Pixelfed and Mastodon both render figcaption alongside
+	 * attached media. The stripper lifts each non-empty figcaption
+	 * out as a `<p>` in the figure's place before removing the
+	 * wrapper.
+	 */
+	public function test_content_filter_preserves_figcaption_text(): void {
+		$post     = $this->make_post( '', '', 'image', 1 );
+		$content  = '<figure class="wp-block-image"><img src="https://example.test/a.jpg"/><figcaption>Sunset over the bay.</figcaption></figure>';
+		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
+
+		$this->assertStringNotContainsString( '<img', $filtered );
+		$this->assertStringNotContainsString( '<figure', $filtered );
+		$this->assertStringNotContainsString( '<figcaption', $filtered );
+		$this->assertStringContainsString( 'Sunset over the bay.', $filtered );
+	}
+
+	/**
+	 * Empty `<figcaption>` shells (no user-supplied text) must not
+	 * leak through as blank paragraphs after stripping.
+	 */
+	public function test_content_filter_drops_empty_figcaption(): void {
+		$post     = $this->make_post( '', '', 'image', 1 );
+		$content  = '<figure class="wp-block-image"><img src="https://example.test/a.jpg"/><figcaption></figcaption></figure><p>Real caption.</p>';
+		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
+
+		$this->assertStringNotContainsString( '<figcaption', $filtered );
+		// No leading empty `<p>` from the missing figcaption.
+		$this->assertStringNotContainsString( '<p></p>', $filtered );
+		$this->assertStringContainsString( 'Real caption.', $filtered );
+	}
+
+	/**
 	 * Single-quoted class attributes — uncommon but valid HTML — must
 	 * also strip. The DOM walker reads `@class` regardless of which
 	 * quote style the input used.

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -563,6 +563,70 @@ class Photo_PostTest extends BaseTestCase {
 	 * gallery sail through even when a hypothetical site-level
 	 * cap would block it.
 	 */
+	/**
+	 * `core/post-featured-image` block + thumbnail resolve to the
+	 * same attachment id; bundled AP dedupes by id and emits one
+	 * attachment. The cap check must not double-count. With cap=1,
+	 * a single-featured-image photo post must still detect.
+	 */
+	public function test_featured_image_block_with_thumbnail_does_not_double_count_against_cap(): void {
+		add_filter(
+			'activitypub_max_image_attachments',
+			static function () {
+				return 1;
+			}
+		);
+
+		$featured = '<!-- wp:post-featured-image /-->';
+		$post     = $this->make_post( $featured, '', 'image', 1 );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * `activitypub_max_image_attachments = 0` disables attachments
+	 * entirely in bundled AP. Photo treatment in that mode would
+	 * strip image figures while AP emits nothing — caption-only
+	 * Note with no image. Detection must reject before any rule
+	 * fires.
+	 */
+	public function test_zero_attachment_cap_rejects_photo_treatment(): void {
+		add_filter(
+			'activitypub_max_image_attachments',
+			static function () {
+				return 0;
+			}
+		);
+
+		$image = $this->resolve_image_placeholders(
+			'<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+		);
+		$post  = $this->make_post( $image );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Freeform / classic-editor body with an inline `<img>` (no
+	 * block wrapper, no `attrs.id` — typically an external URL)
+	 * must NOT pass Rule 1 even when a Featured Image anchors
+	 * detection. The content stripper's orphan-img pass removes
+	 * standalone `<img>` tags, so allowing this combination would
+	 * silently drop the inline image. Mirrors the
+	 * `core/image`-with-external-URL guard for freeform bodies.
+	 */
+	public function test_image_format_with_thumbnail_plus_freeform_inline_img_does_not_detect(): void {
+		$post = $this->make_post( '<p>See <img src="https://elsewhere.test/inline.jpg"/> the photo.</p>', '', 'image', 1 );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Per-post `activitypub_max_image_attachments` postmeta wins
+	 * over the site-level option/filter (mirrors bundled AP's read
+	 * order). A two-image gallery passes when the per-post override
+	 * raises the cap even if the site-level cap would block it.
+	 */
 	public function test_image_count_with_per_post_cap_override_detects(): void {
 		$two_image_gallery = $this->resolve_image_placeholders(
 			'<!-- wp:gallery -->'

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -372,7 +372,9 @@ class Photo_PostTest extends BaseTestCase {
 			}
 		);
 
-		$post = $this->make_post( '', '', 'image' );
+		// Format + thumbnail anchors Rule 1 in the new
+		// federation-aware detector; bare format isn't enough.
+		$post = $this->make_post( '', '', 'image', 1 );
 
 		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
 	}
@@ -412,35 +414,89 @@ class Photo_PostTest extends BaseTestCase {
 	// ---------------------------------------------------------------
 
 	/**
-	 * Post Format `image` is the canonical "this is a photo" signal in
-	 * WordPress and maps 1:1 to Pixelfed's "this is a photo" gate.
+	 * Post Format `image` / `gallery` is the canonical "this is a
+	 * photo" signal in WordPress, but on its own isn't enough —
+	 * Rule 1 requires the body to carry an AP-resolvable image
+	 * source (block or featured image) so photo treatment doesn't
+	 * silently produce a Note with no attachment. This test uses a
+	 * body with no image content and no thumbnail to confirm bare
+	 * format alone does NOT drive detection on any slug.
 	 *
 	 * @param string $format Post format slug.
-	 * @param bool   $expected Whether the detector should flag the post.
 	 *
 	 * @dataProvider post_format_cases
 	 */
 	#[DataProvider( 'post_format_cases' )]
-	public function test_post_format_drives_detection( string $format, bool $expected ): void {
+	public function test_post_format_alone_does_not_drive_detection( string $format ): void {
 		$post = $this->make_post( '<!-- wp:paragraph --><p>caption</p><!-- /wp:paragraph -->', '', $format );
 
-		$this->assertSame( $expected, Photo_Post::is_photo_post( $post ) );
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
 	}
 
 	/**
-	 * Data provider for `test_post_format_drives_detection`.
+	 * Data provider for `test_post_format_alone_does_not_drive_detection`.
 	 *
-	 * @return array<string, array{0:string, 1:bool}>
+	 * @return array<string, array{0:string}>
 	 */
 	public static function post_format_cases(): array {
 		return array(
-			'image format'    => array( 'image', true ),
-			'gallery format'  => array( 'gallery', true ),
-			'status format'   => array( 'status', false ),
-			'standard format' => array( 'standard', false ),
-			'video format'    => array( 'video', false ),
-			'audio format'    => array( 'audio', false ),
+			'image format'    => array( 'image' ),
+			'gallery format'  => array( 'gallery' ),
+			'status format'   => array( 'status' ),
+			'standard format' => array( 'standard' ),
+			'video format'    => array( 'video' ),
+			'audio format'    => array( 'audio' ),
 		);
+	}
+
+	/**
+	 * Rule 1 fires when `post_format = image` / `gallery` AND the
+	 * body carries a resolvable image block. The format hint
+	 * relaxes Rule 2's strict "exactly one image + ≤1 paragraph"
+	 * shape constraint — a user who explicitly opted in via post
+	 * format gets photo treatment even when the body has more
+	 * paragraphs or other non-image blocks alongside the photo.
+	 */
+	public function test_image_format_with_resolvable_block_detects(): void {
+		$image = $this->resolve_image_placeholders(
+			'<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+		);
+		$post  = $this->make_post( $image, '', 'image' );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * `post_format = image` plus a featured image is enough for
+	 * Rule 1 — the thumbnail is the federatable image source even
+	 * when the body itself has no image block. This relaxes Rule
+	 * 3's "≤1 paragraph" constraint for users who explicitly
+	 * signalled photo intent via post format.
+	 */
+	public function test_image_format_with_featured_image_detects(): void {
+		$post = $this->make_post(
+			'<!-- wp:paragraph --><p>First.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>Second.</p><!-- /wp:paragraph -->',
+			'',
+			'image',
+			1
+		);
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * `post_format = image` with ONLY external-URL image blocks
+	 * (no `id` attribute, no thumbnail) must NOT detect — bundled
+	 * AP would emit zero attachments and photo treatment would
+	 * strip the image markup, leaving the user's image gone
+	 * entirely. The body falls through to article behavior so the
+	 * external URLs remain inline.
+	 */
+	public function test_image_format_with_only_external_image_does_not_detect(): void {
+		$external = '<!-- wp:image --><figure class="wp-block-image"><img src="https://elsewhere.test/x.jpg"/></figure><!-- /wp:image -->';
+		$post     = $this->make_post( $external, '', 'image' );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
 	}
 
 	// ---------------------------------------------------------------
@@ -621,7 +677,9 @@ class Photo_PostTest extends BaseTestCase {
 	 * timeline rendering.
 	 */
 	public function test_object_type_filter_forces_note_for_photo_post(): void {
-		$post = $this->make_post( '', '', 'image' );
+		// Format + thumbnail anchors Rule 1 — bare format alone
+		// no longer drives detection.
+		$post = $this->make_post( '', '', 'image', 1 );
 
 		$type = apply_filters( 'activitypub_post_object_type', 'Article', $post );
 
@@ -658,7 +716,11 @@ class Photo_PostTest extends BaseTestCase {
 	 * caption only — the photo lives in `attachment[]`.
 	 */
 	public function test_content_filter_strips_image_block(): void {
-		$post     = $this->make_post( '', '', 'image' );
+		// Format + thumbnail anchors Rule 1 so the post is
+		// classified as a photo even though the body itself is
+		// rendered HTML (the test exercises the strip logic, not
+		// the block-shape detector).
+		$post     = $this->make_post( '', '', 'image', 1 );
 		$content  = '<figure class="wp-block-image"><img src="https://example.test/a.jpg" alt="Sunset"/></figure><p>Sunset over the bay.</p>';
 		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
 
@@ -672,7 +734,7 @@ class Photo_PostTest extends BaseTestCase {
 	 * cleanly without leaving inner `<img>` orphans.
 	 */
 	public function test_content_filter_strips_gallery_block(): void {
-		$post     = $this->make_post( '', '', 'gallery' );
+		$post     = $this->make_post( '', '', 'gallery', 1 );
 		$content  = '<figure class="wp-block-gallery"><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure></figure><p>Trip recap.</p>';
 		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
 
@@ -686,7 +748,7 @@ class Photo_PostTest extends BaseTestCase {
 	 * must strip the same way.
 	 */
 	public function test_content_filter_strips_post_featured_image_block(): void {
-		$post     = $this->make_post( '', '', 'image' );
+		$post     = $this->make_post( '', '', 'image', 1 );
 		$content  = '<figure class="wp-block-post-featured-image"><img src="https://example.test/a.jpg"/></figure><p>Caption.</p>';
 		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
 
@@ -700,7 +762,7 @@ class Photo_PostTest extends BaseTestCase {
 	 * content gets a leading `<p></p>` shell.
 	 */
 	public function test_content_filter_cleans_empty_paragraph_wrappers(): void {
-		$post     = $this->make_post( '', '', 'image' );
+		$post     = $this->make_post( '', '', 'image', 1 );
 		$content  = '<p><img src="https://example.test/a.jpg"/></p><p>Caption.</p>';
 		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
 
@@ -996,7 +1058,7 @@ class Photo_PostTest extends BaseTestCase {
 	 * removes the outermost matching figure as a node.
 	 */
 	public function test_content_filter_strips_nested_gallery_cleanly(): void {
-		$post     = $this->make_post( '', '', 'gallery' );
+		$post     = $this->make_post( '', '', 'gallery', 1 );
 		$content  = '<figure class="wp-block-gallery">'
 			. '<figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure>'
 			. '<figure class="wp-block-image"><img src="https://example.test/b.jpg"/></figure>'
@@ -1016,7 +1078,7 @@ class Photo_PostTest extends BaseTestCase {
 	 * quote style the input used.
 	 */
 	public function test_content_filter_handles_single_quoted_class(): void {
-		$post     = $this->make_post( '', '', 'image' );
+		$post     = $this->make_post( '', '', 'image', 1 );
 		$content  = "<figure class='wp-block-image'><img src='https://example.test/a.jpg'/></figure><p>Caption.</p>";
 		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
 

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -1209,4 +1209,75 @@ class Photo_PostTest extends BaseTestCase {
 
 		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
 	}
+
+	/**
+	 * A gallery whose innerBlocks mix local-id `core/image` children
+	 * with external-URL `core/image` children must NOT classify as a
+	 * photo post. Bundled AP would extract only the local-id
+	 * children, and the content filter would strip the entire
+	 * gallery wrapper — the external images would disappear from the
+	 * federated post entirely. Falling back to article behavior
+	 * keeps every figure in the body intact.
+	 */
+	public function test_mixed_local_and_external_gallery_does_not_detect(): void {
+		$mixed_gallery = '<!-- wp:gallery -->'
+			. '<figure class="wp-block-gallery">'
+			. '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image --><figure class="wp-block-image"><img src="https://elsewhere.test/a.jpg"/></figure><!-- /wp:image -->'
+			. '</figure>'
+			. '<!-- /wp:gallery -->';
+		$post          = $this->make_post( $mixed_gallery );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Rule 3 (Featured Image + ≤1 paragraph) explicitly targets the
+	 * mobile WP-app / classic-editor flow where the body is just a
+	 * classic-shape caption like `<p>Caption.</p>` (no block-comment
+	 * wrapper). `parse_blocks()` emits that as a single freeform
+	 * block with `blockName: null`, and the detector recognizes the
+	 * paragraph-shaped innerHTML as one caption paragraph. Without
+	 * this recognition the documented flow would silently fail.
+	 */
+	public function test_featured_thumbnail_with_classic_caption_detects(): void {
+		$post = $this->make_post( '<p>Caption.</p>', '', '', 1 );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * The classic-caption heuristic must NOT promote substantive
+	 * freeform bodies. Anything containing `<img>`, `<figure>`,
+	 * headings, lists, tables, blockquotes, `<pre>`, or `<hr>` is
+	 * article content, not a caption — those posts stay as articles
+	 * even when a Featured Image is set.
+	 */
+	public function test_featured_thumbnail_with_classic_article_does_not_detect(): void {
+		$post = $this->make_post( '<p>Intro.</p><h2>Heading</h2><p>More body.</p>', '', '', 1 );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * The Pass-3 URL-suffix regex matches against the path component,
+	 * not the full URL. A non-resized image URL whose query string
+	 * happens to contain `-WIDTHxHEIGHT.ext` (e.g. a redirect target,
+	 * tracker, or signed-URL param pointing at a different resized
+	 * derivative) must NOT pick up those dimensions — the actual
+	 * media is the URL's path file, not whatever the query string
+	 * references.
+	 */
+	public function test_attachment_filter_ignores_suffix_in_query_string(): void {
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://example.test/wp-content/uploads/2026/05/original.jpg?next=photo-1024x768.jpg',
+			'mediaType' => 'image/jpeg',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, 0 );
+
+		$this->assertArrayNotHasKey( 'width', $out );
+		$this->assertArrayNotHasKey( 'height', $out );
+	}
 }

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -50,6 +50,17 @@ class Photo_PostTest extends BaseTestCase {
 		// default empty-content rejection so `wp_insert_post` returns
 		// an id for those cases too.
 		add_filter( 'wp_insert_post_empty_content', '__return_false' );
+
+		// WorDBless installs the kses `content_save_pre` filter
+		// regardless of user context, so every `wp_insert_post`
+		// would slash block-attribute JSON — but in production
+		// admin users (with `unfiltered_html`) skip that filter
+		// entirely. Strip it here so test inserts represent the
+		// admin-authored path. The `test_slashed_block_attributes_*`
+		// case re-introduces slashes explicitly via `addslashes()`
+		// when it needs to exercise the non-admin storage shape.
+		remove_filter( 'content_save_pre', 'wp_filter_post_kses' );
+		remove_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
 	}
 
 	/**
@@ -299,14 +310,24 @@ class Photo_PostTest extends BaseTestCase {
 	 * @return array<string, array{0:string, 1:bool}>
 	 */
 	public static function block_shape_cases(): array {
-		// Block fixtures use `id` / `ids` attributes that signal a
+		// Block fixtures use `id` attributes that signal a
 		// local attachment to `Photo_Post::block_resolves_locally`.
-		// External-URL image blocks (no `id`) and post-featured-image
-		// blocks (which require a real thumbnail) are exercised in
-		// dedicated test methods below — the data provider is static
-		// and cannot wire up per-case thumbnail state.
+		// Galleries use the WP 5.9+ block-nested shape (innerBlocks
+		// containing `core/image` children) — legacy galleries with
+		// only a top-level `attrs.ids` array are intentionally not
+		// recognized because bundled AP's extractor doesn't read
+		// that path either. External-URL image blocks (no `id`) and
+		// post-featured-image blocks (which require a real
+		// thumbnail) are exercised in dedicated test methods below —
+		// the data provider is static and cannot wire up per-case
+		// thumbnail state.
 		$image     = '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img src="https://example.test/a.jpg" alt=""/></figure><!-- /wp:image -->';
-		$gallery   = '<!-- wp:gallery {"ids":[42,43]} --><figure class="wp-block-gallery"></figure><!-- /wp:gallery -->';
+		$gallery   = '<!-- wp:gallery -->'
+			. '<figure class="wp-block-gallery">'
+			. '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":43} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '</figure>'
+			. '<!-- /wp:gallery -->';
 		$paragraph = '<!-- wp:paragraph --><p>caption text</p><!-- /wp:paragraph -->';
 		$heading   = '<!-- wp:heading --><h2>headline</h2><!-- /wp:heading -->';
 		$spacer    = '<!-- wp:spacer --><div class="wp-block-spacer"></div><!-- /wp:spacer -->';
@@ -1133,22 +1154,40 @@ class Photo_PostTest extends BaseTestCase {
 
 	/**
 	 * `wp_filter_post_kses` slashes block-attribute JSON in
-	 * post_content for users without `unfiltered_html` (Contributors,
-	 * multisite Authors). Without the `wp_unslash()` call in
-	 * `Photo_Post::detect()`, `parse_blocks()` deserializes attrs as
-	 * `null` from the slashed JSON and `block_resolves_locally()`
-	 * misses the `id` — the post then falls through to article shape
-	 * even though it's a legitimate photo post.
-	 *
-	 * This test mutates the stored `post_content` to the slashed form
-	 * a non-admin author would produce and asserts detection still
-	 * fires. Without `wp_unslash`, the assertion fails.
+	 * post_content for non-admin authors (Contributors, multisite
+	 * Authors lacking `unfiltered_html`). `parse_blocks()` then
+	 * returns `null` attrs for the slashed JSON, so both FOSSE's
+	 * detector and bundled AP's `get_block_attachments()` extractor
+	 * fail to read `attrs.id` — and that's the contract. The
+	 * detector deliberately uses the same raw `post_content` view
+	 * AP's extractor uses: when AP can't surface an image attachment,
+	 * the post must NOT be classified as a photo post, otherwise the
+	 * federated Note would be caption-only with no image. Slashed
+	 * content falls through to article shape; the image markup stays
+	 * in the body for receivers to render inline.
 	 */
-	public function test_detection_handles_slashed_block_attributes(): void {
+	public function test_slashed_block_attributes_do_not_detect(): void {
 		$slashed_body = \addslashes( '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure><!-- /wp:image -->' );
 		$post         = $this->make_post( $slashed_body );
 
-		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Legacy WP <5.9 galleries store image IDs in `attrs.ids` rather
+	 * than nesting `core/image` blocks. Bundled AP's extractor
+	 * doesn't read this path for `core/gallery` (only for
+	 * jetpack/slideshow + jetpack/tiled-gallery), so classifying the
+	 * post as a photo here would force `Note` while AP emits no
+	 * attachment — caption-only Note with no image. Detection falls
+	 * through to article behavior, keeping the gallery markup intact
+	 * in the body where receivers can still render the images.
+	 */
+	public function test_legacy_gallery_ids_attribute_does_not_detect(): void {
+		$legacy_gallery = '<!-- wp:gallery {"ids":[42,43]} --><figure class="wp-block-gallery"></figure><!-- /wp:gallery -->';
+		$post           = $this->make_post( $legacy_gallery );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
 	}
 
 	/**

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -8,6 +8,7 @@
 namespace Automattic\Fosse\Tests;
 
 use Automattic\Fosse\Photo_Post;
+use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
@@ -25,6 +26,43 @@ use WP_Post;
  * load-bearing instead of poking the helpers in isolation.
  */
 class Photo_PostTest extends BaseTestCase {
+
+	/**
+	 * Whether `wp_filter_post_kses` was hooked on
+	 * `content_save_pre` before `reset_state()` ran. Tracked so the
+	 * after-hook can restore the original filter chain when the
+	 * test class is done — otherwise sibling test classes inherit
+	 * the kses-less state and may produce unexpected escaping.
+	 *
+	 * @var bool
+	 */
+	private bool $had_content_save_pre_kses = false;
+
+	/**
+	 * Mirror of {@see self::$had_content_save_pre_kses} for the
+	 * `content_filtered_save_pre` filter.
+	 *
+	 * @var bool
+	 */
+	private bool $had_content_filtered_save_pre_kses = false;
+
+	/**
+	 * Attachment id of the canonical image fixture created per test.
+	 * Block-shape tests substitute this into fixture markup
+	 * (`{"id":PHOTO_ID}`) so `wp_attachment_is_image()` resolves to
+	 * true inside `Photo_Post::block_resolves_locally()`.
+	 *
+	 * @var int
+	 */
+	private int $image_id = 0;
+
+	/**
+	 * Secondary image fixture id for tests that need two distinct
+	 * resolvable images (gallery cases, two-image scenarios).
+	 *
+	 * @var int
+	 */
+	private int $image_id_alt = 0;
 
 	/**
 	 * Reset filter / cache state before each test and register the
@@ -59,8 +97,90 @@ class Photo_PostTest extends BaseTestCase {
 		// admin-authored path. The `test_slashed_block_attributes_*`
 		// case re-introduces slashes explicitly via `addslashes()`
 		// when it needs to exercise the non-admin storage shape.
-		remove_filter( 'content_save_pre', 'wp_filter_post_kses' );
-		remove_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
+		// Track removal status so the after-hook can restore the
+		// original chain — leaking the kses-less state into sibling
+		// test classes would cause silent corruption when their
+		// fixtures depend on default escaping.
+		$this->had_content_save_pre_kses          = false !== has_filter( 'content_save_pre', 'wp_filter_post_kses' );
+		$this->had_content_filtered_save_pre_kses = false !== has_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
+		if ( $this->had_content_save_pre_kses ) {
+			remove_filter( 'content_save_pre', 'wp_filter_post_kses' );
+		}
+		if ( $this->had_content_filtered_save_pre_kses ) {
+			remove_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
+		}
+
+		// Create canonical image attachments for block fixtures.
+		// `Photo_Post::block_resolves_locally()` now requires the
+		// `id` on a `core/image` block to resolve via
+		// `wp_attachment_is_image()`, so block-shape fixtures that
+		// reference image ids need real attachment posts with image
+		// MIME types behind them. Fixtures use the `PHOTO_ID` /
+		// `PHOTO_ID_ALT` placeholders; the
+		// {@see self::resolve_image_placeholders()} helper swaps in
+		// these real ids at use time.
+		$this->image_id     = $this->insert_image_attachment( 'fixture-primary.jpg' );
+		$this->image_id_alt = $this->insert_image_attachment( 'fixture-alt.jpg' );
+	}
+
+	/**
+	 * Restore the kses filter chain when the test class is done so
+	 * later classes don't inherit our kses-less state. Idempotent —
+	 * `add_filter` dedupes identical callable registrations, so
+	 * re-adding the filter when the chain is already healthy is
+	 * harmless.
+	 *
+	 * @after
+	 */
+	#[After]
+	public function restore_kses_filters(): void {
+		if ( $this->had_content_save_pre_kses ) {
+			add_filter( 'content_save_pre', 'wp_filter_post_kses' );
+		}
+		if ( $this->had_content_filtered_save_pre_kses ) {
+			add_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
+		}
+	}
+
+	/**
+	 * Insert a real image attachment WorDBless will resolve through
+	 * `wp_attachment_is_image()`. Both the `post_mime_type` (which
+	 * the function inspects directly) and the `_wp_attached_file`
+	 * postmeta (which `get_attached_file()` requires before
+	 * `wp_attachment_is()` will return true) are populated.
+	 *
+	 * @param string $filename The attachment file basename.
+	 * @return int The attachment post id.
+	 */
+	private function insert_image_attachment( string $filename ): int {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'fixture',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', $filename );
+		return $attachment_id;
+	}
+
+	/**
+	 * Substitute `PHOTO_ID` / `PHOTO_ID_ALT` placeholders in block
+	 * markup with the per-test attachment ids. Lets static data
+	 * providers stay pure (they can't reach instance state) while
+	 * keeping the block fixtures wired to real attachments the new
+	 * `wp_attachment_is_image()` guard will accept.
+	 *
+	 * @param string $content Block markup with placeholders.
+	 * @return string Content with placeholders replaced.
+	 */
+	private function resolve_image_placeholders( string $content ): string {
+		return \str_replace(
+			array( 'PHOTO_ID_ALT', 'PHOTO_ID' ),
+			array( (string) $this->image_id_alt, (string) $this->image_id ),
+			$content
+		);
 	}
 
 	/**
@@ -299,7 +419,7 @@ class Photo_PostTest extends BaseTestCase {
 	 */
 	#[DataProvider( 'block_shape_cases' )]
 	public function test_block_shape_drives_detection( string $content, bool $expected ): void {
-		$post = $this->make_post( $content );
+		$post = $this->make_post( $this->resolve_image_placeholders( $content ) );
 
 		$this->assertSame( $expected, Photo_Post::is_photo_post( $post ) );
 	}
@@ -321,11 +441,11 @@ class Photo_PostTest extends BaseTestCase {
 		// thumbnail) are exercised in dedicated test methods below —
 		// the data provider is static and cannot wire up per-case
 		// thumbnail state.
-		$image     = '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img src="https://example.test/a.jpg" alt=""/></figure><!-- /wp:image -->';
+		$image     = '<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img src="https://example.test/a.jpg" alt=""/></figure><!-- /wp:image -->';
 		$gallery   = '<!-- wp:gallery -->'
 			. '<figure class="wp-block-gallery">'
-			. '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
-			. '<!-- wp:image {"id":43} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":PHOTO_ID_ALT} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
 			. '</figure>'
 			. '<!-- /wp:gallery -->';
 		$paragraph = '<!-- wp:paragraph --><p>caption text</p><!-- /wp:paragraph -->';
@@ -360,7 +480,9 @@ class Photo_PostTest extends BaseTestCase {
 	 * Caption." to still count.
 	 */
 	public function test_title_does_not_suppress_detection(): void {
-		$image = '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure><!-- /wp:image -->';
+		$image = $this->resolve_image_placeholders(
+			'<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure><!-- /wp:image -->'
+		);
 		$post  = $this->make_post( $image, 'My Photo Title' );
 
 		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
@@ -917,12 +1039,14 @@ class Photo_PostTest extends BaseTestCase {
 	 * galleries still detect.
 	 */
 	public function test_gallery_with_inner_image_blocks_detects(): void {
-		$nested_gallery = '<!-- wp:gallery -->'
+		$nested_gallery = $this->resolve_image_placeholders(
+			'<!-- wp:gallery -->'
 			. '<figure class="wp-block-gallery">'
-			. '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
-			. '<!-- wp:image {"id":43} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":PHOTO_ID_ALT} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
 			. '</figure>'
-			. '<!-- /wp:gallery -->';
+			. '<!-- /wp:gallery -->'
+		);
 		$post           = $this->make_post( $nested_gallery );
 
 		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
@@ -1219,13 +1343,65 @@ class Photo_PostTest extends BaseTestCase {
 	 * federated post entirely. Falling back to article behavior
 	 * keeps every figure in the body intact.
 	 */
+	/**
+	 * A `core/image` block whose `id` attribute points at an
+	 * attachment that no longer exists (deleted media library
+	 * entry, never-imported id from a migration, etc.) must NOT
+	 * classify as a photo post. Without the
+	 * `wp_attachment_is_image()` guard the detector would force
+	 * `Note` and strip the image markup, but bundled AP's
+	 * `transform_attachment()` would drop the broken id — leaving
+	 * the user with a caption-only Note and no image. Falling back
+	 * to article behavior keeps the figure intact in the body
+	 * (where the broken image renders as a placeholder, but at
+	 * least carries the intent).
+	 */
+	public function test_image_block_with_nonexistent_id_does_not_detect(): void {
+		$ghost_image = '<!-- wp:image {"id":99999999} --><figure class="wp-block-image"><img src="https://example.test/ghost.jpg"/></figure><!-- /wp:image -->';
+		$post        = $this->make_post( $ghost_image );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Multi-paragraph classic body + Featured Image = article, not
+	 * photo. The freeform branch counts substantive `<p>` opens, so
+	 * `<p>One.</p><p>Two.</p>` registers as two paragraphs and
+	 * disqualifies Rule 3 even though the heuristic's structural-tag
+	 * blacklist (img/figure/heading/list/table/blockquote/pre/hr)
+	 * doesn't match either body.
+	 */
+	public function test_featured_thumbnail_with_classic_multi_paragraph_does_not_detect(): void {
+		$post = $this->make_post( '<p>One.</p><p>Two.</p>', '', '', 1 );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * A gallery whose innerBlocks mix local-id `core/image` children
+	 * with external-URL `core/image` children must NOT classify as a
+	 * photo post. Bundled AP would extract only the local-id
+	 * children, and the content filter would strip the entire
+	 * gallery wrapper — the external images would disappear from
+	 * the federated post entirely. Falling back to article behavior
+	 * keeps every figure in the body intact.
+	 */
 	public function test_mixed_local_and_external_gallery_does_not_detect(): void {
-		$mixed_gallery = '<!-- wp:gallery -->'
+		// First child resolves locally (real attachment id from the
+		// fixture pool); second child is an external-URL image block
+		// with no `id`. The rejection must fire because of the mix —
+		// otherwise both children would be unresolvable and the
+		// gallery would return false for the trivial reason. Using
+		// a real id forces the "one resolvable, one not" path that
+		// the rule actually targets.
+		$mixed_gallery = $this->resolve_image_placeholders(
+			'<!-- wp:gallery -->'
 			. '<figure class="wp-block-gallery">'
-			. '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
 			. '<!-- wp:image --><figure class="wp-block-image"><img src="https://elsewhere.test/a.jpg"/></figure><!-- /wp:image -->'
 			. '</figure>'
-			. '<!-- /wp:gallery -->';
+			. '<!-- /wp:gallery -->'
+		);
 		$post          = $this->make_post( $mixed_gallery );
 
 		$this->assertFalse( Photo_Post::is_photo_post( $post ) );

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -45,12 +45,6 @@ class Photo_PostTest extends BaseTestCase {
 		Photo_Post::reset_cache_for_testing();
 		Photo_Post::register();
 
-		// `register_post_format_support()` normally runs on
-		// `after_setup_theme`, which has already fired by the time
-		// PHPUnit gets here — call it directly so format-aware
-		// detection sees `get_post_format()` consulting the term.
-		Photo_Post::register_post_format_support();
-
 		// Empty bodies are valid photo posts (Featured Image + no
 		// caption, or "image format with zero text"). Override WP's
 		// default empty-content rejection so `wp_insert_post` returns
@@ -59,7 +53,8 @@ class Photo_PostTest extends BaseTestCase {
 	}
 
 	/**
-	 * Build a real WP post with optional title and post format.
+	 * Build a real WP post with optional title, post format, and a
+	 * featured-image thumbnail.
 	 *
 	 * Post format is injected via a `get_the_terms` filter rather than
 	 * `set_post_format()` — WorDBless's database-less storage layer
@@ -70,15 +65,28 @@ class Photo_PostTest extends BaseTestCase {
 	 * same code path `get_post_format()` actually uses (the
 	 * `get_the_terms` filter chain) and works under WorDBless.
 	 *
+	 * When `$thumbnail_id` is non-zero, we also need
+	 * `wp_attachment_is_image()` to return true — that check runs an
+	 * `attachment.mime_type` lookup, so we insert a real attachment
+	 * post with an image MIME type. Pass a negative `$thumbnail_id`
+	 * to simulate a deleted thumbnail (postmeta survives, attachment
+	 * does not).
+	 *
 	 * Each call generates a fresh post id so the per-post memoization
 	 * cache doesn't leak between cases.
 	 *
-	 * @param string $content     Raw post content.
-	 * @param string $title       Optional post title.
-	 * @param string $post_format Optional post format slug (image, gallery, status, …).
+	 * @param string $content      Raw post content.
+	 * @param string $title        Optional post title.
+	 * @param string $post_format  Optional post format slug (image, gallery, status, …).
+	 * @param int    $thumbnail_id 0 = no thumbnail; >0 = create attachment + meta; <0 = postmeta only (simulates deleted attachment).
 	 * @return WP_Post
 	 */
-	private function make_post( string $content, string $title = '', string $post_format = '' ): WP_Post {
+	private function make_post(
+		string $content,
+		string $title = '',
+		string $post_format = '',
+		int $thumbnail_id = 0
+	): WP_Post {
 		$post_id = wp_insert_post(
 			array(
 				'post_title'   => $title,
@@ -109,32 +117,22 @@ class Photo_PostTest extends BaseTestCase {
 			);
 		}
 
-		return get_post( $post_id );
-	}
-
-	/**
-	 * Insert a real post and (optionally) attach a thumbnail meta. Used
-	 * for featured-image-aware detection cases where `has_post_thumbnail`
-	 * needs to consult postmeta. We do not need an actual attachment
-	 * post — `has_post_thumbnail` only checks for a non-zero
-	 * `_thumbnail_id` meta value.
-	 *
-	 * @param string $content       Post content.
-	 * @param bool   $with_thumbnail Whether to set `_thumbnail_id`.
-	 * @return WP_Post
-	 */
-	private function insert_post_with_thumbnail( string $content, bool $with_thumbnail = true ): WP_Post {
-		$post_id = wp_insert_post(
-			array(
-				'post_title'   => '',
-				'post_content' => $content,
-				'post_status'  => 'publish',
-				'post_type'    => 'post',
-			)
-		);
-
-		if ( $with_thumbnail ) {
-			update_post_meta( $post_id, '_thumbnail_id', 999 );
+		if ( $thumbnail_id > 0 ) {
+			$attachment_id = wp_insert_post(
+				array(
+					'post_type'      => 'attachment',
+					'post_status'    => 'inherit',
+					'post_mime_type' => 'image/jpeg',
+					'post_title'     => 'thumb',
+				)
+			);
+			// `wp_attachment_is_image()` calls `get_attached_file()`,
+			// which reads `_wp_attached_file`. Without it the helper
+			// returns false even on a properly-MIMEd attachment row.
+			update_post_meta( $attachment_id, '_wp_attached_file', 'thumb.jpg' );
+			update_post_meta( $post_id, '_thumbnail_id', $attachment_id );
+		} elseif ( $thumbnail_id < 0 ) {
+			update_post_meta( $post_id, '_thumbnail_id', 999999 );
 		}
 
 		return get_post( $post_id );
@@ -354,7 +352,7 @@ class Photo_PostTest extends BaseTestCase {
 	 * `parse_blocks('')` yields nothing.
 	 */
 	public function test_featured_thumbnail_with_empty_body_detects(): void {
-		$post = $this->insert_post_with_thumbnail( '' );
+		$post = $this->make_post( '', '', '', 1 );
 
 		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
 	}
@@ -365,7 +363,7 @@ class Photo_PostTest extends BaseTestCase {
 	 */
 	public function test_featured_thumbnail_with_single_paragraph_detects(): void {
 		$paragraph = '<!-- wp:paragraph --><p>Caption.</p><!-- /wp:paragraph -->';
-		$post      = $this->insert_post_with_thumbnail( $paragraph );
+		$post      = $this->make_post( $paragraph, '', '', 1 );
 
 		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
 	}
@@ -377,7 +375,7 @@ class Photo_PostTest extends BaseTestCase {
 	 */
 	public function test_featured_thumbnail_with_two_paragraphs_does_not_detect(): void {
 		$paragraph = '<!-- wp:paragraph --><p>A line.</p><!-- /wp:paragraph -->';
-		$post      = $this->insert_post_with_thumbnail( $paragraph . $paragraph );
+		$post      = $this->make_post( $paragraph . $paragraph, '', '', 1 );
 
 		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
 	}
@@ -389,7 +387,7 @@ class Photo_PostTest extends BaseTestCase {
 	 */
 	public function test_single_paragraph_without_thumbnail_does_not_detect(): void {
 		$paragraph = '<!-- wp:paragraph --><p>Caption.</p><!-- /wp:paragraph -->';
-		$post      = $this->insert_post_with_thumbnail( $paragraph, false );
+		$post      = $this->make_post( $paragraph );
 
 		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
 	}
@@ -624,5 +622,247 @@ class Photo_PostTest extends BaseTestCase {
 
 		$this->assertArrayNotHasKey( 'width', $out );
 		$this->assertArrayNotHasKey( 'height', $out );
+	}
+
+	// ---------------------------------------------------------------
+	// AP hook: attachment dimensions — URL/size matching.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Bundled AP emits image URLs at the `large` derivative
+	 * (`wp_get_attachment_image_src( $id, 'large' )`). The dimensions
+	 * we attach must describe THAT file, not the 4000-pixel original
+	 * sitting on disk — Pixelfed enforces dimensions server-side and
+	 * rejects mismatched values. Resized derivatives carry a
+	 * `-WIDTHxHEIGHT.<ext>` suffix in the filename, which is the
+	 * stable signal we key off.
+	 */
+	public function test_attachment_filter_uses_filename_suffix_dimensions(): void {
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://example.test/wp-content/uploads/2026/05/sunset-1024x683.jpg',
+			'mediaType' => 'image/jpeg',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, 0 );
+
+		$this->assertSame( 1024, $out['width'] );
+		$this->assertSame( 683, $out['height'] );
+	}
+
+	/**
+	 * The suffix match must tolerate a query string (CDN cache-bust)
+	 * or fragment (rare but valid). Real-world CDN rewrites tack
+	 * `?ver=…` onto image URLs frequently.
+	 */
+	public function test_attachment_filter_filename_suffix_with_query_string(): void {
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://cdn.example.test/sunset-800x600.webp?ver=42',
+			'mediaType' => 'image/webp',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, 0 );
+
+		$this->assertSame( 800, $out['width'] );
+		$this->assertSame( 600, $out['height'] );
+	}
+
+	/**
+	 * When the URL points at the original (no `-WIDTHxHEIGHT` suffix)
+	 * and no intermediate size matches, fall back to full-size
+	 * metadata. Mirrors the behavior `Image` consumers expect when
+	 * bundled AP emits the original file as the URL.
+	 */
+	public function test_attachment_filter_falls_back_to_full_metadata(): void {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'orig',
+			)
+		);
+		wp_update_attachment_metadata(
+			$attachment_id,
+			array(
+				'file'   => '2026/05/original.jpg',
+				'width'  => 4000,
+				'height' => 3000,
+			)
+		);
+
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://example.test/wp-content/uploads/2026/05/original.jpg',
+			'mediaType' => 'image/jpeg',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, $attachment_id );
+
+		$this->assertSame( 4000, $out['width'] );
+		$this->assertSame( 3000, $out['height'] );
+	}
+
+	/**
+	 * Metadata with non-positive `width` is malformed — Pixelfed
+	 * rejects width-0 attachments in `verifyAttachments`, so omit
+	 * the keys rather than emit an invalid pair.
+	 */
+	public function test_attachment_filter_omits_non_positive_dimensions(): void {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		wp_update_attachment_metadata(
+			$attachment_id,
+			array(
+				'width'  => 0,
+				'height' => 0,
+			)
+		);
+
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://example.test/orig.jpg',
+			'mediaType' => 'image/jpeg',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, $attachment_id );
+
+		$this->assertArrayNotHasKey( 'width', $out );
+		$this->assertArrayNotHasKey( 'height', $out );
+	}
+
+	/**
+	 * SVGs and other formats without dimensions stored in metadata
+	 * land here. Without `width`/`height` keys present, the
+	 * attachment passes through untouched.
+	 */
+	public function test_attachment_filter_skips_when_metadata_lacks_dimensions(): void {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/svg+xml',
+			)
+		);
+		wp_update_attachment_metadata( $attachment_id, array( 'file' => 'logo.svg' ) );
+
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://example.test/logo.svg',
+			'mediaType' => 'image/svg+xml',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, $attachment_id );
+
+		$this->assertArrayNotHasKey( 'width', $out );
+		$this->assertArrayNotHasKey( 'height', $out );
+	}
+
+	/**
+	 * A non-array first arg must not crash and must not be coerced
+	 * into something a downstream callback could mishandle. Returning
+	 * an empty array is intentional: it signals "nothing to attach"
+	 * to bundled AP's `array_filter` after the per-attachment filter
+	 * runs, so the malformed value is dropped from the final
+	 * attachment list.
+	 */
+	public function test_attachment_filter_handles_non_array_input(): void {
+		$out = apply_filters( 'activitypub_attachment', 'not-an-array', 0 );
+
+		$this->assertSame( array(), $out );
+	}
+
+	// ---------------------------------------------------------------
+	// AP hook: content filter — guard tests + nested gallery.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Non-WP_Post second arg must pass content through unchanged.
+	 * `activitypub_the_content` also fires from
+	 * `bundled/activitypub/includes/transformer/class-comment.php` with
+	 * a `WP_Comment`, so the guard prevents a stray photo-strip on
+	 * comment content.
+	 */
+	public function test_content_filter_passes_through_on_non_wp_post(): void {
+		$content  = '<p>caption text</p>';
+		$filtered = apply_filters( 'activitypub_the_content', $content, null );
+
+		$this->assertSame( $content, $filtered );
+	}
+
+	/**
+	 * Nested gallery markup — `<figure class="wp-block-gallery">`
+	 * wrapping multiple `<figure class="wp-block-image">` children —
+	 * must strip cleanly without leaving orphan `</figure>` tags.
+	 * This was the regression a naive non-greedy `.*?</figure>` regex
+	 * would emit; the DOM-based stripper handles it because it
+	 * removes the outermost matching figure as a node.
+	 */
+	public function test_content_filter_strips_nested_gallery_cleanly(): void {
+		$post     = $this->make_post( '', '', 'gallery' );
+		$content  = '<figure class="wp-block-gallery">'
+			. '<figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure>'
+			. '<figure class="wp-block-image"><img src="https://example.test/b.jpg"/></figure>'
+			. '</figure>'
+			. '<p>Trip recap.</p>';
+		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
+
+		$this->assertStringNotContainsString( '<figure', $filtered );
+		$this->assertStringNotContainsString( '</figure>', $filtered );
+		$this->assertStringNotContainsString( '<img', $filtered );
+		$this->assertStringContainsString( 'Trip recap.', $filtered );
+	}
+
+	/**
+	 * Single-quoted class attributes — uncommon but valid HTML — must
+	 * also strip. The DOM walker reads `@class` regardless of which
+	 * quote style the input used.
+	 */
+	public function test_content_filter_handles_single_quoted_class(): void {
+		$post     = $this->make_post( '', '', 'image' );
+		$content  = "<figure class='wp-block-image'><img src='https://example.test/a.jpg'/></figure><p>Caption.</p>";
+		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
+
+		$this->assertStringNotContainsString( '<img', $filtered );
+		$this->assertStringContainsString( 'Caption.', $filtered );
+	}
+
+	// ---------------------------------------------------------------
+	// Detection: classic / freeform content + deleted thumbnail guard.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Classic-editor / freeform content emits a single null-blockName
+	 * block from `parse_blocks()` whose `innerHTML` is the raw body.
+	 * If non-empty, the detector must classify the post as "other"
+	 * content (not a photo post). Without coverage, the rule-3 path
+	 * could silently misclassify classic blog posts with featured
+	 * images as photo posts.
+	 */
+	public function test_classic_freeform_body_does_not_detect(): void {
+		$post = $this->make_post( '<p>Plain classic body without a wp:block wrapper.</p>' );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * A featured image whose underlying attachment has been deleted
+	 * (postmeta survives) must not classify the post as a photo post —
+	 * bundled AP would silently drop the broken attachment, leaving a
+	 * Note that promises a photo and delivers nothing. Falling back to
+	 * article behavior is the less surprising degradation.
+	 */
+	public function test_deleted_thumbnail_does_not_detect(): void {
+		// $thumbnail_id < 0 in make_post() sets the postmeta to a
+		// non-existent attachment id, simulating deletion.
+		$post = $this->make_post( '', '', '', -1 );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
 	}
 }

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -1,0 +1,628 @@
+<?php
+/**
+ * Tests for the photo-post detector + AP federation-shape projector.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests;
+
+use Automattic\Fosse\Photo_Post;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+use WP_Post;
+
+/**
+ * Covers `Photo_Post::is_photo_post()` detection rules, the
+ * `fosse_pre_is_photo_post` short-circuit, the `fosse_is_photo_post`
+ * final filter, and the three AP transformer hooks
+ * (`activitypub_post_object_type`, `activitypub_the_content`,
+ * `activitypub_attachment`).
+ *
+ * Detection is exercised through `apply_filters` round-trips wherever
+ * possible — keeps the contract that "FOSSE projects onto AP filters"
+ * load-bearing instead of poking the helpers in isolation.
+ */
+class Photo_PostTest extends BaseTestCase {
+
+	/**
+	 * Reset filter / cache state before each test and register the
+	 * projector.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function reset_state(): void {
+		remove_all_filters( 'activitypub_post_object_type' );
+		remove_all_filters( 'activitypub_the_content' );
+		remove_all_filters( 'activitypub_attachment' );
+		remove_all_filters( 'fosse_pre_is_photo_post' );
+		remove_all_filters( 'fosse_is_photo_post' );
+		remove_all_filters( 'get_the_terms' );
+		remove_all_filters( 'wp_insert_post_empty_content' );
+
+		Photo_Post::reset_cache_for_testing();
+		Photo_Post::register();
+
+		// `register_post_format_support()` normally runs on
+		// `after_setup_theme`, which has already fired by the time
+		// PHPUnit gets here — call it directly so format-aware
+		// detection sees `get_post_format()` consulting the term.
+		Photo_Post::register_post_format_support();
+
+		// Empty bodies are valid photo posts (Featured Image + no
+		// caption, or "image format with zero text"). Override WP's
+		// default empty-content rejection so `wp_insert_post` returns
+		// an id for those cases too.
+		add_filter( 'wp_insert_post_empty_content', '__return_false' );
+	}
+
+	/**
+	 * Build a real WP post with optional title and post format.
+	 *
+	 * Post format is injected via a `get_the_terms` filter rather than
+	 * `set_post_format()` — WorDBless's database-less storage layer
+	 * accepts term inserts but does not round-trip the
+	 * object/term relationships back through `wp_get_object_terms()`,
+	 * so `get_post_format()` reads empty even after a successful
+	 * `set_post_format()` call. The filter approach exercises the
+	 * same code path `get_post_format()` actually uses (the
+	 * `get_the_terms` filter chain) and works under WorDBless.
+	 *
+	 * Each call generates a fresh post id so the per-post memoization
+	 * cache doesn't leak between cases.
+	 *
+	 * @param string $content     Raw post content.
+	 * @param string $title       Optional post title.
+	 * @param string $post_format Optional post format slug (image, gallery, status, …).
+	 * @return WP_Post
+	 */
+	private function make_post( string $content, string $title = '', string $post_format = '' ): WP_Post {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => $title,
+				'post_content' => $content,
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+
+		if ( '' !== $post_format ) {
+			$term = (object) array(
+				'slug'     => 'post-format-' . $post_format,
+				'name'     => $post_format,
+				'taxonomy' => 'post_format',
+				'term_id'  => 999,
+			);
+
+			add_filter(
+				'get_the_terms',
+				static function ( $terms, $object_id, $taxonomy ) use ( $post_id, $term ) {
+					if ( (int) $object_id === (int) $post_id && 'post_format' === $taxonomy ) {
+						return array( $term );
+					}
+					return $terms;
+				},
+				10,
+				3
+			);
+		}
+
+		return get_post( $post_id );
+	}
+
+	/**
+	 * Insert a real post and (optionally) attach a thumbnail meta. Used
+	 * for featured-image-aware detection cases where `has_post_thumbnail`
+	 * needs to consult postmeta. We do not need an actual attachment
+	 * post — `has_post_thumbnail` only checks for a non-zero
+	 * `_thumbnail_id` meta value.
+	 *
+	 * @param string $content       Post content.
+	 * @param bool   $with_thumbnail Whether to set `_thumbnail_id`.
+	 * @return WP_Post
+	 */
+	private function insert_post_with_thumbnail( string $content, bool $with_thumbnail = true ): WP_Post {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => '',
+				'post_content' => $content,
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+
+		if ( $with_thumbnail ) {
+			update_post_meta( $post_id, '_thumbnail_id', 999 );
+		}
+
+		return get_post( $post_id );
+	}
+
+	// ---------------------------------------------------------------
+	// Discriminator: guards.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Non-`WP_Post` input must short-circuit to false. Defends against
+	 * stray filter contract drift — a stranger calling `is_photo_post`
+	 * with garbage shouldn't be able to flip the AP envelope.
+	 */
+	public function test_discriminator_returns_false_for_non_post_input(): void {
+		$this->assertFalse( Photo_Post::is_photo_post( null ) );
+		$this->assertFalse( Photo_Post::is_photo_post( 'not-a-post' ) );
+		$this->assertFalse( Photo_Post::is_photo_post( 999999 ) );
+	}
+
+	// ---------------------------------------------------------------
+	// Discriminator: pre-filter short-circuit.
+	// ---------------------------------------------------------------
+
+	/**
+	 * `fosse_pre_is_photo_post` returning true wins outright — built-in
+	 * detection must not run. This is the documented escape hatch for
+	 * sites with a custom photo CPT that want to hardwire the answer.
+	 */
+	public function test_pre_filter_short_circuits_to_true(): void {
+		add_filter( 'fosse_pre_is_photo_post', '__return_true' );
+
+		// Body is a plain paragraph, which the built-in detector would
+		// classify as not a photo. The pre-filter wins anyway.
+		$post = $this->make_post( '<!-- wp:paragraph --><p>Nothing photographic.</p><!-- /wp:paragraph -->' );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * `fosse_pre_is_photo_post` returning false also short-circuits —
+	 * a site can suppress photo treatment for posts the built-in
+	 * detector would otherwise catch.
+	 */
+	public function test_pre_filter_short_circuits_to_false(): void {
+		add_filter( 'fosse_pre_is_photo_post', '__return_false' );
+
+		$post = $this->make_post( '', '', 'image' );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Returning null from the pre-filter is the documented "no opinion"
+	 * sentinel — detection must run as if the pre-filter weren't there.
+	 */
+	public function test_pre_filter_null_falls_through_to_detection(): void {
+		add_filter(
+			'fosse_pre_is_photo_post',
+			static function () {
+				return null;
+			}
+		);
+
+		$post = $this->make_post( '', '', 'image' );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	// ---------------------------------------------------------------
+	// Discriminator: final filter.
+	// ---------------------------------------------------------------
+
+	/**
+	 * `fosse_is_photo_post` can downgrade a detected positive — e.g.
+	 * "exclude posts in the announcements category from being treated
+	 * as photo posts even when the body is image-only."
+	 */
+	public function test_final_filter_can_downgrade_detected_positive(): void {
+		add_filter( 'fosse_is_photo_post', '__return_false' );
+
+		$post = $this->make_post( '', '', 'image' );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * `fosse_is_photo_post` can upgrade a detected negative — useful for
+	 * CPTs whose body uses a custom block FOSSE doesn't recognize as
+	 * image-like.
+	 */
+	public function test_final_filter_can_upgrade_detected_negative(): void {
+		add_filter( 'fosse_is_photo_post', '__return_true' );
+
+		$post = $this->make_post( '<!-- wp:paragraph --><p>Just text.</p><!-- /wp:paragraph -->' );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	// ---------------------------------------------------------------
+	// Detection: post format.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Post Format `image` is the canonical "this is a photo" signal in
+	 * WordPress and maps 1:1 to Pixelfed's "this is a photo" gate.
+	 *
+	 * @param string $format Post format slug.
+	 * @param bool   $expected Whether the detector should flag the post.
+	 *
+	 * @dataProvider post_format_cases
+	 */
+	#[DataProvider( 'post_format_cases' )]
+	public function test_post_format_drives_detection( string $format, bool $expected ): void {
+		$post = $this->make_post( '<!-- wp:paragraph --><p>caption</p><!-- /wp:paragraph -->', '', $format );
+
+		$this->assertSame( $expected, Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Data provider for `test_post_format_drives_detection`.
+	 *
+	 * @return array<string, array{0:string, 1:bool}>
+	 */
+	public static function post_format_cases(): array {
+		return array(
+			'image format'    => array( 'image', true ),
+			'gallery format'  => array( 'gallery', true ),
+			'status format'   => array( 'status', false ),
+			'standard format' => array( 'standard', false ),
+			'video format'    => array( 'video', false ),
+			'audio format'    => array( 'audio', false ),
+		);
+	}
+
+	// ---------------------------------------------------------------
+	// Detection: block-shape (Rule 2).
+	// ---------------------------------------------------------------
+
+	/**
+	 * Body shape decides detection when post format is absent. The
+	 * scenarios here mirror the rule set documented on the class:
+	 *  - one image-like block (with or without a paragraph) → photo
+	 *  - image + 2+ paragraphs → not a photo (it's an article)
+	 *  - paragraph only → not a photo
+	 *  - image + non-paragraph block (heading) → not a photo
+	 *  - empty paragraphs / spacer / separator → ignored
+	 *
+	 * @param string $content  Raw block markup.
+	 * @param bool   $expected Whether the detector should flag the post.
+	 *
+	 * @dataProvider block_shape_cases
+	 */
+	#[DataProvider( 'block_shape_cases' )]
+	public function test_block_shape_drives_detection( string $content, bool $expected ): void {
+		$post = $this->make_post( $content );
+
+		$this->assertSame( $expected, Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Data provider for `test_block_shape_drives_detection`.
+	 *
+	 * @return array<string, array{0:string, 1:bool}>
+	 */
+	public static function block_shape_cases(): array {
+		$image     = '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img src="https://example.test/a.jpg" alt=""/></figure><!-- /wp:image -->';
+		$gallery   = '<!-- wp:gallery --><figure class="wp-block-gallery"></figure><!-- /wp:gallery -->';
+		$featured  = '<!-- wp:post-featured-image /-->';
+		$paragraph = '<!-- wp:paragraph --><p>caption text</p><!-- /wp:paragraph -->';
+		$heading   = '<!-- wp:heading --><h2>headline</h2><!-- /wp:heading -->';
+		$spacer    = '<!-- wp:spacer --><div class="wp-block-spacer"></div><!-- /wp:spacer -->';
+		$separator = '<!-- wp:separator --><hr class="wp-block-separator"/><!-- /wp:separator -->';
+		$empty_p   = '<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->';
+
+		return array(
+			'image only'                     => array( $image, true ),
+			'image plus single paragraph'    => array( $image . $paragraph, true ),
+			'image plus two paragraphs'      => array( $image . $paragraph . $paragraph, false ),
+			'paragraph only'                 => array( $paragraph, false ),
+			'gallery only'                   => array( $gallery, true ),
+			'gallery plus paragraph'         => array( $gallery . $paragraph, true ),
+			'featured image block only'      => array( $featured, true ),
+			'featured image block plus para' => array( $featured . $paragraph, true ),
+			'image plus heading'             => array( $image . $heading, false ),
+			'two images'                     => array( $image . $image, false ),
+			'image plus empty paragraph'     => array( $image . $empty_p, true ),
+			'image plus spacer plus para'    => array( $image . $spacer . $paragraph, true ),
+			'image plus separator'           => array( $image . $separator, true ),
+			'empty content'                  => array( '', false ),
+		);
+	}
+
+	// ---------------------------------------------------------------
+	// Detection: title presence is not a disqualifier.
+	// ---------------------------------------------------------------
+
+	/**
+	 * A non-empty title must not suppress photo detection — the user
+	 * explicitly asked on `DOTCOM-17143` for "Headline. Big photo.
+	 * Caption." to still count.
+	 */
+	public function test_title_does_not_suppress_detection(): void {
+		$image = '<!-- wp:image --><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure><!-- /wp:image -->';
+		$post  = $this->make_post( $image, 'My Photo Title' );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	// ---------------------------------------------------------------
+	// Detection: featured-image-thumbnail flow (Rule 3).
+	// ---------------------------------------------------------------
+
+	/**
+	 * Empty body + Featured Image set = "set thumbnail, hit publish"
+	 * mobile-app flow. Detector must catch this case even though
+	 * `parse_blocks('')` yields nothing.
+	 */
+	public function test_featured_thumbnail_with_empty_body_detects(): void {
+		$post = $this->insert_post_with_thumbnail( '' );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Featured Image set + body = single caption paragraph should also
+	 * detect — classic-editor flow where the body is the caption.
+	 */
+	public function test_featured_thumbnail_with_single_paragraph_detects(): void {
+		$paragraph = '<!-- wp:paragraph --><p>Caption.</p><!-- /wp:paragraph -->';
+		$post      = $this->insert_post_with_thumbnail( $paragraph );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Featured Image + 2 paragraphs is an article that happens to have
+	 * a hero image. Don't classify as a photo post — that's a
+	 * blog-post-with-image, not a photo-with-caption.
+	 */
+	public function test_featured_thumbnail_with_two_paragraphs_does_not_detect(): void {
+		$paragraph = '<!-- wp:paragraph --><p>A line.</p><!-- /wp:paragraph -->';
+		$post      = $this->insert_post_with_thumbnail( $paragraph . $paragraph );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Same body shape without a featured image must NOT detect. Guards
+	 * against the rule-3 path firing on plain text posts just because
+	 * they happen to fit "≤1 paragraph."
+	 */
+	public function test_single_paragraph_without_thumbnail_does_not_detect(): void {
+		$paragraph = '<!-- wp:paragraph --><p>Caption.</p><!-- /wp:paragraph -->';
+		$post      = $this->insert_post_with_thumbnail( $paragraph, false );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	// ---------------------------------------------------------------
+	// Detection: caching.
+	// ---------------------------------------------------------------
+
+	/**
+	 * The decision is memoized per post id so the AP transformer
+	 * hooks (which can each call `is_photo_post` independently in one
+	 * pass) don't re-parse the body each time.
+	 */
+	public function test_decision_is_cached_per_post(): void {
+		$image = '<!-- wp:image --><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure><!-- /wp:image -->';
+		$post  = $this->make_post( $image );
+
+		$call_count = 0;
+		add_filter(
+			'fosse_pre_is_photo_post',
+			static function ( $value ) use ( &$call_count ) {
+				++$call_count;
+				return $value;
+			}
+		);
+
+		Photo_Post::is_photo_post( $post );
+		Photo_Post::is_photo_post( $post );
+		Photo_Post::is_photo_post( $post );
+
+		$this->assertSame( 1, $call_count, 'Pre-filter must run exactly once per post id thanks to memoization.' );
+	}
+
+	// ---------------------------------------------------------------
+	// AP hook: object type.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Photo posts get `type: "Note"` regardless of what bundled AP
+	 * would have computed — the prerequisite for Pixelfed's photo
+	 * timeline rendering.
+	 */
+	public function test_object_type_filter_forces_note_for_photo_post(): void {
+		$post = $this->make_post( '', '', 'image' );
+
+		$type = apply_filters( 'activitypub_post_object_type', 'Article', $post );
+
+		$this->assertSame( 'Note', $type );
+	}
+
+	/**
+	 * Non-photo posts pass through — bundled AP's own Note / Article /
+	 * Page decision stays authoritative.
+	 */
+	public function test_object_type_filter_passes_through_for_non_photo_post(): void {
+		$post = $this->make_post( '<!-- wp:paragraph --><p>essay</p><!-- /wp:paragraph -->' );
+
+		$type = apply_filters( 'activitypub_post_object_type', 'Article', $post );
+
+		$this->assertSame( 'Article', $type );
+	}
+
+	/**
+	 * Defensive: a non-WP_Post second arg must not blow up the filter.
+	 */
+	public function test_object_type_filter_passes_through_on_non_wp_post(): void {
+		$type = apply_filters( 'activitypub_post_object_type', 'Article', null );
+
+		$this->assertSame( 'Article', $type );
+	}
+
+	// ---------------------------------------------------------------
+	// AP hook: content stripping.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Image-block markup must be stripped so the AP `content` is the
+	 * caption only — the photo lives in `attachment[]`.
+	 */
+	public function test_content_filter_strips_image_block(): void {
+		$post     = $this->make_post( '', '', 'image' );
+		$content  = '<figure class="wp-block-image"><img src="https://example.test/a.jpg" alt="Sunset"/></figure><p>Sunset over the bay.</p>';
+		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
+
+		$this->assertStringNotContainsString( '<img', $filtered );
+		$this->assertStringNotContainsString( 'wp-block-image', $filtered );
+		$this->assertStringContainsString( 'Sunset over the bay.', $filtered );
+	}
+
+	/**
+	 * Gallery wrappers (which contain nested figures) must also strip
+	 * cleanly without leaving inner `<img>` orphans.
+	 */
+	public function test_content_filter_strips_gallery_block(): void {
+		$post     = $this->make_post( '', '', 'gallery' );
+		$content  = '<figure class="wp-block-gallery"><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure></figure><p>Trip recap.</p>';
+		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
+
+		$this->assertStringNotContainsString( '<img', $filtered );
+		$this->assertStringNotContainsString( 'wp-block', $filtered );
+		$this->assertStringContainsString( 'Trip recap.', $filtered );
+	}
+
+	/**
+	 * The Featured Image block renders to its own wrapper class and
+	 * must strip the same way.
+	 */
+	public function test_content_filter_strips_post_featured_image_block(): void {
+		$post     = $this->make_post( '', '', 'image' );
+		$content  = '<figure class="wp-block-post-featured-image"><img src="https://example.test/a.jpg"/></figure><p>Caption.</p>';
+		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
+
+		$this->assertStringNotContainsString( '<img', $filtered );
+		$this->assertStringContainsString( 'Caption.', $filtered );
+	}
+
+	/**
+	 * Empty paragraph wrappers left behind by the editor after the
+	 * image is stripped should clean up too — otherwise federated
+	 * content gets a leading `<p></p>` shell.
+	 */
+	public function test_content_filter_cleans_empty_paragraph_wrappers(): void {
+		$post     = $this->make_post( '', '', 'image' );
+		$content  = '<p><img src="https://example.test/a.jpg"/></p><p>Caption.</p>';
+		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
+
+		$this->assertStringNotContainsString( '<p></p>', $filtered );
+		$this->assertStringContainsString( 'Caption.', $filtered );
+	}
+
+	/**
+	 * Non-photo posts must NOT have their content stripped — long-form
+	 * articles need their inline images preserved.
+	 */
+	public function test_content_filter_passes_through_for_non_photo_post(): void {
+		$post     = $this->make_post( '<!-- wp:paragraph --><p>essay</p><!-- /wp:paragraph -->' );
+		$content  = '<figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure><p>essay body</p>';
+		$filtered = apply_filters( 'activitypub_the_content', $content, $post );
+
+		$this->assertSame( $content, $filtered );
+	}
+
+	// ---------------------------------------------------------------
+	// AP hook: attachment dimensions.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Images without `width`/`height` get them filled in from
+	 * `wp_get_attachment_metadata()`. Pixelfed enforces the bounds
+	 * server-side; Mastodon uses them for layout.
+	 */
+	public function test_attachment_filter_adds_width_height_from_metadata(): void {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'test',
+			)
+		);
+		wp_update_attachment_metadata(
+			$attachment_id,
+			array(
+				'width'  => 2048,
+				'height' => 1365,
+			)
+		);
+
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://example.test/a.jpg',
+			'mediaType' => 'image/jpeg',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, $attachment_id );
+
+		$this->assertSame( 2048, $out['width'] );
+		$this->assertSame( 1365, $out['height'] );
+	}
+
+	/**
+	 * Non-image attachments (audio / video) must not be touched —
+	 * bundled AP already adds width/height for those, and this filter
+	 * is purely "close the gap on images."
+	 */
+	public function test_attachment_filter_skips_non_image(): void {
+		$input = array(
+			'type'      => 'Video',
+			'url'       => 'https://example.test/a.mp4',
+			'mediaType' => 'video/mp4',
+			'width'     => 1920,
+			'height'    => 1080,
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, 0 );
+
+		$this->assertSame( $input, $out );
+	}
+
+	/**
+	 * Pre-existing dimensions must be preserved — never overwrite what
+	 * an upstream callback (or future bundled-AP improvement) already
+	 * computed.
+	 */
+	public function test_attachment_filter_preserves_existing_dimensions(): void {
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://example.test/a.jpg',
+			'mediaType' => 'image/jpeg',
+			'width'     => 100,
+			'height'    => 200,
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, 0 );
+
+		$this->assertSame( 100, $out['width'] );
+		$this->assertSame( 200, $out['height'] );
+	}
+
+	/**
+	 * Missing or non-array metadata is the common "external image with
+	 * no local attachment" case — leave the attachment unchanged.
+	 */
+	public function test_attachment_filter_skips_when_metadata_missing(): void {
+		$input = array(
+			'type'      => 'Image',
+			'url'       => 'https://example.test/a.jpg',
+			'mediaType' => 'image/jpeg',
+		);
+
+		$out = apply_filters( 'activitypub_attachment', $input, 0 );
+
+		$this->assertArrayNotHasKey( 'width', $out );
+		$this->assertArrayNotHasKey( 'height', $out );
+	}
+}

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -86,7 +86,11 @@ class Photo_PostTest extends BaseTestCase {
 		// Empty bodies are valid photo posts (Featured Image + no
 		// caption, or "image format with zero text"). Override WP's
 		// default empty-content rejection so `wp_insert_post` returns
-		// an id for those cases too.
+		// an id for those cases too. The matching `#[After]` hook
+		// removes this callback so sibling test classes don't
+		// inherit it (their `wp_insert_post` calls should still see
+		// WP's default empty-content rejection unless they opt in
+		// explicitly).
 		add_filter( 'wp_insert_post_empty_content', '__return_false' );
 
 		// WorDBless installs the kses `content_save_pre` filter
@@ -140,6 +144,13 @@ class Photo_PostTest extends BaseTestCase {
 		if ( $this->had_content_filtered_save_pre_kses ) {
 			add_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
 		}
+
+		// Drop the test-only empty-content override so later test
+		// classes see WP's default rejection again. Without this
+		// removal, any sibling that calls `wp_insert_post` with an
+		// empty body would get an id back instead of WP's normal
+		// no-content failure, masking real bugs in their fixtures.
+		remove_filter( 'wp_insert_post_empty_content', '__return_false' );
 	}
 
 	/**
@@ -282,6 +293,39 @@ class Photo_PostTest extends BaseTestCase {
 		$this->assertFalse( Photo_Post::is_photo_post( null ) );
 		$this->assertFalse( Photo_Post::is_photo_post( 'not-a-post' ) );
 		$this->assertFalse( Photo_Post::is_photo_post( 999999 ) );
+		$this->assertFalse( Photo_Post::is_photo_post( false ) );
+		$this->assertFalse( Photo_Post::is_photo_post( '' ) );
+	}
+
+	/**
+	 * `get_post()`'s contract: empty input (null, 0, false, '')
+	 * falls back to `$GLOBALS['post']`. The discriminator must
+	 * short-circuit on empty input BEFORE handing off, otherwise
+	 * calling `Photo_Post::is_photo_post( null )` during template
+	 * rendering would silently classify the current loop post — not
+	 * the "no post" answer the docblock promises. This test seeds
+	 * a global photo-format post and asserts the empty-input call
+	 * still returns false.
+	 */
+	public function test_discriminator_returns_false_when_global_post_is_set(): void {
+		$global_post = $this->make_post( '', '', 'image' );
+
+		$previous_global = $GLOBALS['post'] ?? null;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$GLOBALS['post'] = $global_post;
+
+		try {
+			$this->assertFalse( Photo_Post::is_photo_post( null ) );
+			$this->assertFalse( Photo_Post::is_photo_post( false ) );
+			$this->assertFalse( Photo_Post::is_photo_post( '' ) );
+		} finally {
+			if ( null === $previous_global ) {
+				unset( $GLOBALS['post'] );
+			} else {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$GLOBALS['post'] = $previous_global;
+			}
+		}
 	}
 
 	// ---------------------------------------------------------------


### PR DESCRIPTION
Refs [DOTCOM-17143](https://linear.app/a8c/issue/DOTCOM-17143).

## Summary

Detects when a WordPress post is shaped like a photo post and projects that decision onto bundled ActivityPub's transformer filters so the outbound activity matches what Pixelfed (and Mastodon's media-attached toot rendering) renders natively in a photo grid — `type: Note`, caption-only `content`, and dimensionally-complete `attachment[]`.

External AP consumers (Pixelfed, Mastodon, Misskey, …) have no visibility into WordPress internals — CPTs, taxonomies, block structure — so this is purely a transformer-side problem: detect "this is a photo post" on the WP side, then emit the correct shape. Slots into FOSSE's existing per-network projector pattern (`Object_Type`, `Bsky_Short_Form_Fit`).

No new CPT. The "Image" / "Gallery" Post Format is the canonical WP discriminator; block-shape detection covers the modern block-editor flow where users may not engage with Post Formats at all.

## What it does

### Detection (`Photo_Post::is_photo_post( \$post )`)

Three-stage pipeline so callers can intervene at either boundary:

1. `fosse_pre_is_photo_post` short-circuit. Return a non-null bool to hardwire the decision — the documented recipe for sites with a custom photo CPT that already know what's a photo and don't need block introspection.
2. Built-in rules:
   - Rule 1: post format is `image` or `gallery`.
   - Rule 2: block content is "one image-like block + at most one paragraph block." Image-like blocks: `core/image`, `core/gallery`, `core/post-featured-image`. Empty paragraphs / spacer / separator are ignored.
   - Rule 3: post has a featured image and the body is empty or at most one paragraph. Catches the "set thumbnail, type one line, hit publish" mobile-app flow.
   - Title presence is intentionally not a disqualifier — "Headline. Big photo. Caption." is still a photo post.
3. `fosse_is_photo_post` final filter so callers can upgrade or downgrade the detection result.

Result is memoized per post id; the three AP hooks below each call into `is_photo_post()` independently in one federation pass, so block parsing happens once.

### AP transformer hooks

| Hook | Behavior |
|------|----------|
| `activitypub_post_object_type` | Force `Note` for photo posts. Pixelfed only renders Notes in its photo timeline; Articles drop into the long-form reader path regardless of attachment quality. |
| `activitypub_the_content` | Strip image / gallery / featured-image block markup so AP `content` is the caption only. Pixelfed accepts HTML but the IG-grid feel wants a short caption next to the attachment, not an article that opens with an image. |
| `activitypub_attachment` | Add `width` / `height` to every image attachment from `wp_get_attachment_metadata()`. Fires **unconditionally** (not gated on `is_photo_post()`) because dimensions are universally useful — Mastodon uses them for layout, Pixelfed enforces 1–5000 server-side, and bundled AP already emits dimensions for video/audio but not images. Closing that gap is a strict superset. |

Also: `add_post_type_support( 'post', 'post-formats' )` on `after_setup_theme` priority 99 — block themes increasingly skip this, which silently makes `get_post_format()` return `false` even when the term is set. Narrow on purpose: we register the post-type support flag the function actually checks, but do **not** call `add_theme_support( 'post-formats', […] )` because that would either overwrite the theme's curated list or require a brittle merge. UI-side concerns (surfacing the Gutenberg format picker on themes that don't already opt in) are a separate UX problem.

## Out of scope (follow-up tickets to file)

- **`blurhash` on AP attachments** — needs a PHP encoder dep + a background job at attachment upload time. Synchronous encoding on the federation hot path is too slow.
- **`app.bsky.embed.images` for AT Protocol** — Atmosphere today emits `app.bsky.embed.external` link cards for posts with images. Native image embeds for AT need `uploadBlob`, blob caching, a 4-image cap with overflow strategy, and probably its own `Photo_Post::register_atmosphere_hooks()` path.
- **`sensitive` / `summary` (content warnings)** — needs a UX decision on the source of truth: taxonomy, postmeta, or per-network.
- **Auto-populating the format picker dropdown via `add_theme_support`** — UX nicety so users on minimal block themes can pick "Image" without admin gymnastics.

## Test plan

- [x] `composer run-script test-php` — 607 tests pass (44 new in `Photo_PostTest`).
- [x] `composer lint-php` — clean.
- [ ] Manual smoke on a wpcom or Playground site: publish a post with Post Format = Image + one image block + a caption. Confirm the outbound AP activity is `type: Note`, `attachment[].width`/`height` present, and `content` does not include the figure/img markup.
- [ ] Manual smoke: publish a long-form post that happens to contain an inline image. Confirm AP still emits `Article` with the inline image intact (i.e. detection said "not a photo").
- [ ] Manual smoke: publish a post with only a Featured Image and an empty body. Confirm detection picks it up (Rule 3) and AP emits `Note` + the featured image as the sole attachment.

## Files

- `src/class-photo-post.php` — the projector class (detector + hooks).
- `fosse.php` — register on `init`, same posture as `Object_Type` and `Bsky_Short_Form_Fit`.
- `tests/php/Photo_PostTest.php` — 44 cases covering detection rules, both filters, caching, and each AP hook.