### PR TITLE
Photo-post AT Protocol federation shape

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -212,6 +212,25 @@ add_action(
 );
 
 /*
+ * Photo-post AT Protocol federation-shape projector.
+ *
+ * Sibling of the AP-side Photo_Post projector. Routes a photo-shaped
+ * WP post into Atmosphere's short-form path and replaces the default
+ * external link card with a native `app.bsky.embed.images` embed so
+ * Flashes / Pinksky render it as a native photo post. See
+ * `DOTCOM-17143` and `class-photo-post-atmosphere.php`.
+ */
+add_action(
+	'init',
+	static function () {
+		if ( ! class_exists( \Automattic\Fosse\Photo_Post_Atmosphere::class ) ) {
+			return;
+		}
+		\Automattic\Fosse\Photo_Post_Atmosphere::register();
+	}
+);
+
+/*
  * Cross-network post-type projector.
  *
  * Feeds ActivityPub's stored `activitypub_support_post_types` option into

--- a/src/class-photo-post-atmosphere.php
+++ b/src/class-photo-post-atmosphere.php
@@ -47,6 +47,27 @@ use WP_Post;
  * see the class docblock notes below for the cleaner two-line
  * switchover.
  *
+ * Failure-mode posture:
+ *
+ *   - If the *featured image* upload fails, the projector returns
+ *     the record unchanged. Featured Image is the post's hero shot;
+ *     silently shipping a gallery missing its hero shot is the
+ *     worst failure mode for a photo feature.
+ *   - If a non-featured image upload fails, that one attachment is
+ *     dropped from the embed and an `error_log` line is written so
+ *     operators can correlate with PDS errors.
+ *   - If *every* upload fails, the projector returns the record
+ *     unchanged so Atmosphere ships short-form text with no embed.
+ *     When the post body is also empty (the canonical Featured-Image-
+ *     only photo post), the projector additionally logs the empty-
+ *     record outcome so a publish failure isn't silent.
+ *   - Filter / upload exceptions are caught per-attachment so one
+ *     misbehaving listener can't crater the entire federation event.
+ *   - Synchronous blob uploads are bounded by
+ *     `fosse_photo_post_atmosphere_upload_budget_seconds` (default
+ *     30s) so a degraded PDS can't tie up a publish request for
+ *     minutes.
+ *
  * Out of scope (separate tickets):
  *
  *   - >4 image overflow strategy (thread, fall back to link card,
@@ -76,6 +97,10 @@ class Photo_Post_Atmosphere {
 	 * remainder so a future projector can decide how to recover
 	 * (split into a thread, fall back to a link card, etc.).
 	 *
+	 * Intentionally public so downstream overflow listeners and
+	 * tests can compare attachment counts against the cap without
+	 * duplicating the magic number.
+	 *
 	 * @var int
 	 */
 	public const MAX_IMAGES = 4;
@@ -92,9 +117,21 @@ class Photo_Post_Atmosphere {
 	private const TEXT_BUDGET = 300;
 
 	/**
-	 * Register the Atmosphere filter callbacks. Safe to call more than
-	 * once per request — WordPress dedupes identical callable-as-array
-	 * registrations.
+	 * Default wall-time budget for all synchronous blob uploads in a
+	 * single federation event, in seconds. Overridable via the
+	 * `fosse_photo_post_atmosphere_upload_budget_seconds` filter.
+	 *
+	 * @var int
+	 */
+	private const DEFAULT_UPLOAD_BUDGET_SECONDS = 30;
+
+	/**
+	 * Register the Atmosphere filter callbacks.
+	 *
+	 * Safe to call more than once per request because
+	 * `add_filter()` keys callbacks by `(callable identity, priority)`
+	 * — identical static-callable registrations collide on the same
+	 * key and don't stack.
 	 *
 	 * @return void
 	 */
@@ -149,11 +186,13 @@ class Photo_Post_Atmosphere {
 	 * `_wp_attachment_image_alt` postmeta) and `aspectRatio` (from
 	 * `wp_get_attachment_metadata()`).
 	 *
-	 * If every blob upload fails (network error, all attachments
-	 * exceed AT Protocol's 1 MB blob cap, etc.) the record is
-	 * returned unchanged — Atmosphere ships the short-form post body
-	 * with no embed, which is a graceful degradation: the user's
-	 * caption still federates, just without the image grid.
+	 * Failure handling — see class docblock for the full rationale:
+	 *   - Featured-image upload failure → return unchanged. A
+	 *     gallery missing its hero shot is worse than no gallery.
+	 *   - Non-featured upload failure → drop that attachment, log,
+	 *     keep going.
+	 *   - Every upload failed → return unchanged so Atmosphere ships
+	 *     short-form text; if the body is also empty, log it.
 	 *
 	 * @param array $record  Bsky post record under construction.
 	 * @param mixed $post    The post being transformed.
@@ -181,18 +220,67 @@ class Photo_Post_Atmosphere {
 			return $record;
 		}
 
-		$attached = array();
-		$overflow = array();
-		$idx      = 0;
+		// `collect_image_attachment_ids()` contractually orders the
+		// featured image first when it exists. Capture that decision
+		// here so an early upload failure on the hero shot can bail
+		// the whole projection rather than ship a gallery with the
+		// canonical image silently missing.
+		$featured_id      = (int) \get_post_thumbnail_id( $post );
+		$has_featured     = $featured_id > 0 && ! empty( $image_ids ) && $image_ids[0] === $featured_id;
+		$budget_seconds   = self::upload_budget_seconds( $post );
+		$budget_deadline  = $budget_seconds > 0 ? \microtime( true ) + (float) $budget_seconds : null;
+		$attached         = array();
+		$overflow         = array();
+		$attempted        = 0;
+		$budget_exhausted = false;
 
 		foreach ( $image_ids as $attachment_id ) {
-			if ( $idx >= self::MAX_IMAGES ) {
+			if ( $attempted >= self::MAX_IMAGES ) {
 				$overflow[] = $attachment_id;
 				continue;
 			}
 
+			if ( null !== $budget_deadline && \microtime( true ) >= $budget_deadline ) {
+				$budget_exhausted = true;
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal for operators; behind a budget that defaults to 30s.
+				\error_log(
+					\sprintf(
+						'[fosse:photo-post-atmosphere] upload budget (%ds) exhausted on post %d; dropping remaining attachments.',
+						$budget_seconds,
+						$post->ID
+					)
+				);
+				break;
+			}
+
 			$blob = self::upload_blob( $attachment_id );
+
 			if ( null === $blob ) {
+				if ( $has_featured && 0 === $attempted ) {
+					// Featured image is the hero shot — refuse to ship
+					// a gallery missing it. Return unchanged so
+					// Atmosphere falls back to short-form text and the
+					// operator gets a log line to act on.
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal for operators.
+					\error_log(
+						\sprintf(
+							'[fosse:photo-post-atmosphere] featured image upload failed on post %d; aborting photo projection.',
+							$post->ID
+						)
+					);
+					return $record;
+				}
+
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal for operators.
+				\error_log(
+					\sprintf(
+						'[fosse:photo-post-atmosphere] attachment %d upload failed on post %d; dropping from embed.',
+						$attachment_id,
+						$post->ID
+					)
+				);
+
+				++$attempted;
 				continue;
 			}
 
@@ -207,47 +295,56 @@ class Photo_Post_Atmosphere {
 			}
 
 			$attached[] = $image;
-			++$idx;
+			++$attempted;
 		}
 
 		if ( empty( $attached ) ) {
-			// Every upload failed — bail without mutating the record so
-			// Atmosphere ships the caption with no embed (better than
-			// shipping a broken images embed).
+			// Every upload failed. Return unchanged so Atmosphere ships
+			// the caption with no embed (better than a malformed
+			// embed); if the body is also empty, log so the silent
+			// "user federated literally nothing" outcome surfaces.
+			if ( '' === \trim( (string) ( $record['text'] ?? '' ) ) ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal for operators.
+				\error_log(
+					\sprintf(
+						'[fosse:photo-post-atmosphere] all uploads failed and post %d has empty body; record will federate as an empty post.',
+						$post->ID
+					)
+				);
+			}
 			return $record;
 		}
 
+		// Budget-exhausted attachments aren't surfaced via the overflow
+		// action — overflow is documented as "more images than the
+		// lexicon cap" and a downstream listener can't usefully retry
+		// budget drops in the same federation event. The error_log
+		// line above is the operator-facing signal.
+		unset( $budget_exhausted );
+
 		if ( ! empty( $overflow ) ) {
-			/**
-			 * Fires when a photo post has more resolvable image
-			 * attachments than {@see self::MAX_IMAGES}. Subscribers
-			 * can implement an overflow strategy (split into a
-			 * thread, fall back to a link card, surface a notice to
-			 * the user) without modifying this projector.
-			 *
-			 * @param WP_Post $post     The post being projected.
-			 * @param int[]   $overflow Attachment ids dropped from the embed.
-			 */
-			\do_action( 'fosse_photo_post_atmosphere_overflow', $post, $overflow );
+			self::fire_overflow_action( $post, $overflow );
 		}
 
-		$caption         = Photo_Post::caption_text( $post );
-		$text            = self::truncate_text( $caption );
-		$record['text']  = $text;
+		$caption        = Photo_Post::caption_text( $post );
+		$text           = self::truncate_text( $caption );
+		$record['text'] = $text;
+
 		$record['embed'] = array(
 			'$type'  => 'app.bsky.embed.images',
 			'images' => $attached,
 		);
 
-		// Atmosphere's `transform()` already extracted facets against
-		// the pre-strip text. Re-extract against the caption-only text
-		// so byte offsets line up; drop the field if no facets exist
-		// against the new text.
-		$facets = self::extract_facets( $text );
-		if ( empty( $facets ) ) {
+		// Re-extract facets against the rewritten caption so byte
+		// offsets line up with the new text. Extract against the
+		// *untruncated* caption first, then drop any facet whose byte
+		// range falls past the truncated length — protects URLs that
+		// straddle the 300-grapheme boundary.
+		$new_facets = self::extract_facets_for_text( $caption, $text );
+		if ( empty( $new_facets ) ) {
 			unset( $record['facets'] );
 		} else {
-			$record['facets'] = $facets;
+			$record['facets'] = $new_facets;
 		}
 
 		return $record;
@@ -265,42 +362,144 @@ class Photo_Post_Atmosphere {
 	 * resyncs, switch the call site below to the new name.
 	 *
 	 * The `fosse_photo_post_atmosphere_upload_blob` filter is the
-	 * extension seam: returning a non-null value short-circuits the
-	 * default delegation. Useful for sites that want to inject a
-	 * different upload pipeline (a media-CDN bridge, a backfill
-	 * worker that pre-uploads blobs, etc.) and for tests that need
-	 * to stub the upload without hitting the live PDS.
+	 * extension seam. Three return shapes are honored:
+	 *
+	 *   - `null` (default): fall through to Atmosphere's
+	 *     `upload_thumbnail()`.
+	 *   - A validly-shaped blob-ref array: short-circuit with a
+	 *     successful upload. The structure is validated before use.
+	 *   - Anything else (`false`, `WP_Error`, string, int, malformed
+	 *     array): short-circuit with a failed upload; the attachment
+	 *     is dropped from the embed and Atmosphere is NOT called.
+	 *     Use this when you want to suppress a specific attachment
+	 *     without paying Atmosphere's upload cost.
+	 *
+	 * Filter exceptions are caught per-attachment so one misbehaving
+	 * listener can't crater the entire federation event; the bad
+	 * attachment is treated as a failed upload and the loop continues.
 	 *
 	 * @param int $attachment_id WordPress attachment ID.
-	 * @return array|null Blob reference array (`$type`, `ref`, `mimeType`, `size`) or null on failure.
+	 * @return array|null Validated blob reference array, or null on any failure.
 	 */
 	private static function upload_blob( int $attachment_id ): ?array {
-		/**
-		 * Filters the AT Protocol blob upload for a photo-post image
-		 * attachment.
-		 *
-		 * Return a non-null array to short-circuit the default
-		 * Atmosphere-backed upload — the array becomes the blob ref
-		 * that lands inside the `app.bsky.embed.images` entry. Return
-		 * an explicit `false` to force a failure (the projector treats
-		 * the attachment as if upload failed and skips it). The
-		 * default `null` falls through to Atmosphere.
-		 *
-		 * @param mixed $pre           Pre-resolved blob ref or null to fall through.
-		 * @param int   $attachment_id Attachment id being uploaded.
-		 */
-		$pre = \apply_filters( 'fosse_photo_post_atmosphere_upload_blob', null, $attachment_id );
+		try {
+			/**
+			 * Filters the AT Protocol blob upload for a photo-post
+			 * image attachment.
+			 *
+			 * Three return shapes are honored:
+			 *
+			 *   - `null` (default): fall through to Atmosphere's
+			 *     `upload_thumbnail()`.
+			 *   - A validly-shaped blob-ref array (`$type === 'blob'`,
+			 *     `ref`, `mimeType` like `image/jpeg`, `size`):
+			 *     short-circuit with a successful upload. The return
+			 *     is validated structurally; a malformed array is
+			 *     treated as a failed upload.
+			 *   - Anything else (`false`, `WP_Error`, string, int):
+			 *     short-circuit with a failed upload; the attachment
+			 *     is dropped and Atmosphere is NOT called. Use this
+			 *     when you want to suppress a specific attachment
+			 *     without paying Atmosphere's upload cost.
+			 *
+			 * @param mixed $pre           Pre-resolved blob ref or null to fall through.
+			 * @param int   $attachment_id Attachment id being uploaded.
+			 */
+			$pre = \apply_filters( 'fosse_photo_post_atmosphere_upload_blob', null, $attachment_id );
+		} catch ( \Throwable $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Surface third-party filter crashes so operators can spot the bad plugin.
+			\error_log(
+				\sprintf(
+					'[fosse:photo-post-atmosphere] fosse_photo_post_atmosphere_upload_blob listener threw for attachment %d: %s',
+					$attachment_id,
+					$e->getMessage()
+				)
+			);
+			return null;
+		}
+
+		if ( \is_array( $pre ) ) {
+			return self::is_valid_blob_ref( $pre ) ? $pre : null;
+		}
+
 		if ( null !== $pre ) {
-			return \is_array( $pre ) ? $pre : null;
+			// Non-null non-array (`false`, `WP_Error`, string, int)
+			// = explicit "skip this attachment, don't fall through to
+			// Atmosphere." Useful for sites that want to suppress a
+			// specific attachment without paying Atmosphere's upload
+			// cost, and for tests that stub uploads without hitting
+			// the live PDS.
+			return null;
 		}
 
 		if ( ! \class_exists( '\Atmosphere\Transformer\Post' ) ) {
 			return null;
 		}
 
-		$blob = \Atmosphere\Transformer\Post::upload_thumbnail( $attachment_id );
+		try {
+			$blob = \Atmosphere\Transformer\Post::upload_thumbnail( $attachment_id );
+		} catch ( \Throwable $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal: surface unexpected upload-pipeline crashes.
+			\error_log(
+				\sprintf(
+					'[fosse:photo-post-atmosphere] Atmosphere upload_thumbnail threw for attachment %d: %s',
+					$attachment_id,
+					$e->getMessage()
+				)
+			);
+			return null;
+		}
 
-		return \is_array( $blob ) ? $blob : null;
+		if ( ! \is_array( $blob ) ) {
+			return null;
+		}
+
+		return self::is_valid_blob_ref( $blob ) ? $blob : null;
+	}
+
+	/**
+	 * Structural validation for an AT Protocol blob reference.
+	 *
+	 * Required keys: `$type === 'blob'`, `mimeType` (image/*),
+	 * `size` (positive int ≤ 1 MB, matching Atmosphere's blob cap),
+	 * and `ref` (a string CID or an associative array containing a
+	 * `$link` string — both shapes appear in the wild). Anything
+	 * else is treated as a malformed return and rejected.
+	 *
+	 * Protects the federation envelope from a third-party filter that
+	 * returns an arbitrary array — without validation, a forged ref
+	 * pointing at unauthorized PDS content could ship unchanged.
+	 *
+	 * @param array $blob Candidate blob reference.
+	 * @return bool True when the array matches the AT blob-ref shape.
+	 */
+	private static function is_valid_blob_ref( array $blob ): bool {
+		if ( 'blob' !== ( $blob['$type'] ?? null ) ) {
+			return false;
+		}
+
+		$mime = $blob['mimeType'] ?? null;
+		if ( ! \is_string( $mime ) || 0 !== \strpos( $mime, 'image/' ) ) {
+			return false;
+		}
+
+		$size = $blob['size'] ?? null;
+		if ( ! \is_int( $size ) || $size <= 0 || $size > 1_000_000 ) {
+			return false;
+		}
+
+		if ( ! isset( $blob['ref'] ) ) {
+			return false;
+		}
+		$ref = $blob['ref'];
+		if ( \is_string( $ref ) ) {
+			return '' !== $ref;
+		}
+		if ( \is_array( $ref ) && isset( $ref['$link'] ) && \is_string( $ref['$link'] ) && '' !== $ref['$link'] ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -362,6 +561,77 @@ class Photo_Post_Atmosphere {
 	}
 
 	/**
+	 * Resolve the wall-time budget for synchronous blob uploads.
+	 *
+	 * Each `Post::upload_thumbnail()` call can take up to 60s on a
+	 * degraded PDS; four of those in a row exceed typical PHP
+	 * execution-time limits. The default 30s budget keeps the
+	 * publish request from hanging when the PDS is slow.
+	 *
+	 * Filter return is coerced to non-negative int. Zero disables
+	 * the budget (uploads run to completion regardless of wall
+	 * time) — useful for CLI / background-job contexts that don't
+	 * share the publish request's time budget.
+	 *
+	 * @param WP_Post $post The post being projected.
+	 * @return int Budget in seconds (zero disables the budget).
+	 */
+	private static function upload_budget_seconds( WP_Post $post ): int {
+		/**
+		 * Filters the wall-time budget for synchronous photo-post
+		 * blob uploads in a single federation event.
+		 *
+		 * @param int     $seconds Default budget in seconds.
+		 * @param WP_Post $post    The post being projected.
+		 */
+		$seconds = \apply_filters( 'fosse_photo_post_atmosphere_upload_budget_seconds', self::DEFAULT_UPLOAD_BUDGET_SECONDS, $post );
+
+		$seconds = (int) $seconds;
+		return $seconds > 0 ? $seconds : 0;
+	}
+
+	/**
+	 * Fire the overflow action with exception isolation.
+	 *
+	 * The action's documented use cases (split into a thread, fall
+	 * back to a link card, surface a notice to the user) are I/O-
+	 * flavored — a slow or throwing listener shouldn't crater the
+	 * already-built embed.
+	 *
+	 * @param WP_Post $post     The post being projected.
+	 * @param int[]   $overflow Attachment ids dropped from the embed.
+	 * @return void
+	 */
+	private static function fire_overflow_action( WP_Post $post, array $overflow ): void {
+		try {
+			/**
+			 * Fires when a photo post has more resolvable image
+			 * attachments than {@see self::MAX_IMAGES}. Subscribers
+			 * can implement an overflow strategy (split into a
+			 * thread, fall back to a link card, surface a notice to
+			 * the user) without modifying this projector.
+			 *
+			 * Listeners must be fast and non-throwing — exceptions
+			 * are caught here so a misbehaving subscriber can't
+			 * crater the already-built embed.
+			 *
+			 * @param WP_Post $post     The post being projected.
+			 * @param int[]   $overflow Attachment ids dropped from the embed.
+			 */
+			\do_action( 'fosse_photo_post_atmosphere_overflow', $post, $overflow );
+		} catch ( \Throwable $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal: surface bad overflow listeners without breaking federation.
+			\error_log(
+				\sprintf(
+					'[fosse:photo-post-atmosphere] fosse_photo_post_atmosphere_overflow listener threw for post %d: %s',
+					$post->ID,
+					$e->getMessage()
+				)
+			);
+		}
+	}
+
+	/**
 	 * Truncate caption text to Bluesky's per-record budget.
 	 *
 	 * Uses `mb_substr` because AT Protocol counts graphemes / Unicode
@@ -382,25 +652,70 @@ class Photo_Post_Atmosphere {
 	}
 
 	/**
-	 * Re-extract Bluesky facets (URLs, mentions, hashtags) against the
-	 * rewritten text.
+	 * Re-extract Bluesky facets and align them with the truncated text.
+	 *
+	 * Extracts facets against the *untruncated* caption first, then
+	 * drops any whose byte range falls past the truncated length.
+	 * This protects URLs that straddle the 300-grapheme truncation
+	 * boundary — without it, a URL starting before character 300 with
+	 * its closing offset past 300 would produce either a silent
+	 * facet drop, a facet pointing at a wrong target, or an offset
+	 * that fails PDS validation entirely.
+	 *
+	 * Exceptions from `Facet::extract()` are caught — better to ship
+	 * a record without facets than to fail the whole federation event
+	 * over a regex hiccup.
 	 *
 	 * Returns an empty array when Atmosphere's `Facet` class isn't
-	 * loaded (test environments without the bundled plugin, or a
-	 * future structural change). Atmosphere itself stores facets as
-	 * an empty array → no facets, so returning empty is the safe
-	 * fallback.
+	 * loaded (test environments, future structural change).
 	 *
-	 * @param string $text Caption text.
-	 * @return array Facet entries, or an empty array.
+	 * @param string $caption_full Full caption text (pre-truncation).
+	 * @param string $text_final   Final record text (post-truncation).
+	 * @return array Facet entries usable against `$text_final`, or an empty array.
 	 */
-	private static function extract_facets( string $text ): array {
+	private static function extract_facets_for_text( string $caption_full, string $text_final ): array {
 		if ( ! \class_exists( '\Atmosphere\Transformer\Facet' ) ) {
 			return array();
 		}
 
-		$facets = \Atmosphere\Transformer\Facet::extract( $text );
+		try {
+			$facets = \Atmosphere\Transformer\Facet::extract( $caption_full );
+		} catch ( \Throwable $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal: surface unexpected facet-extractor crashes.
+			\error_log(
+				\sprintf(
+					'[fosse:photo-post-atmosphere] Facet::extract threw: %s',
+					$e->getMessage()
+				)
+			);
+			return array();
+		}
 
-		return \is_array( $facets ) ? $facets : array();
+		if ( ! \is_array( $facets ) || empty( $facets ) ) {
+			return array();
+		}
+
+		// When the caption fit inside the budget the truncated string
+		// is byte-identical to the untruncated one; the byte-range
+		// filter below is a no-op in that case but cheap.
+		$final_byte_length = \strlen( $text_final );
+
+		$kept = array();
+		foreach ( $facets as $facet ) {
+			if ( ! \is_array( $facet ) ) {
+				continue;
+			}
+			$index = $facet['index'] ?? null;
+			if ( ! \is_array( $index ) ) {
+				continue;
+			}
+			$byte_end = isset( $index['byteEnd'] ) ? (int) $index['byteEnd'] : -1;
+			if ( $byte_end < 0 || $byte_end > $final_byte_length ) {
+				continue;
+			}
+			$kept[] = $facet;
+		}
+
+		return $kept;
 	}
 }

--- a/src/class-photo-post-atmosphere.php
+++ b/src/class-photo-post-atmosphere.php
@@ -1,0 +1,406 @@
+<?php
+/**
+ * Photo-post AT Protocol federation-shape projector.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse;
+
+use WP_Post;
+
+/**
+ * Projects {@see Photo_Post::is_photo_post()} onto Atmosphere's
+ * Bluesky transformer so a WordPress photo-shaped post lands in
+ * Flashes / Pinksky as a native image post (`app.bsky.embed.images`)
+ * instead of as the default `app.bsky.embed.external` link card.
+ *
+ * Pixelfed and the AT-protocol photo apps (Flashes, Pinksky) both
+ * decide "this is a photo" purely from the wire envelope — the
+ * external client has no way to read WordPress's CPT / taxonomy /
+ * block structure, so the projection has to happen on the WP side.
+ * Detection lives in `Photo_Post`; this class is the AT-side
+ * projection, the AT counterpart of `Photo_Post::register()`'s AP
+ * hooks.
+ *
+ * Two filter callbacks do the work:
+ *
+ *   1. `atmosphere_is_short_form_post` — for photo posts, force the
+ *      short-form path so Atmosphere skips link-card / teaser-thread
+ *      composition entirely. The transformer's "short-form" path is
+ *      already "post body becomes the text, no external card" — the
+ *      shape closest to a native Bluesky photo post.
+ *   2. `atmosphere_transform_bsky_post` — on the short-form root
+ *      record for a photo post, rewrite `text` to the caption-only
+ *      plain text (same stripping the AP `activitypub_the_content`
+ *      filter does) and replace `embed` with `app.bsky.embed.images`
+ *      built from up to {@see self::MAX_IMAGES} uploaded blob refs.
+ *
+ * Upstream Atmosphere
+ * (`Automattic/wordpress-atmosphere` PR 72) adds a focused
+ * `atmosphere_post_embed` seam and a public `upload_image_blob()`
+ * rename. This projector deliberately targets the *shipped*
+ * Atmosphere surface (`atmosphere_transform_bsky_post` + the
+ * already-public `Post::upload_thumbnail()`) so the photo-post AT
+ * federation works as soon as this PR lands, with or without that
+ * upstream change. When PR 72 lands and the bundled copy resyncs,
+ * see the class docblock notes below for the cleaner two-line
+ * switchover.
+ *
+ * Out of scope (separate tickets):
+ *
+ *   - >4 image overflow strategy (thread, fall back to link card,
+ *     drop extras). For now the cap is enforced and a
+ *     `fosse_photo_post_atmosphere_overflow` action fires so a
+ *     follow-up projector can subscribe without changing this
+ *     class.
+ *   - Alt-text gap when the Featured Image lacks an `_wp_attachment_image_alt`
+ *     postmeta — covered by `DOTCOM-16806`. The projector emits an
+ *     empty string for `alt`; AT Protocol's image embed lexicon
+ *     accepts it but the accessibility hit is on us until that
+ *     ticket lands.
+ *   - Animated GIF handling — AT Proto's `embed.images` doesn't
+ *     animate; users who federate a GIF expecting motion get a still
+ *     frame. Detection-time disqualification belongs in
+ *     `Photo_Post::block_resolves_locally()`, not here.
+ */
+class Photo_Post_Atmosphere {
+
+	/**
+	 * Hard cap on images per `app.bsky.embed.images` embed.
+	 *
+	 * AT Protocol's lexicon caps the `images` array at 4
+	 * ({@link https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/images.json}).
+	 * Posts with more resolvable image attachments emit the first
+	 * four and fire `fosse_photo_post_atmosphere_overflow` with the
+	 * remainder so a future projector can decide how to recover
+	 * (split into a thread, fall back to a link card, etc.).
+	 *
+	 * @var int
+	 */
+	public const MAX_IMAGES = 4;
+
+	/**
+	 * Bluesky's per-record character budget for `text`.
+	 *
+	 * Atmosphere's transformer already clamps short-form text to 300
+	 * graphemes; we re-truncate after stripping image markup because
+	 * the strip changes the byte count.
+	 *
+	 * @var int
+	 */
+	private const TEXT_BUDGET = 300;
+
+	/**
+	 * Register the Atmosphere filter callbacks. Safe to call more than
+	 * once per request — WordPress dedupes identical callable-as-array
+	 * registrations.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		\add_filter( 'atmosphere_is_short_form_post', array( self::class, 'filter_is_short_form_post' ), 10, 2 );
+		\add_filter( 'atmosphere_transform_bsky_post', array( self::class, 'filter_transform_bsky_post' ), 10, 3 );
+	}
+
+	/**
+	 * Force the short-form path for photo posts.
+	 *
+	 * Defaults to whatever Atmosphere's discriminator already returned
+	 * — only upgrades a `false` to `true` when the post is a photo
+	 * post. Never downgrades: an explicit upstream `true` (untitled
+	 * post, post-format-status, etc.) stays `true`.
+	 *
+	 * @param mixed $is_short Whether Atmosphere's default classification is short-form.
+	 * @param mixed $post     The post being evaluated (Atmosphere passes a WP_Post; defensive cast).
+	 * @return bool
+	 */
+	public static function filter_is_short_form_post( $is_short, $post ): bool {
+		if ( $post instanceof WP_Post && Photo_Post::is_photo_post( $post ) ) {
+			return true;
+		}
+
+		return (bool) $is_short;
+	}
+
+	/**
+	 * Replace the record's `text` and `embed` for photo posts.
+	 *
+	 * Only acts when:
+	 *   - `$post` is a `WP_Post`,
+	 *   - it's a photo post per the shared discriminator,
+	 *   - Atmosphere's composition context indicates a short-form
+	 *     root record (`strategy === 'short-form'` and not a thread
+	 *     reply).
+	 *
+	 * The strategy / thread-reply gate is defensive: a photo post
+	 * forces `is_short_form_post() === true` via
+	 * {@see self::filter_is_short_form_post()}, so the long-form
+	 * branches never run. If a future Atmosphere change reroutes
+	 * short-form through a thread shape, this gate prevents us from
+	 * rewriting every entry in that thread.
+	 *
+	 * When at least one image blob uploads cleanly, the record's
+	 * `text` is replaced with the plain-text caption
+	 * ({@see Photo_Post::caption_text()}), facets are re-extracted
+	 * against the new text, and `embed` becomes
+	 * `app.bsky.embed.images` with up to {@see self::MAX_IMAGES}
+	 * entries. Each image carries `alt` (from
+	 * `_wp_attachment_image_alt` postmeta) and `aspectRatio` (from
+	 * `wp_get_attachment_metadata()`).
+	 *
+	 * If every blob upload fails (network error, all attachments
+	 * exceed AT Protocol's 1 MB blob cap, etc.) the record is
+	 * returned unchanged — Atmosphere ships the short-form post body
+	 * with no embed, which is a graceful degradation: the user's
+	 * caption still federates, just without the image grid.
+	 *
+	 * @param array $record  Bsky post record under construction.
+	 * @param mixed $post    The post being transformed.
+	 * @param mixed $context Atmosphere's composition context.
+	 * @return array Mutated record (or the input unchanged when no projection applies).
+	 */
+	public static function filter_transform_bsky_post( array $record, $post, $context = array() ): array {
+		if ( ! $post instanceof WP_Post ) {
+			return $record;
+		}
+
+		if ( ! Photo_Post::is_photo_post( $post ) ) {
+			return $record;
+		}
+
+		$strategy        = \is_array( $context ) && isset( $context['strategy'] ) ? (string) $context['strategy'] : '';
+		$is_thread_reply = \is_array( $context ) && ! empty( $context['is_thread_reply'] );
+
+		if ( 'short-form' !== $strategy || $is_thread_reply ) {
+			return $record;
+		}
+
+		$image_ids = Photo_Post::collect_image_attachment_ids( $post );
+		if ( empty( $image_ids ) ) {
+			return $record;
+		}
+
+		$attached = array();
+		$overflow = array();
+		$idx      = 0;
+
+		foreach ( $image_ids as $attachment_id ) {
+			if ( $idx >= self::MAX_IMAGES ) {
+				$overflow[] = $attachment_id;
+				continue;
+			}
+
+			$blob = self::upload_blob( $attachment_id );
+			if ( null === $blob ) {
+				continue;
+			}
+
+			$image = array(
+				'image' => $blob,
+				'alt'   => self::get_alt_text( $attachment_id ),
+			);
+
+			$aspect_ratio = self::get_aspect_ratio( $attachment_id );
+			if ( null !== $aspect_ratio ) {
+				$image['aspectRatio'] = $aspect_ratio;
+			}
+
+			$attached[] = $image;
+			++$idx;
+		}
+
+		if ( empty( $attached ) ) {
+			// Every upload failed — bail without mutating the record so
+			// Atmosphere ships the caption with no embed (better than
+			// shipping a broken images embed).
+			return $record;
+		}
+
+		if ( ! empty( $overflow ) ) {
+			/**
+			 * Fires when a photo post has more resolvable image
+			 * attachments than {@see self::MAX_IMAGES}. Subscribers
+			 * can implement an overflow strategy (split into a
+			 * thread, fall back to a link card, surface a notice to
+			 * the user) without modifying this projector.
+			 *
+			 * @param WP_Post $post     The post being projected.
+			 * @param int[]   $overflow Attachment ids dropped from the embed.
+			 */
+			\do_action( 'fosse_photo_post_atmosphere_overflow', $post, $overflow );
+		}
+
+		$caption         = Photo_Post::caption_text( $post );
+		$text            = self::truncate_text( $caption );
+		$record['text']  = $text;
+		$record['embed'] = array(
+			'$type'  => 'app.bsky.embed.images',
+			'images' => $attached,
+		);
+
+		// Atmosphere's `transform()` already extracted facets against
+		// the pre-strip text. Re-extract against the caption-only text
+		// so byte offsets line up; drop the field if no facets exist
+		// against the new text.
+		$facets = self::extract_facets( $text );
+		if ( empty( $facets ) ) {
+			unset( $record['facets'] );
+		} else {
+			$record['facets'] = $facets;
+		}
+
+		return $record;
+	}
+
+	/**
+	 * Upload an image attachment to the AT Protocol PDS and return the
+	 * blob reference.
+	 *
+	 * Delegates to Atmosphere's `Post::upload_thumbnail()` —
+	 * misleadingly-named today (the body is attachment-agnostic), but
+	 * the only public blob-upload surface on shipped Atmosphere.
+	 * Upstream PR 72 (`Automattic/wordpress-atmosphere`) renames this
+	 * to `upload_image_blob()`; once that lands and the bundled copy
+	 * resyncs, switch the call site below to the new name.
+	 *
+	 * The `fosse_photo_post_atmosphere_upload_blob` filter is the
+	 * extension seam: returning a non-null value short-circuits the
+	 * default delegation. Useful for sites that want to inject a
+	 * different upload pipeline (a media-CDN bridge, a backfill
+	 * worker that pre-uploads blobs, etc.) and for tests that need
+	 * to stub the upload without hitting the live PDS.
+	 *
+	 * @param int $attachment_id WordPress attachment ID.
+	 * @return array|null Blob reference array (`$type`, `ref`, `mimeType`, `size`) or null on failure.
+	 */
+	private static function upload_blob( int $attachment_id ): ?array {
+		/**
+		 * Filters the AT Protocol blob upload for a photo-post image
+		 * attachment.
+		 *
+		 * Return a non-null array to short-circuit the default
+		 * Atmosphere-backed upload — the array becomes the blob ref
+		 * that lands inside the `app.bsky.embed.images` entry. Return
+		 * an explicit `false` to force a failure (the projector treats
+		 * the attachment as if upload failed and skips it). The
+		 * default `null` falls through to Atmosphere.
+		 *
+		 * @param mixed $pre           Pre-resolved blob ref or null to fall through.
+		 * @param int   $attachment_id Attachment id being uploaded.
+		 */
+		$pre = \apply_filters( 'fosse_photo_post_atmosphere_upload_blob', null, $attachment_id );
+		if ( null !== $pre ) {
+			return \is_array( $pre ) ? $pre : null;
+		}
+
+		if ( ! \class_exists( '\Atmosphere\Transformer\Post' ) ) {
+			return null;
+		}
+
+		$blob = \Atmosphere\Transformer\Post::upload_thumbnail( $attachment_id );
+
+		return \is_array( $blob ) ? $blob : null;
+	}
+
+	/**
+	 * Read an attachment's stored alt text.
+	 *
+	 * WordPress stores alt text in `_wp_attachment_image_alt` postmeta
+	 * — set by the Media Library's "Alternative Text" field, the
+	 * Block Editor's image-block alt UI, and the REST API. Returns
+	 * an empty string when missing; AT Protocol's `embed.images`
+	 * lexicon requires the `alt` key but accepts an empty string.
+	 *
+	 * @param int $attachment_id WordPress attachment ID.
+	 * @return string
+	 */
+	private static function get_alt_text( int $attachment_id ): string {
+		$alt = \get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+
+		return \is_string( $alt ) ? $alt : '';
+	}
+
+	/**
+	 * Read an image attachment's intrinsic pixel dimensions.
+	 *
+	 * Returns `[ 'width' => int, 'height' => int ]` for use as
+	 * `aspectRatio` in `app.bsky.embed.images`. The lexicon's
+	 * `aspectRatio` is documented as "intended display aspect" — AT
+	 * clients use it for layout before the blob downloads, so
+	 * approximate is fine; pixel-perfect intrinsic dims (from
+	 * `wp_get_attachment_metadata()`) are the most reliable source.
+	 *
+	 * Returns null when metadata is missing or non-positive — a
+	 * newly-uploaded attachment whose subsizes haven't been generated
+	 * yet, or a non-image attachment that slipped through somehow.
+	 *
+	 * Once Atmosphere PR 72 lands and the bundled copy resyncs, this
+	 * delegate can be replaced with `Post::get_attachment_aspect_ratio()`.
+	 *
+	 * @param int $attachment_id WordPress attachment ID.
+	 * @return array|null `[ 'width' => int, 'height' => int ]` or null.
+	 */
+	private static function get_aspect_ratio( int $attachment_id ): ?array {
+		$meta = \wp_get_attachment_metadata( $attachment_id );
+
+		if ( ! \is_array( $meta ) ) {
+			return null;
+		}
+
+		$width  = isset( $meta['width'] ) ? (int) $meta['width'] : 0;
+		$height = isset( $meta['height'] ) ? (int) $meta['height'] : 0;
+
+		if ( $width <= 0 || $height <= 0 ) {
+			return null;
+		}
+
+		return array(
+			'width'  => $width,
+			'height' => $height,
+		);
+	}
+
+	/**
+	 * Truncate caption text to Bluesky's per-record budget.
+	 *
+	 * Uses `mb_substr` because AT Protocol counts graphemes / Unicode
+	 * code points, not bytes. No fancy sentence / word break — the
+	 * source is already a short caption in practice, and Atmosphere's
+	 * upstream short-form path uses the same plain `mb_substr`-style
+	 * truncate.
+	 *
+	 * @param string $text Caption text.
+	 * @return string Truncated to {@see self::TEXT_BUDGET} graphemes.
+	 */
+	private static function truncate_text( string $text ): string {
+		if ( \mb_strlen( $text ) <= self::TEXT_BUDGET ) {
+			return $text;
+		}
+
+		return \mb_substr( $text, 0, self::TEXT_BUDGET );
+	}
+
+	/**
+	 * Re-extract Bluesky facets (URLs, mentions, hashtags) against the
+	 * rewritten text.
+	 *
+	 * Returns an empty array when Atmosphere's `Facet` class isn't
+	 * loaded (test environments without the bundled plugin, or a
+	 * future structural change). Atmosphere itself stores facets as
+	 * an empty array → no facets, so returning empty is the safe
+	 * fallback.
+	 *
+	 * @param string $text Caption text.
+	 * @return array Facet entries, or an empty array.
+	 */
+	private static function extract_facets( string $text ): array {
+		if ( ! \class_exists( '\Atmosphere\Transformer\Facet' ) ) {
+			return array();
+		}
+
+		$facets = \Atmosphere\Transformer\Facet::extract( $text );
+
+		return \is_array( $facets ) ? $facets : array();
+	}
+}

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -669,6 +669,103 @@ class Photo_Post {
 	}
 
 	/**
+	 * Ordered list of resolvable image attachment ids for a photo post.
+	 *
+	 * Order is deterministic so downstream projectors emit attachments
+	 * in a stable sequence across federation passes:
+	 *
+	 *   1. Featured image (when it resolves to a live image attachment),
+	 *      since the Featured Image is the post's canonical hero shot
+	 *      whether or not the body also embeds a `core/post-featured-image`
+	 *      block.
+	 *   2. Image-like blocks in document order: `core/image` ids,
+	 *      `core/post-featured-image` (skipped because the featured
+	 *      image is already first — avoids double-counting), and
+	 *      `core/gallery` inner `core/image` ids walked left-to-right.
+	 *
+	 * Deduplicated: a post that includes its featured image both as
+	 * postmeta and via a `core/image` block (a common publish path)
+	 * yields one attachment id, not two.
+	 *
+	 * Only "resolves locally" blocks contribute — mirrors the
+	 * detection-time gate so the projector can't propose an attachment
+	 * that bundled AP / Atmosphere would later silently drop. External
+	 * `core/image` blocks (no `id` attribute, URL points off-site)
+	 * intentionally fall through here; they're handled by the
+	 * detection-time disqualification, not the attachment list.
+	 *
+	 * @param WP_Post $post The photo post.
+	 * @return int[] Resolvable image attachment ids in projection order.
+	 */
+	public static function collect_image_attachment_ids( WP_Post $post ): array {
+		$ordered = array();
+
+		$thumbnail_id = (int) \get_post_thumbnail_id( $post );
+		if ( $thumbnail_id > 0 && \wp_attachment_is_image( $thumbnail_id ) ) {
+			$ordered[] = $thumbnail_id;
+		}
+
+		$content = (string) ( $post->post_content ?? '' );
+		if ( '' !== \trim( $content ) ) {
+			$blocks = \function_exists( 'parse_blocks' ) ? \parse_blocks( $content ) : array();
+			if ( \is_array( $blocks ) ) {
+				foreach ( $blocks as $block ) {
+					if ( \is_array( $block ) ) {
+						$ordered = \array_merge( $ordered, self::block_image_ids( $block, $post ) );
+					}
+				}
+			}
+		}
+
+		// Dedup while preserving order — the featured image may also
+		// appear as a `core/image` block by id.
+		return \array_values( \array_unique( $ordered ) );
+	}
+
+	/**
+	 * Recursive helper: gather resolvable image attachment ids from a
+	 * single parsed block. Mirrors the resolution rules in
+	 * {@see self::block_resolves_locally()} but yields ids rather than
+	 * a boolean.
+	 *
+	 * `core/post-featured-image` is intentionally elided — the
+	 * featured image id is contributed by the caller's thumbnail pass,
+	 * so reading it again here would double-add. `core/gallery` walks
+	 * its `innerBlocks` recursively; legacy `attrs.ids` galleries are
+	 * not recognized, matching detection.
+	 *
+	 * @param array<string, mixed> $block A parsed block.
+	 * @param WP_Post              $post  The post being walked (for context).
+	 * @return int[] Resolvable attachment ids contributed by this block.
+	 */
+	private static function block_image_ids( array $block, WP_Post $post ): array {
+		$name = $block['blockName'] ?? '';
+
+		if ( 'core/image' === $name ) {
+			$id = (int) ( $block['attrs']['id'] ?? 0 );
+			if ( $id > 0 && \wp_attachment_is_image( $id ) ) {
+				return array( $id );
+			}
+			return array();
+		}
+
+		if ( 'core/gallery' === $name ) {
+			$ids          = array();
+			$inner_blocks = $block['innerBlocks'] ?? array();
+			if ( \is_array( $inner_blocks ) ) {
+				foreach ( $inner_blocks as $sub_block ) {
+					if ( \is_array( $sub_block ) ) {
+						$ids = \array_merge( $ids, self::block_image_ids( $sub_block, $post ) );
+					}
+				}
+			}
+			return $ids;
+		}
+
+		return array();
+	}
+
+	/**
 	 * Force `type: "Note"` for photo posts. Hooked on
 	 * `activitypub_post_object_type`.
 	 *
@@ -746,6 +843,34 @@ class Photo_Post {
 		}
 
 		return self::strip_image_block_markup( $content );
+	}
+
+	/**
+	 * Caption text for a photo post: rendered post content with all
+	 * image-block markup stripped and tags removed.
+	 *
+	 * Shared helper used by both the AP `activitypub_the_content` path
+	 * (where it lands as `content`) and the AT Protocol projector
+	 * (where it lands as `text` on a `app.bsky.feed.post` record next
+	 * to an `app.bsky.embed.images` embed). Renders the post body
+	 * through `the_content`, runs the same DOM-strip the AP filter
+	 * uses, and then collapses to plain text — caption-shaped output
+	 * suitable for either an HTML-tolerant or plain-text backend.
+	 *
+	 * Untrimmed return preserves whitespace inside the caption (line
+	 * breaks between paragraphs) so callers can do their own truncation
+	 * against an external character cap (Bluesky's 300, for instance)
+	 * before normalizing.
+	 *
+	 * @param WP_Post $post The photo post.
+	 * @return string Plain-text caption with image markup removed.
+	 */
+	public static function caption_text( WP_Post $post ): string {
+		$rendered = \apply_filters( 'the_content', $post->post_content ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
+		$stripped = '' === \trim( (string) $rendered ) ? '' : self::strip_image_block_markup( (string) $rendered );
+		$plain    = \wp_strip_all_tags( $stripped );
+
+		return \trim( (string) $plain );
 	}
 
 	/**

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -866,7 +866,46 @@ class Photo_Post {
 	 * @return string Plain-text caption with image markup removed.
 	 */
 	public static function caption_text( WP_Post $post ): string {
-		$rendered = \apply_filters( 'the_content', $post->post_content ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
+		// `the_content` callbacks (blocks, shortcodes, oEmbed) read
+		// `$GLOBALS['post']` via `get_the_ID()` and similar helpers;
+		// running this filter outside The Loop — which is exactly
+		// what federation hot paths do, on cron and REST — would let
+		// those callbacks resolve against whichever post happens to
+		// be in the global, not the one we're rendering. Snapshot
+		// the prior global so we can restore it on the way out, then
+		// set up the global ourselves so the caption matches the
+		// front-end render byte-for-byte.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Read-and-restore of the WP loop global.
+		$previous_global = $GLOBALS['post'] ?? null;
+		\setup_postdata( $post );
+
+		try {
+			$rendered = \apply_filters( 'the_content', $post->post_content ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
+		} catch ( \Throwable $e ) {
+			// A misbehaving `the_content` listener shouldn't crater
+			// the federation event — fall back to an empty caption
+			// so the AT projector ships images with no caption, and
+			// the AP projector ships caption-less content.
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Surface third-party filter crashes so operators can spot the bad plugin.
+			\error_log(
+				\sprintf(
+					'[fosse:photo-post] the_content filter threw while building caption for post %d: %s',
+					$post->ID,
+					$e->getMessage()
+				)
+			);
+			$rendered = '';
+		} finally {
+			\wp_reset_postdata();
+			if ( null !== $previous_global ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring the prior global we explicitly captured.
+				$GLOBALS['post'] = $previous_global;
+			} else {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Cleaning up the global we created.
+				unset( $GLOBALS['post'] );
+			}
+		}
+
 		$stripped = '' === \trim( (string) $rendered ) ? '' : self::strip_image_block_markup( (string) $rendered );
 		$plain    = \wp_strip_all_tags( $stripped );
 

--- a/tests/php/Photo_Post_AtmosphereTest.php
+++ b/tests/php/Photo_Post_AtmosphereTest.php
@@ -1,0 +1,644 @@
+<?php
+/**
+ * Tests for the photo-post AT Protocol federation-shape projector.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests;
+
+use Automattic\Fosse\Photo_Post;
+use Automattic\Fosse\Photo_Post_Atmosphere;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use WorDBless\BaseTestCase;
+use WP_Post;
+
+/**
+ * Covers `Photo_Post_Atmosphere::filter_is_short_form_post()` and
+ * `filter_transform_bsky_post()` through `apply_filters` round-trips
+ * — keeps the contract "FOSSE projects onto Atmosphere's filters"
+ * load-bearing in the tests, the same posture {@see Photo_PostTest}
+ * uses for the AP-side hooks.
+ *
+ * Blob uploads are intercepted via the
+ * `fosse_photo_post_atmosphere_upload_blob` extension filter so tests
+ * don't reach Atmosphere's HTTP layer; the bundled Atmosphere
+ * `Facet::extract()` runs for real against the rewritten text.
+ */
+class Photo_Post_AtmosphereTest extends BaseTestCase {
+
+	/**
+	 * Whether `wp_filter_post_kses` was hooked on `content_save_pre`
+	 * before {@see self::reset_state()} ran. Tracked so the
+	 * after-hook can restore the filter chain — sibling test classes
+	 * depend on the default escaping.
+	 *
+	 * @var bool
+	 */
+	private bool $had_content_save_pre_kses = false;
+
+	/**
+	 * Mirror of {@see self::$had_content_save_pre_kses} for
+	 * `content_filtered_save_pre`.
+	 *
+	 * @var bool
+	 */
+	private bool $had_content_filtered_save_pre_kses = false;
+
+	/**
+	 * Canonical primary image attachment id used by fixtures.
+	 *
+	 * @var int
+	 */
+	private int $image_id = 0;
+
+	/**
+	 * Secondary image attachment id for multi-image gallery fixtures.
+	 *
+	 * @var int
+	 */
+	private int $image_id_alt = 0;
+
+	/**
+	 * Per-test map: attachment id → fake blob ref returned by the
+	 * `fosse_photo_post_atmosphere_upload_blob` interception. Tests
+	 * call {@see self::stub_blob_for()} to seed this map; the
+	 * `#[Before]` hook installs a single filter that reads it.
+	 *
+	 * @var array<int, array>
+	 */
+	private array $blob_stubs = array();
+
+	/**
+	 * Reset filters / cache / fixtures before each test and register
+	 * the projector.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function reset_state(): void {
+		remove_all_filters( 'atmosphere_is_short_form_post' );
+		remove_all_filters( 'atmosphere_transform_bsky_post' );
+		remove_all_filters( 'fosse_pre_is_photo_post' );
+		remove_all_filters( 'fosse_is_photo_post' );
+		remove_all_filters( 'fosse_photo_post_atmosphere_upload_blob' );
+		remove_all_filters( 'activitypub_max_image_attachments' );
+		remove_all_filters( 'get_the_terms' );
+		remove_all_filters( 'wp_insert_post_empty_content' );
+		remove_all_actions( 'fosse_photo_post_atmosphere_overflow' );
+
+		Photo_Post::reset_cache_for_testing();
+		Photo_Post_Atmosphere::register();
+
+		// Empty bodies are valid photo posts (Featured Image + no
+		// caption). Same pattern as Photo_PostTest::reset_state().
+		add_filter( 'wp_insert_post_empty_content', '__return_false' );
+
+		$this->had_content_save_pre_kses          = false !== has_filter( 'content_save_pre', 'wp_filter_post_kses' );
+		$this->had_content_filtered_save_pre_kses = false !== has_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
+		if ( $this->had_content_save_pre_kses ) {
+			remove_filter( 'content_save_pre', 'wp_filter_post_kses' );
+		}
+		if ( $this->had_content_filtered_save_pre_kses ) {
+			remove_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
+		}
+
+		$this->image_id     = $this->insert_image_attachment( 'fixture-primary.jpg', 1600, 1200 );
+		$this->image_id_alt = $this->insert_image_attachment( 'fixture-alt.jpg', 800, 800 );
+
+		// Reset stub state and install the interception filter.
+		// Unstubbed attachments return `false` so the projector
+		// treats them as failed uploads without falling through to
+		// Atmosphere's real `upload_thumbnail()` (which would try to
+		// read a real file and warn).
+		$this->blob_stubs = array();
+		add_filter(
+			'fosse_photo_post_atmosphere_upload_blob',
+			function ( $pre, int $attachment_id ) {
+				if ( null !== $pre ) {
+					return $pre;
+				}
+				return $this->blob_stubs[ $attachment_id ] ?? false;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Restore the kses filter chain and drop the empty-content
+	 * override so sibling test classes see WP's default behavior.
+	 *
+	 * @after
+	 */
+	#[After]
+	public function restore_kses_filters(): void {
+		if ( $this->had_content_save_pre_kses ) {
+			add_filter( 'content_save_pre', 'wp_filter_post_kses' );
+		}
+		if ( $this->had_content_filtered_save_pre_kses ) {
+			add_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
+		}
+		remove_filter( 'wp_insert_post_empty_content', '__return_false' );
+	}
+
+	/**
+	 * Insert a real image attachment, seeding both `_wp_attached_file`
+	 * (required for `wp_attachment_is_image()`) and
+	 * `_wp_attachment_metadata` (required for `aspectRatio` on the
+	 * emitted `app.bsky.embed.images` entry).
+	 *
+	 * @param string $filename Filename (no path).
+	 * @param int    $width    Optional intrinsic width (0 = no metadata).
+	 * @param int    $height   Optional intrinsic height (0 = no metadata).
+	 * @return int Attachment post id.
+	 */
+	private function insert_image_attachment( string $filename, int $width = 0, int $height = 0 ): int {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'fixture',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', $filename );
+
+		if ( $width > 0 && $height > 0 ) {
+			update_post_meta(
+				$attachment_id,
+				'_wp_attachment_metadata',
+				array(
+					'width'  => $width,
+					'height' => $height,
+					'file'   => $filename,
+				)
+			);
+		}
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Build a real WP post with optional Featured Image and body.
+	 *
+	 * @param string $content      Post content.
+	 * @param int    $thumbnail_id Attachment id to set as featured image (0 = none).
+	 * @param string $title        Optional post title.
+	 * @return WP_Post
+	 */
+	private function make_post( string $content, int $thumbnail_id = 0, string $title = '' ): WP_Post {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => $title,
+				'post_content' => $content,
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+
+		if ( $thumbnail_id > 0 ) {
+			update_post_meta( $post_id, '_thumbnail_id', $thumbnail_id );
+		}
+
+		return get_post( $post_id );
+	}
+
+	/**
+	 * Seed the upload-blob stub so a given attachment id returns a
+	 * fake blob ref through the interception filter.
+	 *
+	 * @param int    $attachment_id Attachment id.
+	 * @param string $cid           Fake CID for the blob ref.
+	 * @return array The blob ref that was registered.
+	 */
+	private function stub_blob_for( int $attachment_id, string $cid = 'bafyfake' ): array {
+		$blob                               = array(
+			'$type'    => 'blob',
+			'ref'      => array( '$link' => $cid ),
+			'mimeType' => 'image/jpeg',
+			'size'     => 12345,
+		);
+		$this->blob_stubs[ $attachment_id ] = $blob;
+		return $blob;
+	}
+
+	/**
+	 * Apply the `atmosphere_transform_bsky_post` filter against a
+	 * short-form record envelope.
+	 *
+	 * @param WP_Post $post      The post being transformed.
+	 * @param array   $overrides Optional record overrides.
+	 * @return array Filtered record.
+	 */
+	private function apply_transform_filter( WP_Post $post, array $overrides = array() ): array {
+		$record = array_merge(
+			array(
+				'$type'     => 'app.bsky.feed.post',
+				'text'      => 'baseline caption',
+				'createdAt' => '2026-05-19T00:00:00Z',
+				'langs'     => array( 'en' ),
+			),
+			$overrides
+		);
+
+		return apply_filters(
+			'atmosphere_transform_bsky_post',
+			$record,
+			$post,
+			array(
+				'strategy'        => 'short-form',
+				'thread_index'    => 0,
+				'is_thread_reply' => false,
+			)
+		);
+	}
+
+	// ---------------------------------------------------------------
+	// is_short_form filter.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Photo posts must federate as Bluesky short-form so the
+	 * link-card / teaser-thread compositions never engage. Without
+	 * this hook, a titled photo post would default to link-card and
+	 * ship as `app.bsky.embed.external` — the exact failure mode the
+	 * issue is fighting.
+	 */
+	public function test_is_short_form_filter_forces_true_for_photo_post(): void {
+		$post = $this->make_post( '', $this->image_id );
+
+		$this->assertTrue( apply_filters( 'atmosphere_is_short_form_post', false, $post ) );
+	}
+
+	/**
+	 * Non-photo posts pass through — Atmosphere's own discriminator
+	 * stays authoritative.
+	 */
+	public function test_is_short_form_filter_passes_through_for_non_photo_post(): void {
+		$post = $this->make_post( '<!-- wp:paragraph --><p>essay body</p><!-- /wp:paragraph -->' );
+
+		$this->assertFalse( apply_filters( 'atmosphere_is_short_form_post', false, $post ) );
+		$this->assertTrue( apply_filters( 'atmosphere_is_short_form_post', true, $post ) );
+	}
+
+	/**
+	 * Defensive: a non-WP_Post second arg must not blow up the
+	 * filter.
+	 */
+	public function test_is_short_form_filter_passes_through_on_non_wp_post(): void {
+		$this->assertTrue( apply_filters( 'atmosphere_is_short_form_post', true, null ) );
+		$this->assertFalse( apply_filters( 'atmosphere_is_short_form_post', false, 'not-a-post' ) );
+	}
+
+	// ---------------------------------------------------------------
+	// transform filter: photo-post embed rewrite.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Photo post with one resolvable image: record's embed becomes
+	 * `app.bsky.embed.images` with one entry carrying blob + alt +
+	 * aspectRatio.
+	 */
+	public function test_transform_filter_rewrites_embed_to_images_for_photo_post(): void {
+		$this->stub_blob_for( $this->image_id, 'bafyone' );
+		update_post_meta( $this->image_id, '_wp_attachment_image_alt', 'A sunset.' );
+
+		$post = $this->make_post( '', $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertArrayHasKey( 'embed', $record );
+		$this->assertSame( 'app.bsky.embed.images', $record['embed']['$type'] );
+		$this->assertCount( 1, $record['embed']['images'] );
+
+		$image = $record['embed']['images'][0];
+		$this->assertSame( 'A sunset.', $image['alt'] );
+		$this->assertSame( array( '$link' => 'bafyone' ), $image['image']['ref'] );
+		$this->assertSame(
+			array(
+				'width'  => 1600,
+				'height' => 1200,
+			),
+			$image['aspectRatio']
+		);
+	}
+
+	/**
+	 * Non-photo posts pass through — the record is returned
+	 * unchanged.
+	 */
+	public function test_transform_filter_passes_through_for_non_photo_post(): void {
+		$post = $this->make_post( '<!-- wp:paragraph --><p>not a photo</p><!-- /wp:paragraph -->' );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertSame( 'baseline caption', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * The text rewrite uses caption-only content: image-block markup
+	 * stripped, paragraph caption preserved.
+	 */
+	public function test_transform_filter_rewrites_text_to_caption_only(): void {
+		$this->stub_blob_for( $this->image_id );
+
+		$content = '<!-- wp:image {"id":' . $this->image_id . '} --><figure class="wp-block-image"><img src="https://example.test/a.jpg"/></figure><!-- /wp:image -->'
+			. '<!-- wp:paragraph --><p>Sunset over the bay.</p><!-- /wp:paragraph -->';
+
+		$post = $this->make_post( $content, $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertStringContainsString( 'Sunset over the bay', $record['text'] );
+		$this->assertStringNotContainsString( '<img', $record['text'] );
+		$this->assertStringNotContainsString( 'figure', $record['text'] );
+	}
+
+	/**
+	 * Multi-image gallery: emit up to MAX_IMAGES entries in document
+	 * order; the surplus fires the overflow action.
+	 */
+	public function test_transform_filter_caps_at_max_images_and_fires_overflow(): void {
+		// Detection caps at `activitypub_max_image_attachments`
+		// (default 4); bump it to 5 so a 5-image post still counts as
+		// a photo post and reaches the AT-side cap.
+		add_filter( 'activitypub_max_image_attachments', static fn() => 5 );
+
+		// Five resolvable images: featured + four gallery children.
+		$image_ids = array( $this->image_id, $this->image_id_alt );
+		for ( $i = 0; $i < 3; $i++ ) {
+			$image_ids[] = $this->insert_image_attachment( "extra-{$i}.jpg", 1000, 1000 );
+		}
+		foreach ( $image_ids as $i => $id ) {
+			$this->stub_blob_for( $id, 'bafy' . $i );
+		}
+
+		$inner = '';
+		foreach ( array_slice( $image_ids, 1 ) as $id ) {
+			$inner .= '<!-- wp:image {"id":' . $id . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->';
+		}
+		$content = '<!-- wp:gallery -->' . $inner . '<!-- /wp:gallery -->';
+
+		$overflow_payload = null;
+		add_action(
+			'fosse_photo_post_atmosphere_overflow',
+			static function ( $post, $overflow ) use ( &$overflow_payload ) {
+				$overflow_payload = $overflow;
+			},
+			10,
+			2
+		);
+
+		$post = $this->make_post( $content, $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertCount( Photo_Post_Atmosphere::MAX_IMAGES, $record['embed']['images'] );
+		$this->assertSame( array( $image_ids[4] ), $overflow_payload );
+	}
+
+	/**
+	 * Aspect ratio is omitted when metadata is unavailable — the
+	 * `images` entry must still carry `image` + `alt`.
+	 */
+	public function test_transform_filter_omits_aspect_ratio_when_metadata_missing(): void {
+		$bare_id = $this->insert_image_attachment( 'no-meta.jpg', 0, 0 );
+		$this->stub_blob_for( $bare_id );
+
+		$content = '<!-- wp:image {"id":' . $bare_id . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->';
+		$post    = $this->make_post( $content, $bare_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$image = $record['embed']['images'][0];
+		$this->assertArrayHasKey( 'image', $image );
+		$this->assertArrayHasKey( 'alt', $image );
+		$this->assertArrayNotHasKey( 'aspectRatio', $image );
+	}
+
+	/**
+	 * Featured image already in `core/image` form is not duplicated —
+	 * the projector reuses `Photo_Post::collect_image_attachment_ids()`
+	 * which deduplicates.
+	 */
+	public function test_transform_filter_deduplicates_featured_image_in_body(): void {
+		$this->stub_blob_for( $this->image_id );
+
+		$content = '<!-- wp:image {"id":' . $this->image_id . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->';
+		$post    = $this->make_post( $content, $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertCount( 1, $record['embed']['images'] );
+	}
+
+	/**
+	 * Every upload fails: record is returned unchanged. Better to
+	 * ship the user's caption with no embed than to ship a broken
+	 * `images` embed.
+	 */
+	public function test_transform_filter_passes_through_when_all_uploads_fail(): void {
+		// Don't stub any blob: the interception filter returns null
+		// for every attachment, matching real-world upload failure.
+		$post = $this->make_post( '', $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertSame( 'baseline caption', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * Defensive: non-short-form context (e.g. a teaser-thread CTA)
+	 * doesn't trigger the rewrite. Photo posts force
+	 * `is_short_form_post()` true so this gate should never fire in
+	 * practice, but a future Atmosphere change that reroutes
+	 * short-form through a thread shape must not silently rewrite
+	 * every entry.
+	 */
+	public function test_transform_filter_skips_non_short_form_strategy(): void {
+		$this->stub_blob_for( $this->image_id );
+		$post = $this->make_post( '', $this->image_id );
+
+		$record = apply_filters(
+			'atmosphere_transform_bsky_post',
+			array(
+				'$type'     => 'app.bsky.feed.post',
+				'text'      => 'cta text',
+				'createdAt' => '2026-05-19T00:00:00Z',
+				'langs'     => array( 'en' ),
+			),
+			$post,
+			array(
+				'strategy'        => 'teaser-thread',
+				'thread_index'    => 2,
+				'is_thread_reply' => true,
+			)
+		);
+
+		$this->assertSame( 'cta text', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * Defensive: a non-WP_Post second arg passes through unchanged.
+	 */
+	public function test_transform_filter_passes_through_on_non_wp_post(): void {
+		$record = apply_filters(
+			'atmosphere_transform_bsky_post',
+			array(
+				'$type' => 'app.bsky.feed.post',
+				'text'  => 'baseline',
+				'langs' => array( 'en' ),
+			),
+			null,
+			array( 'strategy' => 'short-form' )
+		);
+
+		$this->assertSame( 'baseline', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * Text exceeding Bluesky's 300-grapheme cap is truncated.
+	 */
+	public function test_transform_filter_truncates_caption_to_text_budget(): void {
+		$this->stub_blob_for( $this->image_id );
+
+		$long_caption = str_repeat( 'word ', 120 );
+		$content      = '<!-- wp:image {"id":' . $this->image_id . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:paragraph --><p>' . $long_caption . '</p><!-- /wp:paragraph -->';
+
+		$post = $this->make_post( $content, $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertLessThanOrEqual( 300, mb_strlen( $record['text'] ) );
+	}
+
+	/**
+	 * Facets are re-extracted against the rewritten caption text —
+	 * a URL in the caption produces a `link` facet keyed against the
+	 * new text, not against the pre-strip baseline.
+	 */
+	public function test_transform_filter_re_extracts_facets_against_new_text(): void {
+		$this->stub_blob_for( $this->image_id );
+
+		$content = '<!-- wp:image {"id":' . $this->image_id . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:paragraph --><p>See https://example.test/page for details.</p><!-- /wp:paragraph -->';
+
+		$post = $this->make_post( $content, $this->image_id );
+
+		$record = $this->apply_transform_filter( $post, array( 'facets' => array( array( 'stale' => true ) ) ) );
+
+		$this->assertArrayHasKey( 'facets', $record );
+		$serialized_uris = array_column(
+			array_column( array_column( $record['facets'], 'features' ), 0 ),
+			'uri'
+		);
+		$this->assertContains( 'https://example.test/page', $serialized_uris );
+		$this->assertStringNotContainsString( 'stale', (string) wp_json_encode( $record['facets'], JSON_UNESCAPED_SLASHES ) );
+	}
+
+	/**
+	 * When the re-extracted facets are empty, the field is dropped —
+	 * leaving a stale facets array would lie about the new text's
+	 * link positions.
+	 */
+	public function test_transform_filter_drops_stale_facets_when_re_extract_is_empty(): void {
+		$this->stub_blob_for( $this->image_id );
+
+		$post = $this->make_post( '', $this->image_id );
+
+		$record = $this->apply_transform_filter( $post, array( 'facets' => array( array( 'stale' => true ) ) ) );
+
+		$this->assertArrayNotHasKey( 'facets', $record );
+	}
+
+	// ---------------------------------------------------------------
+	// collect_image_attachment_ids (helper on Photo_Post).
+	// ---------------------------------------------------------------
+
+	/**
+	 * Featured image first, body images in document order.
+	 */
+	public function test_collect_image_ids_orders_featured_first(): void {
+		$content = '<!-- wp:image {"id":' . $this->image_id_alt . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->';
+		$post    = $this->make_post( $content, $this->image_id );
+
+		$ids = Photo_Post::collect_image_attachment_ids( $post );
+
+		$this->assertSame( array( $this->image_id, $this->image_id_alt ), $ids );
+	}
+
+	/**
+	 * Featured image present in both postmeta and a `core/image` block
+	 * appears once.
+	 */
+	public function test_collect_image_ids_deduplicates_featured_when_also_in_body(): void {
+		$content = '<!-- wp:image {"id":' . $this->image_id . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->';
+		$post    = $this->make_post( $content, $this->image_id );
+
+		$ids = Photo_Post::collect_image_attachment_ids( $post );
+
+		$this->assertSame( array( $this->image_id ), $ids );
+	}
+
+	/**
+	 * Gallery walks `innerBlocks` in document order.
+	 */
+	public function test_collect_image_ids_walks_gallery_inner_blocks_in_order(): void {
+		$inner   = '<!-- wp:image {"id":' . $this->image_id_alt . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:image {"id":' . $this->image_id . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->';
+		$content = '<!-- wp:gallery -->' . $inner . '<!-- /wp:gallery -->';
+		$post    = $this->make_post( $content );
+
+		$ids = Photo_Post::collect_image_attachment_ids( $post );
+
+		$this->assertSame( array( $this->image_id_alt, $this->image_id ), $ids );
+	}
+
+	/**
+	 * `core/image` blocks without a resolvable id (external image)
+	 * don't contribute — same gate as detection.
+	 */
+	public function test_collect_image_ids_skips_unresolvable_image_blocks(): void {
+		$content = '<!-- wp:image --><figure class="wp-block-image"><img src="https://example.test/external.jpg"/></figure><!-- /wp:image -->';
+		$post    = $this->make_post( $content );
+
+		$this->assertSame( array(), Photo_Post::collect_image_attachment_ids( $post ) );
+	}
+
+	// ---------------------------------------------------------------
+	// caption_text (helper on Photo_Post).
+	// ---------------------------------------------------------------
+
+	/**
+	 * `caption_text()` returns plain-text caption with image markup
+	 * stripped.
+	 */
+	public function test_caption_text_strips_image_markup_and_returns_plain(): void {
+		$content = '<!-- wp:image {"id":' . $this->image_id . '} --><figure class="wp-block-image"><img src="x.jpg"/></figure><!-- /wp:image -->'
+			. '<!-- wp:paragraph --><p>Caption text.</p><!-- /wp:paragraph -->';
+		$post    = $this->make_post( $content, $this->image_id );
+
+		$text = Photo_Post::caption_text( $post );
+
+		$this->assertStringContainsString( 'Caption text.', $text );
+		$this->assertStringNotContainsString( '<', $text );
+		$this->assertStringNotContainsString( 'figure', $text );
+	}
+
+	/**
+	 * Empty body returns an empty caption — Featured-Image-only photo
+	 * posts have no caption to ship.
+	 */
+	public function test_caption_text_returns_empty_for_empty_body(): void {
+		$post = $this->make_post( '', $this->image_id );
+
+		$this->assertSame( '', Photo_Post::caption_text( $post ) );
+	}
+}

--- a/tests/php/Photo_Post_AtmosphereTest.php
+++ b/tests/php/Photo_Post_AtmosphereTest.php
@@ -441,14 +441,127 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 	 * `images` embed.
 	 */
 	public function test_transform_filter_passes_through_when_all_uploads_fail(): void {
-		// Don't stub any blob: the interception filter returns null
-		// for every attachment, matching real-world upload failure.
+		// Don't stub any blob: the interception filter returns `false`
+		// for every attachment, which the upload_blob() contract
+		// treats as "skip without falling through to Atmosphere."
 		$post = $this->make_post( '', $this->image_id );
 
 		$record = $this->apply_transform_filter( $post );
 
 		$this->assertSame( 'baseline caption', $record['text'] );
 		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * Featured image upload failing aborts the whole projection.
+	 * Featured image is the hero shot; shipping a gallery missing it
+	 * is worse than shipping no embed at all. Asserts the new
+	 * fast-fail path on the first attachment when it matches the
+	 * featured-image id.
+	 */
+	public function test_transform_filter_aborts_when_featured_image_upload_fails(): void {
+		// Two-image post: featured image (no blob stub → upload fails)
+		// + body image (blob stubbed → would upload). The projector
+		// must NOT ship just the body image; it must return the
+		// record unchanged.
+		$this->stub_blob_for( $this->image_id_alt );
+
+		$content = '<!-- wp:image {"id":' . $this->image_id_alt . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->';
+		$post    = $this->make_post( $content, $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertSame( 'baseline caption', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * Non-featured upload failure drops just that attachment from the
+	 * embed while the rest ship. The hero shot is preserved; a partial
+	 * gallery is acceptable degradation.
+	 */
+	public function test_transform_filter_drops_non_featured_failed_upload_but_ships_rest(): void {
+		// Featured stubbed (uploads cleanly), body image not stubbed
+		// (upload fails). Expect the embed to ship with one image —
+		// the featured one — and the body image silently dropped.
+		$this->stub_blob_for( $this->image_id, 'bafyhero' );
+
+		$content = '<!-- wp:image {"id":' . $this->image_id_alt . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->';
+		$post    = $this->make_post( $content, $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertArrayHasKey( 'embed', $record );
+		$this->assertSame( 'app.bsky.embed.images', $record['embed']['$type'] );
+		$this->assertCount( 1, $record['embed']['images'] );
+		$this->assertSame( array( '$link' => 'bafyhero' ), $record['embed']['images'][0]['image']['ref'] );
+	}
+
+	/**
+	 * Filter returns a malformed blob-ref array (missing `$type`):
+	 * projector treats as a failed upload and drops the attachment.
+	 * Protects the federation envelope from a third-party filter that
+	 * returns an arbitrary array.
+	 */
+	public function test_transform_filter_rejects_malformed_blob_ref_from_filter(): void {
+		// Override the per-test stub with one that returns a malformed
+		// array for the featured image.
+		add_filter(
+			'fosse_photo_post_atmosphere_upload_blob',
+			static function () {
+				return array(
+					// Missing $type key — should be rejected.
+					'ref'      => array( '$link' => 'bafyforged' ),
+					'mimeType' => 'image/jpeg',
+					'size'     => 12345,
+				);
+			},
+			20
+		);
+
+		$post = $this->make_post( '', $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		// Malformed featured-image return = failed upload = featured
+		// fast-fail path = unchanged record.
+		$this->assertSame( 'baseline caption', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * Filter throws: projector catches the exception per-attachment
+	 * and treats it as a failed upload. Asserts a misbehaving filter
+	 * listener can't crater the whole federation event.
+	 */
+	public function test_transform_filter_catches_filter_exception_per_attachment(): void {
+		// Featured stubbed cleanly. Add a second filter (higher
+		// priority so it runs after our stub) that throws for the
+		// body image only.
+		$this->stub_blob_for( $this->image_id, 'bafyhero' );
+
+		add_filter(
+			'fosse_photo_post_atmosphere_upload_blob',
+			function ( $pre, int $attachment_id ) {
+				if ( $attachment_id === $this->image_id_alt ) {
+					throw new \RuntimeException( 'simulated filter crash' );
+				}
+				return $pre;
+			},
+			20,
+			2
+		);
+
+		$content = '<!-- wp:image {"id":' . $this->image_id_alt . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->';
+		$post    = $this->make_post( $content, $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		// Throwing on the body image only drops that attachment;
+		// featured still ships.
+		$this->assertArrayHasKey( 'embed', $record );
+		$this->assertCount( 1, $record['embed']['images'] );
+		$this->assertSame( array( '$link' => 'bafyhero' ), $record['embed']['images'][0]['image']['ref'] );
 	}
 
 	/**
@@ -503,7 +616,10 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 	}
 
 	/**
-	 * Text exceeding Bluesky's 300-grapheme cap is truncated.
+	 * Text exceeding Bluesky's 300-grapheme cap is truncated. Asserts
+	 * the truncation actually fired (text length is exactly 300, not
+	 * just <= 300) so a regression that skips truncation entirely
+	 * surfaces here instead of silently passing.
 	 */
 	public function test_transform_filter_truncates_caption_to_text_budget(): void {
 		$this->stub_blob_for( $this->image_id );
@@ -516,7 +632,39 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 
 		$record = $this->apply_transform_filter( $post );
 
-		$this->assertLessThanOrEqual( 300, mb_strlen( $record['text'] ) );
+		$this->assertSame( 300, mb_strlen( $record['text'] ) );
+	}
+
+	/**
+	 * URL straddling the 300-grapheme truncation boundary: the facet
+	 * for it must be dropped from the record. A facet whose byteEnd
+	 * exceeds the final text length would either fail PDS validation
+	 * or render as a wrong-target link in Bluesky's UI.
+	 */
+	public function test_transform_filter_drops_facets_past_truncation_boundary(): void {
+		$this->stub_blob_for( $this->image_id );
+
+		// Pad text so a URL starts in-bounds (under 300 graphemes) but
+		// extends past 300. The padding is just enough to push the
+		// URL's tail past the truncation budget.
+		$padding = str_repeat( 'word ', 58 ); // ~290 chars
+		$url     = 'https://example.test/some/long/path/that/will/be/cut';
+		$content = '<!-- wp:image {"id":' . $this->image_id . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+			. '<!-- wp:paragraph --><p>' . $padding . $url . '</p><!-- /wp:paragraph -->';
+
+		$post = $this->make_post( $content, $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertSame( 300, mb_strlen( $record['text'] ) );
+
+		// Every surviving facet must have byteEnd within the final
+		// text. A truncated URL would have byteEnd past the boundary,
+		// which the projector drops.
+		$final_byte_length = strlen( $record['text'] );
+		foreach ( ( $record['facets'] ?? array() ) as $facet ) {
+			$this->assertLessThanOrEqual( $final_byte_length, (int) $facet['index']['byteEnd'] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Refs [DOTCOM-17143](https://linear.app/a8c/issue/DOTCOM-17143).
Stacked on PR 155 (AP-side projector + detection).

## Summary

Sibling of the AP-side photo-post projector in PR 155. Federates the same WP photo-shaped posts to Bluesky / Flashes / Pinksky as native `app.bsky.embed.images` records instead of the default `app.bsky.embed.external` link card, using the same shared `Photo_Post::is_photo_post()` discriminator.

External AT-protocol clients can't read WP internals — they decide "this is a photo" purely from the wire envelope — so the projection has to happen on the WP side. Same reasoning as PR 155's AP projector.

## What it does

A new `Photo_Post_Atmosphere` class hooks two Atmosphere filters:

1. **`atmosphere_is_short_form_post`** — return `true` for photo posts so Atmosphere skips the link-card / teaser-thread compositions entirely. Short-form is the closest match to a native Bluesky photo post: body becomes the record text, no external card.
2. **`atmosphere_transform_bsky_post`** — on the short-form root record for a photo post:
   - Rewrite `text` to caption-only plain text (image-block markup stripped via the same DOM walk PR 155 uses on the AP `content` filter).
   - Replace `embed` with `app.bsky.embed.images` built from up to MAX_IMAGES (4 — the lexicon cap) uploaded blob refs. Each image carries `alt` (from `_wp_attachment_image_alt` postmeta) and `aspectRatio` (from `wp_get_attachment_metadata()`).
   - Re-extract facets against the rewritten text so byte offsets line up.

Two shared helpers added to `Photo_Post` so both projectors (AP + AT) use the same source of truth:

- `caption_text( WP_Post ): string` — applies `the_content`, strips image markup, returns plain text.
- `collect_image_attachment_ids( WP_Post ): int[]` — featured image first, then `core/image` / `core/gallery > core/image` in document order, deduplicated. Mirrors the resolution rules in detection so the projector never proposes an attachment that detection's "resolves locally" gate would have rejected.

## Why this isn't waiting on the Atmosphere upstream PR

I also opened [`Automattic/wordpress-atmosphere` PR 72](https://github.com/Automattic/wordpress-atmosphere/pull/72), which adds a focused `atmosphere_post_embed` seam and a public `upload_image_blob()` rename. That PR would make this projector cleaner, but it's not strictly required.

This PR deliberately targets the *shipped* Atmosphere surface — `atmosphere_transform_bsky_post` and the existing `Post::upload_thumbnail()` — so the AT federation works as soon as this lands, with or without the upstream change.

### When/if the AT PR lands

After Atmosphere PR 72 lands and the next `tools/sync-bundled.sh` resyncs the bundled copy, two cleanups become possible (small follow-up PR):

1. **Switch the embed swap from `atmosphere_transform_bsky_post` to `atmosphere_post_embed`.** The new filter fires *before* Atmosphere extracts facets and builds the record, so:
   - The projector no longer needs to gate on `$context['strategy'] === 'short-form'` (the new filter only sees the embed, not the strategy-typed record).
   - Manual facet re-extraction goes away — Atmosphere extracts facets against the final text after our embed swap, not before.
   - The text rewrite stays via `atmosphere_transform_bsky_post` (still the only filter that lets us change `text`).
2. **Switch `upload_blob()` from `Post::upload_thumbnail()` to `Post::upload_image_blob()`.** Pure rename — same body, clearer name. Also makes `get_aspect_ratio()` redundant since PR 72 adds `Post::get_attachment_aspect_ratio()` with the same shape.

Neither change is load-bearing for users; both are clarity cleanups.

## Extension seams

- `fosse_photo_post_atmosphere_upload_blob` — pre-filter for blob uploads. Sites can swap in their own AT upload pipeline (CDN bridge, pre-uploaded blob backfill) or stub uploads for tests. Returning a non-null value short-circuits the default Atmosphere delegation.
- `fosse_photo_post_atmosphere_overflow` — action fires when a post has more resolvable images than the lexicon cap allows (only reachable when a site bumps `activitypub_max_image_attachments` above 4 via detection's filter). Lets a follow-up projector implement an overflow strategy (split into a thread, fall back to link card, drop extras) without modifying this class.

## Out of scope (separate tickets)

- **Overflow strategy** for >4 images. The seam is here; the policy is a follow-up.
- **Alt-text gap on Featured Image** — DOTCOM-16806. The projector emits an empty `alt` when the attachment has no `_wp_attachment_image_alt`; the lexicon accepts it but the accessibility hit is on us until that ticket lands.
- **Animated GIF handling** — AT Proto's `embed.images` doesn't animate. Disqualification belongs in `Photo_Post::block_resolves_locally()`, not here.
- **`blurhash`** — same out-of-scope reasoning as PR 155 (needs a sync-side encoder).

## Test plan

- [x] `composer test-php` — full suite 669 tests / 1535 assertions pass (21 new in `Photo_Post_AtmosphereTest`).
- [x] `composer lint-php` — clean.
- [ ] Manual smoke: with the branch active and an Atmosphere connection live, publish a photo-shaped post (Featured Image + caption paragraph, or image block + caption). Confirm the outbound record uses `app.bsky.embed.images` with `alt` + `aspectRatio` populated, and that the record text is caption-only (no figure/img markup).
- [ ] Manual smoke: publish a 4-image gallery post (Featured Image + 3 gallery children). Confirm all four images attach to the embed in document order.
- [ ] Manual smoke: publish a long-form article that happens to contain an inline image. Confirm Atmosphere still emits a link-card / teaser-thread record (not a `embed.images` post) — `is_photo_post()` correctly says "not a photo post" for the long-form shape.

## Files

- `src/class-photo-post-atmosphere.php` — new projector class.
- `src/class-photo-post.php` — adds `caption_text()` and `collect_image_attachment_ids()` shared helpers.
- `fosse.php` — register the projector on `init` (same posture as `Photo_Post::register()`).
- `tests/php/Photo_Post_AtmosphereTest.php` — 21 cases covering both filter callbacks, the shared helpers, MAX_IMAGES cap + overflow action, failed-upload fallback, alt + aspectRatio emission, facet re-extraction, and featured-image dedup.