### PR TITLE
Admin: polish federation identity summary

### DIFF
--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -708,7 +708,8 @@ class Onboarding_Wizard {
 	 * Returns an HTML string. Single-identity branches inline the handle
 	 * after a space; the multi-identity `actor_blog` branch separates
 	 * label and handle with `<br />` and joins lines with `<br />`. The
-	 * consumer escapes via `wp_kses` with `code`, `br`, and `wbr` allowed.
+	 * consumer escapes via `wp_kses` with `code` (allowing the `class`
+	 * attribute that the token markup carries), `br`, and `wbr` allowed.
 	 *
 	 * @param string $mode        Actor mode value.
 	 * @param string $user_handle Normalized `@user@host` for the current user, or empty.
@@ -752,21 +753,37 @@ class Onboarding_Wizard {
 	/**
 	 * Format a completion-summary identity token using shared admin token styles.
 	 *
+	 * The `host` and `handle` types both produce a domain-shaped token, but the
+	 * `host` variant omits the leading `@` so a bare site host (e.g.
+	 * `example.org`) isn't mistaken for a Fediverse address with no local-part.
+	 *
 	 * @param string $value Raw handle or fediverse address.
-	 * @param string $type  Token type: `ap-address`, `handle`, or `host`.
+	 * @param string $type  Token type: `ap-address`, `handle`, or `host`. Unknown
+	 *                      types fall back to the `handle` shape.
 	 * @return string Escaped HTML safe for `wp_kses`.
 	 */
 	private static function format_complete_identity_token( string $value, string $type ): string {
 		$classes = array( 'fosse-token', 'fosse-admin-token' );
 
-		if ( 'ap-address' === $type ) {
-			$classes[] = 'fosse-token--ap-address';
-			$classes[] = 'fosse-admin-token--ap-address';
-			$content   = Status_Formatter::ap_address( $value );
-		} else {
-			$classes[] = 'fosse-token--handle';
-			$classes[] = 'fosse-admin-token--handle';
-			$content   = ( 'host' === $type ? '' : '@' ) . Status_Formatter::handle( ltrim( $value, '@' ) );
+		switch ( $type ) {
+			case 'ap-address':
+				$classes[] = 'fosse-token--ap-address';
+				$classes[] = 'fosse-admin-token--ap-address';
+				$content   = Status_Formatter::ap_address( $value );
+				break;
+
+			case 'host':
+				$classes[] = 'fosse-token--host';
+				$classes[] = 'fosse-admin-token--host';
+				$content   = Status_Formatter::handle( ltrim( $value, '@' ) );
+				break;
+
+			case 'handle':
+			default:
+				$classes[] = 'fosse-token--handle';
+				$classes[] = 'fosse-admin-token--handle';
+				$content   = '@' . Status_Formatter::handle( ltrim( $value, '@' ) );
+				break;
 		}
 
 		return sprintf(
@@ -1682,17 +1699,26 @@ class Onboarding_Wizard {
 		);
 
 		if ( $bluesky['connected'] ) {
-			$bluesky_summary = $bluesky['handle']
-				? sprintf(
-					/* translators: %s: linked Bluesky handle. */
-					__( 'Connected as %s', 'fosse' ),
-					sprintf(
-						'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
-						esc_url( 'https://bsky.app/profile/' . rawurlencode( ltrim( $bluesky['handle'], '@' ) ) ),
-						self::format_complete_identity_token( (string) $bluesky['handle'], 'handle' )
-					)
-				)
-				: __( 'Connected', 'fosse' );
+			$bluesky_handle     = is_string( $bluesky['handle'] ?? null ) ? $bluesky['handle'] : '';
+			$bluesky_normalized = ltrim( $bluesky_handle, '@' );
+
+			if ( '' !== $bluesky_normalized ) {
+				$bluesky_link = sprintf(
+					'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+					esc_url( 'https://bsky.app/profile/' . rawurlencode( $bluesky_normalized ) ),
+					self::format_complete_identity_token( $bluesky_handle, 'handle' )
+				);
+
+				/* translators: %s: linked Bluesky handle. */
+				$bluesky_template = __( 'Connected as %s', 'fosse' );
+
+				// `str_replace` instead of `sprintf` so a translation that
+				// adds, drops, or renumbers placeholders cannot crash the
+				// completion step on PHP 8.
+				$bluesky_summary = str_replace( '%s', $bluesky_link, $bluesky_template );
+			} else {
+				$bluesky_summary = __( 'Connected', 'fosse' );
+			}
 		} elseif ( ! $bluesky['available'] && $includes_bluesky ) {
 			$bluesky_summary = __( 'Unavailable', 'fosse' );
 		} else {

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -1709,28 +1709,11 @@ class Onboarding_Wizard {
 					self::format_complete_identity_token( $bluesky_handle, 'handle' )
 				);
 
-				/* translators: %s: linked Bluesky handle. */
-				$bluesky_template = __( 'Connected as %s', 'fosse' );
-
-				// Replace the first `%s` or `%N$s` placeholder with the link.
-				// Using a regex (rather than `sprintf`) tolerates translations
-				// that use numbered placeholders (`%1$s`) and prevents a
-				// translation that drops, repeats, or otherwise malforms the
-				// placeholder from crashing the completion step on PHP 8.
-				// `preg_replace_callback` avoids backreference interpretation
-				// in the replacement value.
-				$bluesky_summary = preg_replace_callback(
-					'/%(?:\d+\$)?s/',
-					static function () use ( $bluesky_link ) {
-						return $bluesky_link;
-					},
-					$bluesky_template,
-					1
+				$bluesky_summary = sprintf(
+					/* translators: %s: linked Bluesky handle. */
+					__( 'Connected as %s', 'fosse' ),
+					$bluesky_link
 				);
-
-				if ( ! is_string( $bluesky_summary ) ) {
-					$bluesky_summary = __( 'Connected', 'fosse' );
-				}
 			} else {
 				$bluesky_summary = __( 'Connected', 'fosse' );
 			}

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -1712,10 +1712,25 @@ class Onboarding_Wizard {
 				/* translators: %s: linked Bluesky handle. */
 				$bluesky_template = __( 'Connected as %s', 'fosse' );
 
-				// `str_replace` instead of `sprintf` so a translation that
-				// adds, drops, or renumbers placeholders cannot crash the
-				// completion step on PHP 8.
-				$bluesky_summary = str_replace( '%s', $bluesky_link, $bluesky_template );
+				// Replace the first `%s` or `%N$s` placeholder with the link.
+				// Using a regex (rather than `sprintf`) tolerates translations
+				// that use numbered placeholders (`%1$s`) and prevents a
+				// translation that drops, repeats, or otherwise malforms the
+				// placeholder from crashing the completion step on PHP 8.
+				// `preg_replace_callback` avoids backreference interpretation
+				// in the replacement value.
+				$bluesky_summary = preg_replace_callback(
+					'/%(?:\d+\$)?s/',
+					static function () use ( $bluesky_link ) {
+						return $bluesky_link;
+					},
+					$bluesky_template,
+					1
+				);
+
+				if ( ! is_string( $bluesky_summary ) ) {
+					$bluesky_summary = __( 'Connected', 'fosse' );
+				}
 			} else {
 				$bluesky_summary = __( 'Connected', 'fosse' );
 			}

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -708,7 +708,7 @@ class Onboarding_Wizard {
 	 * Returns an HTML string. Single-identity branches inline the handle
 	 * after a space; the multi-identity `actor_blog` branch separates
 	 * label and handle with `<br />` and joins lines with `<br />`. The
-	 * consumer escapes via `wp_kses` with `code` and `br` allowed.
+	 * consumer escapes via `wp_kses` with `code`, `br`, and `wbr` allowed.
 	 *
 	 * @param string $mode        Actor mode value.
 	 * @param string $user_handle Normalized `@user@host` for the current user, or empty.
@@ -720,33 +720,60 @@ class Onboarding_Wizard {
 			case 'actor':
 				if ( '' !== $user_handle ) {
 					return esc_html__( 'As you', 'fosse' )
-						. ' <code>' . esc_html( $user_handle ) . '</code>';
+						. ' ' . self::format_complete_identity_token( $user_handle, 'ap-address' );
 				}
 				return esc_html__( 'As you (author profiles)', 'fosse' );
 
 			case 'blog':
 				if ( '' !== $blog_handle ) {
 					return esc_html__( 'As your site', 'fosse' )
-						. ' <code>' . esc_html( $blog_handle ) . '</code>';
+						. ' ' . self::format_complete_identity_token( $blog_handle, 'ap-address' );
 				}
 				$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
 				return esc_html__( 'As your site', 'fosse' )
-					. ' <code>' . esc_html( $site_host ? $site_host : 'yoursite.com' ) . '</code>';
+					. ' ' . self::format_complete_identity_token( $site_host ? $site_host : 'yoursite.com', 'handle' );
 
 			case 'actor_blog':
 				$lines = array( esc_html__( 'Both (site + authors)', 'fosse' ) );
 				if ( '' !== $user_handle ) {
 					$lines[] = esc_html__( 'As you:', 'fosse' )
-						. '<br /><code>' . esc_html( $user_handle ) . '</code>';
+						. '<br />' . self::format_complete_identity_token( $user_handle, 'ap-address' );
 				}
 				if ( '' !== $blog_handle ) {
 					$lines[] = esc_html__( 'As your site:', 'fosse' )
-						. '<br /><code>' . esc_html( $blog_handle ) . '</code>';
+						. '<br />' . self::format_complete_identity_token( $blog_handle, 'ap-address' );
 				}
 				return implode( '<br />', $lines );
 		}
 
 		return esc_html( $mode );
+	}
+
+	/**
+	 * Format a completion-summary identity token using shared admin token styles.
+	 *
+	 * @param string $value Raw handle or fediverse address.
+	 * @param string $type  Token type: `ap-address` or `handle`.
+	 * @return string Escaped HTML safe for `wp_kses`.
+	 */
+	private static function format_complete_identity_token( string $value, string $type ): string {
+		$classes = array( 'fosse-token', 'fosse-admin-token' );
+
+		if ( 'ap-address' === $type ) {
+			$classes[] = 'fosse-token--ap-address';
+			$classes[] = 'fosse-admin-token--ap-address';
+			$content   = Status_Formatter::ap_address( $value );
+		} else {
+			$classes[] = 'fosse-token--handle';
+			$classes[] = 'fosse-admin-token--handle';
+			$content   = '@' . Status_Formatter::handle( ltrim( $value, '@' ) );
+		}
+
+		return sprintf(
+			'<code class="%1$s">%2$s</code>',
+			esc_attr( implode( ' ', $classes ) ),
+			$content
+		);
 	}
 
 	/**
@@ -1657,9 +1684,13 @@ class Onboarding_Wizard {
 		if ( $bluesky['connected'] ) {
 			$bluesky_summary = $bluesky['handle']
 				? sprintf(
-					/* translators: %s: Bluesky handle. */
+					/* translators: %s: linked Bluesky handle. */
 					__( 'Connected as %s', 'fosse' ),
-					$bluesky['handle']
+					sprintf(
+						'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+						esc_url( 'https://bsky.app/profile/' . rawurlencode( ltrim( $bluesky['handle'], '@' ) ) ),
+						self::format_complete_identity_token( (string) $bluesky['handle'], 'handle' )
+					)
 				)
 				: __( 'Connected', 'fosse' );
 		} elseif ( ! $bluesky['available'] && $includes_bluesky ) {
@@ -1707,16 +1738,36 @@ class Onboarding_Wizard {
 						echo wp_kses(
 							$mode_label,
 							array(
-								'code' => array(),
+								'code' => array(
+									'class' => array(),
+								),
 								'br'   => array(),
+								'wbr'  => array(),
+							)
+						);
+						?>
+					</dd>
+					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Bluesky', 'fosse' ); ?></dt>
+					<dd class="fosse-detail-list__description<?php echo $bluesky['connected'] ? '' : ' fosse-detail-list__description--muted'; ?>">
+						<?php
+						echo wp_kses(
+							$bluesky_summary,
+							array(
+								'a'    => array(
+									'href'   => array(),
+									'target' => array(),
+									'rel'    => array(),
+								),
+								'code' => array(
+									'class' => array(),
+								),
+								'wbr'  => array(),
 							)
 						);
 						?>
 					</dd>
 					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Content types', 'fosse' ); ?></dt>
 					<dd class="fosse-detail-list__description"><?php echo esc_html( implode( ', ', $type_labels ) ); ?></dd>
-					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Bluesky', 'fosse' ); ?></dt>
-					<dd class="fosse-detail-list__description<?php echo $bluesky['connected'] ? '' : ' fosse-detail-list__description--muted'; ?>"><?php echo esc_html( $bluesky_summary ); ?></dd>
 				</dl>
 
 				<div class="fosse-wizard__hint">

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -731,7 +731,7 @@ class Onboarding_Wizard {
 				}
 				$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
 				return esc_html__( 'As your site', 'fosse' )
-					. ' ' . self::format_complete_identity_token( $site_host ? $site_host : 'yoursite.com', 'handle' );
+					. ' ' . self::format_complete_identity_token( $site_host ? $site_host : 'yoursite.com', 'host' );
 
 			case 'actor_blog':
 				$lines = array( esc_html__( 'Both (site + authors)', 'fosse' ) );
@@ -753,7 +753,7 @@ class Onboarding_Wizard {
 	 * Format a completion-summary identity token using shared admin token styles.
 	 *
 	 * @param string $value Raw handle or fediverse address.
-	 * @param string $type  Token type: `ap-address` or `handle`.
+	 * @param string $type  Token type: `ap-address`, `handle`, or `host`.
 	 * @return string Escaped HTML safe for `wp_kses`.
 	 */
 	private static function format_complete_identity_token( string $value, string $type ): string {
@@ -766,7 +766,7 @@ class Onboarding_Wizard {
 		} else {
 			$classes[] = 'fosse-token--handle';
 			$classes[] = 'fosse-admin-token--handle';
-			$content   = '@' . Status_Formatter::handle( ltrim( $value, '@' ) );
+			$content   = ( 'host' === $type ? '' : '@' ) . Status_Formatter::handle( ltrim( $value, '@' ) );
 		}
 
 		return sprintf(

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1500,6 +1500,22 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
+	 * The `blog` fallback shows the site host only when AP cannot resolve a
+	 * real blog actor. It must not render that host as `@example.org`, which
+	 * looks like a fediverse address with no local-part.
+	 */
+	public function test_complete_summary_blog_fallback_host_does_not_render_as_fediverse_address(): void {
+		$output = $this->call_format_mode_label( 'blog', '', '' );
+
+		$this->assertStringContainsString( 'As your site', $output );
+		$this->assertStringContainsString(
+			'<code class="fosse-token fosse-admin-token fosse-token--handle fosse-admin-token--handle">example.<wbr>org</code>',
+			$output
+		);
+		$this->assertStringNotContainsString( '@example', $output );
+	}
+
+	/**
 	 * In `actor` mode the user handle stays with the "As you" label so the
 	 * single-value summary reads as one phrase.
 	 */
@@ -2100,6 +2116,19 @@ class Onboarding_WizardTest extends BaseTestCase {
 	private function call_normalize( string $handle ): string {
 		$method = new ReflectionMethod( Onboarding_Wizard::class, 'normalize_handle_preview' );
 		return (string) $method->invoke( null, $handle );
+	}
+
+	/**
+	 * Invoke the private format_mode_label() helper via reflection.
+	 *
+	 * @param string $mode        Actor mode value.
+	 * @param string $user_handle Normalized `@user@host` for the current user, or empty.
+	 * @param string $blog_handle Normalized `@blog@host` for the site, or empty.
+	 * @return string
+	 */
+	private function call_format_mode_label( string $mode, string $user_handle, string $blog_handle ): string {
+		$method = new ReflectionMethod( Onboarding_Wizard::class, 'format_mode_label' );
+		return (string) $method->invoke( null, $mode, $user_handle, $blog_handle );
 	}
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1502,14 +1502,13 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$fediverse_row = strpos( $output, '<dt class="fosse-detail-list__term">Fediverse identity</dt>' );
 		$bluesky_row   = strpos( $output, '<dt class="fosse-detail-list__term">Bluesky</dt>' );
-		$content_row   = strpos( $output, '<dt class="fosse-detail-list__term">Content types</dt>' );
+		$sharing_row   = strpos( $output, '<dt class="fosse-detail-list__term">Sharing</dt>' );
 
-		$debug = "DEBUG OUTPUT (length=" . strlen( $output ) . "):\n" . $output;
-		$this->assertNotFalse( $fediverse_row, $debug );
-		$this->assertNotFalse( $bluesky_row, $debug );
-		$this->assertNotFalse( $content_row, $debug );
+		$this->assertNotFalse( $fediverse_row );
+		$this->assertNotFalse( $bluesky_row );
+		$this->assertNotFalse( $sharing_row );
 		$this->assertLessThan( $bluesky_row, $fediverse_row, 'Fediverse identity should appear before Bluesky.' );
-		$this->assertLessThan( $content_row, $bluesky_row, 'Bluesky should appear with the identity rows before Content types.' );
+		$this->assertLessThan( $sharing_row, $bluesky_row, 'Bluesky should appear with the identity rows before Sharing.' );
 	}
 
 	/**

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1489,39 +1489,6 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
-	 * A translation that adds, drops, or repeats placeholders must not crash
-	 * the completion step. The regex-based substitution replaces only the
-	 * first matched placeholder, so extra placeholders simply render as
-	 * literal text and the page still renders.
-	 */
-	public function test_complete_summary_bluesky_extra_placeholder_translation_does_not_fatal(): void {
-		Onboarding_Wizard::mark_complete();
-		update_option( 'activitypub_actor_mode', 'blog' );
-		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
-
-		$filter = static function ( $translation, $text, $domain ) {
-			if ( 'fosse' === $domain && 'Connected as %s' === $text ) {
-				return 'Connected as %s and %s';
-			}
-			return $translation;
-		};
-		add_filter( 'gettext', $filter, 10, 3 );
-
-		try {
-			$output = $this->render_wizard_step( 'complete' );
-		} finally {
-			remove_filter( 'gettext', $filter, 10 );
-		}
-
-		$this->assertStringContainsString(
-			'href="https://bsky.app/profile/alice.bsky.social"',
-			$output
-		);
-		// Exactly one placeholder consumed; the second remains as literal text.
-		$this->assertSame( 1, substr_count( $output, '%s' ) );
-	}
-
-	/**
 	 * A corrupted `atmosphere_connection` record where `handle` is non-string
 	 * (e.g. an array) must not throw a `TypeError` and must not render a
 	 * broken link. The wizard treats the missing-handle case as a bare

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1455,6 +1455,73 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
+	 * A translation that uses a numbered placeholder (`%1$s`) — which is
+	 * legal sprintf syntax that WordPress translators routinely emit when
+	 * reordering substitutions — must still substitute the linked handle
+	 * instead of rendering the literal placeholder.
+	 */
+	public function test_complete_summary_bluesky_supports_numbered_translation_placeholder(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_actor_mode', 'blog' );
+		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
+
+		$filter = static function ( $translation, $text, $domain ) {
+			if ( 'fosse' === $domain && 'Connected as %s' === $text ) {
+				return 'Conectado como %1$s';
+			}
+			return $translation;
+		};
+		add_filter( 'gettext', $filter, 10, 3 );
+
+		try {
+			$output = $this->render_wizard_step( 'complete' );
+		} finally {
+			remove_filter( 'gettext', $filter, 10 );
+		}
+
+		$this->assertStringContainsString( 'Conectado como', $output );
+		$this->assertStringContainsString(
+			'href="https://bsky.app/profile/alice.bsky.social"',
+			$output
+		);
+		$this->assertStringNotContainsString( '%1$s', $output );
+		$this->assertStringNotContainsString( '%s', $output );
+	}
+
+	/**
+	 * A translation that adds, drops, or repeats placeholders must not crash
+	 * the completion step. The regex-based substitution replaces only the
+	 * first matched placeholder, so extra placeholders simply render as
+	 * literal text and the page still renders.
+	 */
+	public function test_complete_summary_bluesky_extra_placeholder_translation_does_not_fatal(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_actor_mode', 'blog' );
+		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
+
+		$filter = static function ( $translation, $text, $domain ) {
+			if ( 'fosse' === $domain && 'Connected as %s' === $text ) {
+				return 'Connected as %s and %s';
+			}
+			return $translation;
+		};
+		add_filter( 'gettext', $filter, 10, 3 );
+
+		try {
+			$output = $this->render_wizard_step( 'complete' );
+		} finally {
+			remove_filter( 'gettext', $filter, 10 );
+		}
+
+		$this->assertStringContainsString(
+			'href="https://bsky.app/profile/alice.bsky.social"',
+			$output
+		);
+		// Exactly one placeholder consumed; the second remains as literal text.
+		$this->assertSame( 1, substr_count( $output, '%s' ) );
+	}
+
+	/**
 	 * A corrupted `atmosphere_connection` record where `handle` is non-string
 	 * (e.g. an array) must not throw a `TypeError` and must not render a
 	 * broken link. The wizard treats the missing-handle case as a bare

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1419,6 +1419,67 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
+	 * A stored Bluesky handle that includes a leading `@` must still produce
+	 * a correct `bsky.app/profile/...` URL — `@` is stripped before
+	 * percent-encoding so the link does not become `bsky.app/profile/%40alice...`.
+	 */
+	public function test_complete_summary_strips_leading_at_from_stored_bluesky_handle_in_link(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_actor_mode', 'blog' );
+		$this->seed_bluesky_connection( '@alice.bsky.social', 'did:plc:alice123' );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertStringContainsString(
+			'href="https://bsky.app/profile/alice.bsky.social"',
+			$output
+		);
+		$this->assertStringNotContainsString( 'profile/%40', $output );
+		$this->assertStringNotContainsString( 'profile/@', $output );
+	}
+
+	/**
+	 * A degenerate stored Bluesky handle (e.g. a bare `@` left over from a
+	 * partial connection) must fall back to the plain "Connected" string
+	 * instead of rendering a `@` token linked to an empty bsky.app profile.
+	 */
+	public function test_complete_summary_bluesky_degenerate_handle_falls_back_to_bare_connected(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_actor_mode', 'blog' );
+		$this->seed_bluesky_connection( '@', 'did:plc:alice123' );
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertMatchesRegularExpression( '~<dt[^>]*>Bluesky</dt>\s*<dd[^>]*>\s*Connected\s*</dd>~', $output );
+		$this->assertStringNotContainsString( 'href="https://bsky.app/profile/"', $output );
+	}
+
+	/**
+	 * A corrupted `atmosphere_connection` record where `handle` is non-string
+	 * (e.g. an array) must not throw a `TypeError` and must not render a
+	 * broken link. The wizard treats the missing-handle case as a bare
+	 * "Connected" state.
+	 */
+	public function test_complete_summary_bluesky_non_string_handle_does_not_fatal(): void {
+		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_actor_mode', 'blog' );
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:alice123',
+				'handle'       => array( 'unexpected', 'array' ),
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		$output = $this->render_wizard_step( 'complete' );
+
+		$this->assertMatchesRegularExpression( '~<dt[^>]*>Bluesky</dt>\s*<dd[^>]*>\s*Connected\s*</dd>~', $output );
+		$this->assertStringNotContainsString( 'bsky.app/profile/', $output );
+	}
+
+	/**
 	 * The Review summary includes the selected destination and skipped Bluesky state.
 	 */
 	public function test_complete_summary_shows_fediverse_only_destination_and_skipped_bluesky(): void {
@@ -1502,14 +1563,16 @@ class Onboarding_WizardTest extends BaseTestCase {
 	/**
 	 * The `blog` fallback shows the site host only when AP cannot resolve a
 	 * real blog actor. It must not render that host as `@example.org`, which
-	 * looks like a fediverse address with no local-part.
+	 * looks like a fediverse address with no local-part. The token also
+	 * carries a `--host` modifier (not `--handle`) so the class list reflects
+	 * the value's actual shape.
 	 */
 	public function test_complete_summary_blog_fallback_host_does_not_render_as_fediverse_address(): void {
 		$output = $this->call_format_mode_label( 'blog', '', '' );
 
 		$this->assertStringContainsString( 'As your site', $output );
 		$this->assertStringContainsString(
-			'<code class="fosse-token fosse-admin-token fosse-token--handle fosse-admin-token--handle">example.<wbr>org</code>',
+			'<code class="fosse-token fosse-admin-token fosse-token--host fosse-admin-token--host">example.<wbr>org</code>',
 			$output
 		);
 		$this->assertStringNotContainsString( '@example', $output );

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1388,6 +1388,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 	 */
 	public function test_complete_summary_shows_connected_bluesky_account(): void {
 		Onboarding_Wizard::mark_complete();
+		update_option( 'activitypub_actor_mode', 'blog' );
 		$this->seed_bluesky_connection( 'alice.bsky.social', 'did:plc:alice123' );
 
 		$output = $this->render_wizard_step( 'complete' );
@@ -1396,8 +1397,25 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( '<dl', $output );
 		$this->assertStringContainsString( '<dt', $output );
 		$this->assertStringContainsString( '<dd', $output );
-		$this->assertStringContainsString( 'Connected as alice.bsky.social', $output );
+		$this->assertMatchesRegularExpression(
+			'~Connected as\s*<a[^>]+href="https://bsky\.app/profile/alice\.bsky\.social"[^>]*>\s*<code class="fosse-token fosse-admin-token fosse-token--handle fosse-admin-token--handle">@alice\.<wbr>bsky\.<wbr>social</code>\s*</a>~',
+			$output
+		);
+		$this->assertMatchesRegularExpression(
+			'~<dt class="fosse-detail-list__term">Fediverse identity</dt>\s*<dd class="fosse-detail-list__description">.*<code class="fosse-token fosse-admin-token fosse-token--ap-address fosse-admin-token--ap-address">~s',
+			$output
+		);
 		$this->assertStringNotContainsString( 'Not connected', $output );
+
+		$fediverse_row = strpos( $output, '<dt class="fosse-detail-list__term">Fediverse identity</dt>' );
+		$bluesky_row   = strpos( $output, '<dt class="fosse-detail-list__term">Bluesky</dt>' );
+		$content_row   = strpos( $output, '<dt class="fosse-detail-list__term">Content types</dt>' );
+
+		$this->assertNotFalse( $fediverse_row );
+		$this->assertNotFalse( $bluesky_row );
+		$this->assertNotFalse( $content_row );
+		$this->assertLessThan( $bluesky_row, $fediverse_row, 'Fediverse identity should appear before Bluesky.' );
+		$this->assertLessThan( $content_row, $bluesky_row, 'Bluesky should appear with the identity rows before Content types.' );
 	}
 
 	/**
@@ -1429,7 +1447,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Fediverse only', $output );
 		$this->assertMatchesRegularExpression(
-			'~<dt[^>]*>Bluesky</dt>\s*<dd[^>]*>Connected as alice\.bsky\.social</dd>~',
+			'~<dt[^>]*>Bluesky</dt>\s*<dd[^>]*>\s*Connected as\s*<a[^>]+href="https://bsky\.app/profile/alice\.bsky\.social"[^>]*>\s*<code class="fosse-token fosse-admin-token fosse-token--handle fosse-admin-token--handle">@alice\.<wbr>bsky\.<wbr>social</code>\s*</a>\s*</dd>~',
 			$output,
 			'Connected Bluesky accounts must be reported even when the saved destination is Fediverse-only.'
 		);
@@ -1454,11 +1472,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Both (site + authors)', $output );
 		$this->assertStringContainsString( 'As you:', $output );
 		$this->assertStringContainsString( 'As your site:', $output );
-		// Fediverse handle markup should be wrapped in <code>, with a
-		// `<br />` between the label and the handle so long handles don't
-		// wrap mid-token (#72).
-		$this->assertMatchesRegularExpression( '~As you:<br\s*/?>\s*<code>@[^<]+@[^<]+</code>~', $output );
-		$this->assertMatchesRegularExpression( '~As your site:<br\s*/?>\s*<code>@[^<]+@[^<]+</code>~', $output );
+		// Fediverse handle markup should be wrapped in token-styled <code>,
+		// with a `<br />` between the label and the handle so long handles
+		// don't wrap mid-token (#72).
+		$this->assertMatchesRegularExpression( '~As you:<br\s*/?>\s*<code class="fosse-token fosse-admin-token fosse-token--ap-address fosse-admin-token--ap-address">@[^<]+<wbr>@[^<]+(?:<wbr>[^<]+)*</code>~', $output );
+		$this->assertMatchesRegularExpression( '~As your site:<br\s*/?>\s*<code class="fosse-token fosse-admin-token fosse-token--ap-address fosse-admin-token--ap-address">@[^<]+<wbr>@[^<]+(?:<wbr>[^<]+)*</code>~', $output );
 	}
 
 	/**
@@ -1473,7 +1491,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'complete' );
 
 		$this->assertStringContainsString( 'As your site', $output );
-		$this->assertMatchesRegularExpression( '~As your site\s*<code>@[^<]+@[^<]+</code>~', $output );
+		$this->assertMatchesRegularExpression( '~As your site\s*<code class="fosse-token fosse-admin-token fosse-token--ap-address fosse-admin-token--ap-address">@[^<]+<wbr>@[^<]+(?:<wbr>[^<]+)*</code>~', $output );
 		// Mirror the actor-mode guard so a future revert of the inline-space
 		// change in `format_mode_label()` (back to `<br /><code>`) is caught
 		// for the blog branch too — the assertion above's `\s*` accepts both
@@ -1497,7 +1515,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		}
 
 		$this->assertStringContainsString( 'As you', $output );
-		$this->assertMatchesRegularExpression( '~As you\s*<code>@[^<]+@[^<]+</code>~', $output );
+		$this->assertMatchesRegularExpression( '~As you\s*<code class="fosse-token fosse-admin-token fosse-token--ap-address fosse-admin-token--ap-address">@[^<]+<wbr>@[^<]+(?:<wbr>[^<]+)*</code>~', $output );
 		// The pre-fix wrapper used parens around the handle on the same line;
 		// guard against the parenthesized shape regressing here.
 		$this->assertDoesNotMatchRegularExpression( '~As you \(<code>~', $output );

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1411,9 +1411,10 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$bluesky_row   = strpos( $output, '<dt class="fosse-detail-list__term">Bluesky</dt>' );
 		$content_row   = strpos( $output, '<dt class="fosse-detail-list__term">Content types</dt>' );
 
-		$this->assertNotFalse( $fediverse_row );
-		$this->assertNotFalse( $bluesky_row );
-		$this->assertNotFalse( $content_row );
+		$debug = "DEBUG OUTPUT (length=" . strlen( $output ) . "):\n" . $output;
+		$this->assertNotFalse( $fediverse_row, $debug );
+		$this->assertNotFalse( $bluesky_row, $debug );
+		$this->assertNotFalse( $content_row, $debug );
 		$this->assertLessThan( $bluesky_row, $fediverse_row, 'Fediverse identity should appear before Bluesky.' );
 		$this->assertLessThan( $content_row, $bluesky_row, 'Bluesky should appear with the identity rows before Content types.' );
 	}


### PR DESCRIPTION
## Summary
- Align the onboarding completion summary's Fediverse and Bluesky identity rows visually.
- Render Fediverse and Bluesky identities with shared admin token styling and wrapping behavior.
- Link connected Bluesky handles to their public Bluesky profiles from the completion summary.

## Test Plan
- composer run-script lint-php
- pnpm run format:check
- pnpm run lint
- composer run-script test-php