### PR TITLE
Admin: align Bluesky account summaries

### DIFF
--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -346,12 +346,14 @@ class Bluesky_Provider implements Connection_Provider {
 						<?php esc_html_e( 'FOSSE can share eligible WordPress posts with this Bluesky account.', 'fosse' ); ?>
 					</p>
 					<dl class="fosse-detail-list">
-						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Bluesky handle', 'fosse' ); ?></dt>
-						<dd class="fosse-detail-list__description">
-							<?php
-							echo self::format_handle_link( $status['handle'], 'admin' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- format_handle_link() escapes input and returns safe token/link markup.
-							?>
-						</dd>
+						<?php if ( ! empty( $status['handle'] ) ) : ?>
+							<dt class="fosse-detail-list__term"><?php esc_html_e( 'Bluesky handle', 'fosse' ); ?></dt>
+							<dd class="fosse-detail-list__description">
+								<?php
+								echo self::format_handle_link( $status['handle'], 'admin' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- format_handle_link() escapes input and returns safe token/link markup.
+								?>
+							</dd>
+						<?php endif; ?>
 						<?php if ( null !== $followers_count ) : ?>
 							<dt class="fosse-detail-list__term"><?php esc_html_e( 'Followers', 'fosse' ); ?></dt>
 							<dd class="fosse-detail-list__description"><?php echo esc_html( number_format_i18n( $followers_count ) ); ?></dd>

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -43,6 +43,11 @@ class Bluesky_Provider implements Connection_Provider {
 	private const OAUTH_RETURN_TRANSIENT_PREFIX = 'fosse_bluesky_oauth_return_';
 
 	/**
+	 * Transient prefix for cached Bluesky profile data keyed by DID hash.
+	 */
+	private const PROFILE_TRANSIENT_PREFIX = 'fosse_bluesky_profile_';
+
+	/**
 	 * Hook into fosse_register_providers to self-register.
 	 *
 	 * @return void
@@ -184,6 +189,74 @@ class Bluesky_Provider implements Connection_Provider {
 	}
 
 	/**
+	 * Build a public bsky.app profile URL for a handle.
+	 *
+	 * @param string $handle Bluesky handle.
+	 * @return string Escaped URL.
+	 */
+	private static function get_profile_url( string $handle ): string {
+		return esc_url( 'https://bsky.app/profile/' . rawurlencode( ltrim( $handle, '@' ) ) );
+	}
+
+	/**
+	 * Format a linked Bluesky handle token.
+	 *
+	 * @param string $handle  Bluesky handle.
+	 * @param string $context Token context: `admin` or `status`.
+	 * @return string Escaped HTML safe to echo.
+	 */
+	private static function format_handle_link( string $handle, string $context ): string {
+		if ( 'status' === $context ) {
+			$classes = array( 'fosse-token', 'fosse-status-card__token', 'fosse-token--handle', 'fosse-status-card__token--handle' );
+		} else {
+			$classes = array( 'fosse-token', 'fosse-admin-token', 'fosse-token--handle', 'fosse-admin-token--handle' );
+		}
+
+		return sprintf(
+			'<a href="%1$s" target="_blank" rel="noopener noreferrer"><code class="%2$s">@%3$s</code></a>',
+			self::get_profile_url( $handle ),
+			esc_attr( implode( ' ', $classes ) ),
+			Status_Formatter::handle( ltrim( $handle, '@' ) )
+		);
+	}
+
+	/**
+	 * Fetch the connected Bluesky follower count from the profile API.
+	 *
+	 * Successful counts are cached briefly so Settings and Status rendering
+	 * does not turn every admin page load into a PDS request. Failures are
+	 * silent and uncached; the UI simply omits the optional row.
+	 *
+	 * @param array<string, mixed> $status Bluesky status snapshot.
+	 * @return int|null Followers count, or null when unavailable.
+	 */
+	private static function get_followers_count( array $status ): ?int {
+		if ( empty( $status['connected'] ) || empty( $status['did'] ) || ! empty( $status['token_error'] ) ) {
+			return null;
+		}
+
+		$cache_key = self::PROFILE_TRANSIENT_PREFIX . md5( (string) $status['did'] );
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return (int) $cached;
+		}
+
+		if ( ! class_exists( '\Atmosphere\API' ) || ! method_exists( '\Atmosphere\API', 'get' ) ) {
+			return null;
+		}
+
+		$result = \Atmosphere\API::get( '/xrpc/app.bsky.actor.getProfile', array( 'actor' => (string) $status['did'] ) );
+		if ( is_wp_error( $result ) || ! is_array( $result ) || ! array_key_exists( 'followersCount', $result ) || ! is_numeric( $result['followersCount'] ) ) {
+			return null;
+		}
+
+		$count = max( 0, (int) $result['followersCount'] );
+		set_transient( $cache_key, $count, 15 * MINUTE_IN_SECONDS );
+
+		return $count;
+	}
+
+	/**
 	 * Render Bluesky-specific settings inside the unified Settings form.
 	 *
 	 * Currently a no-op. The auto-publish toggle that used to render here
@@ -212,7 +285,8 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return void
 	 */
 	public function render_connection_actions(): void {
-		$status = $this->get_status();
+		$status          = $this->get_status();
+		$followers_count = self::get_followers_count( $status );
 		?>
 		<div class="fosse-connection-section fosse-admin-card" id="fosse-provider-bluesky">
 			<div class="fosse-card-header">
@@ -274,12 +348,14 @@ class Bluesky_Provider implements Connection_Provider {
 					<dl class="fosse-detail-list">
 						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Bluesky handle', 'fosse' ); ?></dt>
 						<dd class="fosse-detail-list__description">
-							<strong class="fosse-token fosse-admin-token fosse-token--handle fosse-admin-token--handle">
-								<?php
-								echo Status_Formatter::handle( $status['handle'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::handle() escapes input and returns safe HTML with <wbr>.
-								?>
-							</strong>
+							<?php
+							echo self::format_handle_link( $status['handle'], 'admin' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- format_handle_link() escapes input and returns safe token/link markup.
+							?>
 						</dd>
+						<?php if ( null !== $followers_count ) : ?>
+							<dt class="fosse-detail-list__term"><?php esc_html_e( 'Followers', 'fosse' ); ?></dt>
+							<dd class="fosse-detail-list__description"><?php echo esc_html( number_format_i18n( $followers_count ) ); ?></dd>
+						<?php endif; ?>
 						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Account ID', 'fosse' ); ?></dt>
 						<dd class="fosse-detail-list__description">
 							<code class="fosse-token fosse-admin-token fosse-token--did fosse-admin-token--did">
@@ -442,9 +518,10 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return void
 	 */
 	public function render_status_card(): void {
-		$status       = $this->get_status();
-		$status_class = $status['connected'] ? 'connected' : 'disconnected';
-		$status_label = $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' );
+		$status          = $this->get_status();
+		$status_class    = $status['connected'] ? 'connected' : 'disconnected';
+		$status_label    = $status['connected'] ? __( 'Connected', 'fosse' ) : __( 'Disconnected', 'fosse' );
+		$followers_count = self::get_followers_count( $status );
 		?>
 		<div class="fosse-status-card fosse-admin-card">
 			<div class="fosse-status-card__header fosse-card-header">
@@ -465,12 +542,14 @@ class Bluesky_Provider implements Connection_Provider {
 					<?php if ( $status['handle'] ) : ?>
 						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Handle', 'fosse' ); ?></dt>
 						<dd class="fosse-detail-list__description">
-								<strong class="fosse-token fosse-status-card__token fosse-token--handle fosse-status-card__token--handle">
-									<?php
-									echo Status_Formatter::handle( $status['handle'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Status_Formatter::handle() escapes input and returns safe HTML with <wbr>.
-									?>
-								</strong>
+								<?php
+								echo self::format_handle_link( $status['handle'], 'status' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- format_handle_link() escapes input and returns safe token/link markup.
+								?>
 						</dd>
+					<?php endif; ?>
+					<?php if ( null !== $followers_count ) : ?>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Followers', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description"><?php echo esc_html( number_format_i18n( $followers_count ) ); ?></dd>
 					<?php endif; ?>
 					<?php if ( $status['did'] ) : ?>
 						<dt class="fosse-detail-list__term"><?php esc_html_e( 'DID', 'fosse' ); ?></dt>

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -57,10 +57,18 @@ class Bluesky_Provider implements Connection_Provider {
 	 *
 	 * A sentinel value of -1 is written into the transient so subsequent
 	 * admin page renders during a sustained PDS outage skip the live HTTP
-	 * call (Atmosphere's wp_remote_request timeout is 30s) instead of
-	 * blocking every render until the network catches up.
+	 * call until the negative cache expires.
 	 */
 	private const PROFILE_FAILURE_TTL = 2 * MINUTE_IN_SECONDS;
+
+	/**
+	 * HTTP timeout (seconds) for the optional follower-count enrichment.
+	 *
+	 * Overrides Atmosphere's 30s default. The Followers row is decorative
+	 * and is omitted entirely on failure, so admin rendering should not
+	 * wait longer than this for it even on the first uncached request.
+	 */
+	private const PROFILE_REQUEST_TIMEOUT = 5;
 
 	/**
 	 * Hook into fosse_register_providers to self-register.
@@ -248,13 +256,19 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Fetch the connected Bluesky follower count from the profile API.
 	 *
-	 * Successful counts are cached for {@see self::PROFILE_SUCCESS_TTL} so
-	 * Settings and Status rendering does not turn every admin page load
-	 * into a PDS request. Remote-call failures are negative-cached for
-	 * {@see self::PROFILE_FAILURE_TTL} using a `-1` sentinel; without that
-	 * a sustained PDS outage would block every admin page render on the
-	 * 30s wp_remote_request timeout. The UI omits the optional row in
-	 * both the null-return and negative-cache hit cases.
+	 * The Followers row is an optional UI enrichment, so the fetch uses
+	 * {@see Atmosphere\API::request()} directly with a short
+	 * {@see self::PROFILE_REQUEST_TIMEOUT} override instead of the
+	 * `::get()` helper that inherits Atmosphere's 30s default — a slow
+	 * PDS must not stall the entire Settings/Status render for a row
+	 * that the UI omits on failure anyway.
+	 *
+	 * Successful counts are cached for {@see self::PROFILE_SUCCESS_TTL}.
+	 * Remote-call failures are negative-cached for
+	 * {@see self::PROFILE_FAILURE_TTL} using a `-1` sentinel so a
+	 * sustained outage cannot turn every uncached admin render into a
+	 * fresh HTTP wait. The UI omits the row in both the null-return and
+	 * negative-cache-hit cases.
 	 *
 	 * @param array<string, mixed> $status Bluesky status snapshot.
 	 * @return int|null Followers count, or null when unavailable.
@@ -272,11 +286,12 @@ class Bluesky_Provider implements Connection_Provider {
 			return $cached_int < 0 ? null : $cached_int;
 		}
 
-		if ( ! class_exists( '\Atmosphere\API' ) || ! method_exists( '\Atmosphere\API', 'get' ) ) {
+		if ( ! class_exists( '\Atmosphere\API' ) || ! method_exists( '\Atmosphere\API', 'request' ) ) {
 			return null;
 		}
 
-		$result = \Atmosphere\API::get( '/xrpc/app.bsky.actor.getProfile', array( 'actor' => (string) $status['did'] ) );
+		$endpoint = '/xrpc/app.bsky.actor.getProfile?' . http_build_query( array( 'actor' => (string) $status['did'] ) );
+		$result   = \Atmosphere\API::request( 'GET', $endpoint, array( 'timeout' => self::PROFILE_REQUEST_TIMEOUT ) );
 		if ( is_wp_error( $result ) || ! is_array( $result ) || ! array_key_exists( 'followersCount', $result ) || ! is_numeric( $result['followersCount'] ) ) {
 			set_transient( $cache_key, -1, self::PROFILE_FAILURE_TTL );
 			return null;

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -43,9 +43,24 @@ class Bluesky_Provider implements Connection_Provider {
 	private const OAUTH_RETURN_TRANSIENT_PREFIX = 'fosse_bluesky_oauth_return_';
 
 	/**
-	 * Transient prefix for cached Bluesky profile data keyed by DID hash.
+	 * Transient prefix for cached Bluesky profile data keyed by sanitized DID.
 	 */
 	private const PROFILE_TRANSIENT_PREFIX = 'fosse_bluesky_profile_';
+
+	/**
+	 * TTL applied when the profile fetch succeeds.
+	 */
+	private const PROFILE_SUCCESS_TTL = 15 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Short negative-cache TTL applied when the profile fetch fails.
+	 *
+	 * A sentinel value of -1 is written into the transient so subsequent
+	 * admin page renders during a sustained PDS outage skip the live HTTP
+	 * call (Atmosphere's wp_remote_request timeout is 30s) instead of
+	 * blocking every render until the network catches up.
+	 */
+	private const PROFILE_FAILURE_TTL = 2 * MINUTE_IN_SECONDS;
 
 	/**
 	 * Hook into fosse_register_providers to self-register.
@@ -189,32 +204,42 @@ class Bluesky_Provider implements Connection_Provider {
 	}
 
 	/**
-	 * Build a public bsky.app profile URL for a handle.
+	 * Build a public bsky.app profile URL.
 	 *
+	 * Prefers the DID when available so the link survives a handle
+	 * reassignment on Bluesky's side (handles can be moved between
+	 * accounts; DIDs are stable). Falls back to the handle when no DID
+	 * is available — typically only the brief pre-OAuth window.
+	 *
+	 * @param string $did    Stable DID identifier (empty when unknown).
 	 * @param string $handle Bluesky handle.
 	 * @return string Escaped URL.
 	 */
-	private static function get_profile_url( string $handle ): string {
-		return esc_url( 'https://bsky.app/profile/' . rawurlencode( ltrim( $handle, '@' ) ) );
+	private static function get_profile_url( string $did, string $handle ): string {
+		$identifier = '' !== $did ? $did : ltrim( $handle, '@' );
+
+		return esc_url( 'https://bsky.app/profile/' . rawurlencode( $identifier ) );
 	}
 
 	/**
 	 * Format a linked Bluesky handle token.
 	 *
-	 * @param string $handle  Bluesky handle.
-	 * @param string $context Token context: `admin` or `status`.
+	 * Callers own the class set so this method stays free of per-surface
+	 * branching. The href is built from the DID when present (see
+	 * {@see self::get_profile_url()}) so handle reassignments don't point
+	 * the link at a different account than the one shown.
+	 *
+	 * @param array<string, mixed> $status  Bluesky status snapshot.
+	 * @param string[]             $classes CSS classes to apply to the inner <code> token.
 	 * @return string Escaped HTML safe to echo.
 	 */
-	private static function format_handle_link( string $handle, string $context ): string {
-		if ( 'status' === $context ) {
-			$classes = array( 'fosse-token', 'fosse-status-card__token', 'fosse-token--handle', 'fosse-status-card__token--handle' );
-		} else {
-			$classes = array( 'fosse-token', 'fosse-admin-token', 'fosse-token--handle', 'fosse-admin-token--handle' );
-		}
+	private static function format_handle_link( array $status, array $classes ): string {
+		$did    = isset( $status['did'] ) ? (string) $status['did'] : '';
+		$handle = isset( $status['handle'] ) ? (string) $status['handle'] : '';
 
 		return sprintf(
 			'<a href="%1$s" target="_blank" rel="noopener noreferrer"><code class="%2$s">@%3$s</code></a>',
-			self::get_profile_url( $handle ),
+			self::get_profile_url( $did, $handle ),
 			esc_attr( implode( ' ', $classes ) ),
 			Status_Formatter::handle( ltrim( $handle, '@' ) )
 		);
@@ -223,9 +248,13 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Fetch the connected Bluesky follower count from the profile API.
 	 *
-	 * Successful counts are cached briefly so Settings and Status rendering
-	 * does not turn every admin page load into a PDS request. Failures are
-	 * silent and uncached; the UI simply omits the optional row.
+	 * Successful counts are cached for {@see self::PROFILE_SUCCESS_TTL} so
+	 * Settings and Status rendering does not turn every admin page load
+	 * into a PDS request. Remote-call failures are negative-cached for
+	 * {@see self::PROFILE_FAILURE_TTL} using a `-1` sentinel; without that
+	 * a sustained PDS outage would block every admin page render on the
+	 * 30s wp_remote_request timeout. The UI omits the optional row in
+	 * both the null-return and negative-cache hit cases.
 	 *
 	 * @param array<string, mixed> $status Bluesky status snapshot.
 	 * @return int|null Followers count, or null when unavailable.
@@ -235,10 +264,12 @@ class Bluesky_Provider implements Connection_Provider {
 			return null;
 		}
 
-		$cache_key = self::PROFILE_TRANSIENT_PREFIX . md5( (string) $status['did'] );
+		$cache_key = self::PROFILE_TRANSIENT_PREFIX . sanitize_key( (string) $status['did'] );
 		$cached    = get_transient( $cache_key );
 		if ( false !== $cached ) {
-			return (int) $cached;
+			$cached_int = (int) $cached;
+
+			return $cached_int < 0 ? null : $cached_int;
 		}
 
 		if ( ! class_exists( '\Atmosphere\API' ) || ! method_exists( '\Atmosphere\API', 'get' ) ) {
@@ -247,11 +278,12 @@ class Bluesky_Provider implements Connection_Provider {
 
 		$result = \Atmosphere\API::get( '/xrpc/app.bsky.actor.getProfile', array( 'actor' => (string) $status['did'] ) );
 		if ( is_wp_error( $result ) || ! is_array( $result ) || ! array_key_exists( 'followersCount', $result ) || ! is_numeric( $result['followersCount'] ) ) {
+			set_transient( $cache_key, -1, self::PROFILE_FAILURE_TTL );
 			return null;
 		}
 
 		$count = max( 0, (int) $result['followersCount'] );
-		set_transient( $cache_key, $count, 15 * MINUTE_IN_SECONDS );
+		set_transient( $cache_key, $count, self::PROFILE_SUCCESS_TTL );
 
 		return $count;
 	}
@@ -350,7 +382,10 @@ class Bluesky_Provider implements Connection_Provider {
 							<dt class="fosse-detail-list__term"><?php esc_html_e( 'Bluesky handle', 'fosse' ); ?></dt>
 							<dd class="fosse-detail-list__description">
 								<?php
-								echo self::format_handle_link( $status['handle'], 'admin' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- format_handle_link() escapes input and returns safe token/link markup.
+								echo self::format_handle_link( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- format_handle_link() escapes input and returns safe token/link markup.
+									$status,
+									array( 'fosse-token', 'fosse-admin-token', 'fosse-token--handle', 'fosse-admin-token--handle' )
+								);
 								?>
 							</dd>
 						<?php endif; ?>
@@ -545,7 +580,10 @@ class Bluesky_Provider implements Connection_Provider {
 						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Handle', 'fosse' ); ?></dt>
 						<dd class="fosse-detail-list__description">
 								<?php
-								echo self::format_handle_link( $status['handle'], 'status' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- format_handle_link() escapes input and returns safe token/link markup.
+								echo self::format_handle_link( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- format_handle_link() escapes input and returns safe token/link markup.
+									$status,
+									array( 'fosse-token', 'fosse-status-card__token', 'fosse-token--handle', 'fosse-status-card__token--handle' )
+								);
 								?>
 						</dd>
 					<?php endif; ?>

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -1788,9 +1788,11 @@ class Onboarding_Wizard {
 	/**
 	 * Emit `fosse_wizard_completed` with destination / actor / post-types / bluesky state.
 	 *
-	 * Called from `handle_complete()` immediately before
-	 * `mark_complete()` — capability and nonce have already been
-	 * verified by that point.
+	 * Called immediately before `mark_complete()` from two sites that
+	 * have already verified capability and nonce: the Sharing branch of
+	 * `handle_save()` (the normal completion path for every destination)
+	 * and the legacy `handle_complete()` endpoint kept for stale nonced
+	 * links from pre-reorder wizard renders.
 	 *
 	 * @return void
 	 */

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -13,8 +13,8 @@ namespace Automattic\Fosse\Admin;
  * Steps:
  *  1. Destinations - destination intent selection
  *  2. Appearance - actor mode selection (blog / actor / actor_blog)
- *  3. Content - post type selection
- *  4. Bluesky - optional OAuth connection
+ *  3. Bluesky - optional OAuth connection
+ *  4. Sharing - post type selection
  *  5. Review - summary and handoff to Setup/Status pages
  */
 class Onboarding_Wizard {
@@ -64,7 +64,7 @@ class Onboarding_Wizard {
 	 *
 	 * @var string[]
 	 */
-	private const STEPS = array( 'destinations', 'appearance', 'content', 'bluesky', 'complete' );
+	private const STEPS = array( 'destinations', 'appearance', 'bluesky', 'content', 'complete' );
 
 	/**
 	 * Destination intent that includes the Bluesky connection step.
@@ -159,6 +159,9 @@ class Onboarding_Wizard {
 	public static function register(): void {
 		add_action( 'admin_post_fosse_wizard_save', array( static::class, 'handle_save' ) );
 		add_action( 'admin_post_fosse_wizard_skip', array( static::class, 'handle_skip' ) );
+		// Current wizard UI completes through the Sharing/content save handler. Keep
+		// this endpoint for stale nonced links rendered by earlier wizard
+		// versions or an already-open admin page during an upgrade.
 		add_action( 'admin_post_fosse_wizard_complete', array( static::class, 'handle_complete' ) );
 		add_action( 'admin_post_fosse_wizard_reset', array( static::class, 'handle_reset' ) );
 	}
@@ -339,14 +342,14 @@ class Onboarding_Wizard {
 			// On rejection, persist the surfaced errors via the per-user
 			// notice transient and bounce back to the appearance step so the
 			// user can correct the input. Without this the wizard would
-			// silently advance to Content with no feedback and no way to fix
+			// silently advance to Sharing with no feedback and no way to fix
 			// the colliding handle.
 			if ( $blog_identifier_rejected ) {
 				User_Notices::persist();
 				self::redirect_to_step( 'appearance', array( 'settings-updated' => 'true' ) );
 			}
 
-			self::redirect_to_step( 'content' );
+			self::redirect_to_step( self::destination_includes_bluesky() ? 'bluesky' : 'content' );
 		}
 
 		if ( 'content' === $step ) {
@@ -379,14 +382,10 @@ class Onboarding_Wizard {
 			}
 
 			update_option( 'activitypub_support_post_types', $post_types );
-			if ( self::destination_includes_bluesky() ) {
-				self::redirect_to_step( 'bluesky' );
-			}
 
-			// Fediverse-only completion path: the wizard ends here without
-			// passing through `handle_complete`, so emit the funnel event
-			// directly. Without this, fediverse-only users are invisible
-			// to the started → completed funnel.
+			// The wizard ends here without passing through `handle_complete`,
+			// so emit the funnel event directly. Without this, users are
+			// invisible to the started → completed funnel.
 			if ( ! self::is_complete() ) {
 				self::record_wizard_completed();
 			}
@@ -595,7 +594,7 @@ class Onboarding_Wizard {
 			return 'destinations';
 		}
 
-		return self::destination_includes_bluesky() ? 'bluesky' : 'content';
+		return 'content';
 	}
 
 	/**
@@ -913,8 +912,8 @@ class Onboarding_Wizard {
 		$labels    = array(
 			'destinations' => __( 'Destinations', 'fosse' ),
 			'appearance'   => __( 'Identity', 'fosse' ),
-			'content'      => __( 'Content', 'fosse' ),
 			'bluesky'      => __( 'Bluesky', 'fosse' ),
+			'content'      => __( 'Sharing', 'fosse' ),
 			'complete'     => __( 'Review', 'fosse' ),
 		);
 		$step_keys = array_keys( $labels );
@@ -1292,7 +1291,7 @@ class Onboarding_Wizard {
 	}
 
 	/**
-	 * Render Step 3: Content (post types).
+	 * Render Sharing step (post types).
 	 *
 	 * @return void
 	 */
@@ -1302,6 +1301,7 @@ class Onboarding_Wizard {
 		$post_types     = get_option( 'activitypub_support_post_types', array( 'post' ) );
 		$all_post_types = Post_Type_Chooser::types();
 		$nonce          = wp_create_nonce( 'fosse_wizard' );
+		$back_step      = self::destination_includes_bluesky() ? 'bluesky' : 'appearance';
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only check on a redirect-back error code.
 		$has_empty_error = isset( $_GET['error'] ) && 'empty_post_types' === $_GET['error'];
@@ -1316,7 +1316,7 @@ class Onboarding_Wizard {
 				<?php
 				self::render_step_card_header(
 					__( 'What do you want to share?', 'fosse' ),
-					__( 'Choose what to share with people who follow your site. You can change this anytime.', 'fosse' )
+					__( 'Choose what FOSSE should share to your selected destinations.', 'fosse' )
 				);
 				?>
 				<div class="fosse-card-body">
@@ -1378,7 +1378,7 @@ class Onboarding_Wizard {
 
 				<div class="fosse-card-footer">
 					<div class="fosse-wizard__actions">
-						<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=appearance' ) ); ?>" class="button">
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=' . $back_step ) ); ?>" class="button">
 							&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
 						</a>
 						<div class="fosse-wizard__actions-primary">
@@ -1395,7 +1395,7 @@ class Onboarding_Wizard {
 	}
 
 	/**
-	 * Render Step 4: Bluesky.
+	 * Render Bluesky step.
 	 *
 	 * Three states drive the rendered markup:
 	 *  - Unavailable (provider not registered or not is_available): info notice.
@@ -1418,8 +1418,8 @@ class Onboarding_Wizard {
 			: __( 'Connect to Bluesky', 'fosse' );
 
 		$description = $is_connected
-			? __( 'Review the connected account below before finishing setup.', 'fosse' )
-			: __( 'Connect your Bluesky account to share eligible WordPress posts there too. This is optional, and you can do it later in FOSSE Settings.', 'fosse' );
+			? __( 'Review the connected account below. Next, you will choose what FOSSE can share.', 'fosse' )
+			: __( 'Connect your Bluesky account now. Next, you will choose what FOSSE can share.', 'fosse' );
 		?>
 		<div class="fosse-wizard__card fosse-admin-card">
 			<?php self::render_step_card_header( $title, $description ); ?>
@@ -1456,7 +1456,7 @@ class Onboarding_Wizard {
 				<div class="notice notice-info inline fosse-wizard__notice">
 					<p>
 						<strong><?php esc_html_e( 'Bluesky setup is unavailable.', 'fosse' ); ?></strong>
-						<?php esc_html_e( 'You can finish setup now and connect from FOSSE Settings later.', 'fosse' ); ?>
+						<?php esc_html_e( 'You can continue setup now and connect from FOSSE Settings later.', 'fosse' ); ?>
 					</p>
 				</div>
 			<?php elseif ( $is_connected ) : ?>
@@ -1599,24 +1599,25 @@ class Onboarding_Wizard {
 			<?php endif; ?>
 			</div>
 
-		<?php $complete_url = wp_nonce_url( admin_url( 'admin-post.php?action=fosse_wizard_complete' ), 'fosse_wizard_complete' ); ?>
+		<?php
+		$content_url       = admin_url( 'admin.php?page=fosse-wizard&step=content' );
+		$is_connect_prompt = $status['available'] && ! $is_connected;
+		$continue_class    = $is_connect_prompt ? 'button' : 'button button-primary';
+		$continue_label    = $is_connect_prompt ? __( 'Skip Bluesky for now', 'fosse' ) : __( 'Continue', 'fosse' );
+		?>
 			<div class="fosse-card-footer">
 				<div class="fosse-wizard__actions">
-					<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=content' ) ); ?>" class="button">
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=fosse-wizard&step=appearance' ) ); ?>" class="button">
 						&larr; <?php esc_html_e( 'Back', 'fosse' ); ?>
 					</a>
 					<div class="fosse-wizard__actions-primary">
-						<?php if ( $status['available'] && ! $is_connected ) : ?>
-							<a href="<?php echo esc_url( $complete_url ); ?>" class="button">
-								<?php esc_html_e( 'Skip Bluesky for now', 'fosse' ); ?>
-							</a>
+						<a href="<?php echo esc_url( $content_url ); ?>" class="<?php echo esc_attr( $continue_class ); ?>">
+							<?php echo esc_html( $continue_label ); ?>
+						</a>
+						<?php if ( $is_connect_prompt ) : ?>
 							<button type="submit" form="fosse-wizard-bluesky-connect-form" class="button button-primary">
 								<?php esc_html_e( 'Connect Bluesky', 'fosse' ); ?>
 							</button>
-						<?php else : ?>
-							<a href="<?php echo esc_url( $complete_url ); ?>" class="button button-primary">
-								<?php echo esc_html( $is_connected ? __( 'Finish setup', 'fosse' ) : __( 'Skip for now', 'fosse' ) ); ?>
-							</a>
 						<?php endif; ?>
 					</div>
 				</div>
@@ -1713,7 +1714,7 @@ class Onboarding_Wizard {
 						);
 						?>
 					</dd>
-					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Content types', 'fosse' ); ?></dt>
+					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Sharing', 'fosse' ); ?></dt>
 					<dd class="fosse-detail-list__description"><?php echo esc_html( implode( ', ', $type_labels ) ); ?></dd>
 					<dt class="fosse-detail-list__term"><?php esc_html_e( 'Bluesky', 'fosse' ); ?></dt>
 					<dd class="fosse-detail-list__description<?php echo $bluesky['connected'] ? '' : ' fosse-detail-list__description--muted'; ?>"><?php echo esc_html( $bluesky_summary ); ?></dd>

--- a/tests/e2e/onboarding-wizard.spec.ts
+++ b/tests/e2e/onboarding-wizard.spec.ts
@@ -16,7 +16,7 @@ const selectDestination = async ( page: Page, destination: string ) => {
 const openBlueskyStep = async ( page: Page ) => {
 	await selectDestination( page, 'Fediverse + Bluesky' );
 	// This helper intentionally jumps to Bluesky after setting destination
-	// intent; it does not seed appearance/content state, so keep full-flow
+	// intent; it does not seed identity/content state, so keep full-flow
 	// dependencies covered by the sequential wizard specs below.
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
 };
@@ -24,6 +24,9 @@ const openBlueskyStep = async ( page: Page ) => {
 const completeThroughBlueskySkip = async ( page: Page ) => {
 	await openBlueskyStep( page );
 	await page.getByRole( 'link', { name: 'Skip Bluesky for now' } ).click();
+	await expect( page ).toHaveURL( /step=content/ );
+	await page.getByRole( 'checkbox', { name: 'Posts' } ).check();
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
 	await expect( page ).toHaveURL( /step=complete/ );
 };
 
@@ -348,14 +351,14 @@ test( 'Appearance step swaps the visible address preview when the actor mode cha
 test( 'Selecting a mode and continuing saves the option', async ( {
 	page,
 } ) => {
-	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=appearance' );
+	await selectDestination( page, 'Fediverse + Bluesky' );
 
 	// Select "As you" (actor mode). Use exact title match to avoid
 	// substring collision with "As your site".
 	await page.getByText( 'As you', { exact: true } ).click();
 	await page.getByRole( 'button', { name: 'Continue' } ).click();
 
-	await expect( page ).toHaveURL( /step=content/ );
+	await expect( page ).toHaveURL( /step=bluesky/ );
 
 	// Verify the option was saved by going back to the appearance step
 	// and checking the radio is still selected.
@@ -365,12 +368,9 @@ test( 'Selecting a mode and continuing saves the option', async ( {
 	).toBeChecked();
 } );
 
-test( 'Content step saves post types and advances to Bluesky', async ( {
+test( 'Sharing step saves post types and completes setup', async ( {
 	page,
 } ) => {
-	// Persist the Fediverse + Bluesky destination so the post-content
-	// redirect deterministically lands on the Bluesky step regardless of any
-	// stale destination state left behind by a prior run.
 	await selectDestination( page, 'Fediverse + Bluesky' );
 	await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=content' );
 
@@ -378,7 +378,7 @@ test( 'Content step saves post types and advances to Bluesky', async ( {
 	await page.getByRole( 'checkbox', { name: 'Pages' } ).check();
 	await page.getByRole( 'button', { name: 'Continue' } ).click();
 
-	await expect( page ).toHaveURL( /step=bluesky/ );
+	await expect( page ).toHaveURL( /step=complete/ );
 } );
 
 test( 'Bluesky step shows connect form', async ( { page } ) => {
@@ -439,6 +439,7 @@ test.describe( 'Bluesky step — connected (post-OAuth completion)', () => {
 	test( 'connected state suppresses "connect later" copy and shows summary', async ( {
 		page,
 	} ) => {
+		await selectDestination( page, 'Fediverse + Bluesky' );
 		await page.goto( '/wp-admin/admin.php?page=fosse-wizard&step=bluesky' );
 
 		await expect(
@@ -457,9 +458,38 @@ test.describe( 'Bluesky step — connected (post-OAuth completion)', () => {
 			page.getByRole( 'link', { name: 'Create one' } )
 		).toHaveCount( 0 );
 		await expect(
-			page.getByRole( 'link', { name: 'Finish setup' } )
+			page.getByRole( 'link', { name: 'Continue' } )
 		).toBeVisible();
+		await expect(
+			page.getByRole( 'link', { name: 'Finish setup' } )
+		).toHaveCount( 0 );
 	} );
+} );
+
+test( 'Fediverse + Bluesky path visits Bluesky before Sharing', async ( {
+	page,
+} ) => {
+	await page.goto( '/wp-admin/admin.php?page=fosse-wizard' );
+
+	await page.getByText( 'Fediverse + Bluesky', { exact: true } ).click();
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
+
+	await expect( page ).toHaveURL( /step=appearance/ );
+	await page.getByText( 'As you', { exact: true } ).click();
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
+
+	await expect( page ).toHaveURL( /step=bluesky/ );
+	await page.getByRole( 'link', { name: 'Skip Bluesky for now' } ).click();
+
+	await expect( page ).toHaveURL( /step=content/ );
+	await page.getByRole( 'checkbox', { name: 'Posts' } ).check();
+	await page.getByRole( 'button', { name: 'Continue' } ).click();
+
+	await expect( page ).toHaveURL( /step=complete/ );
+	await expect(
+		page.locator( 'dt' ).filter( { hasText: /^Destinations$/ } )
+	).toBeVisible();
+	await expect( page.getByText( 'Fediverse + Bluesky' ) ).toBeVisible();
 } );
 
 test( 'Fediverse-only path skips the Bluesky connect step', async ( {
@@ -475,6 +505,7 @@ test( 'Fediverse-only path skips the Bluesky connect step', async ( {
 	await page.getByRole( 'button', { name: 'Continue' } ).click();
 
 	await expect( page ).toHaveURL( /step=content/ );
+	await page.getByRole( 'checkbox', { name: 'Posts' } ).check();
 	await page.getByRole( 'button', { name: 'Continue' } ).click();
 
 	await expect( page ).toHaveURL( /step=complete/ );
@@ -485,13 +516,13 @@ test( 'Fediverse-only path skips the Bluesky connect step', async ( {
 	await expect( page.getByText( 'Skipped' ) ).toBeVisible();
 } );
 
-test( 'Skip Bluesky for now goes to completion', async ( { page } ) => {
+test( 'Skip Bluesky for now goes to Sharing', async ( { page } ) => {
 	await openBlueskyStep( page );
 
 	await page.getByRole( 'link', { name: 'Skip Bluesky for now' } ).click();
-	await expect( page ).toHaveURL( /step=complete/ );
+	await expect( page ).toHaveURL( /step=content/ );
 	await expect(
-		page.getByRole( 'heading', { name: "You're all set!" } )
+		page.getByRole( 'heading', { name: 'What do you want to share?' } )
 	).toBeVisible();
 } );
 
@@ -505,7 +536,7 @@ test( 'Completion step shows summary', async ( { page } ) => {
 		page.locator( 'dt' ).filter( { hasText: /^Fediverse identity$/ } )
 	).toBeVisible();
 	await expect(
-		page.locator( 'dt' ).filter( { hasText: /^Content types$/ } )
+		page.locator( 'dt' ).filter( { hasText: /^Sharing$/ } )
 	).toBeVisible();
 	await expect(
 		page.locator( 'dt' ).filter( { hasText: /^Bluesky$/ } )

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -56,6 +56,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		delete_option( 'atmosphere_connection' );
 		delete_option( 'atmosphere_auto_publish' );
 		delete_option( Bluesky_Domain_Handle::OPTION_PREVIOUS_HANDLE );
+		delete_transient( 'fosse_bluesky_profile_' . md5( 'did:plc:test123' ) );
 
 		// Reset the one-shot revert hand-off so a prior test's successful
 		// revert can't surface a ghost snapshot in this test's reads.
@@ -432,7 +433,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->provider->render_connection_actions();
 		$output = ob_get_clean();
 
-		$this->assertStringNotContainsString( 'https://bsky.app/', $output );
+		$this->assertStringNotContainsString( 'Create one', $output );
 		$this->assertStringNotContainsString( 'Need a Bluesky account', $output );
 	}
 
@@ -591,6 +592,62 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringNotContainsString( 'Open Bluesky settings', $output );
+	}
+
+	/**
+	 * Connected status card links the Bluesky handle to the public profile.
+	 */
+	public function test_render_status_card_links_handle_to_public_profile(): void {
+		$this->seed_connected_atmosphere_connection();
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression(
+			'~<a[^>]+href="https://bsky\.app/profile/alice\.bsky\.social"[^>]*>\s*<code class="fosse-token fosse-status-card__token fosse-token--handle fosse-status-card__token--handle">@alice\.<wbr>bsky\.<wbr>social</code>\s*</a>~',
+			$output
+		);
+	}
+
+	/**
+	 * Connected settings panel links the Bluesky handle and includes the cached
+	 * follower count from the Bluesky profile response.
+	 */
+	public function test_render_connection_actions_connected_links_handle_and_shows_followers(): void {
+		$this->seed_api_capable_atmosphere_connection();
+		$request_count = $this->mock_bluesky_profile_followers( 1234 );
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression(
+			'~<a[^>]+href="https://bsky\.app/profile/alice\.bsky\.social"[^>]*>\s*<code class="fosse-token fosse-admin-token fosse-token--handle fosse-admin-token--handle">@alice\.<wbr>bsky\.<wbr>social</code>\s*</a>~',
+			$output
+		);
+		$this->assertMatchesRegularExpression( '~<dt[^>]*>\s*Followers\s*</dt>\s*<dd[^>]*>\s*1,234\s*</dd>~', $output );
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		ob_get_clean();
+
+		$this->assertSame( 1, $request_count(), 'The second render should use the cached Bluesky profile count.' );
+	}
+
+	/**
+	 * Connected status card includes the cached Bluesky follower count too, so
+	 * the Settings and Status surfaces expose the same account summary.
+	 */
+	public function test_render_status_card_shows_followers(): void {
+		$this->seed_api_capable_atmosphere_connection();
+		$this->mock_bluesky_profile_followers( 9876 );
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '~<dt[^>]*>\s*Followers\s*</dt>\s*<dd[^>]*>\s*9,876\s*</dd>~', $output );
 	}
 
 	/**
@@ -2015,6 +2072,70 @@ class Bluesky_ProviderTest extends BaseTestCase {
 				'access_token' => Encryption::encrypt( 'token' ),
 			)
 		);
+	}
+
+	/**
+	 * Seed a connected Atmosphere connection with the DPoP key required for
+	 * authenticated profile API calls.
+	 *
+	 * @return void
+	 */
+	private function seed_api_capable_atmosphere_connection(): void {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+				'dpop_jwk'     => Encryption::encrypt( wp_json_encode( \Atmosphere\OAuth\DPoP::generate_key(), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ) ),
+			)
+		);
+	}
+
+	/**
+	 * Mock the Bluesky profile API response and expose how often it was called.
+	 *
+	 * @param int $followers Followers count to return.
+	 * @return callable(): int
+	 */
+	private function mock_bluesky_profile_followers( int $followers ): callable {
+		$requests = 0;
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( &$requests, $followers ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, '/xrpc/app.bsky.actor.getProfile' ) ) {
+					return $preempt;
+				}
+
+				++$requests;
+
+				return array(
+					'headers'  => array(),
+					'body'     => wp_json_encode(
+						array(
+							'did'            => 'did:plc:test123',
+							'handle'         => 'alice.bsky.social',
+							'followersCount' => $followers,
+						),
+						JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+					),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+
+		return static function () use ( &$requests ): int {
+			return $requests;
+		};
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -636,6 +636,32 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Connected settings panel omits the linked handle row when the stored
+	 * Atmosphere connection is partial and has no handle to name.
+	 */
+	public function test_render_connection_actions_connected_omits_handle_row_when_handle_empty(): void {
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => '',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Connected account', $output );
+		$this->assertStringContainsString( 'Account ID', $output );
+		$this->assertDoesNotMatchRegularExpression( '~<dt class="fosse-detail-list__term">\s*Bluesky handle\s*</dt>~', $output );
+		$this->assertStringNotContainsString( 'https://bsky.app/profile/"', $output );
+		$this->assertStringNotContainsString( '>@</code>', $output );
+	}
+
+	/**
 	 * Connected status card includes the cached Bluesky follower count too, so
 	 * the Settings and Status surfaces expose the same account summary.
 	 */

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -56,7 +56,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		delete_option( 'atmosphere_connection' );
 		delete_option( 'atmosphere_auto_publish' );
 		delete_option( Bluesky_Domain_Handle::OPTION_PREVIOUS_HANDLE );
-		delete_transient( 'fosse_bluesky_profile_' . md5( 'did:plc:test123' ) );
+		delete_transient( 'fosse_bluesky_profile_' . sanitize_key( 'did:plc:test123' ) );
 
 		// Reset the one-shot revert hand-off so a prior test's successful
 		// revert can't surface a ghost snapshot in this test's reads.
@@ -605,7 +605,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression(
-			'~<a[^>]+href="https://bsky\.app/profile/alice\.bsky\.social"[^>]*>\s*<code class="fosse-token fosse-status-card__token fosse-token--handle fosse-status-card__token--handle">@alice\.<wbr>bsky\.<wbr>social</code>\s*</a>~',
+			'~<a[^>]+href="https://bsky\.app/profile/did%3Aplc%3Atest123"[^>]*>\s*<code class="fosse-token fosse-status-card__token fosse-token--handle fosse-status-card__token--handle">@alice\.<wbr>bsky\.<wbr>social</code>\s*</a>~',
 			$output
 		);
 	}
@@ -623,7 +623,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression(
-			'~<a[^>]+href="https://bsky\.app/profile/alice\.bsky\.social"[^>]*>\s*<code class="fosse-token fosse-admin-token fosse-token--handle fosse-admin-token--handle">@alice\.<wbr>bsky\.<wbr>social</code>\s*</a>~',
+			'~<a[^>]+href="https://bsky\.app/profile/did%3Aplc%3Atest123"[^>]*>\s*<code class="fosse-token fosse-admin-token fosse-token--handle fosse-admin-token--handle">@alice\.<wbr>bsky\.<wbr>social</code>\s*</a>~',
 			$output
 		);
 		$this->assertMatchesRegularExpression( '~<dt[^>]*>\s*Followers\s*</dt>\s*<dd[^>]*>\s*1,234\s*</dd>~', $output );
@@ -674,6 +674,126 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '~<dt[^>]*>\s*Followers\s*</dt>\s*<dd[^>]*>\s*9,876\s*</dd>~', $output );
+	}
+
+	/**
+	 * A status snapshot with a token_error set short-circuits before any
+	 * HTTP call so a stale OAuth session cannot block admin rendering on
+	 * the 30s wp_remote_request timeout.
+	 */
+	public function test_get_followers_count_short_circuits_when_token_error_present(): void {
+		$request_count = $this->mock_bluesky_profile_followers( 1234 );
+
+		$followers = $this->invoke_get_followers_count(
+			array(
+				'connected'   => true,
+				'did'         => 'did:plc:test123',
+				'handle'      => 'alice.bsky.social',
+				'token_error' => 'invalid_token',
+			)
+		);
+
+		$this->assertNull( $followers );
+		$this->assertSame( 0, $request_count(), 'No profile request must fire when token_error is set.' );
+	}
+
+	/**
+	 * A disconnected status short-circuits before any HTTP call.
+	 */
+	public function test_get_followers_count_short_circuits_when_disconnected(): void {
+		$request_count = $this->mock_bluesky_profile_followers( 1234 );
+
+		$followers = $this->invoke_get_followers_count(
+			array(
+				'connected'   => false,
+				'did'         => 'did:plc:test123',
+				'handle'      => 'alice.bsky.social',
+				'token_error' => null,
+			)
+		);
+
+		$this->assertNull( $followers );
+		$this->assertSame( 0, $request_count(), 'No profile request must fire when status is disconnected.' );
+	}
+
+	/**
+	 * A WP_Error from the profile fetch suppresses the Followers row and is
+	 * negative-cached so a second render skips the live request (otherwise a
+	 * PDS outage would block every admin page render on the 30s timeout).
+	 */
+	public function test_render_status_card_negative_caches_wp_error_from_profile(): void {
+		$this->seed_api_capable_atmosphere_connection();
+		$request_count = $this->mock_bluesky_profile_response(
+			new \WP_Error( 'http_request_failed', 'connection refused' )
+		);
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'Followers', $output );
+
+		ob_start();
+		$this->provider->render_status_card();
+		ob_get_clean();
+
+		$this->assertSame( 1, $request_count(), 'Negative-cache must suppress the second profile request after a WP_Error.' );
+	}
+
+	/**
+	 * A profile response missing followersCount yields null and is
+	 * negative-cached.
+	 */
+	public function test_render_status_card_handles_missing_followers_count_key(): void {
+		$this->seed_api_capable_atmosphere_connection();
+		$this->mock_bluesky_profile_response_body(
+			array(
+				'did'    => 'did:plc:test123',
+				'handle' => 'alice.bsky.social',
+			)
+		);
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'Followers', $output );
+	}
+
+	/**
+	 * A non-numeric followersCount value (e.g. an unexpected payload shape)
+	 * yields null and is negative-cached rather than coerced to 0.
+	 */
+	public function test_render_status_card_handles_non_numeric_followers_count(): void {
+		$this->seed_api_capable_atmosphere_connection();
+		$this->mock_bluesky_profile_response_body(
+			array(
+				'did'            => 'did:plc:test123',
+				'handle'         => 'alice.bsky.social',
+				'followersCount' => 'nope',
+			)
+		);
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'Followers', $output );
+	}
+
+	/**
+	 * A negative followersCount value is clamped to 0 so the UI never
+	 * surfaces a nonsensical negative number.
+	 */
+	public function test_render_status_card_clamps_negative_followers_count_to_zero(): void {
+		$this->seed_api_capable_atmosphere_connection();
+		$this->mock_bluesky_profile_followers( -5 );
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '~<dt[^>]*>\s*Followers\s*</dt>\s*<dd[^>]*>\s*0\s*</dd>~', $output );
 	}
 
 	/**
@@ -2084,6 +2204,21 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Invoke the private static `get_followers_count` method directly so
+	 * error-branch tests don't depend on the live OAuth probe that
+	 * `get_status()` runs.
+	 *
+	 * @param array<string, mixed> $status Status snapshot to pass.
+	 * @return int|null
+	 */
+	private function invoke_get_followers_count( array $status ): ?int {
+		$method = new ReflectionMethod( Bluesky_Provider::class, 'get_followers_count' );
+		$result = $method->invoke( null, $status );
+
+		return $result;
+	}
+
+	/**
 	 * Seed a connected Atmosphere connection (handle, did, encrypted token).
 	 *
 	 * @return void
@@ -2154,6 +2289,78 @@ class Bluesky_ProviderTest extends BaseTestCase {
 					'cookies'  => array(),
 					'filename' => null,
 				);
+			},
+			10,
+			3
+		);
+
+		return static function () use ( &$requests ): int {
+			return $requests;
+		};
+	}
+
+	/**
+	 * Mock the Bluesky profile API to return a fixed body shape (post-JSON-decode).
+	 *
+	 * Used by error-branch tests that need to assert on missing keys or
+	 * non-numeric followersCount values without rebuilding the full pre_http_request
+	 * shape in each test.
+	 *
+	 * @param array<string, mixed> $body Decoded body to return.
+	 * @return callable(): int Returns how many requests the mock saw.
+	 */
+	private function mock_bluesky_profile_response_body( array $body ): callable {
+		$requests = 0;
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( &$requests, $body ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, '/xrpc/app.bsky.actor.getProfile' ) ) {
+					return $preempt;
+				}
+
+				++$requests;
+
+				return array(
+					'headers'  => array(),
+					'body'     => wp_json_encode( $body, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+
+		return static function () use ( &$requests ): int {
+			return $requests;
+		};
+	}
+
+	/**
+	 * Mock the Bluesky profile API to return an arbitrary pre_http_request
+	 * payload — used to inject WP_Error or non-2xx responses.
+	 *
+	 * @param mixed $response Value to return from the pre_http_request filter.
+	 * @return callable(): int Returns how many requests the mock saw.
+	 */
+	private function mock_bluesky_profile_response( $response ): callable {
+		$requests = 0;
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( &$requests, $response ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, '/xrpc/app.bsky.actor.getProfile' ) ) {
+					return $preempt;
+				}
+
+				++$requests;
+
+				return $response;
 			},
 			10,
 			3

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -229,6 +229,60 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertTrue( $fired, 'update_option_activitypub_actor_mode should fire on value change.' );
 	}
 
+	/**
+	 * Saving identity on the Fediverse + Bluesky path routes to Bluesky setup.
+	 */
+	public function test_handle_save_appearance_bluesky_destination_redirects_to_bluesky(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_bluesky' );
+
+		$captured = null;
+		$this->simulate_save_request( 'appearance', array( 'activitypub_actor_mode' => 'actor' ) );
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new RedirectFired( 'redirect' );
+			},
+			9
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertStringContainsString( 'step=bluesky', (string) $captured );
+		$this->assertStringNotContainsString( 'step=content', (string) $captured );
+	}
+
+	/**
+	 * Saving identity on the Fediverse-only path routes directly to Sharing.
+	 */
+	public function test_handle_save_appearance_fediverse_only_destination_redirects_to_content(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+
+		$captured = null;
+		$this->simulate_save_request( 'appearance', array( 'activitypub_actor_mode' => 'actor' ) );
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) use ( &$captured ) {
+				$captured = (string) $location;
+				throw new RedirectFired( 'redirect' );
+			},
+			9
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertStringContainsString( 'step=content', (string) $captured );
+		$this->assertStringNotContainsString( 'step=bluesky', (string) $captured );
+	}
+
 	// --- handle_save: content step ---
 
 	/**
@@ -241,6 +295,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'content' );
 
 		$this->assertStringContainsString( 'name="activitypub_support_post_types[]"', $output );
+		$this->assertStringContainsString( 'Choose what FOSSE should share to your selected destinations.', $output );
 		$this->assertStringNotContainsString(
 			'value="attachment"',
 			$output,
@@ -498,10 +553,15 @@ class Onboarding_WizardTest extends BaseTestCase {
 	}
 
 	/**
-	 * Saving content on the fediverse-only path completes the wizard and skips Bluesky.
+	 * Saving content completes the wizard for every destination path.
+	 *
+	 * @dataProvider destination_provider
+	 *
+	 * @param string $destination Destination intent.
 	 */
-	public function test_handle_save_content_fediverse_only_redirects_to_complete(): void {
-		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+	#[DataProvider( 'destination_provider' )]
+	public function test_handle_save_content_redirects_to_complete( string $destination ): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, $destination );
 
 		$captured = null;
 		$this->simulate_save_request( 'content', array( 'activitypub_support_post_types' => array( 'post' ) ) );
@@ -678,14 +738,29 @@ class Onboarding_WizardTest extends BaseTestCase {
 	 * Progress reflects the destination-first flow and labels the final step Review.
 	 */
 	public function test_progress_uses_destination_first_labels(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_bluesky' );
+
 		$output = $this->render_wizard_step( 'destinations' );
 
-		$this->assertStringContainsString( 'Destinations', $output );
-		$this->assertStringContainsString( 'Identity', $output );
-		$this->assertStringContainsString( 'Content', $output );
-		$this->assertStringContainsString( 'Bluesky', $output );
-		$this->assertStringContainsString( 'Review', $output );
+		$this->assertSame(
+			array( 'Destinations', 'Identity', 'Bluesky', 'Sharing', 'Review' ),
+			$this->extract_progress_labels( $output )
+		);
 		$this->assertStringNotContainsString( '>Welcome<', $output );
+	}
+
+	/**
+	 * Fediverse-only progress hides the conditional Bluesky step.
+	 */
+	public function test_progress_hides_bluesky_for_fediverse_only_destination(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_only' );
+
+		$output = $this->render_wizard_step( 'destinations' );
+
+		$this->assertSame(
+			array( 'Destinations', 'Identity', 'Sharing', 'Review' ),
+			$this->extract_progress_labels( $output )
+		);
 	}
 
 	/**
@@ -1050,14 +1125,21 @@ class Onboarding_WizardTest extends BaseTestCase {
 	 * The Bluesky wizard step renders the live OAuth connect form when disconnected.
 	 */
 	public function test_render_bluesky_step_disconnected_shows_connect_form(): void {
+		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_bluesky' );
+
 		$output = $this->render_wizard_step( 'bluesky' );
 
 		$this->assertStringContainsString( 'fosse_connect_bluesky', $output );
+		$this->assertStringContainsString( 'Next, you will choose what FOSSE can share.', $output );
 		$this->assertStringContainsString( 'bluesky_handle', $output );
 		$this->assertStringContainsString( 'fosse_bluesky_return', $output );
 		$this->assertStringContainsString( 'value="wizard"', $output );
 		$this->assertStringContainsString( 'Connect Bluesky', $output );
 		$this->assertStringContainsString( 'Skip Bluesky for now', $output );
+		$this->assertMatchesRegularExpression(
+			'/<a\b(?=[^>]*href="[^"]*step=content[^"]*")[^>]*>\s*Skip Bluesky for now\s*<\/a>/i',
+			$output
+		);
 		$this->assertStringContainsString( 'Bluesky handle', $output );
 		$this->assertStringContainsString( 'Enter your Bluesky handle, such as yourname.bsky.social. If you use your own domain as your handle, enter that.', $output );
 		$this->assertStringNotContainsString( 'Coming Soon', $output );
@@ -1080,7 +1162,10 @@ class Onboarding_WizardTest extends BaseTestCase {
 			$output,
 			'Connect Bluesky should submit the in-step connect form.'
 		);
-		$this->assertStringContainsString( 'Skip Bluesky for now', $output );
+		$this->assertMatchesRegularExpression(
+			'/<a\b(?=[^>]*href="[^"]*step=content[^"]*")[^>]*>\s*Skip Bluesky for now\s*<\/a>/i',
+			$output
+		);
 	}
 
 	/**
@@ -1224,7 +1309,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$output = $this->render_wizard_step( 'bluesky' );
 
 		$this->assertStringContainsString( 'Bluesky setup is unavailable', $output );
-		$this->assertStringContainsString( 'Skip for now', $output );
+		$this->assertMatchesRegularExpression(
+			'/<a\b(?=[^>]*href="[^"]*step=content[^"]*")[^>]*>\s*Continue\s*<\/a>/i',
+			$output
+		);
+		$this->assertStringNotContainsString( 'Skip for now', $output );
 		$this->assertStringNotContainsString( 'fosse_connect_bluesky', $output );
 		$this->assertStringNotContainsString( 'fosse-bsky-handle', $output );
 	}
@@ -1241,7 +1330,11 @@ class Onboarding_WizardTest extends BaseTestCase {
 		$this->assertSame( 1, substr_count( $output, 'Bluesky is connected' ) );
 		$this->assertStringContainsString( 'alice.bsky.social', $output );
 		$this->assertStringContainsString( 'did:plc:alice123', $output );
-		$this->assertStringContainsString( 'Finish setup', $output );
+		$this->assertMatchesRegularExpression(
+			'/<a\b(?=[^>]*href="[^"]*step=content[^"]*")[^>]*>\s*Continue\s*<\/a>/i',
+			$output
+		);
+		$this->assertStringNotContainsString( 'Finish setup', $output );
 		$this->assertStringNotContainsString( 'fosse_connect_bluesky', $output );
 	}
 
@@ -1411,7 +1504,7 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Destinations', $output );
 		$this->assertStringContainsString( 'Fediverse identity', $output );
-		$this->assertStringContainsString( 'Content types', $output );
+		$this->assertStringContainsString( 'Sharing', $output );
 		$this->assertStringContainsString( 'Fediverse only', $output );
 		$this->assertStringContainsString( 'Skipped', $output );
 	}
@@ -1653,23 +1746,24 @@ class Onboarding_WizardTest extends BaseTestCase {
 
 	/**
 	 * Direct GETs to the review step on an incomplete Fediverse + Bluesky
-	 * wizard land on the Bluesky step — the latest in-flow step before
+	 * wizard land on the Sharing step — the final required step before
 	 * completion — so a partially-finished run resumes near where the
 	 * user left off instead of restarting from step 1.
 	 */
-	public function test_render_complete_step_before_completion_routes_to_bluesky_for_saved_bluesky_destination(): void {
+	public function test_render_complete_step_before_completion_routes_to_content_for_saved_bluesky_destination(): void {
 		update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_bluesky' );
 
 		$output = $this->render_wizard_step( 'complete' );
 
-		$this->assertStringContainsString( 'Connect to Bluesky', $output );
+		$this->assertStringContainsString( 'What do you want to share?', $output );
+		$this->assertStringNotContainsString( 'Connect to Bluesky', $output );
 		$this->assertStringNotContainsString( 'Where should your WordPress posts appear?', $output );
 		$this->assertStringNotContainsString( 'You&#039;re all set!', $output );
 	}
 
 	/**
 	 * Direct GETs to the review step on an incomplete Fediverse-only wizard
-	 * land on the Content step — the last step that submits and marks the
+	 * land on the Sharing step — the last step that submits and marks the
 	 * wizard complete on this destination path.
 	 */
 	public function test_render_complete_step_before_completion_routes_to_content_for_saved_fediverse_only(): void {
@@ -1917,6 +2011,18 @@ class Onboarding_WizardTest extends BaseTestCase {
 		);
 	}
 
+	/**
+	 * Destination intents.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public static function destination_provider(): array {
+		return array(
+			'fediverse + bluesky' => array( 'fediverse_bluesky' ),
+			'fediverse only'      => array( 'fediverse_only' ),
+		);
+	}
+
 	// --- normalize_handle_preview ---
 
 	/**
@@ -2107,6 +2213,38 @@ class Onboarding_WizardTest extends BaseTestCase {
 		}
 
 		return (string) $output;
+	}
+
+	/**
+	 * Extract visible setup progress labels from rendered wizard markup.
+	 *
+	 * @param string $output Rendered wizard markup.
+	 * @return string[]
+	 */
+	private function extract_progress_labels( string $output ): array {
+		$prior = libxml_use_internal_errors( true );
+
+		$document = new \DOMDocument( '1.0', 'UTF-8' );
+		$document->loadHTML( '<?xml encoding="UTF-8">' . $output );
+
+		$xpath = new \DOMXPath( $document );
+		$items = $xpath->query( '//ol[@aria-label="Setup progress"]/li[not(@aria-hidden="true")]' );
+
+		$labels = array();
+		if ( false !== $items ) {
+			foreach ( $items as $item ) {
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOMNode public property.
+				$label = preg_replace( '/\s+/', ' ', trim( $item->textContent ) );
+				if ( null !== $label && '' !== $label ) {
+					$labels[] = $label;
+				}
+			}
+		}
+
+		libxml_clear_errors();
+		libxml_use_internal_errors( $prior );
+
+		return $labels;
 	}
 
 	/**

--- a/tests/php/Admin/Wizard_MetricsTest.php
+++ b/tests/php/Admin/Wizard_MetricsTest.php
@@ -265,4 +265,48 @@ class Wizard_MetricsTest extends BaseTestCase {
 		);
 		$this->assertSame( 'fediverse_only', $captured[0]['properties']['destination'] );
 	}
+
+	/**
+	 * Fediverse + Bluesky `handle_save` reaches `mark_complete` through the
+	 * Sharing content step too (the wizard reorder moved Bluesky setup ahead
+	 * of Sharing), so the same content branch is now the only completion
+	 * path for both destinations. Without an explicit assertion the
+	 * fediverse_bluesky path could silently regress to not emitting the
+	 * funnel event.
+	 */
+	public function test_handle_save_fediverse_bluesky_emits_completed(): void {
+		\update_option( Onboarding_Wizard::DESTINATION_OPTION, 'fediverse_bluesky' );
+		\update_option( 'activitypub_actor_mode', 'actor' );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'action'                         => 'fosse_wizard_save',
+			'_wpnonce'                       => \wp_create_nonce( 'fosse_wizard' ),
+			'fosse_wizard_step'              => 'content',
+			'activitypub_support_post_types' => array( 'post' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		\add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			Onboarding_Wizard::handle_save();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$captured = $this->tracks_channel()->events_for( 'fosse_wizard_completed' );
+		$this->assertCount(
+			1,
+			$captured,
+			'Fediverse + Bluesky completion via handle_save must emit fosse_wizard_completed.'
+		);
+		$this->assertSame( 'fediverse_bluesky', $captured[0]['properties']['destination'] );
+	}
 }


### PR DESCRIPTION
## Summary
- Link connected Bluesky handles to their public bsky.app profiles in Settings and Status cards.
- Render Bluesky handles as @handle code tokens, matching the wizard identity treatment.
- Add cached Bluesky follower counts to connected Settings and Status summaries when the profile API returns one.
- Move the conditional Bluesky setup step before Sharing for the Fediverse + Bluesky onboarding path while keeping Fediverse-only on Destinations -> Identity -> Sharing -> Review.
- Rename the user-facing Content step/summary/progress copy to Sharing and keep wizard completion centralized on the Sharing save.

cc @kraftbj: this now tries a new wizard order, Destinations -> Identity -> Bluesky -> Sharing -> Review, so Bluesky feels like destination setup before choosing what to share. Would appreciate your read on whether that order feels right or whether Bluesky setup should stay after sharing choices.

## Test Plan
- [x] composer run-script lint-php
- [x] composer run-script test-php -- --filter Bluesky_ProviderTest
- [x] composer run-script test-php -- --filter Onboarding_WizardTest
- [x] composer run-script test-php
- [x] pnpm test
- [x] pnpm run format:check
- [x] pnpm run lint
- [x] pnpm run test:e2e -- tests/e2e/onboarding-wizard.spec.ts
- [x] pnpm run test:e2e
- [x] git diff --check