### PR TITLE
chore: bump version to 0.1.2-alpha

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -3,7 +3,7 @@
  * Plugin Name: FOSSE
  * Plugin URI:  https://github.com/Automattic/fosse
  * Description: Social Web
- * Version:     0.1.1
+ * Version:     0.1.2-alpha
  * Requires at least: 6.9
  * Tested up to: 7.0
  * Requires PHP: 8.2
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  * `ACTIVITYPUB_PLUGIN_VERSION` / `ATMOSPHERE_VERSION` pattern of the
  * bundled backends. Keep in sync with the `Version:` header above.
  */
-define( 'FOSSE_VERSION', '0.1.1' );
+define( 'FOSSE_VERSION', '0.1.2-alpha' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload_packages.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload_packages.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fosse",
-	"version": "0.1.1",
+	"version": "0.1.2-alpha",
 	"description": "Social Web for WordPress.",
 	"private": true,
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Summary

- Bumps the FOSSE plugin version from 0.1.1 to 0.1.2-alpha in fosse.php (`Version:` header and `FOSSE_VERSION` constant) and package.json
- Distinguishes in-development builds on trunk from the 0.1.1 stable release so testers and embedders can tell them apart

## Test plan

- [ ] Verify `FOSSE_VERSION` reports `0.1.2-alpha` after activating the plugin
- [ ] Verify the WP admin Plugins screen shows `0.1.2-alpha` for FOSSE