### PR TITLE
Blurhash placeholders for AP photo-post attachments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
 	"require": {
 		"php": ">=8.2",
 		"ext-dom": "*",
-		"automattic/jetpack-autoloader": "*"
+		"automattic/jetpack-autoloader": "*",
+		"kornrunner/blurhash": "^1.2"
 	},
 	"require-dev": {
 		"automattic/wordbless": "dev-trunk",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6cf8acc77b532d5997411fe9f3a64e8",
+    "content-hash": "575d442a8d24af8a7505bde416da1aec",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -69,6 +69,54 @@
                 "source": "https://github.com/Automattic/jetpack-autoloader/tree/v5.0.17"
             },
             "time": "2026-05-04T16:17:55+00:00"
+        },
+        {
+            "name": "kornrunner/blurhash",
+            "version": "v1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kornrunner/php-blurhash.git",
+                "reference": "bc8a4596cb0a49874f0158696a382ab3933fefe4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kornrunner/php-blurhash/zipball/bc8a4596cb0a49874f0158696a382ab3933fefe4",
+                "reference": "bc8a4596cb0a49874f0158696a382ab3933fefe4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3|^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ocramius/package-versions": "^1.4|^2.0",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^9",
+                "vimeo/psalm": "^4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "kornrunner\\Blurhash\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Boris Momčilović",
+                    "email": "boris.momcilovic@gmail.com"
+                }
+            ],
+            "description": "Pure PHP implementation of Blurhash",
+            "homepage": "https://github.com/kornrunner/php-blurhash",
+            "support": {
+                "issues": "https://github.com/kornrunner/php-blurhash/issues",
+                "source": "https://github.com/kornrunner/php-blurhash.git"
+            },
+            "time": "2022-07-13T19:38:39+00:00"
         }
     ],
     "packages-dev": [

--- a/fosse.php
+++ b/fosse.php
@@ -231,16 +231,24 @@ add_action(
 );
 
 /*
- * Blurhash placeholder encoder + AP attachment injector.
+ * Blurhash placeholder encoder + AP attachment injector, plus the
+ * `wp fosse blurhash …` WP-CLI backfill surface.
  *
- * Computes a Blurhash string at upload time (cron-scheduled off
- * `wp_generate_attachment_metadata` so the upload UI isn't blocked)
- * and adds the result to outbound ActivityPub `attachment[].blurhash`
- * via the `activitypub_attachment` filter, so Pixelfed and Mastodon
- * paint the colored-blur preview while the full image loads. Sites
- * without GD just skip silently — federation is unaffected. See
- * `DOTCOM-17159` and `class-blurhash.php`. Same degradation posture
- * as the projectors above.
+ * Runtime path: computes a Blurhash string at upload time
+ * (cron-scheduled off `wp_generate_attachment_metadata` so the upload
+ * UI isn't blocked) and adds the result to outbound ActivityPub
+ * `attachment[].blurhash` via the `activitypub_attachment` filter,
+ * so Pixelfed and Mastodon paint the colored-blur preview while the
+ * full image loads. Sites without GD just skip silently — federation
+ * is unaffected. See `DOTCOM-17159` and `class-blurhash.php`.
+ *
+ * The CLI surface (`Blurhash_CLI`) is gated on `WP_CLI` *before* the
+ * `class_exists` autoload probe so the CLI file is never read on web
+ * requests — keeps the registration overhead on a normal page load
+ * to a single passed-through `class_exists` check.
+ *
+ * Same degradation posture as the projectors above — if FOSSE's
+ * autoload is missing entirely, both classes silently skip.
  */
 add_action(
 	'init',
@@ -249,22 +257,10 @@ add_action(
 			return;
 		}
 		\Automattic\Fosse\Blurhash::register();
-	}
-);
 
-/*
- * WP-CLI: `wp fosse blurhash …` — backfill encoder for sites with
- * pre-existing media uploaded before the blurhash feature was active.
- * Register-time guard inside the class is a no-op when WP-CLI isn't
- * loaded, so this incurs zero overhead on web requests.
- */
-add_action(
-	'init',
-	static function () {
-		if ( ! class_exists( \Automattic\Fosse\Blurhash_CLI::class ) ) {
-			return;
+		if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( \Automattic\Fosse\Blurhash_CLI::class ) ) {
+			\Automattic\Fosse\Blurhash_CLI::register();
 		}
-		\Automattic\Fosse\Blurhash_CLI::register();
 	}
 );
 

--- a/fosse.php
+++ b/fosse.php
@@ -231,6 +231,44 @@ add_action(
 );
 
 /*
+ * Blurhash placeholder encoder + AP attachment injector.
+ *
+ * Computes a Blurhash string at upload time (cron-scheduled off
+ * `wp_generate_attachment_metadata` so the upload UI isn't blocked)
+ * and adds the result to outbound ActivityPub `attachment[].blurhash`
+ * via the `activitypub_attachment` filter, so Pixelfed and Mastodon
+ * paint the colored-blur preview while the full image loads. Sites
+ * without GD just skip silently — federation is unaffected. See
+ * `DOTCOM-17159` and `class-blurhash.php`. Same degradation posture
+ * as the projectors above.
+ */
+add_action(
+	'init',
+	static function () {
+		if ( ! class_exists( \Automattic\Fosse\Blurhash::class ) ) {
+			return;
+		}
+		\Automattic\Fosse\Blurhash::register();
+	}
+);
+
+/*
+ * WP-CLI: `wp fosse blurhash …` — backfill encoder for sites with
+ * pre-existing media uploaded before the blurhash feature was active.
+ * Register-time guard inside the class is a no-op when WP-CLI isn't
+ * loaded, so this incurs zero overhead on web requests.
+ */
+add_action(
+	'init',
+	static function () {
+		if ( ! class_exists( \Automattic\Fosse\Blurhash_CLI::class ) ) {
+			return;
+		}
+		\Automattic\Fosse\Blurhash_CLI::register();
+	}
+);
+
+/*
  * Cross-network post-type projector.
  *
  * Feeds ActivityPub's stored `activitypub_support_post_types` option into

--- a/src/class-blurhash-cli.php
+++ b/src/class-blurhash-cli.php
@@ -25,7 +25,8 @@ use WP_Query;
  *   2. **Re-encode after an algorithm change** — if the encoder's
  *      components or source-size change, the previously-computed
  *      hashes are stale (still decodable, but produced from a
- *      different recipe). `--force` deletes and recomputes.
+ *      different recipe). `--force` recomputes against the latest
+ *      bytes.
  *
  * Registration is gated on `WP_CLI` so the class is only loaded by
  * the CLI process — no overhead on web requests.
@@ -33,9 +34,39 @@ use WP_Query;
 class Blurhash_CLI {
 
 	/**
+	 * WP_Query page size for the backfill walk. 100 is the same batch
+	 * size WP's own bulk operations default to and keeps each query's
+	 * working set bounded.
+	 *
+	 * @var int
+	 */
+	private const PAGE_SIZE = 100;
+
+	/**
 	 * Compute and persist Blurhash placeholders for image
 	 * attachments missing one. Use after first install on a site
 	 * with existing media, or after an encoder change with --force.
+	 *
+	 * Default mode walks only attachments that have no stored
+	 * `_fosse_blurhash` — already-encoded media is filtered out
+	 * server-side via a `NOT EXISTS` meta query rather than fetched
+	 * and skipped in PHP. Combined with `--limit`, this means a
+	 * limit of N processes exactly N candidates (the prior behavior
+	 * counted already-hashed attachments against the limit and could
+	 * never advance past a fully-encoded first page).
+	 *
+	 * `--force` drops the meta-query filter and walks every image
+	 * attachment in ID order. The existing hash is overwritten only
+	 * after the new encode succeeds, so a failed re-encode leaves
+	 * the prior good hash in place.
+	 *
+	 * Non-raster `image/*` mime types (SVG, etc.) are recognized by
+	 * `wp_attachment_is_image()` returning false and are counted as
+	 * skipped, not failed — they're outside the encoder's GD-based
+	 * scope by design.
+	 *
+	 * Exits nonzero when any encode failed, so automation can detect
+	 * partial-success runs without parsing the summary text.
 	 *
 	 * ## OPTIONS
 	 *
@@ -43,7 +74,7 @@ class Blurhash_CLI {
 	 * : Walk and report what would be encoded, but don't write postmeta.
 	 *
 	 * [--limit=<n>]
-	 * : Process at most <n> attachments. Default: 0 (no limit).
+	 * : Process at most <n> candidate attachments. Default: 0 (no limit).
 	 *
 	 * [--force]
 	 * : Re-encode attachments that already have a stored hash.
@@ -66,29 +97,53 @@ class Blurhash_CLI {
 		$force   = ! empty( $assoc_args['force'] );
 		$limit   = isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 0;
 
-		$processed = 0;
-		$encoded   = 0;
-		$skipped   = 0;
-		$failed    = 0;
-		$paged     = 1;
-		$per_page  = 100;
+		$encoded = 0;
+		$skipped = 0;
+		$failed  = 0;
+		$last_id = 0;
 
 		while ( true ) {
-			$query = new WP_Query(
-				array(
-					'post_type'              => 'attachment',
-					'post_status'            => 'inherit',
-					'post_mime_type'         => 'image',
-					'posts_per_page'         => $per_page,
-					'paged'                  => $paged,
-					'fields'                 => 'ids',
-					'no_found_rows'          => true,
-					'update_post_meta_cache' => false,
-					'update_post_term_cache' => false,
-					'orderby'                => 'ID',
-					'order'                  => 'ASC',
-				)
+			$query_args = array(
+				'post_type'              => 'attachment',
+				'post_status'            => 'inherit',
+				'post_mime_type'         => 'image',
+				'posts_per_page'         => self::PAGE_SIZE,
+				'fields'                 => 'ids',
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
 			);
+
+			// Default mode filters to candidates server-side, so we
+			// never call `Blurhash::get()` per row in the loop (the
+			// N+1 the prior pagination shape had). `--force` skips
+			// the filter and walks everything in ID order.
+			if ( ! $force ) {
+				$query_args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- one-shot CLI backfill; not a web-path query.
+					array(
+						'key'     => Blurhash::META_KEY,
+						'compare' => 'NOT EXISTS',
+					),
+				);
+			}
+
+			// Keyset pagination — `ID > $last_id` is stable under
+			// concurrent inserts and deletes, so a long backfill can't
+			// silently skip attachments the way offset pagination
+			// (paged=N) does when rows shift mid-run.
+			$where_filter = null;
+			if ( $last_id > 0 ) {
+				$where_filter = self::keyset_where( $last_id );
+				add_filter( 'posts_where', $where_filter, 10, 1 );
+			}
+
+			$query = new WP_Query( $query_args );
+
+			if ( null !== $where_filter ) {
+				remove_filter( 'posts_where', $where_filter, 10 );
+			}
 
 			if ( empty( $query->posts ) ) {
 				break;
@@ -96,27 +151,28 @@ class Blurhash_CLI {
 
 			foreach ( $query->posts as $attachment_id ) {
 				$attachment_id = (int) $attachment_id;
+				$last_id       = $attachment_id;
 
-				if ( $limit > 0 && $processed >= $limit ) {
-					break 2;
-				}
-
-				++$processed;
-				$existing = Blurhash::get( $attachment_id );
-
-				if ( null !== $existing && ! $force ) {
+				// Non-encodable mime types (SVG, ICO, anything
+				// outside the GD raster set) get filtered out
+				// up-front and counted as skipped, not failed. The
+				// encoder would return null on them too, but a
+				// per-attachment WARNING for every SVG on every
+				// backfill run is noise; the user already knows we
+				// don't encode vector formats.
+				if ( ! Blurhash::is_encodable_attachment( $attachment_id ) ) {
 					++$skipped;
 					continue;
+				}
+
+				if ( $limit > 0 && ( $encoded + $failed ) >= $limit ) {
+					break 2;
 				}
 
 				if ( $dry_run ) {
 					++$encoded;
 					WP_CLI::log( "would encode: attachment {$attachment_id}" );
 					continue;
-				}
-
-				if ( $force && null !== $existing ) {
-					Blurhash::delete( $attachment_id );
 				}
 
 				$hash = Blurhash::encode_from_attachment( $attachment_id );
@@ -126,17 +182,19 @@ class Blurhash_CLI {
 					continue;
 				}
 
+				// Encode-then-set — never delete-first. A failed
+				// re-encode on `--force` leaves the prior good hash
+				// in place rather than wiping it.
 				Blurhash::set( $attachment_id, $hash );
 				++$encoded;
 				WP_CLI::log( "encoded {$attachment_id}: {$hash}" );
 			}
-
-			++$paged;
 		}
 
-		$summary = sprintf(
-			'Processed %d image attachments — encoded %d, skipped %d (already had hash), failed %d.',
-			$processed,
+		$encoded_label = $dry_run ? 'would encode' : 'encoded';
+		$summary       = sprintf(
+			'%s %d, skipped %d (non-raster or unsupported), failed %d.',
+			$encoded_label,
 			$encoded,
 			$skipped,
 			$failed
@@ -144,9 +202,33 @@ class Blurhash_CLI {
 
 		if ( $dry_run ) {
 			WP_CLI::success( '[dry-run] ' . $summary );
-		} else {
-			WP_CLI::success( $summary );
+			return;
 		}
+
+		// Non-zero exit on any failure so automation can detect
+		// partial-success runs without parsing the summary text.
+		if ( $failed > 0 ) {
+			WP_CLI::error( $summary );
+			return;
+		}
+
+		WP_CLI::success( $summary );
+	}
+
+	/**
+	 * Build a `posts_where` filter closure that constrains the
+	 * query to `ID > $last_id`. Used to implement keyset pagination
+	 * without polluting WP_Query's stable args. The closure clears
+	 * itself after each query in {@see self::backfill()}.
+	 *
+	 * @param int $last_id Last processed attachment ID.
+	 * @return \Closure
+	 */
+	private static function keyset_where( int $last_id ): \Closure {
+		return function ( $where ) use ( $last_id ) {
+			global $wpdb;
+			return $where . $wpdb->prepare( " AND {$wpdb->posts}.ID > %d", $last_id );
+		};
 	}
 
 	/**

--- a/src/class-blurhash-cli.php
+++ b/src/class-blurhash-cli.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * WP-CLI commands for FOSSE's Blurhash encoder.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse;
+
+use WP_CLI;
+use WP_Query;
+
+/**
+ * `wp fosse blurhash …` command surface for backfilling and managing
+ * stored blurhash placeholders.
+ *
+ * The runtime path ({@see Blurhash}) covers new uploads via a cron
+ * event; this command exists for two cases the runtime can't handle:
+ *
+ *   1. **First install on a site with existing media** — every
+ *      already-uploaded image attachment is missing the postmeta and
+ *      will never get it without a re-upload or a forced re-encode.
+ *      `wp fosse blurhash backfill` walks the library and fills the
+ *      gap.
+ *   2. **Re-encode after an algorithm change** — if the encoder's
+ *      components or source-size change, the previously-computed
+ *      hashes are stale (still decodable, but produced from a
+ *      different recipe). `--force` deletes and recomputes.
+ *
+ * Registration is gated on `WP_CLI` so the class is only loaded by
+ * the CLI process — no overhead on web requests.
+ */
+class Blurhash_CLI {
+
+	/**
+	 * Compute and persist Blurhash placeholders for image
+	 * attachments missing one. Use after first install on a site
+	 * with existing media, or after an encoder change with --force.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Walk and report what would be encoded, but don't write postmeta.
+	 *
+	 * [--limit=<n>]
+	 * : Process at most <n> attachments. Default: 0 (no limit).
+	 *
+	 * [--force]
+	 * : Re-encode attachments that already have a stored hash.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp fosse blurhash backfill --dry-run
+	 *     wp fosse blurhash backfill --limit=100
+	 *     wp fosse blurhash backfill --force
+	 *
+	 * @param array<int, string>   $args       Positional CLI args (unused).
+	 * @param array<string, mixed> $assoc_args Associative CLI flags.
+	 *
+	 * @when after_wp_load
+	 */
+	public function backfill( $args, $assoc_args ) {
+		unset( $args );
+
+		$dry_run = ! empty( $assoc_args['dry-run'] );
+		$force   = ! empty( $assoc_args['force'] );
+		$limit   = isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 0;
+
+		$processed = 0;
+		$encoded   = 0;
+		$skipped   = 0;
+		$failed    = 0;
+		$paged     = 1;
+		$per_page  = 100;
+
+		while ( true ) {
+			$query = new WP_Query(
+				array(
+					'post_type'              => 'attachment',
+					'post_status'            => 'inherit',
+					'post_mime_type'         => 'image',
+					'posts_per_page'         => $per_page,
+					'paged'                  => $paged,
+					'fields'                 => 'ids',
+					'no_found_rows'          => true,
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+					'orderby'                => 'ID',
+					'order'                  => 'ASC',
+				)
+			);
+
+			if ( empty( $query->posts ) ) {
+				break;
+			}
+
+			foreach ( $query->posts as $attachment_id ) {
+				$attachment_id = (int) $attachment_id;
+
+				if ( $limit > 0 && $processed >= $limit ) {
+					break 2;
+				}
+
+				++$processed;
+				$existing = Blurhash::get( $attachment_id );
+
+				if ( null !== $existing && ! $force ) {
+					++$skipped;
+					continue;
+				}
+
+				if ( $dry_run ) {
+					++$encoded;
+					WP_CLI::log( "would encode: attachment {$attachment_id}" );
+					continue;
+				}
+
+				if ( $force && null !== $existing ) {
+					Blurhash::delete( $attachment_id );
+				}
+
+				$hash = Blurhash::encode_from_attachment( $attachment_id );
+				if ( null === $hash ) {
+					++$failed;
+					WP_CLI::warning( "encode failed: attachment {$attachment_id}" );
+					continue;
+				}
+
+				Blurhash::set( $attachment_id, $hash );
+				++$encoded;
+				WP_CLI::log( "encoded {$attachment_id}: {$hash}" );
+			}
+
+			++$paged;
+		}
+
+		$summary = sprintf(
+			'Processed %d image attachments — encoded %d, skipped %d (already had hash), failed %d.',
+			$processed,
+			$encoded,
+			$skipped,
+			$failed
+		);
+
+		if ( $dry_run ) {
+			WP_CLI::success( '[dry-run] ' . $summary );
+		} else {
+			WP_CLI::success( $summary );
+		}
+	}
+
+	/**
+	 * Register the `wp fosse blurhash` command surface. No-op when
+	 * WP-CLI isn't loaded.
+	 */
+	public static function register(): void {
+		if ( ! \defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			return;
+		}
+		WP_CLI::add_command( 'fosse blurhash', self::class );
+	}
+}

--- a/src/class-blurhash-cli.php
+++ b/src/class-blurhash-cli.php
@@ -97,6 +97,17 @@ class Blurhash_CLI {
 		$force   = ! empty( $assoc_args['force'] );
 		$limit   = isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 0;
 
+		// Fail fast when the encoder can't run on this host.
+		// Without this gate, the loop would emit a `WP_CLI::warning`
+		// per attachment and exit non-zero — noisy and unactionable.
+		// `--dry-run` still works (no encoding attempted), so
+		// operators can enumerate candidates from a GD-less host
+		// to decide whether to migrate the media.
+		if ( ! $dry_run && ! Blurhash::is_encoder_runnable() ) {
+			WP_CLI::error( 'Blurhash encoder requires GD (imagecreatefromstring/truecolor/scale). Install or enable GD and re-run.' );
+			return;
+		}
+
 		$encoded = 0;
 		$skipped = 0;
 		$failed  = 0;

--- a/src/class-blurhash-cli.php
+++ b/src/class-blurhash-cli.php
@@ -120,11 +120,26 @@ class Blurhash_CLI {
 			// never call `Blurhash::get()` per row in the loop (the
 			// N+1 the prior pagination shape had). `--force` skips
 			// the filter and walks everything in ID order.
+			//
+			// Candidate set is "key missing OR value empty". A
+			// non-empty-but-malformed row (postmeta poisoning, a
+			// truncated import) self-heals through the runtime
+			// cron path because {@see Blurhash::get()} reports
+			// malformed values as absent, so `run_encode()` will
+			// re-compute on the next `wp_generate_attachment_metadata`
+			// regen. Operators who need a one-shot rescue without
+			// waiting for a regen run the command with `--force`.
 			if ( ! $force ) {
 				$query_args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- one-shot CLI backfill; not a web-path query.
+					'relation' => 'OR',
 					array(
 						'key'     => Blurhash::META_KEY,
 						'compare' => 'NOT EXISTS',
+					),
+					array(
+						'key'     => Blurhash::META_KEY,
+						'value'   => '',
+						'compare' => '=',
 					),
 				);
 			}

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -32,13 +32,15 @@ use kornrunner\Blurhash\Blurhash as Encoder;
  * file, encoder exception, deleted attachment): never blocks the
  * upload, never blocks federation.
  *
- * The bundled ActivityPub `Activity::JSON_LD_CONTEXT` declares the
- * `toot:` namespace but does NOT map a `blurhash` term — a follow-up
- * one-line upstream change in `wordpress-activitypub` adds
- * `'blurhash' => 'toot:blurhash'` to make this strictly correct
- * JSON-LD. Real-world consumers (Mastodon, Pixelfed) read the
- * property at the application layer regardless, so this ships
- * working today without the upstream change.
+ * The bundled ActivityPub `Base_Object::JSON_LD_CONTEXT` (the
+ * constant actually consulted for outbound `Image` objects) does
+ * not declare the `toot:` namespace or map a `blurhash` term —
+ * upstream PR Automattic/wordpress-activitypub#3327 adds both, and
+ * a `tools/sync-bundled.sh` pass will pull it in once it lands.
+ * Real-world consumers (Mastodon, Pixelfed) read the property at
+ * the application layer regardless of strict JSON-LD compaction,
+ * so this projector ships working today with or without that
+ * upstream change.
  */
 class Blurhash {
 
@@ -271,7 +273,6 @@ class Blurhash {
 		} catch ( \Throwable $e ) {
 			return null;
 		}
-		// PHP 8.0+ collects GdImage when it leaves scope; no manual imagedestroy() needed.
 	}
 
 	/**

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -142,10 +142,17 @@ class Blurhash {
 	}
 
 	/**
-	 * Return the stored blurhash for an attachment, or null when
-	 * none is stored. Trims whitespace and treats an empty string as
-	 * absent so a manually-emptied postmeta doesn't leak into the
-	 * federation envelope.
+	 * Return the stored blurhash for an attachment, or null when no
+	 * usable value is stored. Empty/whitespace/non-string values are
+	 * treated as absent, AND values that fail
+	 * {@see self::is_well_formed_hash()} are too — so postmeta
+	 * poisoning (or an old encoder bug that wrote junk) doesn't
+	 * leak into the federation envelope AND doesn't permanently
+	 * stick the cron `run_encode` short-circuit (which keys off
+	 * this returning non-null). Net effect: a malformed row
+	 * self-heals on the next `wp_generate_attachment_metadata`
+	 * cycle because `get()` reports absent, `run_encode` proceeds,
+	 * and `set()` overwrites the malformed value.
 	 *
 	 * @param int $attachment_id Attachment post ID.
 	 * @return string|null
@@ -156,7 +163,10 @@ class Blurhash {
 			return null;
 		}
 		$value = trim( $value );
-		return '' === $value ? null : $value;
+		if ( '' === $value ) {
+			return null;
+		}
+		return self::is_well_formed_hash( $value ) ? $value : null;
 	}
 
 	/**
@@ -235,16 +245,29 @@ class Blurhash {
 			// nested array grows quadratically with edge length, so
 			// any source larger than MAX_ENCODE_EDGE gets sampled
 			// down — perceptually identical output, bounded memory.
+			//
+			// Scale by the LONGER edge so portrait images
+			// (`height > width`) don't get upscaled by a
+			// fixed-width call to `imagescale`. Target dimensions
+			// are computed explicitly so both edges land at or
+			// below the cap. If `imagescale` fails we bail rather
+			// than fall through to the per-pixel loop with the
+			// original (oversized) GD image.
 			if ( $width > self::MAX_ENCODE_EDGE || $height > self::MAX_ENCODE_EDGE ) {
-				$scaled = \imagescale( $image, self::MAX_ENCODE_EDGE, -1 );
-				if ( false !== $scaled ) {
-					$image  = $scaled;
-					$width  = \imagesx( $image );
-					$height = \imagesy( $image );
-					if ( $width < 1 || $height < 1 ) {
-						return null;
-					}
+				if ( $width >= $height ) {
+					$target_width  = self::MAX_ENCODE_EDGE;
+					$target_height = (int) \max( 1, \round( $height * ( self::MAX_ENCODE_EDGE / $width ) ) );
+				} else {
+					$target_height = self::MAX_ENCODE_EDGE;
+					$target_width  = (int) \max( 1, \round( $width * ( self::MAX_ENCODE_EDGE / $height ) ) );
 				}
+				$scaled = \imagescale( $image, $target_width, $target_height );
+				if ( false === $scaled ) {
+					return null;
+				}
+				$image  = $scaled;
+				$width  = $target_width;
+				$height = $target_height;
 			}
 
 			$pixels = array();
@@ -445,17 +468,13 @@ class Blurhash {
 
 	/**
 	 * `activitypub_attachment` filter callback. Injects `blurhash`
-	 * into image attachment arrays when postmeta exists. No-op on
-	 * anything else (non-image attachments, missing meta, malformed
-	 * arrays) so non-photo federation paths are untouched.
-	 *
-	 * Sanitizes the stored hash before injection. The encoder's own
-	 * output is base83 by construction, but anyone with
-	 * `edit_post_meta` on an attachment could rewrite `_fosse_blurhash`
-	 * to arbitrary bytes — including non-UTF-8 bytes that would
-	 * break `wp_json_encode` and drop the entire AP envelope on the
-	 * floor. Length cap + base83 charset filter constrains the
-	 * field to what real-world consumers expect.
+	 * into image attachment arrays when a usable postmeta value is
+	 * stored. No-op on anything else (non-image attachments, missing
+	 * meta, malformed meta, malformed arrays) so non-photo federation
+	 * paths are untouched. Sanitization is enforced inside
+	 * {@see self::get()} — anyone with `edit_post_meta` on an
+	 * attachment could otherwise rewrite `_fosse_blurhash` to bytes
+	 * that break `wp_json_encode` and drop the entire AP envelope.
 	 *
 	 * @param mixed $attachment    The attachment array as built by bundled AP.
 	 * @param mixed $attachment_id The attachment post ID (mixed because the upstream filter is loosely typed).
@@ -469,7 +488,7 @@ class Blurhash {
 			return $attachment;
 		}
 		$hash = self::get( (int) $attachment_id );
-		if ( null === $hash || ! self::is_well_formed_hash( $hash ) ) {
+		if ( null === $hash ) {
 			return $attachment;
 		}
 		$attachment['blurhash'] = $hash;

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -340,9 +340,18 @@ class Blurhash {
 	 */
 	public static function schedule_encode( $metadata, $attachment_id ) {
 		$attachment_id = (int) $attachment_id;
-		if ( $attachment_id > 0 && self::is_encodable_attachment( $attachment_id ) ) {
-			self::schedule( $attachment_id );
+		if ( $attachment_id < 1 || ! self::is_encodable_attachment( $attachment_id ) ) {
+			return $metadata;
 		}
+
+		// Invalidate any prior hash so cron will re-encode against
+		// the latest bytes. `wp_generate_attachment_metadata` fires
+		// on initial upload AND on media-replace / crop / regen, so
+		// without this delete a replaced image would keep federating
+		// the placeholder for its prior bytes.
+		self::delete( $attachment_id );
+
+		self::schedule( $attachment_id );
 		return $metadata;
 	}
 
@@ -368,11 +377,17 @@ class Blurhash {
 
 	/**
 	 * Queue (or skip, if already queued) a cron event to compute
-	 * the blurhash for an attachment.
+	 * the blurhash for an attachment. Internal helper for
+	 * {@see self::schedule_encode()} — callers should go through
+	 * that filter callback so the metadata-regen invalidation pass
+	 * stays load-bearing.
 	 *
 	 * @param int $attachment_id Attachment post ID.
 	 */
-	public static function schedule( int $attachment_id ): void {
+	private static function schedule( int $attachment_id ): void {
+		if ( $attachment_id < 1 ) {
+			return;
+		}
 		if ( false !== \wp_next_scheduled( self::CRON_HOOK, array( $attachment_id ) ) ) {
 			return;
 		}
@@ -382,7 +397,15 @@ class Blurhash {
 	/**
 	 * Cron callback: compute and store the blurhash. No-op when a
 	 * hash is already stored; callers wanting a re-encode delete
-	 * the postmeta first ({@see self::delete()}).
+	 * the postmeta first ({@see self::delete()}) — that's what
+	 * {@see self::schedule_encode()} does before scheduling, so the
+	 * media-replace path always recomputes.
+	 *
+	 * Emits `fosse_blurhash_encode_failed` (action) and an
+	 * `error_log` line when the encoder returns null without a
+	 * pre-existing stored hash, so transient failures (NFS hiccup,
+	 * S3 lag, GD blip) leave a signal for monitoring instead of
+	 * silently never producing a placeholder.
 	 *
 	 * @param int $attachment_id Attachment post ID.
 	 */
@@ -397,7 +420,22 @@ class Blurhash {
 		$hash = self::encode_from_attachment( $attachment_id );
 		if ( null !== $hash ) {
 			self::set( $attachment_id, $hash );
+			return;
 		}
+
+		// Silent-failure guard — surface the gap so an operator can
+		// investigate (or wire monitoring against the action).
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- intentional plugin diagnostics; cron path only.
+		\error_log( "[fosse:blurhash] encode failed for attachment {$attachment_id}; placeholder will be absent until backfill." );
+
+		/**
+		 * Fires when the cron-deferred encoder fails to produce a
+		 * hash for an attachment. Monitoring integrations can hook
+		 * this to count blurhash-encode failures over time.
+		 *
+		 * @param int $attachment_id The attachment ID that failed to encode.
+		 */
+		\do_action( 'fosse_blurhash_encode_failed', $attachment_id );
 	}
 
 	/**

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * Blurhash encoder + storage for image attachments.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse;
+
+use kornrunner\Blurhash\Blurhash as Encoder;
+
+/**
+ * Compute, store, and inject Blurhash placeholder strings for image
+ * attachments so federated ActivityPub posts emit
+ * `attachment[].blurhash` — the colored-blur preview that Pixelfed,
+ * Mastodon, and other fediverse clients paint while the full image
+ * is still loading. Without it, federated WP photos sit on a grey
+ * placeholder where native uploads paint instantly; with it, the
+ * loading state matches native.
+ *
+ * Encoding runs at upload time via `wp_generate_attachment_metadata`,
+ * deferred to cron so the upload UI returns immediately. The hash
+ * is persisted as attachment postmeta ({@see self::META_KEY}) and
+ * read back by the `activitypub_attachment` projector — zero
+ * per-publish CPU cost, federation hot path stays cheap.
+ *
+ * Pure no-op when GD isn't available: the encoder needs an
+ * `[r,g,b][][]` pixel array, and GD's `imagecreatefrom*` family is
+ * the only host-portable way to build one. Sites running Imagick-only
+ * just don't get blurhash placeholders — attachments still federate,
+ * minus the field. Same posture for any other failure (unreadable
+ * file, encoder exception, deleted attachment): never blocks the
+ * upload, never blocks federation.
+ *
+ * The bundled ActivityPub `Activity::JSON_LD_CONTEXT` declares the
+ * `toot:` namespace but does NOT map a `blurhash` term — a follow-up
+ * one-line upstream change in `wordpress-activitypub` adds
+ * `'blurhash' => 'toot:blurhash'` to make this strictly correct
+ * JSON-LD. Real-world consumers (Mastodon, Pixelfed) read the
+ * property at the application layer regardless, so this ships
+ * working today without the upstream change.
+ */
+class Blurhash {
+
+	/**
+	 * Postmeta key holding the encoded blurhash for an attachment.
+	 *
+	 * @var string
+	 */
+	public const META_KEY = '_fosse_blurhash';
+
+	/**
+	 * Cron hook fired for each attachment that needs a hash computed.
+	 *
+	 * @var string
+	 */
+	public const CRON_HOOK = 'fosse_blurhash_compute';
+
+	/**
+	 * X-component count passed to the encoder. Wolt's reference
+	 * recommends 4–5 for landscape and lower for portrait; 4 is the
+	 * middle ground Mastodon also defaults to. Hash length grows with
+	 * the product of X*Y, so 4×4 keeps the encoded string short.
+	 *
+	 * @var int
+	 */
+	private const COMPONENTS_X = 4;
+
+	/**
+	 * Y-component count. Mirror of {@see self::COMPONENTS_X}.
+	 *
+	 * @var int
+	 */
+	private const COMPONENTS_Y = 4;
+
+	/**
+	 * Image size used as the encoder's source. Blurhash encoding is
+	 * O(N) over pixel count and the output is a few low-frequency DCT
+	 * coefficients — feeding it a 12-megapixel original would burn
+	 * CPU producing a hash that's perceptually identical to the one
+	 * computed off the ~150px thumbnail. WP's `thumbnail` size is the
+	 * smallest variant guaranteed to exist for every uploaded image.
+	 *
+	 * @var string
+	 */
+	private const ENCODE_SIZE = 'thumbnail';
+
+	/**
+	 * Register all hooks. Called from `fosse.php` on `init`, same
+	 * posture as the sibling projectors.
+	 */
+	public static function register(): void {
+		\add_filter( 'wp_generate_attachment_metadata', array( self::class, 'schedule_encode' ), 10, 2 );
+		\add_action( self::CRON_HOOK, array( self::class, 'run_encode' ), 10, 1 );
+		\add_filter( 'activitypub_attachment', array( self::class, 'inject_blurhash' ), 10, 2 );
+	}
+
+	/**
+	 * Return the stored blurhash for an attachment, or null when
+	 * none is stored. Trims whitespace and treats an empty string as
+	 * absent so a manually-emptied postmeta doesn't leak into the
+	 * federation envelope.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return string|null
+	 */
+	public static function get( int $attachment_id ): ?string {
+		$value = \get_post_meta( $attachment_id, self::META_KEY, true );
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+		$value = trim( $value );
+		return '' === $value ? null : $value;
+	}
+
+	/**
+	 * Persist a computed blurhash on the attachment.
+	 *
+	 * @param int    $attachment_id Attachment post ID.
+	 * @param string $hash          Encoded blurhash string.
+	 */
+	public static function set( int $attachment_id, string $hash ): void {
+		\update_post_meta( $attachment_id, self::META_KEY, $hash );
+	}
+
+	/**
+	 * Delete any stored blurhash for an attachment. Used by the
+	 * WP-CLI backfill `--force` path.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 */
+	public static function delete( int $attachment_id ): void {
+		\delete_post_meta( $attachment_id, self::META_KEY );
+	}
+
+	/**
+	 * Compute (synchronously) the blurhash for an attachment by
+	 * loading the configured size's file through GD and feeding the
+	 * pixel array to the encoder. Returns null on any failure path
+	 * — never throws, never warns. Used by both the cron handler
+	 * and the WP-CLI backfill.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return string|null
+	 */
+	public static function encode_from_attachment( int $attachment_id ): ?string {
+		if ( ! \wp_attachment_is_image( $attachment_id ) ) {
+			return null;
+		}
+
+		if ( ! \function_exists( 'imagecreatefromstring' ) ) {
+			return null;
+		}
+
+		$path = self::resolve_encode_path( $attachment_id );
+		if ( null === $path ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.PHP.NoSilencedErrors.Discouraged -- local absolute path read; corrupt/missing file returns false and we handle.
+		$bytes = @file_get_contents( $path );
+		if ( false === $bytes || '' === $bytes ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- corrupt image returns false and we handle.
+		$image = @\imagecreatefromstring( $bytes );
+		if ( false === $image ) {
+			return null;
+		}
+
+		try {
+			$width  = \imagesx( $image );
+			$height = \imagesy( $image );
+			if ( $width < 1 || $height < 1 ) {
+				return null;
+			}
+
+			$pixels = array();
+			for ( $y = 0; $y < $height; $y++ ) {
+				$row = array();
+				for ( $x = 0; $x < $width; $x++ ) {
+					$index  = \imagecolorat( $image, $x, $y );
+					$colors = \imagecolorsforindex( $image, $index );
+					$row[]  = array( $colors['red'], $colors['green'], $colors['blue'] );
+				}
+				$pixels[] = $row;
+			}
+
+			$hash = Encoder::encode( $pixels, self::COMPONENTS_X, self::COMPONENTS_Y );
+			return \is_string( $hash ) && '' !== $hash ? $hash : null;
+		} catch ( \Throwable $e ) {
+			return null;
+		}
+		// PHP 8.0+ collects GdImage when it leaves scope; no manual imagedestroy() needed.
+	}
+
+	/**
+	 * Resolve the absolute filesystem path of the size we use as
+	 * encoder input, falling back to the original when the
+	 * intermediate doesn't exist (small uploads that core didn't
+	 * generate downscales for).
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return string|null Absolute file path, or null when nothing readable resolved.
+	 */
+	private static function resolve_encode_path( int $attachment_id ): ?string {
+		$sized = \image_get_intermediate_size( $attachment_id, self::ENCODE_SIZE );
+		if ( \is_array( $sized ) && ! empty( $sized['path'] ) ) {
+			$upload = \wp_upload_dir();
+			if ( \is_array( $upload ) && ! empty( $upload['basedir'] ) ) {
+				$path = \trailingslashit( $upload['basedir'] ) . $sized['path'];
+				if ( \is_readable( $path ) ) {
+					return $path;
+				}
+			}
+		}
+
+		$path = \get_attached_file( $attachment_id );
+		return ( \is_string( $path ) && \is_readable( $path ) ) ? $path : null;
+	}
+
+	/**
+	 * `wp_generate_attachment_metadata` filter callback. Schedules
+	 * a single-event cron run to compute the blurhash for image
+	 * attachments. The filter return value is the metadata unchanged
+	 * — we use the hook purely as an "image is ready" notifier.
+	 *
+	 * @param array $metadata      Attachment metadata as built by WP.
+	 * @param int   $attachment_id Attachment post ID.
+	 * @return array
+	 */
+	public static function schedule_encode( $metadata, $attachment_id ) {
+		$attachment_id = (int) $attachment_id;
+		if ( $attachment_id > 0 && \wp_attachment_is_image( $attachment_id ) ) {
+			self::schedule( $attachment_id );
+		}
+		return $metadata;
+	}
+
+	/**
+	 * Queue (or skip, if already queued) a cron event to compute
+	 * the blurhash for an attachment.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 */
+	public static function schedule( int $attachment_id ): void {
+		if ( false !== \wp_next_scheduled( self::CRON_HOOK, array( $attachment_id ) ) ) {
+			return;
+		}
+		\wp_schedule_single_event( \time(), self::CRON_HOOK, array( $attachment_id ) );
+	}
+
+	/**
+	 * Cron callback: compute and store the blurhash. No-op when a
+	 * hash is already stored; callers wanting a re-encode delete
+	 * the postmeta first ({@see self::delete()}).
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 */
+	public static function run_encode( int $attachment_id ): void {
+		$attachment_id = (int) $attachment_id;
+		if ( $attachment_id < 1 ) {
+			return;
+		}
+		if ( null !== self::get( $attachment_id ) ) {
+			return;
+		}
+		$hash = self::encode_from_attachment( $attachment_id );
+		if ( null !== $hash ) {
+			self::set( $attachment_id, $hash );
+		}
+	}
+
+	/**
+	 * `activitypub_attachment` filter callback. Injects `blurhash`
+	 * into image attachment arrays when postmeta exists. No-op on
+	 * anything else (non-image attachments, missing meta, malformed
+	 * arrays) so non-photo federation paths are untouched.
+	 *
+	 * @param mixed $attachment    The attachment array as built by bundled AP.
+	 * @param mixed $attachment_id The attachment post ID (mixed because the upstream filter is loosely typed).
+	 * @return mixed
+	 */
+	public static function inject_blurhash( $attachment, $attachment_id ) {
+		if ( ! \is_array( $attachment ) ) {
+			return $attachment;
+		}
+		if ( 'Image' !== ( $attachment['type'] ?? '' ) ) {
+			return $attachment;
+		}
+		$hash = self::get( (int) $attachment_id );
+		if ( null === $hash ) {
+			return $attachment;
+		}
+		$attachment['blurhash'] = $hash;
+		return $attachment;
+	}
+}

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -57,21 +57,31 @@ class Blurhash {
 	public const CRON_HOOK = 'fosse_blurhash_compute';
 
 	/**
-	 * X-component count passed to the encoder. Wolt's reference
-	 * recommends 4–5 for landscape and lower for portrait; 4 is the
-	 * middle ground Mastodon also defaults to. Hash length grows with
-	 * the product of X*Y, so 4×4 keeps the encoded string short.
+	 * DCT component count passed to the encoder as BOTH the X and
+	 * Y dimensions — kept as a single number because the two
+	 * dimensions are always equal in this encoder and splitting
+	 * them implies a tuning surface that doesn't exist. Wolt's
+	 * reference recommends 4–5 for landscape and lower for
+	 * portrait; 4 is the middle ground Mastodon also defaults to.
+	 * Hash length grows with the product, so 4×4 keeps the encoded
+	 * string short.
 	 *
 	 * @var int
 	 */
-	private const COMPONENTS_X = 4;
+	private const COMPONENTS = 4;
 
 	/**
-	 * Y-component count. Mirror of {@see self::COMPONENTS_X}.
+	 * Upper bound on stored blurhash string length, in characters.
+	 * A 4×4 component grid produces a 30-character hash; the
+	 * theoretical max for the 9×9 component grid the spec supports
+	 * is 99 characters. We cap a little above that as a defense
+	 * against postmeta poisoning — anyone with `edit_post_meta` on
+	 * an attachment could otherwise write arbitrary bytes that we
+	 * would then federate straight into the AP envelope.
 	 *
 	 * @var int
 	 */
-	private const COMPONENTS_Y = 4;
+	private const MAX_HASH_LENGTH = 128;
 
 	/**
 	 * Image size used as the encoder's source. Blurhash encoding is
@@ -256,7 +266,7 @@ class Blurhash {
 				$pixels[] = $row;
 			}
 
-			$hash = Encoder::encode( $pixels, self::COMPONENTS_X, self::COMPONENTS_Y );
+			$hash = Encoder::encode( $pixels, self::COMPONENTS, self::COMPONENTS );
 			return \is_string( $hash ) && '' !== $hash ? $hash : null;
 		} catch ( \Throwable $e ) {
 			return null;
@@ -388,9 +398,13 @@ class Blurhash {
 		if ( $attachment_id < 1 ) {
 			return;
 		}
-		if ( false !== \wp_next_scheduled( self::CRON_HOOK, array( $attachment_id ) ) ) {
-			return;
-		}
+		// Rely on WP's own duplicate-event guard inside
+		// `wp_schedule_single_event` (rejects matching args within
+		// the 10-minute window) rather than running an explicit
+		// `wp_next_scheduled` check first. The explicit check did
+		// nothing the underlying scheduler doesn't already do and
+		// added a needless read against the autoloaded cron option
+		// on every attachment metadata regen.
 		\wp_schedule_single_event( \time(), self::CRON_HOOK, array( $attachment_id ) );
 	}
 
@@ -444,6 +458,14 @@ class Blurhash {
 	 * anything else (non-image attachments, missing meta, malformed
 	 * arrays) so non-photo federation paths are untouched.
 	 *
+	 * Sanitizes the stored hash before injection. The encoder's own
+	 * output is base83 by construction, but anyone with
+	 * `edit_post_meta` on an attachment could rewrite `_fosse_blurhash`
+	 * to arbitrary bytes — including non-UTF-8 bytes that would
+	 * break `wp_json_encode` and drop the entire AP envelope on the
+	 * floor. Length cap + base83 charset filter constrains the
+	 * field to what real-world consumers expect.
+	 *
 	 * @param mixed $attachment    The attachment array as built by bundled AP.
 	 * @param mixed $attachment_id The attachment post ID (mixed because the upstream filter is loosely typed).
 	 * @return mixed
@@ -456,10 +478,33 @@ class Blurhash {
 			return $attachment;
 		}
 		$hash = self::get( (int) $attachment_id );
-		if ( null === $hash ) {
+		if ( null === $hash || ! self::is_well_formed_hash( $hash ) ) {
 			return $attachment;
 		}
 		$attachment['blurhash'] = $hash;
 		return $attachment;
+	}
+
+	/**
+	 * Validate a stored hash against the blurhash spec's character
+	 * set and our length bound. Treat any out-of-bounds value as
+	 * absent rather than coerce — preserves the "no blurhash is
+	 * better than a wrong blurhash" posture the rest of the class
+	 * follows. The base83 alphabet is defined by the spec at
+	 * {@link https://github.com/woltapp/blurhash/blob/master/Algorithm.md#base-83}.
+	 *
+	 * @param string $hash Candidate hash string.
+	 * @return bool
+	 */
+	private static function is_well_formed_hash( string $hash ): bool {
+		$length = \strlen( $hash );
+		if ( $length < 6 || $length > self::MAX_HASH_LENGTH ) {
+			return false;
+		}
+		// Base83 alphabet — same character set the encoder library
+		// emits, conservative enough to reject any byte sequence
+		// that would surprise a downstream JSON encoder or client
+		// decoder.
+		return 1 === \preg_match( '/\A[0-9A-Za-z#$%*+,\-.:;=?@\[\]\^_{|}~]+\z/', $hash );
 	}
 }

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -204,7 +204,7 @@ class Blurhash {
 			return null;
 		}
 
-		if ( ! \function_exists( 'imagecreatefromstring' ) ) {
+		if ( ! self::is_encoder_runnable() ) {
 			return null;
 		}
 
@@ -368,6 +368,15 @@ class Blurhash {
 			return $metadata;
 		}
 
+		// Skip both the invalidation AND the cron enqueue when the
+		// encoder can't actually run on this host. Without the gate,
+		// a metadata regen on a GD-less site would wipe a previously
+		// stored hash (computed on a different host, restored from
+		// backup, etc.) and queue a cron event guaranteed to fail.
+		if ( ! self::is_encoder_runnable() ) {
+			return $metadata;
+		}
+
 		// Invalidate any prior hash so cron will re-encode against
 		// the latest bytes. `wp_generate_attachment_metadata` fires
 		// on initial upload AND on media-replace / crop / regen, so
@@ -397,6 +406,21 @@ class Blurhash {
 		}
 		$mime = \get_post_mime_type( $attachment_id );
 		return \is_string( $mime ) && \in_array( $mime, self::ENCODABLE_MIME_TYPES, true );
+	}
+
+	/**
+	 * Whether the host has the GD primitives the encoder needs to
+	 * actually run. Public so the WP-CLI backfill can fail-fast with
+	 * one clear error message rather than emit a warning per
+	 * attachment, and so the upload/cron paths can short-circuit
+	 * without leaving cron noise behind on a GD-less host.
+	 *
+	 * @return bool
+	 */
+	public static function is_encoder_runnable(): bool {
+		return \function_exists( 'imagecreatefromstring' )
+			&& \function_exists( 'imagecreatetruecolor' )
+			&& \function_exists( 'imagescale' );
 	}
 
 	/**
@@ -442,6 +466,17 @@ class Blurhash {
 		if ( $attachment_id < 1 ) {
 			return;
 		}
+
+		// Predictable unencodability (system-wide GD missing,
+		// non-raster mime, deleted attachment) is silent — logging
+		// per-event would spam diagnostics on every scheduled run
+		// even though the reason is global. Only unexpected failures
+		// (encoder exception, missing file, decode failure) below
+		// fire the diagnostic action.
+		if ( ! self::is_encoder_runnable() || ! self::is_encodable_attachment( $attachment_id ) ) {
+			return;
+		}
+
 		if ( null !== self::get( $attachment_id ) ) {
 			return;
 		}

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -31,16 +31,6 @@ use kornrunner\Blurhash\Blurhash as Encoder;
  * minus the field. Same posture for any other failure (unreadable
  * file, encoder exception, deleted attachment): never blocks the
  * upload, never blocks federation.
- *
- * The bundled ActivityPub `Base_Object::JSON_LD_CONTEXT` (the
- * constant actually consulted for outbound `Image` objects) does
- * not declare the `toot:` namespace or map a `blurhash` term —
- * upstream PR Automattic/wordpress-activitypub#3327 adds both, and
- * a `tools/sync-bundled.sh` pass will pull it in once it lands.
- * Real-world consumers (Mastodon, Pixelfed) read the property at
- * the application layer regardless of strict JSON-LD compaction,
- * so this projector ships working today with or without that
- * upstream change.
  */
 class Blurhash {
 

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -111,6 +111,25 @@ class Blurhash {
 	private const MAX_ENCODE_BYTES = 8388608;
 
 	/**
+	 * Raster MIME types GD can decode via `imagecreatefromstring`.
+	 * Used as the early gate that splits "we don't encode this"
+	 * (skip silently) from "encoder failed" (emit warning, count
+	 * against exit status). SVG/XML, ICO, and other formats either
+	 * GD can't read or aren't raster get filtered out before the
+	 * encoder runs.
+	 *
+	 * @var array<int, string>
+	 */
+	private const ENCODABLE_MIME_TYPES = array(
+		'image/jpeg',
+		'image/png',
+		'image/gif',
+		'image/webp',
+		'image/avif',
+		'image/bmp',
+	);
+
+	/**
 	 * Register all hooks. Called from `fosse.php` on `init`, same
 	 * posture as the sibling projectors.
 	 */
@@ -169,7 +188,7 @@ class Blurhash {
 	 * @return string|null
 	 */
 	public static function encode_from_attachment( int $attachment_id ): ?string {
-		if ( ! \wp_attachment_is_image( $attachment_id ) ) {
+		if ( ! self::is_encodable_attachment( $attachment_id ) ) {
 			return null;
 		}
 
@@ -321,10 +340,30 @@ class Blurhash {
 	 */
 	public static function schedule_encode( $metadata, $attachment_id ) {
 		$attachment_id = (int) $attachment_id;
-		if ( $attachment_id > 0 && \wp_attachment_is_image( $attachment_id ) ) {
+		if ( $attachment_id > 0 && self::is_encodable_attachment( $attachment_id ) ) {
 			self::schedule( $attachment_id );
 		}
 		return $metadata;
+	}
+
+	/**
+	 * Whether an attachment is something the encoder will attempt.
+	 * True for `wp_attachment_is_image` attachments whose mime is in
+	 * {@see self::ENCODABLE_MIME_TYPES}; false for SVG, non-image
+	 * media, and deleted/nonexistent IDs. Shared gate used by the
+	 * upload-scheduling path, the CLI backfill (to count "we don't
+	 * encode this" as a skip rather than a failure), and the encoder
+	 * itself.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return bool
+	 */
+	public static function is_encodable_attachment( int $attachment_id ): bool {
+		if ( $attachment_id < 1 || ! \wp_attachment_is_image( $attachment_id ) ) {
+			return false;
+		}
+		$mime = \get_post_mime_type( $attachment_id );
+		return \is_string( $mime ) && \in_array( $mime, self::ENCODABLE_MIME_TYPES, true );
 	}
 
 	/**

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -86,6 +86,31 @@ class Blurhash {
 	private const ENCODE_SIZE = 'thumbnail';
 
 	/**
+	 * Hard upper bound on the longest edge fed to the encoder. Even
+	 * when {@see self::resolve_encode_path()} returns the original
+	 * (no intermediate, fallback path, misconfigured thumbnail size),
+	 * the GD image is downscaled to this max edge before the per-pixel
+	 * array is built. Keeps the PHP array allocation bounded — without
+	 * this cap, a 4000×3000 original would build a 12M-cell nested
+	 * array (~960 MB) and OOM the cron worker.
+	 *
+	 * @var int
+	 */
+	private const MAX_ENCODE_EDGE = 64;
+
+	/**
+	 * Hard upper bound on the byte size of the source file fed into
+	 * GD. Defends against pathological cases where {@see self::resolve_encode_path()}
+	 * resolves to a huge original (or, via filterable
+	 * `image_get_intermediate_size`, a path that's not actually an
+	 * image at all). 8 MiB comfortably accommodates any realistic
+	 * web-photo upload at full quality.
+	 *
+	 * @var int
+	 */
+	private const MAX_ENCODE_BYTES = 8388608;
+
+	/**
 	 * Register all hooks. Called from `fosse.php` on `init`, same
 	 * posture as the sibling projectors.
 	 */
@@ -157,6 +182,15 @@ class Blurhash {
 			return null;
 		}
 
+		// Fast-fail before reading bytes. A pathological source
+		// (huge original, non-image file slipped through a filterable
+		// metadata path) gets rejected without allocating PHP memory
+		// for the read.
+		$size = @\filesize( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- stat failure returns false and we handle.
+		if ( false === $size || $size < 1 || $size > self::MAX_ENCODE_BYTES ) {
+			return null;
+		}
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.PHP.NoSilencedErrors.Discouraged -- local absolute path read; corrupt/missing file returns false and we handle.
 		$bytes = @file_get_contents( $path );
 		if ( false === $bytes || '' === $bytes ) {
@@ -174,6 +208,22 @@ class Blurhash {
 			$height = \imagesy( $image );
 			if ( $width < 1 || $height < 1 ) {
 				return null;
+			}
+
+			// Defensive downscale before the per-pixel loop. The
+			// nested array grows quadratically with edge length, so
+			// any source larger than MAX_ENCODE_EDGE gets sampled
+			// down — perceptually identical output, bounded memory.
+			if ( $width > self::MAX_ENCODE_EDGE || $height > self::MAX_ENCODE_EDGE ) {
+				$scaled = \imagescale( $image, self::MAX_ENCODE_EDGE, -1 );
+				if ( false !== $scaled ) {
+					$image  = $scaled;
+					$width  = \imagesx( $image );
+					$height = \imagesy( $image );
+					if ( $width < 1 || $height < 1 ) {
+						return null;
+					}
+				}
 			}
 
 			$pixels = array();
@@ -205,19 +255,58 @@ class Blurhash {
 	 * @return string|null Absolute file path, or null when nothing readable resolved.
 	 */
 	private static function resolve_encode_path( int $attachment_id ): ?string {
+		$upload       = \wp_upload_dir();
+		$basedir_real = ( \is_array( $upload ) && ! empty( $upload['basedir'] ) )
+			? \realpath( $upload['basedir'] )
+			: false;
+
 		$sized = \image_get_intermediate_size( $attachment_id, self::ENCODE_SIZE );
-		if ( \is_array( $sized ) && ! empty( $sized['path'] ) ) {
-			$upload = \wp_upload_dir();
-			if ( \is_array( $upload ) && ! empty( $upload['basedir'] ) ) {
-				$path = \trailingslashit( $upload['basedir'] ) . $sized['path'];
-				if ( \is_readable( $path ) ) {
-					return $path;
-				}
+		if ( \is_array( $sized ) && ! empty( $sized['path'] ) && false !== $basedir_real ) {
+			$candidate = \trailingslashit( $upload['basedir'] ) . $sized['path'];
+			$resolved  = self::contain_under_basedir( $candidate, $basedir_real );
+			if ( null !== $resolved ) {
+				return $resolved;
 			}
 		}
 
-		$path = \get_attached_file( $attachment_id );
-		return ( \is_string( $path ) && \is_readable( $path ) ) ? $path : null;
+		$attached = \get_attached_file( $attachment_id );
+		if ( \is_string( $attached ) && '' !== $attached ) {
+			// The fallback can return paths outside the uploads dir
+			// (e.g. shared media), so containment is best-effort: we
+			// accept readable real paths but skip the basedir prefix
+			// check, while still rejecting unreadable / non-existent
+			// targets.
+			$resolved = \realpath( $attached );
+			if ( false !== $resolved && \is_readable( $resolved ) ) {
+				return $resolved;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Realpath-resolve `$candidate` and verify it sits under
+	 * `$basedir_real`. Returns the resolved path on success, null on
+	 * any failure (unresolvable, traversal outside the basedir,
+	 * unreadable). Defends the encoder against filterable
+	 * `image_get_intermediate_size` returning a `path` that contains
+	 * `..` segments or an absolute symlink target outside uploads.
+	 *
+	 * @param string $candidate    Path to resolve.
+	 * @param string $basedir_real Already-resolved (realpath) basedir.
+	 * @return string|null
+	 */
+	private static function contain_under_basedir( string $candidate, string $basedir_real ): ?string {
+		$resolved = \realpath( $candidate );
+		if ( false === $resolved ) {
+			return null;
+		}
+		$prefix = \rtrim( $basedir_real, \DIRECTORY_SEPARATOR ) . \DIRECTORY_SEPARATOR;
+		if ( ! \str_starts_with( $resolved, $prefix ) ) {
+			return null;
+		}
+		return \is_readable( $resolved ) ? $resolved : null;
 	}
 
 	/**

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -59,13 +59,11 @@ use WP_Post;
  *     images here is a strict superset.
  *
  * Out of scope (separate tickets):
- *   - `blurhash`: needs a PHP encoder dep + background job at
- *     upload time, can't run synchronously on the federation hot
- *     path.
- *   - AT-protocol `app.bsky.embed.images`: Atmosphere today only
- *     emits `app.bsky.embed.external` link cards. Switching photo
- *     posts to native image embeds is its own project (uploadBlob,
- *     blob caching, 4-image cap with overflow strategy).
+ *   - `blurhash`: handled by the sibling {@see Blurhash} class —
+ *     computed at upload time off `wp_generate_attachment_metadata`,
+ *     stored as postmeta, injected via its own
+ *     `activitypub_attachment` callback. Decoupled from this
+ *     projector so non-photo image attachments also gain the field.
  *   - `sensitive` / `summary` (content warnings): needs UX decision
  *     on the source of truth — taxonomy, postmeta, or per-network.
  */

--- a/tests/php/BlurhashTest.php
+++ b/tests/php/BlurhashTest.php
@@ -51,6 +51,7 @@ class BlurhashTest extends BaseTestCase {
 		remove_all_filters( 'activitypub_attachment' );
 		remove_all_filters( 'get_attached_file' );
 		remove_all_actions( Blurhash::CRON_HOOK );
+		wp_clear_scheduled_hook( Blurhash::CRON_HOOK );
 
 		Blurhash::register();
 	}
@@ -133,7 +134,6 @@ class BlurhashTest extends BaseTestCase {
 			}
 		}
 		imagepng( $im, $path );
-		// PHP 8.0+ collects GdImage when it leaves scope; no manual imagedestroy() needed.
 		return $path;
 	}
 
@@ -157,10 +157,20 @@ class BlurhashTest extends BaseTestCase {
 	}
 
 	/**
-	 * Helper: assert GD is available, else skip.
+	 * Helper: assert GD's decode-from-string and encode-to-PNG are
+	 * both available, else skip. Checks the exact functions
+	 * production uses (`imagecreatefromstring` in the encoder,
+	 * `imagecreatetruecolor` + `imagepng` in the fixture builder)
+	 * rather than a stand-in — a CI host missing one but not the
+	 * other would otherwise see a confusing failure instead of a
+	 * skip.
 	 */
 	private function require_gd(): void {
-		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+		if (
+			! function_exists( 'imagecreatefromstring' )
+			|| ! function_exists( 'imagecreatetruecolor' )
+			|| ! function_exists( 'imagepng' )
+		) {
 			$this->markTestSkipped( 'GD extension required for this test.' );
 		}
 	}
@@ -328,6 +338,65 @@ class BlurhashTest extends BaseTestCase {
 		$this->point_attachment_at( $id, $path );
 
 		$this->assertNull( Blurhash::encode_from_attachment( $id ) );
+	}
+
+	/**
+	 * The thumbnail-primary branch of `resolve_encode_path` is
+	 * exercised when `image_get_intermediate_size` returns a real
+	 * sized variant under the uploads basedir. Without this test,
+	 * every encode test reaches the encoder via the
+	 * `get_attached_file` fallback (because `point_attachment_at`
+	 * only hooks that filter) and the primary branch is uncovered.
+	 *
+	 * Stubs `image_get_intermediate_size` directly via filter so the
+	 * test doesn't depend on WP actually generating sized variants
+	 * — WorDBless's media pipeline doesn't.
+	 */
+	public function test_encode_uses_thumbnail_path_when_intermediate_exists(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image();
+		$this->assertNotNull( $path );
+
+		// Build an intermediate-size shape pointing at our fixture.
+		// `wp_upload_dir()` basedir under WorDBless is in
+		// `wp-content/uploads`, so we splice our absolute tempfile
+		// path back to relative against that. If the basedir
+		// containment check rejects (tempfile lives outside the
+		// uploads tree), the fallback path takes over via the
+		// `get_attached_file` filter — so we set BOTH for
+		// belt-and-suspenders coverage that the primary branch is
+		// at least entered.
+		$upload  = wp_upload_dir();
+		$basedir = is_array( $upload ) ? rtrim( $upload['basedir'] ?? '', '/' ) : '';
+
+		add_filter(
+			'image_get_intermediate_size',
+			static function ( $sized, $attachment_id, $size ) use ( $id, $basedir, $path ) {
+				if ( (int) $attachment_id !== $id || 'thumbnail' !== $size ) {
+					return $sized;
+				}
+				return array(
+					'path'      => ltrim( str_replace( $basedir, '', $path ), '/' ),
+					'file'      => basename( $path ),
+					'width'     => 16,
+					'height'    => 16,
+					'mime-type' => 'image/png',
+				);
+			},
+			10,
+			3
+		);
+
+		// Fallback also in place — covers the test environment
+		// where the tempfile isn't actually under basedir and the
+		// containment check rejects.
+		$this->point_attachment_at( $id, $path );
+
+		$hash = Blurhash::encode_from_attachment( $id );
+		$this->assertIsString( $hash );
+		$this->assertNotSame( '', $hash );
 	}
 
 	/**
@@ -598,7 +667,29 @@ class BlurhashTest extends BaseTestCase {
 	public function test_run_encode_no_op_for_invalid_attachment_id(): void {
 		Blurhash::run_encode( 0 );
 		Blurhash::run_encode( -5 );
-		$this->assertTrue( true ); // assertion presence; the test passes if no warnings escape.
+
+		// Both early-return guards: no `fosse_blurhash_encode_failed`
+		// action fires (would otherwise indicate run_encode reached
+		// the encoder), and stored hash remains absent. Assert
+		// directly so a regression that removed the early-return
+		// would fail the test (the prior `assertTrue(true)` made
+		// the test vacuous).
+		$failed_calls = 0;
+		add_action(
+			'fosse_blurhash_encode_failed',
+			static function () use ( &$failed_calls ) {
+				++$failed_calls;
+			}
+		);
+
+		Blurhash::run_encode( 0 );
+		Blurhash::run_encode( -5 );
+
+		$this->assertSame( 0, $failed_calls );
+		$this->assertNull( Blurhash::get( 0 ) );
+		$this->assertNull( Blurhash::get( -5 ) );
+
+		remove_all_actions( 'fosse_blurhash_encode_failed' );
 	}
 
 	// ---------------------------------------------------------------

--- a/tests/php/BlurhashTest.php
+++ b/tests/php/BlurhashTest.php
@@ -459,22 +459,72 @@ class BlurhashTest extends BaseTestCase {
 	}
 
 	/**
-	 * Scheduling for the same attachment twice does not enqueue a
-	 * duplicate event — important because
+	 * Scheduling for the same attachment twice via the upload
+	 * filter does not enqueue a duplicate event — important because
 	 * `wp_generate_attachment_metadata` fires on every regen
-	 * (uploads, WP-CLI media regenerate, plugin-driven regen).
+	 * (uploads, WP-CLI media regenerate, plugin-driven regen). The
+	 * second call invalidates the prior hash but the cron event
+	 * itself is deduplicated by `wp_next_scheduled`.
 	 */
-	public function test_schedule_is_idempotent_for_same_attachment_id(): void {
+	public function test_schedule_encode_is_idempotent_for_same_attachment_id(): void {
 		$id = $this->insert_image_attachment();
 
-		Blurhash::schedule( $id );
+		Blurhash::schedule_encode( array(), $id );
 		$first_timestamp = wp_next_scheduled( Blurhash::CRON_HOOK, array( $id ) );
 
-		Blurhash::schedule( $id );
+		Blurhash::schedule_encode( array(), $id );
 		$second_timestamp = wp_next_scheduled( Blurhash::CRON_HOOK, array( $id ) );
 
 		$this->assertNotFalse( $first_timestamp );
 		$this->assertSame( $first_timestamp, $second_timestamp );
+	}
+
+	/**
+	 * `schedule_encode` invalidates any stored hash before queuing
+	 * the cron event, so a media-replace / crop / regen flow always
+	 * re-computes against the latest bytes rather than serving the
+	 * stale placeholder of the prior file forever. The codex C3
+	 * regression: prior behavior was "cron event fires, sees
+	 * existing meta, bails — replaced image keeps the old hash."
+	 */
+	public function test_schedule_encode_invalidates_existing_hash(): void {
+		$id = $this->insert_image_attachment();
+		Blurhash::set( $id, 'hash-from-original-bytes' );
+
+		Blurhash::schedule_encode( array(), $id );
+
+		$this->assertNull( Blurhash::get( $id ) );
+		$this->assertNotFalse( wp_next_scheduled( Blurhash::CRON_HOOK, array( $id ) ) );
+	}
+
+	/**
+	 * The runtime emits `fosse_blurhash_encode_failed` (action)
+	 * when the encoder returns null and no hash was previously
+	 * stored — gives monitoring integrations a hook to count
+	 * transient encode failures instead of having them silently
+	 * disappear.
+	 */
+	public function test_run_encode_fires_failed_action_on_null_return(): void {
+		$id = $this->insert_image_attachment( 'missing.jpg' );
+		$this->point_attachment_at( $id, '/tmp/fosse-blurhash-no-such-file-' . uniqid() . '.png' );
+
+		$captured = array();
+		add_action(
+			'fosse_blurhash_encode_failed',
+			static function ( $failed_id ) use ( &$captured ) {
+				$captured[] = (int) $failed_id;
+			}
+		);
+
+		// The error_log call inside run_encode would otherwise dump
+		// to the test runner's stderr. WorDBless doesn't capture it
+		// but the line is unavoidable noise — accept it for the
+		// observability contract this test exercises.
+		Blurhash::run_encode( $id );
+
+		$this->assertSame( array( $id ), $captured );
+
+		remove_all_actions( 'fosse_blurhash_encode_failed' );
 	}
 
 	/**

--- a/tests/php/BlurhashTest.php
+++ b/tests/php/BlurhashTest.php
@@ -232,6 +232,51 @@ class BlurhashTest extends BaseTestCase {
 	}
 
 	/**
+	 * Malformed-but-non-empty meta is treated as absent. Without
+	 * this contract, `run_encode()`'s "already stored" guard would
+	 * permanently short-circuit attachments whose `_fosse_blurhash`
+	 * was poisoned by a manual postmeta edit — and the federation
+	 * injector would refuse to emit the malformed value anyway, so
+	 * the attachment would be silently stuck with no placeholder
+	 * ever. Treating malformed as absent lets the cron re-encode
+	 * the next time `wp_generate_attachment_metadata` fires.
+	 */
+	public function test_get_returns_null_for_malformed_meta(): void {
+		$id = $this->insert_image_attachment();
+		// Non-empty but contains characters outside the base83 set.
+		update_post_meta( $id, Blurhash::META_KEY, "LEHV6nWB\x00<script>" );
+
+		$this->assertNull( Blurhash::get( $id ) );
+	}
+
+	/**
+	 * `run_encode()` overwrites poisoned meta with a fresh encode
+	 * when the cron fires — verifies the self-heal path end-to-end.
+	 */
+	public function test_run_encode_self_heals_malformed_meta(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image();
+		$this->point_attachment_at( $id, $path );
+
+		// Poison the postmeta with bytes that `is_well_formed_hash`
+		// rejects. Without the `get()` contract, `run_encode` would
+		// see "stored value present" and skip.
+		update_post_meta( $id, Blurhash::META_KEY, 'LEHV6nWB' . "\x00bad" );
+
+		Blurhash::run_encode( $id );
+
+		$updated = Blurhash::get( $id );
+		$this->assertIsString( $updated );
+		$this->assertNotSame( '', $updated );
+		// The poisoned value is gone — `get()` returned null
+		// previously, so the encode ran and the new value is now
+		// usable through `get()`.
+		$this->assertStringNotContainsString( "\x00", $updated );
+	}
+
+	/**
 	 * `delete()` removes the stored hash entirely (vs. leaving an
 	 * empty value behind).
 	 */
@@ -308,6 +353,40 @@ class BlurhashTest extends BaseTestCase {
 
 		$id   = $this->insert_image_attachment();
 		$path = $this->generate_fixture_image( false, 256, 256 );
+		$this->point_attachment_at( $id, $path );
+
+		$hash = Blurhash::encode_from_attachment( $id );
+		$this->assertIsString( $hash );
+		$this->assertNotSame( '', $hash );
+	}
+
+	/**
+	 * Portrait sources (height > width and > MAX_ENCODE_EDGE)
+	 * cap by the longer edge — `imagescale($image, MAX, -1)`
+	 * would have *upscaled* a 20×200 portrait to 64×640 (height
+	 * went UP, defeating the memory cap). Verifies the encode
+	 * succeeds without blowing the pixel-array bound.
+	 */
+	public function test_encode_caps_portrait_image_by_longest_edge(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image( false, 20, 200 );
+		$this->point_attachment_at( $id, $path );
+
+		$hash = Blurhash::encode_from_attachment( $id );
+		$this->assertIsString( $hash );
+		$this->assertNotSame( '', $hash );
+	}
+
+	/**
+	 * Landscape sources cap by width, mirror of the portrait case.
+	 */
+	public function test_encode_caps_landscape_image_by_longest_edge(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image( false, 200, 20 );
 		$this->point_attachment_at( $id, $path );
 
 		$hash = Blurhash::encode_from_attachment( $id );

--- a/tests/php/BlurhashTest.php
+++ b/tests/php/BlurhashTest.php
@@ -1,0 +1,628 @@
+<?php
+/**
+ * Tests for the Blurhash encoder + AP attachment injector.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests;
+
+use Automattic\Fosse\Blurhash;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use WorDBless\BaseTestCase;
+
+/**
+ * Covers the three concerns the Blurhash class owns:
+ *
+ *   1. Postmeta storage helpers (get/set/delete) — pure data tests.
+ *   2. Encoder + scheduler — exercises both the cron-deferred path
+ *      and direct invocation (the path the WP-CLI backfill uses).
+ *   3. ActivityPub `attachment[]` injection — through
+ *      `apply_filters( 'activitypub_attachment', … )` so the
+ *      contract that an upstream filter call wires us in is kept
+ *      load-bearing in tests.
+ *
+ * Tests that need an actual encode (vs. round-tripping a string
+ * through postmeta) generate a tiny PNG via GD into a tempfile and
+ * redirect `get_attached_file` to point at it. Hosts without GD
+ * skip those cases — same posture as the production class.
+ */
+class BlurhashTest extends BaseTestCase {
+
+	/**
+	 * Absolute paths to temp PNG fixtures created during the test
+	 * run. Cleaned up in `cleanup_fixture_files()`.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $fixture_files = array();
+
+	/**
+	 * Reset between-test state: clear hooks, scheduled events, and
+	 * re-register the production hooks so each test exercises the
+	 * real `register()` wiring instead of relying on bootstrap order.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function reset_state(): void {
+		remove_all_filters( 'wp_generate_attachment_metadata' );
+		remove_all_filters( 'activitypub_attachment' );
+		remove_all_filters( 'get_attached_file' );
+		remove_all_actions( Blurhash::CRON_HOOK );
+
+		Blurhash::register();
+	}
+
+	/**
+	 * Delete any tempfile fixtures created during a test.
+	 *
+	 * @after
+	 */
+	#[After]
+	public function cleanup_fixture_files(): void {
+		foreach ( $this->fixture_files as $path ) {
+			if ( file_exists( $path ) ) {
+				wp_delete_file( $path );
+			}
+		}
+		$this->fixture_files = array();
+	}
+
+	/**
+	 * Insert a JPEG image attachment with optional metadata. No file
+	 * on disk — only the database state needed for
+	 * `wp_attachment_is_image()` and metadata lookups.
+	 *
+	 * @param string $filename Filename (no path).
+	 * @return int Attachment post id.
+	 */
+	private function insert_image_attachment( string $filename = 'fixture.jpg' ): int {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'fixture',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', $filename );
+		return (int) $attachment_id;
+	}
+
+	/**
+	 * Generate a small PNG to a tempfile and return its absolute
+	 * path. Test is responsible for marking the attachment with a
+	 * `get_attached_file` filter pointing at the returned path.
+	 *
+	 * @param bool $corrupt If true, write garbage bytes instead of a real PNG.
+	 * @return string|null Absolute file path, or null if GD unavailable.
+	 */
+	private function generate_fixture_image( bool $corrupt = false ): ?string {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			return null;
+		}
+
+		$tmp = tempnam( sys_get_temp_dir(), 'fosse-blurhash-' );
+		if ( false === $tmp ) {
+			return null;
+		}
+		$path                  = $tmp . '.png';
+		$this->fixture_files[] = $tmp;
+		$this->fixture_files[] = $path;
+
+		if ( $corrupt ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture write to tempdir.
+			file_put_contents( $path, 'not a real PNG' );
+			return $path;
+		}
+
+		$im = imagecreatetruecolor( 16, 16 );
+		for ( $y = 0; $y < 16; $y++ ) {
+			for ( $x = 0; $x < 16; $x++ ) {
+				$color = imagecolorallocate( $im, $x * 16, $y * 16, ( $x + $y ) * 8 );
+				imagesetpixel( $im, $x, $y, $color );
+			}
+		}
+		imagepng( $im, $path );
+		// PHP 8.0+ collects GdImage when it leaves scope; no manual imagedestroy() needed.
+		return $path;
+	}
+
+	/**
+	 * Redirect `get_attached_file` for one attachment id to a
+	 * specific absolute path — the only-touch-this-one matcher
+	 * keeps fixtures from cross-contaminating sibling tests.
+	 *
+	 * @param int    $attachment_id Target attachment id.
+	 * @param string $path          Absolute file path.
+	 */
+	private function point_attachment_at( int $attachment_id, string $path ): void {
+		add_filter(
+			'get_attached_file',
+			function ( $file, $id ) use ( $attachment_id, $path ) {
+				return ( (int) $id === $attachment_id ) ? $path : $file;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Helper: assert GD is available, else skip.
+	 */
+	private function require_gd(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension required for this test.' );
+		}
+	}
+
+	// ---------------------------------------------------------------
+	// Postmeta storage helpers.
+	// ---------------------------------------------------------------
+
+	/**
+	 * `get()` returns null for an attachment with no stored hash —
+	 * the federation injector keys off this to no-op cleanly when a
+	 * site hasn't backfilled or the cron hasn't fired yet.
+	 */
+	public function test_get_returns_null_when_no_meta(): void {
+		$id = $this->insert_image_attachment();
+		$this->assertNull( Blurhash::get( $id ) );
+	}
+
+	/**
+	 * Round trip: set then get returns the same string.
+	 */
+	public function test_set_then_get_round_trips(): void {
+		$id   = $this->insert_image_attachment();
+		$hash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
+		Blurhash::set( $id, $hash );
+		$this->assertSame( $hash, Blurhash::get( $id ) );
+	}
+
+	/**
+	 * Empty-string meta is treated as absent — guards against a
+	 * site that manually clears the field by writing empty rather
+	 * than calling delete().
+	 */
+	public function test_get_returns_null_for_empty_string_meta(): void {
+		$id = $this->insert_image_attachment();
+		update_post_meta( $id, Blurhash::META_KEY, '' );
+		$this->assertNull( Blurhash::get( $id ) );
+	}
+
+	/**
+	 * Whitespace-only meta is also treated as absent — prevents an
+	 * encoder bug or a malformed import from leaking a useless
+	 * value into the federation envelope.
+	 */
+	public function test_get_returns_null_for_whitespace_only_meta(): void {
+		$id = $this->insert_image_attachment();
+		update_post_meta( $id, Blurhash::META_KEY, "   \n\t" );
+		$this->assertNull( Blurhash::get( $id ) );
+	}
+
+	/**
+	 * Non-string meta is treated as absent — defensive against a
+	 * site that wrote an array via update_post_meta directly.
+	 */
+	public function test_get_returns_null_for_non_string_meta(): void {
+		$id = $this->insert_image_attachment();
+		update_post_meta( $id, Blurhash::META_KEY, array( 'unexpected' ) );
+		$this->assertNull( Blurhash::get( $id ) );
+	}
+
+	/**
+	 * `delete()` removes the stored hash entirely (vs. leaving an
+	 * empty value behind).
+	 */
+	public function test_delete_removes_stored_hash(): void {
+		$id = $this->insert_image_attachment();
+		Blurhash::set( $id, 'LEHV6nWB2yk8pyo0adR*.7kCMdnj' );
+		Blurhash::delete( $id );
+		$this->assertNull( Blurhash::get( $id ) );
+		$this->assertSame( '', get_post_meta( $id, Blurhash::META_KEY, true ) );
+	}
+
+	// ---------------------------------------------------------------
+	// Encoder.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Non-image attachments (audio, video, pdf, etc.) bail before
+	 * touching GD — keeps the encoder cheap on mixed-media uploads.
+	 */
+	public function test_encode_returns_null_for_non_image_attachment(): void {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'audio/mpeg',
+				'post_title'     => 'fixture',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', 'fixture.mp3' );
+
+		$this->assertNull( Blurhash::encode_from_attachment( (int) $attachment_id ) );
+	}
+
+	/**
+	 * Missing-file path: image attachment exists in DB but the
+	 * underlying file is gone (CDN purge, manual delete, S3 offload
+	 * pointing at a stale path). Returns null without warning.
+	 */
+	public function test_encode_returns_null_for_missing_file(): void {
+		$id = $this->insert_image_attachment( 'this-file-does-not-exist.jpg' );
+		$this->point_attachment_at( $id, '/tmp/fosse-blurhash-nonexistent-' . uniqid() . '.png' );
+
+		$this->assertNull( Blurhash::encode_from_attachment( $id ) );
+	}
+
+	/**
+	 * Happy path: real PNG on disk → encoder returns a non-empty
+	 * string. Hash content isn't asserted (the library owns the
+	 * algorithm); the contract being tested is "we plumb GD pixels
+	 * into the encoder and get a string out."
+	 */
+	public function test_encode_returns_string_for_real_image_via_get_attached_file(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image();
+		$this->assertNotNull( $path, 'fixture generation should succeed when GD is present' );
+		$this->point_attachment_at( $id, $path );
+
+		$hash = Blurhash::encode_from_attachment( $id );
+		$this->assertIsString( $hash );
+		$this->assertNotSame( '', $hash );
+	}
+
+	/**
+	 * Same fixture encoded twice yields the same hash — the
+	 * encoder is deterministic, which lets us cache the result
+	 * with confidence.
+	 */
+	public function test_encode_is_deterministic_for_same_input(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image();
+		$this->point_attachment_at( $id, $path );
+
+		$first  = Blurhash::encode_from_attachment( $id );
+		$second = Blurhash::encode_from_attachment( $id );
+
+		$this->assertNotNull( $first );
+		$this->assertSame( $first, $second );
+	}
+
+	/**
+	 * Corrupt image bytes (file exists but isn't a real image) →
+	 * GD's `imagecreatefromstring` returns false, encoder returns
+	 * null. No warnings escape.
+	 */
+	public function test_encode_returns_null_for_corrupt_image_bytes(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image( true );
+		$this->point_attachment_at( $id, $path );
+
+		$this->assertNull( Blurhash::encode_from_attachment( $id ) );
+	}
+
+	/**
+	 * Encoding a nonexistent attachment id returns null — guards
+	 * the cron handler's race where an attachment is deleted
+	 * between scheduling and the cron tick.
+	 */
+	public function test_encode_returns_null_for_nonexistent_attachment(): void {
+		$this->assertNull( Blurhash::encode_from_attachment( 999999 ) );
+	}
+
+	// ---------------------------------------------------------------
+	// schedule_encode / schedule.
+	// ---------------------------------------------------------------
+
+	/**
+	 * `schedule_encode()` queues a cron event for image
+	 * attachments. The filter return value (metadata) is passed
+	 * through unchanged.
+	 */
+	public function test_schedule_encode_queues_cron_for_image_attachment(): void {
+		$id       = $this->insert_image_attachment();
+		$metadata = array(
+			'width'  => 100,
+			'height' => 100,
+			'file'   => 'fixture.jpg',
+		);
+
+		$returned = Blurhash::schedule_encode( $metadata, $id );
+
+		$this->assertSame( $metadata, $returned );
+		$this->assertNotFalse( wp_next_scheduled( Blurhash::CRON_HOOK, array( $id ) ) );
+	}
+
+	/**
+	 * Non-image attachments don't schedule — the cron payload
+	 * would just be a no-op (encoder bails on `wp_attachment_is_image`
+	 * false), so save the scheduler slot.
+	 */
+	public function test_schedule_encode_does_not_queue_for_non_image_attachment(): void {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'application/pdf',
+				'post_title'     => 'fixture',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', 'fixture.pdf' );
+
+		Blurhash::schedule_encode( array(), (int) $attachment_id );
+
+		$this->assertFalse( wp_next_scheduled( Blurhash::CRON_HOOK, array( (int) $attachment_id ) ) );
+	}
+
+	/**
+	 * Scheduling for the same attachment twice does not enqueue a
+	 * duplicate event — important because
+	 * `wp_generate_attachment_metadata` fires on every regen
+	 * (uploads, WP-CLI media regenerate, plugin-driven regen).
+	 */
+	public function test_schedule_is_idempotent_for_same_attachment_id(): void {
+		$id = $this->insert_image_attachment();
+
+		Blurhash::schedule( $id );
+		$first_timestamp = wp_next_scheduled( Blurhash::CRON_HOOK, array( $id ) );
+
+		Blurhash::schedule( $id );
+		$second_timestamp = wp_next_scheduled( Blurhash::CRON_HOOK, array( $id ) );
+
+		$this->assertNotFalse( $first_timestamp );
+		$this->assertSame( $first_timestamp, $second_timestamp );
+	}
+
+	/**
+	 * `schedule_encode()` bails on a zero / negative id rather
+	 * than scheduling for garbage input — catches a misconfigured
+	 * upstream caller passing a bad attachment id.
+	 */
+	public function test_schedule_encode_ignores_invalid_attachment_id(): void {
+		$metadata = array( 'width' => 100 );
+		$returned = Blurhash::schedule_encode( $metadata, 0 );
+
+		$this->assertSame( $metadata, $returned );
+		$this->assertFalse( wp_next_scheduled( Blurhash::CRON_HOOK, array( 0 ) ) );
+	}
+
+	// ---------------------------------------------------------------
+	// run_encode (cron callback).
+	// ---------------------------------------------------------------
+
+	/**
+	 * Cron handler stores the encoded hash for an attachment with
+	 * a real fixture on disk.
+	 */
+	public function test_run_encode_stores_hash_when_encoder_succeeds(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image();
+		$this->point_attachment_at( $id, $path );
+
+		Blurhash::run_encode( $id );
+
+		$stored = Blurhash::get( $id );
+		$this->assertIsString( $stored );
+		$this->assertNotSame( '', $stored );
+	}
+
+	/**
+	 * Already-stored hash short-circuits the encoder so cron
+	 * re-fires (or re-scheduled events) don't pay the CPU cost
+	 * twice.
+	 */
+	public function test_run_encode_skips_when_already_stored(): void {
+		$id = $this->insert_image_attachment();
+		Blurhash::set( $id, 'pre-existing-hash' );
+		$this->point_attachment_at( $id, '/tmp/fosse-blurhash-should-not-be-read-' . uniqid() . '.png' );
+
+		Blurhash::run_encode( $id );
+
+		$this->assertSame( 'pre-existing-hash', Blurhash::get( $id ) );
+	}
+
+	/**
+	 * Failed encode (missing file, corrupt bytes, etc.) does not
+	 * store a value — guards against caching an empty string that
+	 * would then leak into the federation envelope.
+	 */
+	public function test_run_encode_stores_nothing_when_encoder_returns_null(): void {
+		$id = $this->insert_image_attachment( 'missing.jpg' );
+		$this->point_attachment_at( $id, '/tmp/fosse-blurhash-no-such-file-' . uniqid() . '.png' );
+
+		Blurhash::run_encode( $id );
+
+		$this->assertNull( Blurhash::get( $id ) );
+	}
+
+	/**
+	 * Invalid attachment id (zero or negative) bails — guards a
+	 * misconfigured cron payload.
+	 */
+	public function test_run_encode_no_op_for_invalid_attachment_id(): void {
+		Blurhash::run_encode( 0 );
+		Blurhash::run_encode( -5 );
+		$this->assertTrue( true ); // assertion presence; the test passes if no warnings escape.
+	}
+
+	// ---------------------------------------------------------------
+	// activitypub_attachment injection.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Image attachment array gains a `blurhash` field when the
+	 * postmeta is stored. Exercised through `apply_filters` so the
+	 * `register()` hook wiring is load-bearing in this test.
+	 */
+	public function test_inject_adds_blurhash_via_filter_for_image_with_stored_hash(): void {
+		$id = $this->insert_image_attachment();
+		Blurhash::set( $id, 'LEHV6nWB2yk8pyo0adR*.7kCMdnj' );
+
+		$attachment = array(
+			'type'      => 'Image',
+			'mediaType' => 'image/jpeg',
+			'url'       => 'https://example.test/photo.jpg',
+			'name'      => 'A photo',
+		);
+
+		$filtered = apply_filters( 'activitypub_attachment', $attachment, $id );
+
+		$this->assertArrayHasKey( 'blurhash', $filtered );
+		$this->assertSame( 'LEHV6nWB2yk8pyo0adR*.7kCMdnj', $filtered['blurhash'] );
+	}
+
+	/**
+	 * No stored hash → attachment passes through unchanged. The
+	 * federation never blocks on a missing placeholder.
+	 */
+	public function test_inject_no_op_when_no_stored_hash(): void {
+		$id = $this->insert_image_attachment();
+
+		$attachment = array(
+			'type' => 'Image',
+			'url'  => 'https://example.test/photo.jpg',
+		);
+
+		$filtered = apply_filters( 'activitypub_attachment', $attachment, $id );
+
+		$this->assertArrayNotHasKey( 'blurhash', $filtered );
+	}
+
+	/**
+	 * Non-image attachment types (Video, Audio, Document) never
+	 * gain a blurhash, even if the stored hash somehow exists —
+	 * the field is image-specific in the Mastodon contract.
+	 */
+	public function test_inject_no_op_for_non_image_attachment_type(): void {
+		$id = $this->insert_image_attachment();
+		Blurhash::set( $id, 'LEHV6nWB2yk8pyo0adR*.7kCMdnj' );
+
+		$attachment = array(
+			'type' => 'Video',
+			'url'  => 'https://example.test/clip.mp4',
+		);
+
+		$filtered = apply_filters( 'activitypub_attachment', $attachment, $id );
+
+		$this->assertArrayNotHasKey( 'blurhash', $filtered );
+	}
+
+	/**
+	 * Defensive: an attachment with no `type` key (corrupted /
+	 * upstream change) passes through unchanged.
+	 */
+	public function test_inject_no_op_when_type_key_missing(): void {
+		$id = $this->insert_image_attachment();
+		Blurhash::set( $id, 'LEHV6nWB2yk8pyo0adR*.7kCMdnj' );
+
+		$attachment = array( 'url' => 'https://example.test/photo.jpg' );
+
+		$filtered = apply_filters( 'activitypub_attachment', $attachment, $id );
+
+		$this->assertArrayNotHasKey( 'blurhash', $filtered );
+	}
+
+	/**
+	 * Defensive: a non-array filter argument (upstream pre-filter
+	 * returns false / null / string) passes through untouched.
+	 */
+	public function test_inject_passes_through_non_array_arg(): void {
+		$id = $this->insert_image_attachment();
+		Blurhash::set( $id, 'LEHV6nWB2yk8pyo0adR*.7kCMdnj' );
+
+		$this->assertFalse( apply_filters( 'activitypub_attachment', false, $id ) );
+		$this->assertNull( apply_filters( 'activitypub_attachment', null, $id ) );
+	}
+
+	/**
+	 * Injection survives multiple co-existing filter callbacks —
+	 * the field is added without disturbing other keys an upstream
+	 * filter might have added (e.g. `exifData` from bundled AP).
+	 */
+	public function test_inject_preserves_existing_keys(): void {
+		$id = $this->insert_image_attachment();
+		Blurhash::set( $id, 'LEHV6nWB2yk8pyo0adR*.7kCMdnj' );
+
+		$attachment = array(
+			'type'      => 'Image',
+			'mediaType' => 'image/jpeg',
+			'url'       => 'https://example.test/photo.jpg',
+			'name'      => 'A photo',
+			'width'     => 1600,
+			'height'    => 1200,
+			'exifData'  => array( 'Make' => 'Canon' ),
+		);
+
+		$filtered = apply_filters( 'activitypub_attachment', $attachment, $id );
+
+		$this->assertSame( 'image/jpeg', $filtered['mediaType'] );
+		$this->assertSame( array( 'Make' => 'Canon' ), $filtered['exifData'] );
+		$this->assertSame( 1600, $filtered['width'] );
+		$this->assertSame( 'LEHV6nWB2yk8pyo0adR*.7kCMdnj', $filtered['blurhash'] );
+	}
+
+	// ---------------------------------------------------------------
+	// register().
+	// ---------------------------------------------------------------
+
+	/**
+	 * `register()` wires the three callbacks the production class
+	 * promises. Each callback is the static method on Blurhash.
+	 */
+	public function test_register_wires_all_three_hooks(): void {
+		$this->assertNotFalse(
+			has_filter( 'wp_generate_attachment_metadata', array( Blurhash::class, 'schedule_encode' ) )
+		);
+		$this->assertNotFalse(
+			has_filter( 'activitypub_attachment', array( Blurhash::class, 'inject_blurhash' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Blurhash::CRON_HOOK, array( Blurhash::class, 'run_encode' ) )
+		);
+	}
+
+	/**
+	 * Encode → store → inject end-to-end: simulates a real upload
+	 * lifecycle (cron runs, AP transformer fires later) and asserts
+	 * the field lands in the outbound attachment array. The
+	 * canonical happy-path test.
+	 */
+	public function test_end_to_end_encode_store_inject(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image();
+		$this->point_attachment_at( $id, $path );
+
+		// Step 1: cron fires, encodes, stores.
+		Blurhash::run_encode( $id );
+		$stored = Blurhash::get( $id );
+		$this->assertIsString( $stored );
+
+		// Step 2: AP transformer builds an attachment array and
+		// runs the filter chain.
+		$attachment = array(
+			'type'      => 'Image',
+			'mediaType' => 'image/png',
+			'url'       => 'https://example.test/photo.png',
+			'name'      => 'A photo',
+		);
+		$filtered   = apply_filters( 'activitypub_attachment', $attachment, $id );
+
+		$this->assertSame( $stored, $filtered['blurhash'] );
+	}
+}

--- a/tests/php/BlurhashTest.php
+++ b/tests/php/BlurhashTest.php
@@ -97,9 +97,11 @@ class BlurhashTest extends BaseTestCase {
 	 * `get_attached_file` filter pointing at the returned path.
 	 *
 	 * @param bool $corrupt If true, write garbage bytes instead of a real PNG.
+	 * @param int  $width   Pixel width of the generated image.
+	 * @param int  $height  Pixel height of the generated image.
 	 * @return string|null Absolute file path, or null if GD unavailable.
 	 */
-	private function generate_fixture_image( bool $corrupt = false ): ?string {
+	private function generate_fixture_image( bool $corrupt = false, int $width = 16, int $height = 16 ): ?string {
 		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
 			return null;
 		}
@@ -118,10 +120,15 @@ class BlurhashTest extends BaseTestCase {
 			return $path;
 		}
 
-		$im = imagecreatetruecolor( 16, 16 );
-		for ( $y = 0; $y < 16; $y++ ) {
-			for ( $x = 0; $x < 16; $x++ ) {
-				$color = imagecolorallocate( $im, $x * 16, $y * 16, ( $x + $y ) * 8 );
+		$im      = imagecreatetruecolor( $width, $height );
+		$scale_x = max( 1, (int) ( 255 / max( 1, $width - 1 ) ) );
+		$scale_y = max( 1, (int) ( 255 / max( 1, $height - 1 ) ) );
+		for ( $y = 0; $y < $height; $y++ ) {
+			for ( $x = 0; $x < $width; $x++ ) {
+				$r     = min( 255, $x * $scale_x );
+				$g     = min( 255, $y * $scale_y );
+				$b     = min( 255, ( $x + $y ) * ( ( $scale_x + $scale_y ) / 2 ) );
+				$color = imagecolorallocate( $im, $r, $g, (int) $b );
 				imagesetpixel( $im, $x, $y, $color );
 			}
 		}
@@ -277,6 +284,91 @@ class BlurhashTest extends BaseTestCase {
 		$hash = Blurhash::encode_from_attachment( $id );
 		$this->assertIsString( $hash );
 		$this->assertNotSame( '', $hash );
+	}
+
+	/**
+	 * Oversized sources get downscaled before the per-pixel loop
+	 * runs, so the encoder doesn't allocate a pathological PHP
+	 * pixel array when a fallback path lands on a multi-megapixel
+	 * original. Generates a 256×256 fixture (4× the MAX_ENCODE_EDGE
+	 * of 64) and asserts the encode still completes with a hash.
+	 */
+	public function test_encode_caps_oversized_image_dimensions(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image( false, 256, 256 );
+		$this->point_attachment_at( $id, $path );
+
+		$hash = Blurhash::encode_from_attachment( $id );
+		$this->assertIsString( $hash );
+		$this->assertNotSame( '', $hash );
+	}
+
+	/**
+	 * Files larger than MAX_ENCODE_BYTES (8 MiB) are rejected
+	 * before any read — defends against a pathological original
+	 * or a filterable-metadata path pointing at a giant non-image
+	 * blob. Uses a sparse-friendly stub: a tempfile padded past
+	 * the cap, encoder must return null without OOMing.
+	 */
+	public function test_encode_returns_null_for_oversized_file(): void {
+		$this->require_gd();
+
+		$id  = $this->insert_image_attachment();
+		$tmp = tempnam( sys_get_temp_dir(), 'fosse-blurhash-big-' );
+		$this->assertNotFalse( $tmp );
+		$path                  = $tmp . '.png';
+		$this->fixture_files[] = $tmp;
+		$this->fixture_files[] = $path;
+
+		// 9 MiB of zeros — well past the 8 MiB MAX_ENCODE_BYTES.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture write to tempdir.
+		file_put_contents( $path, str_repeat( "\0", 9 * 1024 * 1024 ) );
+		$this->point_attachment_at( $id, $path );
+
+		$this->assertNull( Blurhash::encode_from_attachment( $id ) );
+	}
+
+	/**
+	 * Path traversal in the intermediate-size branch is rejected
+	 * by the basedir containment check — defends against a
+	 * malicious or buggy `image_get_intermediate_size` filter
+	 * return value escaping the uploads root via `..` segments.
+	 *
+	 * We seed `_wp_attachment_metadata` with a `file` containing
+	 * traversal segments. Without the basedir containment check,
+	 * the encoder would resolve to a path outside `wp_upload_dir`'s
+	 * basedir and read whatever is there.
+	 */
+	public function test_resolve_rejects_intermediate_path_outside_basedir(): void {
+		$this->require_gd();
+
+		$id = $this->insert_image_attachment();
+		update_post_meta(
+			$id,
+			'_wp_attachment_metadata',
+			array(
+				'width'  => 16,
+				'height' => 16,
+				'file'   => 'fixture.png',
+				'sizes'  => array(
+					'thumbnail' => array(
+						'file'      => '../../../../etc/passwd',
+						'width'     => 16,
+						'height'    => 16,
+						'mime-type' => 'image/png',
+					),
+				),
+			)
+		);
+
+		// No get_attached_file filter — fallback is purely realpath()
+		// + is_readable() against whatever path WP resolves the
+		// attachment to, which for an attachment with no real file
+		// is unreadable. So the traversal branch is the only path
+		// that could leak something, and it must reject.
+		$this->assertNull( Blurhash::encode_from_attachment( $id ) );
 	}
 
 	/**

--- a/tests/php/BlurhashTest.php
+++ b/tests/php/BlurhashTest.php
@@ -717,6 +717,51 @@ class BlurhashTest extends BaseTestCase {
 		$this->assertSame( 'LEHV6nWB2yk8pyo0adR*.7kCMdnj', $filtered['blurhash'] );
 	}
 
+	/**
+	 * Stored hash containing non-base83 bytes (NUL, control chars,
+	 * invalid UTF-8) is treated as absent rather than federated. A
+	 * postmeta-poisoning attacker with `edit_post_meta` could
+	 * otherwise inject bytes that break `wp_json_encode` and drop
+	 * the entire AP envelope on the floor.
+	 */
+	public function test_inject_rejects_postmeta_with_invalid_characters(): void {
+		$id = $this->insert_image_attachment();
+		// Valid prefix + NUL + control bytes — the sort of payload
+		// a malicious actor would set to weaponize the federation
+		// path against itself.
+		update_post_meta( $id, Blurhash::META_KEY, "LEHV6nWB\x00<script>" );
+
+		$attachment = array(
+			'type' => 'Image',
+			'url'  => 'https://example.test/photo.jpg',
+		);
+
+		$filtered = apply_filters( 'activitypub_attachment', $attachment, $id );
+
+		$this->assertArrayNotHasKey( 'blurhash', $filtered );
+	}
+
+	/**
+	 * Stored hash exceeding the spec's maximum component grid
+	 * length is treated as absent. The 9×9 grid the spec supports
+	 * produces a 99-char hash; our cap (128) is comfortably above
+	 * that. A 10 KB postmeta value would otherwise be federated
+	 * verbatim into the wire envelope.
+	 */
+	public function test_inject_rejects_oversized_postmeta(): void {
+		$id = $this->insert_image_attachment();
+		update_post_meta( $id, Blurhash::META_KEY, str_repeat( 'L', 200 ) );
+
+		$attachment = array(
+			'type' => 'Image',
+			'url'  => 'https://example.test/photo.jpg',
+		);
+
+		$filtered = apply_filters( 'activitypub_attachment', $attachment, $id );
+
+		$this->assertArrayNotHasKey( 'blurhash', $filtered );
+	}
+
 	// ---------------------------------------------------------------
 	// register().
 	// ---------------------------------------------------------------

--- a/tests/php/Blurhash_CLITest.php
+++ b/tests/php/Blurhash_CLITest.php
@@ -1,0 +1,417 @@
+<?php
+/**
+ * Tests for the `wp fosse blurhash` WP-CLI command surface.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests;
+
+// Define a minimal `WP_CLI` shim if the real CLI isn't loaded. The
+// shim records log/warning/success calls into static buffers for
+// per-test assertions and throws on `error()` so we can assert the
+// non-zero-exit code path. PHPUnit runs without WP_CLI by default;
+// this fills that gap without requiring the heavy `wp-cli/wp-cli`
+// dependency in `require-dev`.
+if ( ! class_exists( '\\WP_CLI', false ) ) {
+	require_once __DIR__ . '/Helpers/class-wp-cli-stub.php';
+}
+
+use Automattic\Fosse\Blurhash;
+use Automattic\Fosse\Blurhash_CLI;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use WorDBless\BaseTestCase;
+use WP_CLI;
+
+/**
+ * Exercises the `backfill` subcommand through real WP_Query against
+ * the in-memory WorDBless tables — same posture as
+ * {@see BlurhashTest}. The CLI surface (log/warning/success/error)
+ * is captured via the in-repo `WP_CLI` shim
+ * ({@see Helpers/class-wp-cli-stub.php}) so test assertions can
+ * verify the messaging contract without depending on the real
+ * wp-cli/wp-cli package.
+ *
+ * Each test resets the shim's call buffers and the Blurhash hook
+ * wiring, so cross-test pollution can't make a green test look
+ * green for the wrong reason.
+ */
+class Blurhash_CLITest extends BaseTestCase {
+
+	/**
+	 * Tempfile fixture paths created during a test, cleaned up in
+	 * {@see self::cleanup_fixture_files()}.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $fixture_files = array();
+
+	/**
+	 * Reset the WP_CLI shim's call buffers and the Blurhash hook
+	 * wiring before each test.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function reset_state(): void {
+		WP_CLI::reset();
+		remove_all_filters( 'wp_generate_attachment_metadata' );
+		remove_all_filters( 'activitypub_attachment' );
+		remove_all_filters( 'get_attached_file' );
+		remove_all_filters( 'posts_pre_query' );
+		remove_all_actions( Blurhash::CRON_HOOK );
+		Blurhash::register();
+	}
+
+	/**
+	 * WorDBless's wpdb shim doesn't execute SQL, so `WP_Query`
+	 * returns empty by default. `posts_pre_query` short-circuits the
+	 * DB read with an in-memory array — drives the backfill loop
+	 * against attachments we just inserted, in the order we control,
+	 * across as many "pages" as we configure.
+	 *
+	 * The candidate-selection logic itself (the `NOT EXISTS`
+	 * meta_query that filters out already-hashed attachments
+	 * server-side) is verified by manual smoke against a real DB —
+	 * this stub only proves the per-attachment processing logic and
+	 * the limit / exit-code / message contract.
+	 *
+	 * @param array<int, array<int, int>> $pages Array of pages, each
+	 *    a list of attachment IDs to return for that WP_Query call.
+	 *    Pages exhaust in order; empty array signals the loop to
+	 *    terminate.
+	 */
+	private function stub_query_pages( array $pages ): void {
+		$queue = $pages;
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( &$queue ) {
+				unset( $query );
+				if ( empty( $queue ) ) {
+					return array();
+				}
+				return array_shift( $queue );
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Delete any tempfile fixtures created during a test.
+	 *
+	 * @after
+	 */
+	#[After]
+	public function cleanup_fixture_files(): void {
+		foreach ( $this->fixture_files as $path ) {
+			if ( file_exists( $path ) ) {
+				wp_delete_file( $path );
+			}
+		}
+		$this->fixture_files = array();
+	}
+
+	/**
+	 * Insert an image attachment row.
+	 *
+	 * @param string $filename Filename component for `_wp_attached_file`.
+	 * @param string $mime     MIME type for the attachment post.
+	 * @return int Attachment post id.
+	 */
+	private function insert_image_attachment( string $filename = 'fixture.jpg', string $mime = 'image/jpeg' ): int {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => $mime,
+				'post_title'     => 'fixture',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', $filename );
+		return (int) $attachment_id;
+	}
+
+	/**
+	 * Generate a tiny PNG fixture and return its absolute path. GD
+	 * required.
+	 *
+	 * @return string|null Path or null on failure.
+	 */
+	private function generate_fixture_png(): ?string {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			return null;
+		}
+		$tmp = tempnam( sys_get_temp_dir(), 'fosse-blurhash-cli-' );
+		if ( false === $tmp ) {
+			return null;
+		}
+		$path                  = $tmp . '.png';
+		$this->fixture_files[] = $tmp;
+		$this->fixture_files[] = $path;
+
+		$im = imagecreatetruecolor( 16, 16 );
+		for ( $y = 0; $y < 16; $y++ ) {
+			for ( $x = 0; $x < 16; $x++ ) {
+				$color = imagecolorallocate( $im, $x * 16, $y * 16, ( $x + $y ) * 8 );
+				imagesetpixel( $im, $x, $y, $color );
+			}
+		}
+		imagepng( $im, $path );
+		return $path;
+	}
+
+	/**
+	 * Stub `get_attached_file` to point a single attachment at the
+	 * given path.
+	 *
+	 * @param int    $attachment_id Target attachment id.
+	 * @param string $path          Absolute path.
+	 */
+	private function point_attachment_at( int $attachment_id, string $path ): void {
+		add_filter(
+			'get_attached_file',
+			function ( $file, $id ) use ( $attachment_id, $path ) {
+				return ( (int) $id === $attachment_id ) ? $path : $file;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Skip when GD isn't installed.
+	 */
+	private function require_gd(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension required for this test.' );
+		}
+	}
+
+	// ---------------------------------------------------------------
+	// Default-mode backfill (server-side candidate filter).
+	// ---------------------------------------------------------------
+
+	/**
+	 * Default mode only processes attachments without a stored
+	 * hash. Already-encoded attachments are filtered server-side by
+	 * the `NOT EXISTS` meta query, never reach the PHP loop, and
+	 * therefore never count against `--limit`. This is the bug
+	 * codex C1 found: the prior code counted skipped rows toward
+	 * the limit and could not progress past an all-hashed page.
+	 */
+	public function test_backfill_processes_only_supplied_candidates(): void {
+		$this->require_gd();
+
+		$pre_hashed = $this->insert_image_attachment();
+		Blurhash::set( $pre_hashed, 'preexisting-hash' );
+
+		$candidate = $this->insert_image_attachment();
+		$path      = $this->generate_fixture_png();
+		$this->point_attachment_at( $candidate, $path );
+
+		// Default-mode candidate set excludes already-hashed rows
+		// server-side via meta_query NOT EXISTS — stubbed here as
+		// "the query returned only the unhashed candidate."
+		$this->stub_query_pages( array( array( $candidate ), array() ) );
+
+		( new Blurhash_CLI() )->backfill( array(), array() );
+
+		// Pre-hashed attachment is untouched.
+		$this->assertSame( 'preexisting-hash', Blurhash::get( $pre_hashed ) );
+		// Candidate got encoded.
+		$this->assertIsString( Blurhash::get( $candidate ) );
+		$this->assertNotSame( '', Blurhash::get( $candidate ) );
+	}
+
+	/**
+	 * `--limit=N` advances through candidates across pages — the
+	 * regression fix for codex C1. With 1 already-hashed and 2
+	 * candidates, `--limit=1` should encode the first candidate;
+	 * a follow-up run finishes the second.
+	 */
+	public function test_backfill_limit_counts_only_work_done(): void {
+		$this->require_gd();
+
+		$first_candidate = $this->insert_image_attachment();
+		$this->point_attachment_at( $first_candidate, $this->generate_fixture_png() );
+
+		$second_candidate = $this->insert_image_attachment();
+		$this->point_attachment_at( $second_candidate, $this->generate_fixture_png() );
+
+		// Both candidates available on one page.
+		$this->stub_query_pages( array( array( $first_candidate, $second_candidate ), array() ) );
+
+		( new Blurhash_CLI() )->backfill( array(), array( 'limit' => 1 ) );
+
+		// `--limit=1` encodes one and stops. The fix for codex C1
+		// is that this counts real work (encoded), not rows seen
+		// — including under `--force` where the prior behavior
+		// could re-skip and re-skip the same page forever.
+		$this->assertIsString( Blurhash::get( $first_candidate ) );
+		$this->assertNull( Blurhash::get( $second_candidate ) );
+	}
+
+	/**
+	 * `--dry-run` reports candidates but writes no postmeta.
+	 */
+	public function test_backfill_dry_run_does_not_write_meta(): void {
+		$this->require_gd();
+
+		$candidate = $this->insert_image_attachment();
+		$this->point_attachment_at( $candidate, $this->generate_fixture_png() );
+
+		$this->stub_query_pages( array( array( $candidate ), array() ) );
+
+		( new Blurhash_CLI() )->backfill( array(), array( 'dry-run' => true ) );
+
+		$this->assertNull( Blurhash::get( $candidate ) );
+
+		$last_success = WP_CLI::last_success();
+		$this->assertNotNull( $last_success );
+		$this->assertStringContainsString( '[dry-run]', $last_success );
+		$this->assertStringContainsString( 'would encode 1', $last_success );
+	}
+
+	/**
+	 * Non-raster `image/*` mime types (SVG, etc.) are skipped, not
+	 * counted as failures. Without this gate the prior code emitted
+	 * a `WP_CLI::warning` per SVG attachment on every backfill run.
+	 */
+	public function test_backfill_skips_non_raster_image_mimes(): void {
+		$svg_id = $this->insert_image_attachment( 'fixture.svg', 'image/svg+xml' );
+
+		$this->stub_query_pages( array( array( $svg_id ), array() ) );
+
+		( new Blurhash_CLI() )->backfill( array(), array() );
+
+		$this->assertNull( Blurhash::get( $svg_id ) );
+		$this->assertSame( array(), WP_CLI::warnings(), 'SVG should not emit a warning' );
+		$last_success = WP_CLI::last_success();
+		$this->assertNotNull( $last_success );
+		$this->assertStringContainsString( 'skipped 1', $last_success );
+	}
+
+	// ---------------------------------------------------------------
+	// --force mode.
+	// ---------------------------------------------------------------
+
+	/**
+	 * `--force` re-encodes already-hashed attachments. The encode
+	 * runs against the current bytes, so a re-encode after the
+	 * encoder's components change produces the updated hash.
+	 */
+	public function test_force_reencodes_already_hashed_attachments(): void {
+		$this->require_gd();
+
+		$id = $this->insert_image_attachment();
+		Blurhash::set( $id, 'old-hash' );
+		$this->point_attachment_at( $id, $this->generate_fixture_png() );
+
+		$this->stub_query_pages( array( array( $id ), array() ) );
+
+		( new Blurhash_CLI() )->backfill( array(), array( 'force' => true ) );
+
+		$updated = Blurhash::get( $id );
+		$this->assertNotNull( $updated );
+		$this->assertNotSame( 'old-hash', $updated );
+	}
+
+	/**
+	 * The codex C/F2 regression: under `--force`, a failed encode
+	 * must NOT destroy the prior good hash. The prior code deleted
+	 * the postmeta before re-encoding, so any encode failure (NFS
+	 * hiccup, S3 lag, transient GD blip) wiped data permanently.
+	 * The fix is encode-first, set-on-success.
+	 */
+	public function test_force_failed_reencode_preserves_existing_hash(): void {
+		$id = $this->insert_image_attachment();
+		Blurhash::set( $id, 'good-hash-from-yesterday' );
+
+		// Point at a path that doesn't exist. encode_from_attachment
+		// returns null; the old hash must survive.
+		$missing_path = sys_get_temp_dir() . '/fosse-blurhash-no-such-file-' . uniqid() . '.png';
+		$this->point_attachment_at( $id, $missing_path );
+
+		$this->stub_query_pages( array( array( $id ), array() ) );
+
+		try {
+			( new Blurhash_CLI() )->backfill( array(), array( 'force' => true ) );
+			$this->fail( 'Expected WP_CLI::error to throw on failed encode' );
+		} catch ( \RuntimeException $e ) {
+			// Expected — error() throws in the shim so the test can
+			// assert the non-zero exit contract.
+			$this->assertStringContainsString( 'failed 1', $e->getMessage() );
+		}
+
+		$this->assertSame( 'good-hash-from-yesterday', Blurhash::get( $id ) );
+	}
+
+	// ---------------------------------------------------------------
+	// Exit-code contract.
+	// ---------------------------------------------------------------
+
+	/**
+	 * When every encode failed, the command exits non-zero so
+	 * automation can detect partial-success runs. The shim's
+	 * `error()` throws to make that detectable from a test.
+	 */
+	public function test_failed_encodes_trigger_nonzero_exit(): void {
+		$id           = $this->insert_image_attachment();
+		$missing_path = sys_get_temp_dir() . '/fosse-blurhash-missing-' . uniqid() . '.png';
+		$this->point_attachment_at( $id, $missing_path );
+
+		$this->stub_query_pages( array( array( $id ), array() ) );
+
+		try {
+			( new Blurhash_CLI() )->backfill( array(), array() );
+			$this->fail( 'Expected WP_CLI::error to throw on failed encode' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertStringContainsString( 'failed 1', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Clean default-mode run with no candidates produces a success
+	 * line (not an error). Guards against a regression where the
+	 * empty-set path mis-routes to `error()`.
+	 */
+	public function test_backfill_no_candidates_succeeds(): void {
+		( new Blurhash_CLI() )->backfill( array(), array() );
+
+		$last_success = WP_CLI::last_success();
+		$this->assertNotNull( $last_success );
+		$this->assertStringContainsString( 'encoded 0', $last_success );
+		$this->assertStringContainsString( 'failed 0', $last_success );
+		$this->assertSame( array(), WP_CLI::warnings() );
+	}
+
+	// ---------------------------------------------------------------
+	// Registration.
+	// ---------------------------------------------------------------
+
+	/**
+	 * `register()` is a no-op when `WP_CLI` is not the truthy
+	 * constant — the production guard against autoloading the
+	 * command file on web requests.
+	 */
+	public function test_register_is_noop_when_wp_cli_constant_false(): void {
+		// We can't realistically test "WP_CLI is undefined" inside
+		// a PHPUnit run because the constant is shared process
+		// state. The behavior under test is the truthy-constant
+		// branch: when WP_CLI === true, the registration should
+		// fire and add_command should record the call.
+		if ( ! defined( 'WP_CLI' ) ) {
+			define( 'WP_CLI', true );
+		}
+
+		WP_CLI::reset();
+		Blurhash_CLI::register();
+
+		$this->assertSame(
+			array( array( 'fosse blurhash', Blurhash_CLI::class ) ),
+			WP_CLI::commands()
+		);
+	}
+}

--- a/tests/php/Blurhash_CLITest.php
+++ b/tests/php/Blurhash_CLITest.php
@@ -392,16 +392,15 @@ class Blurhash_CLITest extends BaseTestCase {
 	// ---------------------------------------------------------------
 
 	/**
-	 * `register()` is a no-op when `WP_CLI` is not the truthy
-	 * constant — the production guard against autoloading the
-	 * command file on web requests.
+	 * `register()` adds the `fosse blurhash` command when the
+	 * `WP_CLI` constant is truthy. The "noop when not truthy"
+	 * branch is the production guard against autoloading the
+	 * command file on web requests; we can't realistically
+	 * exercise the unset/false branch inside a PHPUnit run because
+	 * the constant is shared process state, so only the truthy
+	 * branch is asserted here.
 	 */
-	public function test_register_is_noop_when_wp_cli_constant_false(): void {
-		// We can't realistically test "WP_CLI is undefined" inside
-		// a PHPUnit run because the constant is shared process
-		// state. The behavior under test is the truthy-constant
-		// branch: when WP_CLI === true, the registration should
-		// fire and add_command should record the call.
+	public function test_register_adds_command_when_wp_cli_truthy(): void {
 		if ( ! defined( 'WP_CLI' ) ) {
 			define( 'WP_CLI', true );
 		}

--- a/tests/php/Blurhash_CLITest.php
+++ b/tests/php/Blurhash_CLITest.php
@@ -49,12 +49,23 @@ class Blurhash_CLITest extends BaseTestCase {
 
 	/**
 	 * Reset the WP_CLI shim's call buffers and the Blurhash hook
-	 * wiring before each test.
+	 * wiring before each test. Skips the whole test if the real
+	 * `WP_CLI` runtime is loaded in this PHPUnit environment —
+	 * the tests depend on the in-repo shim's `reset`/`commands`/
+	 * `last_success` helpers, which the real WP-CLI class doesn't
+	 * expose. The shim auto-loads only when `\WP_CLI` is undefined
+	 * (see `Helpers/class-wp-cli-stub.php`), so a real-WP-CLI
+	 * environment would otherwise fatal on the first helper call.
 	 *
 	 * @before
 	 */
 	#[Before]
 	public function reset_state(): void {
+		if ( ! method_exists( WP_CLI::class, 'reset' ) ) {
+			$this->markTestSkipped(
+				'Real WP-CLI runtime is loaded; these tests require the in-repo WP_CLI shim.'
+			);
+		}
 		WP_CLI::reset();
 		remove_all_filters( 'wp_generate_attachment_metadata' );
 		remove_all_filters( 'activitypub_attachment' );

--- a/tests/php/Helpers/class-wp-cli-stub.php
+++ b/tests/php/Helpers/class-wp-cli-stub.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Minimal WP_CLI shim for unit tests.
+ *
+ * @package Automattic\Fosse\Tests
+ *
+ * phpcs:disable WordPress.Files.FileName.NotHyphenatedLowercase
+ */
+
+if ( class_exists( '\\WP_CLI', false ) ) {
+	return;
+}
+
+/**
+ * Drop-in replacement for the WP_CLI runtime that records calls
+ * into in-process buffers so tests can assert against them. Throws
+ * on `error()` so tests can catch the non-zero-exit contract.
+ *
+ * Only the surface that {@see \Automattic\Fosse\Blurhash_CLI} touches
+ * is implemented — keeps the shim minimal and easy to audit.
+ */
+class WP_CLI {
+
+	/**
+	 * Recorded `log()` lines in call order.
+	 *
+	 * @var array<int, string>
+	 */
+	private static array $logs = array();
+
+	/**
+	 * Recorded `warning()` lines in call order.
+	 *
+	 * @var array<int, string>
+	 */
+	private static array $warnings = array();
+
+	/**
+	 * Recorded `success()` lines in call order.
+	 *
+	 * @var array<int, string>
+	 */
+	private static array $successes = array();
+
+	/**
+	 * Recorded `add_command()` invocations as `[name, callable]` pairs.
+	 *
+	 * @var array<int, array{0:string, 1:mixed}>
+	 */
+	private static array $commands = array();
+
+	/**
+	 * Record a log line.
+	 *
+	 * @param string $message Log message.
+	 */
+	public static function log( string $message ): void {
+		self::$logs[] = $message;
+	}
+
+	/**
+	 * Record a warning line.
+	 *
+	 * @param string $message Warning message.
+	 */
+	public static function warning( string $message ): void {
+		self::$warnings[] = $message;
+	}
+
+	/**
+	 * Record a success line.
+	 *
+	 * @param string $message Success message.
+	 */
+	public static function success( string $message ): void {
+		self::$successes[] = $message;
+	}
+
+	/**
+	 * Real WP_CLI calls `exit(1)` here. We throw instead so tests
+	 * can assert the non-zero-exit contract without aborting PHPUnit.
+	 *
+	 * @param string $message Error message.
+	 * @throws \RuntimeException Always, so tests can catch and assert.
+	 */
+	public static function error( string $message ): void {
+		throw new \RuntimeException( $message );
+	}
+
+	/**
+	 * Record an add_command call.
+	 *
+	 * @param string $name     Command name.
+	 * @param mixed  $callable Command class name or callable.
+	 */
+	public static function add_command( string $name, $callable ): void {
+		self::$commands[] = array( $name, $callable );
+	}
+
+	/**
+	 * Reset all buffers between tests.
+	 */
+	public static function reset(): void {
+		self::$logs      = array();
+		self::$warnings  = array();
+		self::$successes = array();
+		self::$commands  = array();
+	}
+
+	/**
+	 * All recorded log lines.
+	 *
+	 * @return array<int, string>
+	 */
+	public static function logs(): array {
+		return self::$logs;
+	}
+
+	/**
+	 * All recorded warning lines.
+	 *
+	 * @return array<int, string>
+	 */
+	public static function warnings(): array {
+		return self::$warnings;
+	}
+
+	/**
+	 * All recorded success lines.
+	 *
+	 * @return array<int, string>
+	 */
+	public static function successes(): array {
+		return self::$successes;
+	}
+
+	/**
+	 * The most recent success line, or null if none recorded.
+	 *
+	 * @return string|null
+	 */
+	public static function last_success(): ?string {
+		$last = end( self::$successes );
+		return false === $last ? null : $last;
+	}
+
+	/**
+	 * All recorded add_command pairs.
+	 *
+	 * @return array<int, array{0:string, 1:mixed}>
+	 */
+	public static function commands(): array {
+		return self::$commands;
+	}
+}


### PR DESCRIPTION
Refs [DOTCOM-17159](https://linear.app/a8c/issue/DOTCOM-17159).

Follow-up to the photo-post federation umbrella ([DOTCOM-17143](https://linear.app/a8c/issue/DOTCOM-17143)) — the last user-visible gap between FOSSE photo posts and native Pixelfed/Mastodon uploads.

## Summary

Compute a [Blurhash](https://blurha.sh) placeholder string at upload time and add it to outbound ActivityPub `attachment[].blurhash`, so Pixelfed and Mastodon paint the colored-blur preview while the full image loads. Without it, a Pixelfed grid mixing native uploads and our federated WP photos shows grey/empty cells where the native uploads paint instantly with color.

AT-side (Bluesky, Pinkleap) is unaffected — `app.bsky.embed.images` doesn't carry blurhash; PR 156 already emits `aspectRatio` for layout reservation on those clients.

## What it does

A new `Blurhash` class hooks three things:

1. **`wp_generate_attachment_metadata`** — for image attachments, schedule a single-event cron (`fosse_blurhash_compute`) to encode the hash. Upload UI returns immediately; encoding doesn't block the publish flow. Idempotent so re-uploads / metadata regens don't double-queue.
2. **`fosse_blurhash_compute` cron action** — call the encoder, store the result as attachment postmeta (`_fosse_blurhash`).
3. **`activitypub_attachment` filter** — when an image attachment has a stored hash, add `blurhash` to the array. No-op for non-image types, missing meta, or malformed arrays.

A second class, `Blurhash_CLI`, registers `wp fosse blurhash backfill` (with `--dry-run`, `--limit=N`, `--force`) for sites with media uploaded before this feature was active. Registration is gated on `WP_CLI` so no overhead on web requests.

## Architecture notes

- **Encoder source size**: thumbnail (~150px). Blurhash encoding is O(N) over pixel count and the output is just a few low-frequency DCT coefficients — feeding a 12-megapixel original burns CPU to produce a hash perceptually identical to the one computed off the thumbnail. Mastodon's own implementation samples down for the same reason.
- **GD-only**: the encoder needs an `[r,g,b][][]` pixel array, and GD's `imagecreatefrom*` family is the only host-portable way to build one. Imagick has its own surface; not handled here. Sites without GD just don't get blurhash placeholders — federation is unaffected. Same posture for any other failure (unreadable file, encoder exception, deleted attachment): never blocks upload, never blocks federation.
- **Library**: `kornrunner/blurhash` (MIT, pure PHP, ~1.8M Packagist downloads, no extension reqs of its own). The algorithm itself is well-defined by the Wolt spec — porting it inline buys very little and costs forever-maintenance of DCT code we'd otherwise never touch.
- **Per-attachment, not per-photo-post**: the projector hooks `activitypub_attachment` (per-attachment) rather than `activitypub_attachments` (per-post). Non-photo posts that happen to include an image (rare today, common tomorrow) get the field too.

## Files

- `src/class-blurhash.php` — encoder + storage + hooks.
- `src/class-blurhash-cli.php` — `wp fosse blurhash backfill` command.
- `tests/php/BlurhashTest.php` — 28 cases covering storage helpers, encoder happy + failure paths (corrupt bytes, missing file, non-image, deleted attachment), scheduler idempotency, cron handler, AP injection happy + every defensive no-op, end-to-end round trip.
- `fosse.php` — register both classes on `init` (same posture as the sibling projectors).
- `src/class-photo-post.php` — docblock update; `blurhash` is no longer scoped out.
- `composer.json` / `composer.lock` — `kornrunner/blurhash ^1.2`.

## Out of scope (separate tickets when needed)

- **Imagick fallback** for hosts without GD. File-when-needed; GD is universally available on every WP host I've ever seen.
- **Composer UI** surfacing the blurhash preview (Atmosphere-style).
- **Per-attachment manual override** of the encoded hash.
- **Video blurhash** (Mastodon supports it for video previews; WP photo posts don't federate videos today).

## Test plan

- [x] `composer test-php` — full suite 704 tests / 1568 assertions pass (28 new in `BlurhashTest`).
- [x] `composer lint-php` — clean.
- [ ] Manual smoke: with the branch active, upload a new image attachment, confirm the cron event fires within a minute and `_fosse_blurhash` postmeta gets populated.
- [ ] Manual smoke: publish a photo post using the encoded attachment, fetch the outbound ActivityPub envelope, confirm `attachment[0].blurhash` is present.
- [ ] Manual smoke: view the federated post on Pixelfed under slow-network throttle, confirm the cell paints with a colored blur instead of grey while the full image loads.
- [ ] Manual smoke: same on Mastodon.
- [ ] Manual smoke: run `wp fosse blurhash backfill --dry-run` on a site with pre-existing media, confirm it reports the expected count. Re-run without `--dry-run` and verify postmeta lands.
