### PR TITLE
Resync bundled backends + switch photo-post AT projector onto atmosphere_post_embed

### DIFF
--- a/bundled/activitypub/composer.json
+++ b/bundled/activitypub/composer.json
@@ -7,7 +7,7 @@
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"require-dev": {
-		"automattic/jetpack-changelogger": "6.0.14",
+		"automattic/jetpack-changelogger": "6.0.15",
 		"phpunit/phpunit": "^9.6.33",
 		"phpcompatibility/php-compatibility": "*",
 		"phpcompatibility/phpcompatibility-wp": "*",

--- a/bundled/activitypub/includes/activity/class-activity.php
+++ b/bundled/activitypub/includes/activity/class-activity.php
@@ -40,6 +40,7 @@ class Activity extends Base_Object {
 		array(
 			'toot'         => 'http://joinmastodon.org/ns#',
 			'QuoteRequest' => 'toot:QuoteRequest',
+			'blurhash'     => 'toot:blurhash',
 		),
 	);
 

--- a/bundled/activitypub/includes/activity/class-base-object.php
+++ b/bundled/activitypub/includes/activity/class-base-object.php
@@ -162,6 +162,8 @@ class Base_Object extends Generic_Object {
 				'@id'   => 'gts:always',
 				'@type' => '@id',
 			),
+			'toot'              => 'http://joinmastodon.org/ns#',
+			'blurhash'          => 'toot:blurhash',
 		),
 	);
 

--- a/bundled/activitypub/includes/oauth/class-scope.php
+++ b/bundled/activitypub/includes/oauth/class-scope.php
@@ -52,6 +52,23 @@ class Scope {
 	);
 
 	/**
+	 * SWICG ActivityPub API Basic Profile canonical scope aliases.
+	 *
+	 * Advertised in OAuth metadata so Basic Profile clients can discover them,
+	 * and accepted in scope requests (any `activitypub:read:*` collapses to
+	 * `read`, any `activitypub:write:*` collapses to `write`). Enforcement
+	 * stays coarse: there is no per-activity-type access control yet.
+	 *
+	 * @since unreleased
+	 *
+	 * @var array
+	 */
+	const CANONICAL_ALIASES = array(
+		'activitypub:read:all',
+		'activitypub:write:all',
+	);
+
+	/**
 	 * Human-readable descriptions for each scope.
 	 *
 	 * @var array
@@ -79,6 +96,10 @@ class Scope {
 	/**
 	 * Validate and filter requested scopes.
 	 *
+	 * Canonical SWICG ActivityPub API Basic Profile scope names of the form
+	 * `activitypub:read:*` and `activitypub:write:*` are normalized to the
+	 * plugin's internal `read` and `write` scopes before validation.
+	 *
 	 * @param string|array $scopes The requested scopes (space-separated string or array).
 	 * @return array Valid scopes.
 	 */
@@ -91,13 +112,67 @@ class Scope {
 			return self::DEFAULT_SCOPES;
 		}
 
+		$scopes       = self::normalize( $scopes );
 		$valid_scopes = array_intersect( $scopes, self::ALL );
 
 		if ( empty( $valid_scopes ) ) {
 			return self::DEFAULT_SCOPES;
 		}
 
-		return array_values( $valid_scopes );
+		return array_values( array_unique( $valid_scopes ) );
+	}
+
+	/**
+	 * Normalize canonical Basic Profile scope names to internal scopes.
+	 *
+	 * Maps any `activitypub:read:*` to {@see self::READ} and any
+	 * `activitypub:write:*` to {@see self::WRITE}. Unknown values pass through
+	 * unchanged so they can be filtered out by the caller.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array $scopes Requested scope strings.
+	 * @return array Normalized scope strings.
+	 */
+	public static function normalize( $scopes ) {
+		if ( ! is_array( $scopes ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $scopes as $scope ) {
+			if ( ! is_string( $scope ) || '' === $scope ) {
+				continue;
+			}
+
+			if ( 0 === strpos( $scope, 'activitypub:read:' ) ) {
+				$normalized[] = self::READ;
+				continue;
+			}
+
+			if ( 0 === strpos( $scope, 'activitypub:write:' ) ) {
+				$normalized[] = self::WRITE;
+				continue;
+			}
+
+			$normalized[] = $scope;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Return the scope identifiers advertised in OAuth authorization-server metadata.
+	 *
+	 * Includes the plugin's internal scopes plus the SWICG Basic Profile
+	 * canonical aliases so spec-aware clients can discover them.
+	 *
+	 * @since unreleased
+	 *
+	 * @return array Scope identifiers.
+	 */
+	public static function supported() {
+		return array_merge( self::ALL, self::CANONICAL_ALIASES );
 	}
 
 	/**

--- a/bundled/activitypub/includes/oauth/class-server.php
+++ b/bundled/activitypub/includes/oauth/class-server.php
@@ -248,7 +248,7 @@ class Server {
 			'revocation_endpoint'                   => $base_url . 'oauth/revoke',
 			'introspection_endpoint'                => $base_url . 'oauth/introspect',
 			'registration_endpoint'                 => $base_url . 'oauth/clients',
-			'scopes_supported'                      => Scope::ALL,
+			'scopes_supported'                      => Scope::supported(),
 			'response_types_supported'              => array( 'code' ),
 			'response_modes_supported'              => array( 'query' ),
 			'grant_types_supported'                 => array( 'authorization_code', 'refresh_token' ),

--- a/bundled/activitypub/includes/oauth/class-token.php
+++ b/bundled/activitypub/includes/oauth/class-token.php
@@ -141,7 +141,8 @@ class Token {
 		self::enforce_token_limit( $user_id );
 
 		/*
-		 * Get the actor URI for the 'me' parameter (IndieAuth convention).
+		 * Get the actor URI for the 'me' parameter (IndieAuth convention) and
+		 * `activitypub_actor_id` (SWICG ActivityPub API Basic Profile).
 		 * Fall back to blog actor when user actors are disabled.
 		 */
 		$actor = Actors::get_by_id( $user_id );
@@ -151,12 +152,13 @@ class Token {
 		$me = ! \is_wp_error( $actor ) ? $actor->get_id() : null;
 
 		return array(
-			'access_token'  => $access_token,
-			'token_type'    => 'Bearer',
-			'expires_in'    => $expires,
-			'refresh_token' => $refresh_token,
-			'scope'         => Scope::to_string( $token_data['scopes'] ),
-			'me'            => $me,
+			'access_token'         => $access_token,
+			'token_type'           => 'Bearer',
+			'expires_in'           => $expires,
+			'refresh_token'        => $refresh_token,
+			'scope'                => Scope::to_string( $token_data['scopes'] ),
+			'me'                   => $me,
+			'activitypub_actor_id' => $me,
 		);
 	}
 
@@ -919,15 +921,16 @@ class Token {
 		$me = ! \is_wp_error( $actor ) ? $actor->get_id() : null;
 
 		return array(
-			'active'     => true,
-			'scope'      => Scope::to_string( $validated->get_scopes() ),
-			'client_id'  => $validated->get_client_id(),
-			'username'   => $user ? $user->user_login : null,
-			'token_type' => 'Bearer',
-			'exp'        => $validated->get_expires_at(),
-			'iat'        => $validated->get_created_at(),
-			'sub'        => (string) $user_id,
-			'me'         => $me,
+			'active'               => true,
+			'scope'                => Scope::to_string( $validated->get_scopes() ),
+			'client_id'            => $validated->get_client_id(),
+			'username'             => $user ? $user->user_login : null,
+			'token_type'           => 'Bearer',
+			'exp'                  => $validated->get_expires_at(),
+			'iat'                  => $validated->get_created_at(),
+			'sub'                  => (string) $user_id,
+			'me'                   => $me,
+			'activitypub_actor_id' => $me,
 		);
 	}
 }

--- a/bundled/activitypub/includes/rest/oauth/class-authorization-controller.php
+++ b/bundled/activitypub/includes/rest/oauth/class-authorization-controller.php
@@ -153,21 +153,13 @@ class Authorization_Controller extends \WP_REST_Controller {
 		// Rate-limit authorization requests to prevent abuse (max 20 per minute per IP).
 		$ip = get_client_ip();
 		if ( '' === $ip ) {
-			return new \WP_Error(
-				'activitypub_rate_limit',
-				\__( 'Too many authorization requests. Please try again later.', 'activitypub' ),
-				array( 'status' => 429 )
-			);
+			return $this->rate_limit_response( \__( 'Too many authorization requests. Please try again later.', 'activitypub' ) );
 		}
 		$transient_key = 'ap_oauth_auth_' . \md5( $ip );
 		$count         = (int) \get_transient( $transient_key );
 
 		if ( $count >= 20 ) {
-			return new \WP_Error(
-				'activitypub_rate_limit',
-				\__( 'Too many authorization requests. Please try again later.', 'activitypub' ),
-				array( 'status' => 429 )
-			);
+			return $this->rate_limit_response( \__( 'Too many authorization requests. Please try again later.', 'activitypub' ) );
 		}
 
 		\set_transient( $transient_key, $count + 1, MINUTE_IN_SECONDS );
@@ -401,6 +393,27 @@ class Authorization_Controller extends \WP_REST_Controller {
 			null,
 			302,
 			array( 'Location' => $redirect_url )
+		);
+	}
+
+	/**
+	 * Build a 429 rate-limit response with a Retry-After header.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $message Translated human-readable error message.
+	 * @return \WP_REST_Response
+	 */
+	private function rate_limit_response( $message ) {
+		return new \WP_REST_Response(
+			array(
+				'code'    => 'activitypub_rate_limit',
+				'message' => $message,
+				'data'    => array( 'status' => 429 ),
+			),
+			429,
+			// RFC 6585 §4: send Retry-After so clients can back off.
+			array( 'Retry-After' => (string) MINUTE_IN_SECONDS )
 		);
 	}
 }

--- a/bundled/activitypub/includes/rest/oauth/class-clients-controller.php
+++ b/bundled/activitypub/includes/rest/oauth/class-clients-controller.php
@@ -118,21 +118,13 @@ class Clients_Controller extends \WP_REST_Controller {
 		// Rate-limit registrations to prevent DB spam (max 10 per minute per IP).
 		$ip = get_client_ip();
 		if ( '' === $ip ) {
-			return new \WP_Error(
-				'activitypub_rate_limited',
-				\__( 'Too many client registration requests. Please try again later.', 'activitypub' ),
-				array( 'status' => 429 )
-			);
+			return $this->rate_limit_response( \__( 'Too many client registration requests. Please try again later.', 'activitypub' ) );
 		}
 		$transient_key = 'ap_oauth_reg_' . \md5( $ip );
 		$count         = (int) \get_transient( $transient_key );
 
 		if ( $count >= 10 ) {
-			return new \WP_Error(
-				'activitypub_rate_limited',
-				\__( 'Too many client registration requests. Please try again later.', 'activitypub' ),
-				array( 'status' => 429 )
-			);
+			return $this->rate_limit_response( \__( 'Too many client registration requests. Please try again later.', 'activitypub' ) );
 		}
 
 		\set_transient( $transient_key, $count + 1, MINUTE_IN_SECONDS );
@@ -181,6 +173,27 @@ class Clients_Controller extends \WP_REST_Controller {
 			OAuth_Server::get_metadata(),
 			200,
 			array( 'Content-Type' => 'application/json' )
+		);
+	}
+
+	/**
+	 * Build a 429 rate-limit response with a Retry-After header.
+	 *
+	 * @since unreleased
+	 *
+	 * @param string $message Translated human-readable error message.
+	 * @return \WP_REST_Response
+	 */
+	private function rate_limit_response( $message ) {
+		return new \WP_REST_Response(
+			array(
+				'code'    => 'activitypub_rate_limited',
+				'message' => $message,
+				'data'    => array( 'status' => 429 ),
+			),
+			429,
+			// RFC 6585 §4: send Retry-After so clients can back off.
+			array( 'Retry-After' => (string) MINUTE_IN_SECONDS )
 		);
 	}
 }

--- a/bundled/activitypub/includes/rest/oauth/class-token-controller.php
+++ b/bundled/activitypub/includes/rest/oauth/class-token-controller.php
@@ -397,18 +397,25 @@ class Token_Controller extends \WP_REST_Controller {
 	 * @return \WP_REST_Response
 	 */
 	private function token_error( $error, $error_description, $status = 400 ) {
+		$headers = array(
+			'Content-Type'  => 'application/json',
+			// RFC 6749 §5.1 requires the same no-cache headers on error responses as on success responses.
+			'Cache-Control' => 'no-store',
+			'Pragma'        => 'no-cache',
+		);
+
+		// RFC 6585 §4: send Retry-After with rate-limit responses so clients can back off.
+		if ( 429 === $status ) {
+			$headers['Retry-After'] = (string) MINUTE_IN_SECONDS;
+		}
+
 		return new \WP_REST_Response(
 			array(
 				'error'             => $error,
 				'error_description' => $error_description,
 			),
 			$status,
-			array(
-				'Content-Type'  => 'application/json',
-				// RFC 6749 §5.1 requires the same no-cache headers on error responses as on success responses.
-				'Cache-Control' => 'no-store',
-				'Pragma'        => 'no-cache',
-			)
+			$headers
 		);
 	}
 

--- a/bundled/atmosphere/atmosphere.php
+++ b/bundled/atmosphere/atmosphere.php
@@ -3,7 +3,7 @@
  * Plugin Name: ATmosphere
  * Plugin URI: https://github.com/pfefferle/atmosphere
  * Description: Publish WordPress posts to AT Protocol (Bluesky + standard.site) via native OAuth.
- * Version: unreleased
+ * Version: 1.0.0
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL-2.0-or-later
@@ -19,7 +19,7 @@ namespace Atmosphere;
 
 \defined( 'ABSPATH' ) || exit;
 
-\define( 'ATMOSPHERE_VERSION', 'unreleased' );
+\define( 'ATMOSPHERE_VERSION', '1.0.0' );
 \define( 'ATMOSPHERE_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'ATMOSPHERE_PLUGIN_URL', \plugin_dir_url( __FILE__ ) );
 \define( 'ATMOSPHERE_PLUGIN_FILE', __FILE__ );
@@ -64,7 +64,16 @@ function activate() {
  * Deactivation hook.
  */
 function deactivate() {
-	clear_scheduled_hooks();
+	/*
+	 * Use the all-hooks variant: deactivation is the user-visible
+	 * "stop running everything" moment, so any still-queued one-shot
+	 * cron event (notably `atmosphere_revoke_refresh_token`, which
+	 * `Client::disconnect()` schedules outside the regular
+	 * `clear_scheduled_hooks()` set) must be cleared too. Otherwise
+	 * its encrypted ciphertexts sit in `wp_options['cron']` waiting
+	 * for a callback the deactivated plugin no longer registers.
+	 */
+	clear_scheduled_hooks_all();
 	\flush_rewrite_rules();
 }
 \register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );

--- a/bundled/atmosphere/includes/class-api.php
+++ b/bundled/atmosphere/includes/class-api.php
@@ -26,7 +26,7 @@ class API {
 	 *
 	 * @param string      $method   HTTP method.
 	 * @param string      $endpoint XRPC path, e.g. /xrpc/com.atproto.repo.createRecord.
-	 * @param array       $args     wp_remote_request() arguments.
+	 * @param array       $args     wp_safe_remote_request() arguments.
 	 * @param string|null $nonce    Explicit DPoP nonce (used on retry).
 	 * @return array|\WP_Error Decoded JSON body or error.
 	 */
@@ -73,7 +73,7 @@ class API {
 			$args['body'] = \wp_json_encode( $args['body'] );
 		}
 
-		$response = \wp_remote_request( $url, $args );
+		$response = \wp_safe_remote_request( $url, $args );
 
 		if ( \is_wp_error( $response ) ) {
 			return $response;
@@ -81,6 +81,9 @@ class API {
 
 		$status = \wp_remote_retrieve_response_code( $response );
 		$body   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+		if ( ! \is_array( $body ) ) {
+			$body = array();
+		}
 
 		// Persist any nonce the server sends back.
 		$response_nonce = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
@@ -178,10 +181,10 @@ class API {
 		 * actually hitting the PDS.
 		 *
 		 * A common use is `pre_http_request`, but that filter fires
-		 * inside `wp_remote_request`, which is only reached after the
-		 * DPoP proof has been built — so in test environments without
-		 * a real DPoP JWK, the call errors out first. This filter runs
-		 * before any of that.
+		 * inside `wp_safe_remote_request`, which is only reached after
+		 * the DPoP proof has been built — so in test environments
+		 * without a real DPoP JWK, the call errors out first. This
+		 * filter runs before any of that.
 		 *
 		 * @param null|array|\WP_Error $short_circuit Short-circuit value. Return null to skip.
 		 * @param array                $writes        The write batch about to be sent.

--- a/bundled/atmosphere/includes/class-atmosphere.php
+++ b/bundled/atmosphere/includes/class-atmosphere.php
@@ -14,7 +14,6 @@ use Atmosphere\Transformer\Comment;
 use Atmosphere\Transformer\Document;
 use Atmosphere\Transformer\Post;
 use Atmosphere\Transformer\Publication;
-use Atmosphere\Transformer\TID;
 use Atmosphere\Integrations\Load;
 use Atmosphere\WP_Admin\Admin;
 
@@ -36,6 +35,37 @@ class Atmosphere {
 	 * @var string
 	 */
 	private const META_PUBLISH_ATTEMPTS = '_atmosphere_publish_attempts';
+
+	/**
+	 * Post meta marker set when remote records were removed because a
+	 * previously public post left public visibility.
+	 *
+	 * @var string
+	 */
+	private const META_VISIBILITY_CLEANUP = '_atmosphere_visibility_cleanup';
+
+	/**
+	 * Option marking that the historical visibility cleanup migration ran.
+	 *
+	 * @var string
+	 */
+	private const OPTION_VISIBILITY_CLEANUP_MIGRATED = 'atmosphere_visibility_cleanup_migrated';
+
+	/**
+	 * Option storing the highest post ID processed by the historical
+	 * visibility-cleanup migration. Used for keyset (ID > last_seen)
+	 * pagination so concurrent deletes don't shift the cursor.
+	 *
+	 * @var string
+	 */
+	private const OPTION_VISIBILITY_CLEANUP_LAST_ID = 'atmosphere_visibility_cleanup_last_id';
+
+	/**
+	 * Post IDs currently being handled by on_status_change().
+	 *
+	 * @var array<int,bool>
+	 */
+	private static array $publishing_post_ids = array();
 
 	/**
 	 * Maximum re-schedule hops for a child comment waiting on a
@@ -79,6 +109,7 @@ class Atmosphere {
 
 		// Frontend verification headers.
 		\add_action( 'wp_head', array( $this, 'output_document_link' ) );
+		\add_action( 'wp_head', array( $this, 'output_publication_link' ) );
 
 		// Well-known endpoints.
 		\add_action( 'init', array( $this, 'register_wellknown_rewrite' ) );
@@ -94,6 +125,18 @@ class Atmosphere {
 		// Post lifecycle hooks.
 		\add_action( 'transition_post_status', array( $this, 'on_status_change' ), 10, 3 );
 
+		/*
+		 * Historical visibility-cleanup migration is queued (not run)
+		 * on admin_init by a `manage_options`-capable user, and the
+		 * actual batched walk runs in a single-event cron handler.
+		 * Splitting the trigger from the work keeps subscribers from
+		 * driving the full `posts_per_page => -1` walk on their first
+		 * /wp-admin/* hit, and the cron context decouples the long
+		 * walk from any specific admin pageload's timeout budget.
+		 */
+		\add_action( 'admin_init', array( $this, 'maybe_queue_historical_visibility_cleanup' ) );
+		\add_action( 'atmosphere_run_historical_visibility_cleanup', array( $this, 'run_historical_visibility_cleanup' ) );
+
 		// Catch permanent deletes (bypassing trash or emptying trash).
 		\add_action( 'before_delete_post', array( $this, 'on_before_delete' ) );
 
@@ -103,10 +146,27 @@ class Atmosphere {
 		\add_action( 'edit_comment', array( $this, 'on_comment_edit' ) );
 		\add_action( 'delete_comment', array( $this, 'on_comment_before_delete' ) );
 
-		// Auto-sync publication when site identity changes.
+		/*
+		 * Auto-sync the publication record whenever something the record
+		 * derives from changes. The record bakes in WordPress's site
+		 * identity (name, description, icon, home URL) and the active
+		 * theme's primary colours; keeping it in lockstep with those
+		 * sources avoids a stale publication on the PDS until the next
+		 * unrelated event happens to re-sync.
+		 *
+		 * Triggers cover both surfaces a site administrator can edit
+		 * theme colours from: classic-theme Customizer saves
+		 * (`customize_save_after`) and block-theme Site Editor saves
+		 * (the `wp_global_styles` post update).
+		 */
 		\add_action( 'update_option_blogname', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'update_option_blogdescription', array( $this, 'schedule_publication_sync' ) );
 		\add_action( 'update_option_site_icon', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'update_option_home', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'update_option_siteurl', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'switch_theme', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'save_post_wp_global_styles', array( $this, 'schedule_publication_sync' ) );
+		\add_action( 'customize_save_after', array( $this, 'schedule_publication_sync' ) );
 
 		// Token refresh cron.
 		\add_action( 'atmosphere_refresh_token', array( $this, 'cron_refresh_token' ) );
@@ -114,6 +174,19 @@ class Atmosphere {
 		if ( ! \wp_next_scheduled( 'atmosphere_refresh_token' ) && is_connected() ) {
 			\wp_schedule_event( \time(), 'twicedaily', 'atmosphere_refresh_token' );
 		}
+
+		/*
+		 * Async refresh-token revocation, scheduled by
+		 * `Client::disconnect()`. The callback is registered for every
+		 * request so the worker fires correctly when WP-Cron picks up
+		 * the queued event even though the local connection is gone.
+		 */
+		\add_action(
+			'atmosphere_revoke_refresh_token',
+			array( Client::class, 'revoke_refresh_token' ),
+			10,
+			4
+		);
 
 		// Async action hooks (called by WP-Cron).
 		self::register_async_hooks();
@@ -132,9 +205,14 @@ class Atmosphere {
 	 *
 	 * This confirms the bidirectional link between the web page and
 	 * its AT Protocol document record, as required by standard.site.
+	 *
+	 * Gated on `has_identity()` rather than `is_connected()` so the
+	 * verification link survives a temporary OAuth refresh failure —
+	 * the document AT-URI is computed from the DID, which is stable
+	 * across session expiry and `needs_reauth` states.
 	 */
 	public function output_document_link(): void {
-		if ( ! is_connected() || ! \is_singular() ) {
+		if ( ! has_identity() || ! \is_singular() ) {
 			return;
 		}
 
@@ -144,17 +222,20 @@ class Atmosphere {
 			return;
 		}
 
-		if ( ! is_supported_post_type( $post->post_type ) ) {
+		if ( ! is_post_publishable( $post ) ) {
 			return;
 		}
 
-		// Use existing TID or lazily generate one.
-		$doc_tid = \get_post_meta( $post->ID, Document::META_TID, true );
-
-		if ( empty( $doc_tid ) ) {
-			$doc_tid = TID::generate();
-			\update_post_meta( $post->ID, Document::META_TID, $doc_tid );
-		}
+		/*
+		 * Route the TID lookup through `Document::get_rkey()` so the
+		 * lazy mint here writes `META_DID` alongside `META_TID`. The
+		 * inlined fallback that used to live here would have left the
+		 * row in a "TID set, no DID" state, which the mismatch guard
+		 * in `Publisher::delete_post()` treats as "DID unknown, fall
+		 * through to `get_did()`" — re-opening the wrong-repo-delete
+		 * bypass after a reconnect-to-different-account.
+		 */
+		$doc_tid = ( new Document( $post ) )->get_rkey();
 
 		$uri = build_at_uri( get_did(), 'site.standard.document', $doc_tid );
 
@@ -162,6 +243,74 @@ class Atmosphere {
 			'<link rel="site.standard.document" href="%s" />' . "\n",
 			\esc_attr( $uri )
 		);
+	}
+
+	/**
+	 * Output `<link rel="site.standard.publication">` on the URLs that
+	 * map to the publication record's `url` field.
+	 *
+	 * Emitted on:
+	 *
+	 * - Singular publishable posts, so a resolver landing on an article
+	 *   URL can find the parent publication directly without first
+	 *   fetching the document record.
+	 * - The WordPress front page, since the publication record's `url`
+	 *   field is `home_url('/')`. Lets a resolver verify the page <->
+	 *   publication binding by matching AT-URIs, sparing the
+	 *   `.well-known/site.standard.publication` round-trip.
+	 *
+	 * Gated on `has_identity()` (not `is_connected()`) so the
+	 * verification link survives transient OAuth refresh failures, in
+	 * lockstep with {@see Atmosphere::output_document_link()}.
+	 */
+	public function output_publication_link(): void {
+		if ( ! has_identity() ) {
+			return;
+		}
+
+		$pub_tid = \get_option( Publication::OPTION_TID );
+
+		if ( ! $pub_tid ) {
+			return;
+		}
+
+		if ( ! self::is_publication_url() ) {
+			return;
+		}
+
+		$uri = build_at_uri( get_did(), 'site.standard.publication', $pub_tid );
+
+		\printf(
+			'<link rel="site.standard.publication" href="%s" />' . "\n",
+			\esc_attr( $uri )
+		);
+	}
+
+	/**
+	 * Whether the current request URL maps to the publication record's
+	 * `url` field — i.e. a URL where the `<link rel="site.standard.publication">`
+	 * tag belongs.
+	 *
+	 * - The WordPress front page always qualifies, regardless of
+	 *   whether it shows posts or a static page (a static page set
+	 *   as front is both `is_front_page()` AND `is_singular('page')`;
+	 *   checking the front-page condition first is what keeps the
+	 *   tag emitting in that configuration).
+	 * - A publishable singular post qualifies because its document
+	 *   record carries a reference back to the publication.
+	 */
+	private static function is_publication_url(): bool {
+		if ( \is_front_page() ) {
+			return true;
+		}
+
+		if ( ! \is_singular() ) {
+			return false;
+		}
+
+		$post = \get_queried_object();
+
+		return $post instanceof \WP_Post && is_post_publishable( $post );
 	}
 
 	/**
@@ -202,7 +351,15 @@ class Atmosphere {
 			return;
 		}
 
-		if ( ! is_connected() ) {
+		/*
+		 * Identity gate (not connection gate): an expired OAuth session
+		 * must not break domain handle verification. Bluesky's resolver
+		 * re-fetches this endpoint to confirm the bidirectional link
+		 * each time a profile loads, so a transient token failure
+		 * otherwise propagates as "handle no longer resolves" until the
+		 * site admin reconnects.
+		 */
+		if ( ! has_identity() ) {
 			\status_header( 404 );
 			exit;
 		}
@@ -224,7 +381,15 @@ class Atmosphere {
 			return;
 		}
 
-		if ( ! is_connected() ) {
+		/*
+		 * Identity gate (not connection gate): the publication AT-URI is
+		 * derived from the persisted DID + publication TID, both of
+		 * which outlive a transient OAuth refresh failure. Returning 404
+		 * here while waiting for the user to reconnect would break
+		 * standard.site's bidirectional verification each time the
+		 * token rotates.
+		 */
+		if ( ! has_identity() ) {
 			\status_header( 404 );
 			exit;
 		}
@@ -297,56 +462,262 @@ class Atmosphere {
 			return;
 		}
 
-		$is_new_publish = 'publish' === $new_status && 'publish' !== $old_status;
-		$is_update      = 'publish' === $new_status && 'publish' === $old_status;
-		$is_unpublish   = 'publish' === $old_status && 'publish' !== $new_status;
+		$is_publishable         = is_post_publishable( $post );
+		$has_records            = self::has_post_records( $post );
+		$had_visibility_cleanup = self::has_visibility_cleanup_marker( $post );
+		$is_new_publish         = $is_publishable && ! $has_records && ( 'publish' !== $old_status || $had_visibility_cleanup );
+		$is_update              = $is_publishable && ! $is_new_publish;
+		$is_cleanup             = 'publish' === $old_status && ! $is_publishable && $has_records;
 
-		if ( ! $is_new_publish && ! $is_update && ! $is_unpublish ) {
+		if ( ! $is_new_publish && ! $is_update && ! $is_cleanup ) {
 			// Transition between two non-publish states; nothing to schedule.
 			return;
 		}
 
 		/*
-		 * Publish-time decisions respect the supported list so sites
-		 * only sync the post types they've opted into. Unpublish is a
-		 * cleanup path for records that were already synced, so
-		 * narrowing support later must not orphan those remote records:
-		 * unpublish defers to publication metadata (TIDs on the post)
-		 * instead of the current support list.
+		 * Publish-time decisions respect current public visibility.
+		 * Cleanup is different: if a previously-published post becomes
+		 * non-public (draft/private/trash, password-protected, or no
+		 * longer supported), remote records must be removed even though
+		 * the post is no longer publishable.
 		 */
-		if ( ( $is_new_publish || $is_update ) && ! is_supported_post_type( $post->post_type ) ) {
+		if ( isset( self::$publishing_post_ids[ $post->ID ] ) ) {
 			return;
 		}
 
-		if ( $is_unpublish ) {
-			$bsky_tid = \get_post_meta( $post->ID, Transformer\Post::META_TID, true );
-			$doc_tid  = \get_post_meta( $post->ID, Transformer\Document::META_TID, true );
-			if ( ! $bsky_tid && ! $doc_tid ) {
-				// Unpublish of a post that was never synced — nothing to clean up.
-				return;
+		self::$publishing_post_ids[ $post->ID ] = true;
+
+		/*
+		 * Wrap in try/finally so a throwing listener on
+		 * `atmosphere_publishing` (Sentry SDK, JSON_THROW_ON_ERROR in
+		 * a webhook sink, etc.) can't strand the per-post guard. A
+		 * stuck entry silently no-ops every subsequent transition of
+		 * the same post ID in the current PHP process — especially
+		 * painful for WP-CLI bulk imports where one fatal early in
+		 * the run poisons every later transition of that ID.
+		 */
+		try {
+			\do_action( 'atmosphere_publishing', $post );
+
+			if ( $is_publishable ) {
+				\wp_clear_scheduled_hook( 'atmosphere_delete_post', array( $post->ID ) );
 			}
-		}
 
-		// Prevent infinite loops from meta updates.
-		if ( \did_action( 'atmosphere_publishing' ) ) {
+			if ( $is_new_publish ) {
+				\wp_schedule_single_event( \time(), 'atmosphere_publish_post', array( $post->ID ) );
+			} elseif ( $is_update ) {
+				\wp_schedule_single_event( \time(), 'atmosphere_update_post', array( $post->ID ) );
+			} else {
+				self::mark_visibility_cleanup( $post );
+
+				/*
+				 * Genuine unpublish — use atmosphere_delete_post (not
+				 * delete_records) so post meta is cleaned up on success,
+				 * allowing a subsequent restore (trash → publish) to
+				 * republish correctly.
+				 */
+				\wp_schedule_single_event( \time(), 'atmosphere_delete_post', array( $post->ID ) );
+			}
+		} finally {
+			unset( self::$publishing_post_ids[ $post->ID ] );
+		}
+	}
+
+	/**
+	 * Max posts the historical migration scans per cron tick.
+	 *
+	 * Bounded so a site with thousands of historical Atmosphere
+	 * records can't blow the cron handler's execution-time budget on
+	 * a single fire. The handler reschedules itself until the walk is
+	 * exhausted, then sets `OPTION_VISIBILITY_CLEANUP_MIGRATED`.
+	 *
+	 * @var int
+	 */
+	private const VISIBILITY_CLEANUP_BATCH_SIZE = 200;
+
+	/**
+	 * Queue the historical visibility-cleanup walk if needed.
+	 *
+	 * Runs on `admin_init`. Bails on subscriber-level users so the
+	 * cron event is only ever scheduled by an actual administrator,
+	 * even though the walk itself runs in cron context. Bails on
+	 * any other condition that would re-schedule the same event,
+	 * keeping concurrent admin pageloads from queuing duplicates.
+	 */
+	public function maybe_queue_historical_visibility_cleanup(): void {
+		if ( ! \current_user_can( 'manage_options' ) ) {
 			return;
 		}
 
-		\do_action( 'atmosphere_publishing' );
+		if ( ! is_connected() ) {
+			return;
+		}
 
-		if ( $is_new_publish ) {
-			\wp_schedule_single_event( \time(), 'atmosphere_publish_post', array( $post->ID ) );
-		} elseif ( $is_update ) {
-			\wp_schedule_single_event( \time(), 'atmosphere_update_post', array( $post->ID ) );
-		} else {
-			/*
-			 * Genuine unpublish — use atmosphere_delete_post (not
-			 * delete_records) so post meta is cleaned up on success,
-			 * allowing a subsequent restore (trash → publish) to
-			 * republish correctly.
-			 */
+		if ( \get_option( self::OPTION_VISIBILITY_CLEANUP_MIGRATED ) ) {
+			return;
+		}
+
+		if ( \wp_next_scheduled( 'atmosphere_run_historical_visibility_cleanup' ) ) {
+			return;
+		}
+
+		\wp_schedule_single_event( \time(), 'atmosphere_run_historical_visibility_cleanup' );
+	}
+
+	/**
+	 * Cron handler: walk a single batch of historical posts and queue
+	 * cleanup for those that lost public visibility.
+	 *
+	 * Uses keyset (ID > last_seen) paging rather than `offset` — once
+	 * a post's records are deleted, the migration's `meta_query` no
+	 * longer matches it, so offset-paged windows would skip ahead by
+	 * roughly the number of completed deletes per batch. Keyset
+	 * paging is stable against in-flight deletes.
+	 *
+	 * Reschedules itself for the next batch BEFORE processing so a
+	 * mid-batch fatal (OOM, listener fatal) still leaves a recovery
+	 * breadcrumb — the next cron tick picks up at the persisted
+	 * cursor. An empty batch terminates the walk and sets the
+	 * one-shot migration option.
+	 */
+	public function run_historical_visibility_cleanup(): void {
+		if ( \get_option( self::OPTION_VISIBILITY_CLEANUP_MIGRATED ) ) {
+			return;
+		}
+
+		$last_id = (int) \get_option( self::OPTION_VISIBILITY_CLEANUP_LAST_ID, 0 );
+
+		global $wpdb;
+
+		/*
+		 * Raw query because WP_Query's `offset` is unstable under
+		 * concurrent deletes (see method docblock). The meta-key list
+		 * mirrors the OR EXISTS branches the original `meta_query`
+		 * used; `DISTINCT` collapses posts that match on multiple
+		 * keys (very common — most synced posts have both `bsky_tid`
+		 * and `doc_tid`).
+		 */
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		$post_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT p.ID
+				 FROM {$wpdb->posts} p
+				 INNER JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID
+				 WHERE p.ID > %d
+				   AND pm.meta_key IN (%s, %s, %s, %s)
+				 ORDER BY p.ID ASC
+				 LIMIT %d",
+				$last_id,
+				Post::META_TID,
+				Post::META_URI,
+				Post::META_THREAD_RECORDS,
+				Document::META_URI,
+				self::VISIBILITY_CLEANUP_BATCH_SIZE
+			)
+		);
+		// phpcs:enable
+
+		if ( empty( $post_ids ) ) {
+			\delete_option( self::OPTION_VISIBILITY_CLEANUP_LAST_ID );
+			\update_option( self::OPTION_VISIBILITY_CLEANUP_MIGRATED, '1', false );
+			return;
+		}
+
+		/*
+		 * Persist the cursor BEFORE processing the batch and queue
+		 * the next run BEFORE the foreach. A fatal mid-batch then
+		 * leaves a recovery breadcrumb (the next cron pulls up at
+		 * the cursor we've already advanced past in the DB query but
+		 * not in the persisted state) rather than stranding the
+		 * migration until a manage_options admin hits admin_init.
+		 */
+		$max_id = (int) \end( $post_ids );
+		\update_option( self::OPTION_VISIBILITY_CLEANUP_LAST_ID, $max_id, false );
+
+		\wp_schedule_single_event( \time() + 60, 'atmosphere_run_historical_visibility_cleanup' );
+
+		foreach ( $post_ids as $post_id ) {
+			$post = \get_post( (int) $post_id );
+
+			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
+
+			if ( is_post_publishable( $post ) || ! self::has_post_records( $post ) ) {
+				continue;
+			}
+
+			self::mark_visibility_cleanup( $post );
+
+			if ( \wp_next_scheduled( 'atmosphere_delete_post', array( $post->ID ) ) ) {
+				continue;
+			}
+
 			\wp_schedule_single_event( \time(), 'atmosphere_delete_post', array( $post->ID ) );
 		}
+	}
+
+	/**
+	 * Whether the post has local metadata for remote records.
+	 *
+	 * Used to distinguish a cleanup-worthy post from a non-public post
+	 * that never reached the PDS.
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return bool
+	 */
+	private static function has_post_records( \WP_Post $post ): bool {
+		/*
+		 * Drop `Document::META_TID` from the "has records" signal,
+		 * keep everything else.
+		 *
+		 * `Document::META_TID` is the only meta key that can be
+		 * written speculatively: `output_document_link()` (frontend
+		 * `wp_head`) lazily mints it on the first singular pageview
+		 * so the `<link rel="site.standard.document">` tag has
+		 * something to point at — well before any publish to the
+		 * PDS. Treating that pre-publish TID stamp as "has records"
+		 * misclassifies every transition to publish as `is_update`,
+		 * the cron handler refuses because no URI/CID exists to
+		 * update against, and the publish silently no-ops.
+		 *
+		 * `Post::META_TID` is different: Publisher writes it only
+		 * after a successful `applyWrites`, alongside `META_URI` /
+		 * `META_CID`. It's an honest signal of an existing record
+		 * and remains a positive indicator here.
+		 */
+		return ! empty( \get_post_meta( $post->ID, Transformer\Post::META_TID, true ) )
+			|| ! empty( \get_post_meta( $post->ID, Transformer\Post::META_URI, true ) )
+			|| ! empty( \get_post_meta( $post->ID, Transformer\Post::META_THREAD_RECORDS, true ) )
+			|| ! empty( \get_post_meta( $post->ID, Transformer\Document::META_URI, true ) );
+	}
+
+	/**
+	 * Whether this post previously had records removed for visibility.
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return bool
+	 */
+	private static function has_visibility_cleanup_marker( \WP_Post $post ): bool {
+		return (bool) \get_post_meta( $post->ID, self::META_VISIBILITY_CLEANUP, true );
+	}
+
+	/**
+	 * Mark a post as needing fresh publish if it becomes public again.
+	 *
+	 * @param \WP_Post $post Post object.
+	 */
+	public static function mark_visibility_cleanup( \WP_Post $post ): void {
+		\update_post_meta( $post->ID, self::META_VISIBILITY_CLEANUP, '1' );
+	}
+
+	/**
+	 * Clear the visibility-cleanup marker after a successful publish/update.
+	 *
+	 * @param \WP_Post $post Post object.
+	 */
+	private static function clear_visibility_cleanup_marker( \WP_Post $post ): void {
+		\delete_post_meta( $post->ID, self::META_VISIBILITY_CLEANUP );
 	}
 
 	/**
@@ -588,7 +959,23 @@ class Atmosphere {
 			return false;
 		}
 
-		$post_id  = (int) $comment->comment_post_ID;
+		$post_id = (int) $comment->comment_post_ID;
+
+		/*
+		 * Drop the in-process `WP_Post` cache so a concurrent web
+		 * request that just password-protected the parent is visible
+		 * to this worker. Same exposure as the publisher reconcile
+		 * path on installs without a persistent object cache: without
+		 * this invalidation, the cron handler would publish the reply
+		 * against a now-protected parent.
+		 */
+		\clean_post_cache( $post_id );
+		$post = \get_post( $post_id );
+
+		if ( ! $post instanceof \WP_Post || ! is_post_publishable( $post ) ) {
+			return false;
+		}
+
 		$post_uri = \get_post_meta( $post_id, Post::META_URI, true );
 		$post_cid = \get_post_meta( $post_id, Post::META_CID, true );
 
@@ -706,19 +1093,35 @@ class Atmosphere {
 	 */
 	public static function register_async_hooks(): void {
 		/*
-		 * Publish/update cron callbacks re-check post-type support.
-		 * A user (or downstream filter) can disable a post type after a
-		 * cron event was queued, and we must not still publish it.
+		 * Publish/update cron callbacks re-check post visibility.
+		 * A user (or downstream filter) can password-protect a post,
+		 * unpublish it, or disable its post type after a cron event was
+		 * queued, and we must not still publish it.
 		 *
-		 * The delete callback intentionally skips this check so cleanup
-		 * still runs after support is removed.
+		 * The delete callback uses the inverse gate: if the post has
+		 * become publishable again, update the existing records instead
+		 * of deleting them; otherwise clean up any existing remote records.
 		 */
 		\add_action(
 			'atmosphere_publish_post',
 			static function ( int $post_id ): void {
 				$post = \get_post( $post_id );
-				if ( $post && 'publish' === $post->post_status && is_supported_post_type( $post->post_type ) ) {
-					Publisher::publish_post( $post );
+				if ( ! $post ) {
+					return;
+				}
+				if ( is_post_publishable( $post ) ) {
+					$result = self::has_post_records( $post )
+						? Publisher::update_post( $post )
+						: Publisher::publish_post( $post );
+					self::log_cron_error( 'publish_post', $post_id, $result );
+					if ( ! \is_wp_error( $result ) ) {
+						self::clear_visibility_cleanup_marker( $post );
+					}
+					return;
+				}
+				if ( self::has_post_records( $post ) ) {
+					self::mark_visibility_cleanup( $post );
+					self::log_cron_error( 'delete_post', $post_id, Publisher::delete_post( $post ) );
 				}
 			}
 		);
@@ -727,8 +1130,22 @@ class Atmosphere {
 			'atmosphere_update_post',
 			static function ( int $post_id ): void {
 				$post = \get_post( $post_id );
-				if ( $post && 'publish' === $post->post_status && is_supported_post_type( $post->post_type ) ) {
-					Publisher::update_post( $post );
+				if ( ! $post ) {
+					return;
+				}
+				if ( is_post_publishable( $post ) ) {
+					$result = self::has_post_records( $post ) || ! self::has_visibility_cleanup_marker( $post )
+						? Publisher::update_post( $post )
+						: Publisher::publish_post( $post );
+					self::log_cron_error( 'update_post', $post_id, $result );
+					if ( ! \is_wp_error( $result ) ) {
+						self::clear_visibility_cleanup_marker( $post );
+					}
+					return;
+				}
+				if ( self::has_post_records( $post ) ) {
+					self::mark_visibility_cleanup( $post );
+					self::log_cron_error( 'delete_post', $post_id, Publisher::delete_post( $post ) );
 				}
 			}
 		);
@@ -738,7 +1155,20 @@ class Atmosphere {
 			static function ( int $post_id ): void {
 				$post = \get_post( $post_id );
 				if ( $post ) {
-					Publisher::delete_post( $post );
+					if ( is_post_publishable( $post ) ) {
+						$result = self::has_post_records( $post ) || ! self::has_visibility_cleanup_marker( $post )
+							? Publisher::update_post( $post )
+							: Publisher::publish_post( $post );
+						self::log_cron_error( 'delete_post_publishable_reconcile', $post_id, $result );
+						if ( ! \is_wp_error( $result ) ) {
+							self::clear_visibility_cleanup_marker( $post );
+						}
+						return;
+					}
+					if ( self::has_post_records( $post ) ) {
+						self::mark_visibility_cleanup( $post );
+						self::log_cron_error( 'delete_post', $post_id, Publisher::delete_post( $post ) );
+					}
 				}
 			}
 		);
@@ -947,24 +1377,47 @@ class Atmosphere {
 	 * here would lose the breadcrumb operators need to diagnose
 	 * auth, transport, or PDS-side failures.
 	 *
-	 * @param string $op         One of 'publish_comment' | 'update_comment' | 'delete_comment'.
-	 * @param int    $comment_id Comment ID.
-	 * @param mixed  $result     Publisher call result.
+	 * @param string $op        Operation name.
+	 * @param int    $object_id Post or comment ID.
+	 * @param mixed  $result    Publisher call result.
 	 */
-	private static function log_cron_error( string $op, int $comment_id, $result ): void {
+	public static function log_cron_error( string $op, int $object_id, $result ): void {
 		if ( ! \is_wp_error( $result ) ) {
 			return;
 		}
+
+		/*
+		 * PDS error messages flow through `WP_Error::get_error_message()`
+		 * via `API::apply_writes` and can include attacker-controlled
+		 * bytes (CRLF, ANSI escapes, fake `[atmosphere]` prefixes that
+		 * imitate other log lines). `error_log` does not escape them,
+		 * so a misbehaving PDS could otherwise smuggle multiline noise
+		 * into log-shipping pipelines that parse line prefixes.
+		 */
+		$message = \str_replace( array( "\r", "\n" ), ' ', $result->get_error_message() );
 
 		\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			\sprintf(
 				'[atmosphere] %s %d failed: %s — %s',
 				$op,
-				$comment_id,
+				$object_id,
 				$result->get_error_code(),
-				$result->get_error_message()
+				$message
 			)
 		);
+	}
+
+	/**
+	 * Public alias for {@see Atmosphere::log_cron_error()} used by the
+	 * Publisher reconcile path. Routes the cleanup-delete failure
+	 * through a stable op label (`reconcile_cleanup`) so monitors do
+	 * not confuse it with the original publish failure.
+	 *
+	 * @param int   $post_id Post ID whose reconcile cleanup failed.
+	 * @param mixed $result  `WP_Error` from `Publisher::delete_post()`.
+	 */
+	public static function log_reconcile_cleanup_error( int $post_id, $result ): void {
+		self::log_cron_error( 'reconcile_cleanup', $post_id, $result );
 	}
 
 	/**
@@ -988,6 +1441,16 @@ class Atmosphere {
 	 * @param int $comment_id Comment ID just published.
 	 */
 	private static function reconcile_comment_after_publish( int $comment_id ): void {
+		/*
+		 * Drop the in-process `WP_Comment` cache so a concurrent web
+		 * request that just unapproved or deleted this comment is
+		 * visible to the reconcile re-check. Same exposure as the
+		 * publisher reconcile path on installs without a persistent
+		 * object cache: without this invalidation, a moderator's
+		 * mid-publish unapprove races the post-publish read and the
+		 * Bluesky reply stays live with no cleanup scheduled.
+		 */
+		\clean_comment_cache( $comment_id );
 		$fresh = \get_comment( $comment_id );
 
 		if ( $fresh instanceof \WP_Comment && self::should_publish_comment( $fresh ) ) {

--- a/bundled/atmosphere/includes/class-backfill.php
+++ b/bundled/atmosphere/includes/class-backfill.php
@@ -67,6 +67,7 @@ class Backfill {
 			array(
 				'post_type'      => $post_types,
 				'post_status'    => 'publish',
+				'has_password'   => false,
 				'posts_per_page' => -1,
 				'orderby'        => 'date',
 				'order'          => 'DESC',
@@ -113,14 +114,12 @@ class Backfill {
 			\wp_send_json_error( 'No post IDs provided.' );
 		}
 
-		// Resolve supported post types once for the whole batch.
-		$supported = get_supported_post_types();
-		$results   = array();
+		$results = array();
 
 		foreach ( $post_ids as $post_id ) {
 			$post = \get_post( $post_id );
 
-			if ( ! $post || 'publish' !== $post->post_status || ! \in_array( $post->post_type, $supported, true ) ) {
+			if ( ! $post || ! is_post_publishable( $post ) ) {
 				$results[] = array(
 					'id'      => $post_id,
 					'success' => false,

--- a/bundled/atmosphere/includes/class-handle.php
+++ b/bundled/atmosphere/includes/class-handle.php
@@ -315,9 +315,26 @@ class Handle {
 			);
 		}
 
-		$response = API::post(
+		/*
+		 * Called synchronously from `Admin::maybe_set_domain_handle()`
+		 * on `admin_init`, so the submitting administrator waits on
+		 * this HTTP round-trip. The PDS asks the host's
+		 * `/.well-known/atproto-did` for the DID associated with the
+		 * domain; that lookup typically completes well under five
+		 * seconds in practice but can stretch to 15-45s for slow DNS
+		 * or slow-origin combinations. The 60s timeout (versus the
+		 * `wp_safe_remote_post` default of 30s) gives a slow-but-
+		 * eventual success room to land instead of failing the
+		 * verification mid-handshake. The wait is paid by an
+		 * administrator who explicitly clicked the button.
+		 */
+		$response = API::request(
+			'POST',
 			'/xrpc/com.atproto.identity.updateHandle',
-			array( 'handle' => $handle )
+			array(
+				'body'    => array( 'handle' => $handle ),
+				'timeout' => 60,
+			)
 		);
 
 		if ( \is_wp_error( $response ) ) {
@@ -339,12 +356,30 @@ class Handle {
 	 */
 	private static function sync_connection_handle( string $handle ): void {
 		$connection = get_connection();
-		if ( empty( $connection ) ) {
-			return;
+		if ( ! empty( $connection ) ) {
+			$connection['handle'] = $handle;
+			\update_option( 'atmosphere_connection', $connection, false );
 		}
 
-		$connection['handle'] = $handle;
-		\update_option( 'atmosphere_connection', $connection );
+		/*
+		 * Mirror to the durable identity option as well — that is now
+		 * the canonical store consulted by `get_identity()` /
+		 * `has_identity()`, and the publishing UI / verification
+		 * headers read from there. Without this write, a handle change
+		 * would silently drift on the public surface even though the
+		 * PDS has accepted it. Use the namespace helper rather than
+		 * `get_option` directly so a legacy connection still on the
+		 * pre-split shape gets lazy-migrated as a side effect. Identity
+		 * stays autoloaded (true) because it is read on every public
+		 * verification request and contains no secret material; the
+		 * autoload=false above applies only to `atmosphere_connection`,
+		 * which holds the encrypted tokens.
+		 */
+		$identity = get_identity();
+		if ( ! empty( $identity['did'] ) ) {
+			$identity['handle'] = $handle;
+			\update_option( 'atmosphere_identity', $identity, true );
+		}
 	}
 
 	/**

--- a/bundled/atmosphere/includes/class-publisher.php
+++ b/bundled/atmosphere/includes/class-publisher.php
@@ -94,6 +94,17 @@ class Publisher {
 	 * @return array|\WP_Error applyWrites response(s) or error.
 	 */
 	public static function publish_post( \WP_Post $post ): array|\WP_Error {
+		if ( ! is_post_publishable( $post ) ) {
+			$result = new \WP_Error(
+				'atmosphere_post_not_publishable',
+				\__( 'Post is not eligible for AT Protocol publishing.', 'atmosphere' )
+			);
+
+			\do_action( 'atmosphere_publish_post_result', $post, $result );
+
+			return $result;
+		}
+
 		$bsky_transformer = new Post( $post );
 		$doc_transformer  = new Document( $post );
 
@@ -115,6 +126,8 @@ class Publisher {
 			}
 		}
 
+		$result = self::reconcile_post_after_write( $post, $result );
+
 		/**
 		 * Fires after a post publish attempt completes, with the final result.
 		 *
@@ -129,6 +142,63 @@ class Publisher {
 		\do_action( 'atmosphere_publish_post_result', $post, $result );
 
 		return $result;
+	}
+
+	/**
+	 * Remove records that became ineligible while applyWrites was in flight.
+	 *
+	 * @param \WP_Post        $post   Post just written.
+	 * @param array|\WP_Error $result Publisher result.
+	 * @return array|\WP_Error
+	 */
+	private static function reconcile_post_after_write( \WP_Post $post, array|\WP_Error $result ): array|\WP_Error {
+		if ( \is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		/*
+		 * `get_post()` returns the in-process `WP_Object_Cache` copy on
+		 * installs without a persistent object cache drop-in (the
+		 * WordPress default). A concurrent web request that just
+		 * password-protected the post calls `clean_post_cache()` only
+		 * in its own process, so without an explicit invalidation here
+		 * the worker would still see the pre-protect snapshot and
+		 * `is_post_publishable( $fresh )` would return true — letting
+		 * the just-committed records sit live on the PDS.
+		 */
+		\clean_post_cache( $post->ID );
+		$fresh = \get_post( $post->ID );
+
+		if ( $fresh instanceof \WP_Post && is_post_publishable( $fresh ) ) {
+			return $result;
+		}
+
+		if ( ! $fresh instanceof \WP_Post ) {
+			return $result;
+		}
+
+		Atmosphere::mark_visibility_cleanup( $fresh );
+
+		$cleanup = self::delete_post( $fresh );
+
+		if ( \is_wp_error( $cleanup ) ) {
+			/*
+			 * The publish itself succeeded — records are live and meta
+			 * references them. The cleanup-delete failed transiently
+			 * (PDS 429 / network blip / expired refresh token). Surface
+			 * the cleanup failure on its own op label so monitors don't
+			 * mislabel it as a publish failure, but return the original
+			 * publish `$result` so `atmosphere_publish_post_result`
+			 * fires with the publish outcome the caller expects.
+			 * `mark_visibility_cleanup` above leaves the marker in
+			 * place so the next status transition or the historical
+			 * migration revisits the record.
+			 */
+			Atmosphere::log_reconcile_cleanup_error( $fresh->ID, $cleanup );
+			return $result;
+		}
+
+		return $cleanup;
 	}
 
 	/**
@@ -539,6 +609,10 @@ class Publisher {
 	 * @return array|\WP_Error
 	 */
 	public static function update_post( \WP_Post $post ): array|\WP_Error {
+		if ( ! is_post_publishable( $post ) ) {
+			return self::delete_post( $post );
+		}
+
 		$stored = self::stored_thread_records( $post->ID );
 
 		if ( empty( $stored ) ) {
@@ -726,7 +800,7 @@ class Publisher {
 			return $doc_ref_result;
 		}
 
-		return $result;
+		return self::reconcile_post_after_write( $post, $result );
 	}
 
 	/**
@@ -827,7 +901,7 @@ class Publisher {
 			return $doc_ref_result;
 		}
 
-		return $result;
+		return self::reconcile_post_after_write( $post, $result );
 	}
 
 	/**
@@ -967,7 +1041,7 @@ class Publisher {
 	 * @return array|\WP_Error
 	 */
 	public static function delete_post( \WP_Post $post ): array|\WP_Error {
-		$stored  = self::stored_thread_records( $post->ID );
+		$stored  = self::stored_thread_records( $post->ID, true );
 		$doc_tid = \get_post_meta( $post->ID, Document::META_TID, true );
 
 		$comment_tids = self::collect_published_comment_tids( $post->ID );
@@ -976,6 +1050,36 @@ class Publisher {
 			return new \WP_Error(
 				'atmosphere_not_published',
 				\__( 'Post has no AT Protocol records.', 'atmosphere' )
+			);
+		}
+
+		/*
+		 * `applyWrites#delete` always targets the currently-connected
+		 * repo. If the post's records were minted under a different
+		 * DID (disconnect → reconnect-to-different-account, atproto
+		 * account migration), issuing the delete against the current
+		 * DID would silently no-op while leaving the original records
+		 * orphaned on the previous account's PDS. Bail with an
+		 * operator-visible error so the situation is at least logged
+		 * rather than masked behind a successful-looking cleanup.
+		 */
+		$bsky_origin_did = (string) \get_post_meta( $post->ID, Post::META_DID, true );
+		$doc_origin_did  = (string) \get_post_meta( $post->ID, Document::META_DID, true );
+		$current_did     = get_did();
+
+		$bsky_skip = '' !== $bsky_origin_did && '' !== $current_did && $bsky_origin_did !== $current_did;
+		$doc_skip  = '' !== $doc_origin_did && '' !== $current_did && $doc_origin_did !== $current_did;
+
+		if ( ( $bsky_skip && ! empty( $stored ) ) || ( $doc_skip && $doc_tid ) ) {
+			return new \WP_Error(
+				'atmosphere_did_mismatch',
+				\__( 'Cannot delete records that were created under a different connected account.', 'atmosphere' ),
+				array(
+					'post_id'         => $post->ID,
+					'current_did'     => $current_did,
+					'bsky_origin_did' => $bsky_origin_did,
+					'doc_origin_did'  => $doc_origin_did,
+				)
 			);
 		}
 
@@ -1059,6 +1163,17 @@ class Publisher {
 					),
 				),
 				'fields'     => 'ids',
+
+				/*
+				 * Force a deterministic order. `get_comments` defaults
+				 * to `comment_date_gmt DESC`, which ties for comments
+				 * created in the same second — under MySQL 8 / MariaDB
+				 * the tie-break is undefined and varies between PHP
+				 * versions on CI. Ordering by ID matches creation
+				 * order and pins the test contract.
+				 */
+				'orderby'    => 'comment_ID',
+				'order'      => 'ASC',
 			)
 		);
 
@@ -1197,40 +1312,49 @@ class Publisher {
 	 * @return array|\WP_Error
 	 */
 	public static function sync_publication(): array|\WP_Error {
+		$did = get_did();
+
+		/*
+		 * A cron event queued just before `Client::disconnect()` can
+		 * still fire after the connection option is cleared. Calling
+		 * `putRecord` with an empty `repo` would either malform the
+		 * request or — worse — land on whatever DID the auth layer
+		 * happened to cache. Bail before either can happen.
+		 */
+		if ( '' === $did ) {
+			return new \WP_Error(
+				'atmosphere_not_connected',
+				\__( 'Cannot sync the publication record: no active connection.', 'atmosphere' )
+			);
+		}
+
 		$pub = new Publication( null );
 
-		$existing_uri = \get_option( Publication::OPTION_URI );
-
-		if ( $existing_uri ) {
-			$result = API::post(
-				'/xrpc/com.atproto.repo.putRecord',
-				array(
-					'repo'       => get_did(),
-					'collection' => 'site.standard.publication',
-					'rkey'       => $pub->get_rkey(),
-					'record'     => $pub->transform(),
-				)
-			);
-		} else {
-			$result = API::post(
-				'/xrpc/com.atproto.repo.createRecord',
-				array(
-					'repo'       => get_did(),
-					'collection' => 'site.standard.publication',
-					'rkey'       => $pub->get_rkey(),
-					'record'     => $pub->transform(),
-				)
-			);
-		}
-
-		if ( \is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		$uri = $result['uri'] ?? $pub->get_uri();
-		\update_option( Publication::OPTION_URI, $uri, false );
-
-		return $result;
+		/*
+		 * Always `putRecord`. AT Protocol's `putRecord` is an upsert:
+		 * it creates the record when missing and overwrites when
+		 * present. A previous version branched between `createRecord`
+		 * and `putRecord` based on a locally-persisted URI option;
+		 * after disconnect/reconnect-to-a-different-DID that branch
+		 * could pick `createRecord` against a repo that already had
+		 * the record (PDS replies "already exists") or `putRecord`
+		 * against a repo that did not (which `putRecord` handles
+		 * fine, but the inconsistency made the local state hard to
+		 * reason about). Using `putRecord` unconditionally collapses
+		 * both cases into a single upsert against the CURRENT DID +
+		 * locally-persisted TID — the rkey is stable across
+		 * reconnects, so the record always lands at the same address
+		 * for the active owner.
+		 */
+		return API::post(
+			'/xrpc/com.atproto.repo.putRecord',
+			array(
+				'repo'       => $did,
+				'collection' => 'site.standard.publication',
+				'rkey'       => $pub->get_rkey(),
+				'record'     => $pub->transform(),
+			)
+		);
 	}
 
 	/**
@@ -1566,10 +1690,11 @@ class Publisher {
 	 * meta so posts published before this key existed still delete/update
 	 * correctly.
 	 *
-	 * @param int $post_id Post ID.
+	 * @param int  $post_id          Post ID.
+	 * @param bool $include_bare_tid Include a reserved TID even when URI is absent.
 	 * @return array[] Array of { uri, cid, tid } triples, possibly empty.
 	 */
-	private static function stored_thread_records( int $post_id ): array {
+	private static function stored_thread_records( int $post_id, bool $include_bare_tid = false ): array {
 		$stored = \get_post_meta( $post_id, Post::META_THREAD_RECORDS, true );
 		if ( \is_array( $stored ) && ! empty( $stored ) ) {
 			return $stored;
@@ -1585,8 +1710,23 @@ class Publisher {
 		// republish failed). Treat that as "nothing published" so the
 		// caller falls back to a fresh publish and the reserved TID is
 		// reused on the next attempt.
-		if ( ! $uri ) {
+		if ( ! $uri && ( ! $include_bare_tid || ! $tid ) ) {
 			return array();
+		}
+
+		if ( ! $uri && $tid ) {
+			/*
+			 * Synthesize the URI from the DID that minted the TID, not
+			 * the currently-connected DID. After a disconnect+reconnect
+			 * to a different account, `get_did()` would otherwise build
+			 * an AT-URI pointing at the new account's repo for a record
+			 * that lives (or never landed) under the previous account.
+			 */
+			$origin_did = (string) \get_post_meta( $post_id, Post::META_DID, true );
+			if ( '' === $origin_did ) {
+				$origin_did = get_did();
+			}
+			$uri = build_at_uri( $origin_did, 'app.bsky.feed.post', (string) $tid );
 		}
 
 		return array(

--- a/bundled/atmosphere/includes/class-reaction-sync.php
+++ b/bundled/atmosphere/includes/class-reaction-sync.php
@@ -504,6 +504,34 @@ class Reaction_Sync {
 		array $notification,
 		array $profile
 	): int|false {
+		/*
+		 * Deliberately NOT gating on `comments_open( $post_id )` here.
+		 * `paginate()` advances the per-collection watermark to the
+		 * newest URI on each page regardless of whether the per-item
+		 * callback accepted the item; if we dropped reactions on
+		 * closed-comments posts at this gate, the watermark would
+		 * still move past them and a subsequent reopen of comments
+		 * could not recover the missed imports — the WATERMARK_GRACE
+		 * window is only ten items.
+		 *
+		 * Federated reactions are an audit record of activity that
+		 * happened on Bluesky, not a comment-form submission. Insert
+		 * the row, let the moderation pipeline below decide the
+		 * approval state, and accept that imported reactions remain
+		 * in `wp_comments` even on closed-comments posts.
+		 *
+		 * Caveat: WordPress's stock `comments_template()` hides
+		 * comments when `comments_open()` is false, but themes that
+		 * render comments without going through `comments_template()`,
+		 * and the REST `/wp/v2/comments` endpoint, will still surface
+		 * these rows on closed-comments posts. Sites that need
+		 * stricter rendering control should filter `the_comments` /
+		 * `rest_prepare_comment` themselves; we don't register
+		 * display-side filters here because the existence of the
+		 * comment row is the federation history record this method
+		 * is responsible for preserving.
+		 */
+
 		$uri    = $notification['uri'] ?? '';
 		$cid    = $notification['cid'] ?? '';
 		$author = $notification['author'] ?? array();
@@ -521,13 +549,58 @@ class Reaction_Sync {
 			'comment_author'       => $author_name,
 			'comment_author_url'   => \esc_url_raw( 'https://bsky.app/profile/' . \rawurlencode( $author_handle ) ),
 			'comment_author_email' => '',
+			'comment_author_IP'    => '',
 			'comment_content'      => \wp_kses_post( $content ),
 			'comment_date'         => \get_date_from_gmt( $gm_date ),
 			'comment_date_gmt'     => $gm_date,
 			'comment_type'         => $comment_type,
-			'comment_approved'     => 1,
 			'comment_agent'        => 'ATmosphere/' . ATMOSPHERE_VERSION,
+			'user_id'              => 0,
 		);
+
+		/*
+		 * Run the full WordPress moderation pipeline rather than just
+		 * gating on `comment_moderation`. `wp_allow_comment()` evaluates
+		 * the same chain WordPress applies to native comment submissions:
+		 *
+		 *   - `comment_moderation` ("hold all comments")
+		 *   - `comment_whitelist` (previously-approved-author bypass)
+		 *   - `comment_max_links` threshold
+		 *   - `disallowed_keys` blacklist (returns WP_Error)
+		 *   - `moderation_keys` (returns approved=0)
+		 *   - the `pre_comment_approved` filter chain, which is where
+		 *     Akismet stamps spam verdicts and where any third-party
+		 *     anti-spam plugin hooks in.
+		 *
+		 * Without this call, importing Bluesky reactions silently
+		 * bypassed every one of those checks; only `comment_moderation`
+		 * was honoured. A `WP_Error` return means the comment was
+		 * hard-rejected (e.g. disallowed-keys hit) — drop the import.
+		 *
+		 * `wp_is_comment_flood` is short-circuited to false for this
+		 * one call: federated reactions are server-to-server traffic
+		 * without an IP, so WordPress's IP/email-based 15-second flood
+		 * heuristic doesn't model them correctly — rate-limiting for
+		 * inbound reactions happens upstream at Bluesky's relay. The
+		 * filter is removed immediately after the call so it cannot
+		 * affect any subsequent user-submitted comment in the same
+		 * request.
+		 *
+		 * The `ATmosphere/` `comment_agent` stamp keeps the outbound
+		 * comment-publish cron (`atmosphere_publish_comment`) from
+		 * picking the row back up regardless of approval state, so a
+		 * held reaction can be approved in wp-admin later without
+		 * being written back to the Bluesky PDS.
+		 */
+		\add_filter( 'wp_is_comment_flood', '__return_false', 99 );
+		$approved = \wp_allow_comment( $comment_data, true );
+		\remove_filter( 'wp_is_comment_flood', '__return_false', 99 );
+
+		if ( \is_wp_error( $approved ) ) {
+			return false;
+		}
+
+		$comment_data['comment_approved'] = $approved;
 
 		$comment_id = \wp_insert_comment( $comment_data );
 
@@ -646,6 +719,7 @@ class Reaction_Sync {
 				'meta_value'     => $uri, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'posts_per_page' => 1,
 				'post_status'    => 'publish',
+				'has_password'   => false,
 				'fields'         => 'ids',
 			)
 		);
@@ -660,6 +734,7 @@ class Reaction_Sync {
 				'meta_value'     => $uri, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'posts_per_page' => 1,
 				'post_status'    => 'publish',
+				'has_password'   => false,
 				'fields'         => 'ids',
 			)
 		);

--- a/bundled/atmosphere/includes/functions.php
+++ b/bundled/atmosphere/includes/functions.php
@@ -99,7 +99,7 @@ function to_iso8601( string $datetime ): string {
 }
 
 /**
- * Get the stored connection data.
+ * Get the stored connection (OAuth credentials + ephemeral state).
  *
  * @return array
  */
@@ -108,13 +108,94 @@ function get_connection(): array {
 }
 
 /**
- * Check whether the plugin is connected to a PDS.
+ * Get the persisted AT Protocol identity (DID, handle, PDS endpoint).
+ *
+ * Identity is stored separately from the OAuth credentials so that a
+ * failed token refresh — which clears the live session — does not also
+ * wipe the bidirectional verification headers (`.well-known/atproto-did`
+ * and the `<link rel="site.standard.document">` tag). On a legacy
+ * connection that still embeds the identity inside `atmosphere_connection`
+ * this performs a one-shot lazy migration into the new option.
+ *
+ * @return array{did?: string, handle?: string, pds_endpoint?: string}
+ */
+function get_identity(): array {
+	$identity = \get_option( 'atmosphere_identity', array() );
+
+	if ( ! empty( $identity['did'] ) ) {
+		return $identity;
+	}
+
+	$conn = get_connection();
+
+	if ( empty( $conn['did'] ) ) {
+		return array();
+	}
+
+	$identity = array(
+		'did'          => (string) $conn['did'],
+		'handle'       => (string) ( $conn['handle'] ?? '' ),
+		'pds_endpoint' => (string) ( $conn['pds_endpoint'] ?? '' ),
+	);
+
+	\update_option( 'atmosphere_identity', $identity, true );
+
+	return $identity;
+}
+
+/**
+ * Whether a persisted AT Protocol identity is on file.
+ *
+ * Drives the public verification headers and the settings UI's
+ * publishing section so they keep functioning across token expiry.
+ *
+ * @return bool
+ */
+function has_identity(): bool {
+	return ! empty( get_identity()['did'] );
+}
+
+/**
+ * Whether the plugin holds a live OAuth session against the PDS.
+ *
+ * Returns false when the credentials are missing OR the connection
+ * is flagged `needs_reauth` (last refresh attempt was rejected with
+ * a permanent error). Use `has_identity()` for code paths that only
+ * need the site's DID/handle and do not require live credentials.
  *
  * @return bool
  */
 function is_connected(): bool {
+	if ( ! has_identity() ) {
+		return false;
+	}
+
 	$conn = get_connection();
-	return ! empty( $conn['access_token'] ) && ! empty( $conn['did'] );
+
+	if ( ! empty( $conn['needs_reauth'] ) ) {
+		return false;
+	}
+
+	return ! empty( $conn['access_token'] );
+}
+
+/**
+ * Whether the connection requires the user to re-authorize.
+ *
+ * True when an identity is on file but the credentials option is
+ * missing, empty, or flagged `needs_reauth` after a permanent OAuth
+ * refresh failure. False on a never-connected site.
+ *
+ * @return bool
+ */
+function needs_reauth(): bool {
+	if ( ! has_identity() ) {
+		return false;
+	}
+
+	$conn = get_connection();
+
+	return ! empty( $conn['needs_reauth'] ) || empty( $conn['access_token'] );
 }
 
 /**
@@ -123,7 +204,7 @@ function is_connected(): bool {
  * @return string
  */
 function get_did(): string {
-	return get_connection()['did'] ?? '';
+	return (string) ( get_identity()['did'] ?? '' );
 }
 
 /**
@@ -132,7 +213,7 @@ function get_did(): string {
  * @return string
  */
 function get_pds_endpoint(): string {
-	return get_connection()['pds_endpoint'] ?? '';
+	return (string) ( get_identity()['pds_endpoint'] ?? '' );
 }
 
 /**
@@ -158,6 +239,7 @@ function get_cron_hooks(): array {
 		'atmosphere_update_comment',
 		'atmosphere_delete_comment',
 		'atmosphere_delete_comment_record',
+		'atmosphere_run_historical_visibility_cleanup',
 		// Legacy hook from an early build of the comment publisher; cleared
 		// for users upgrading from that snapshot.
 		'atmosphere_sync_comments',
@@ -165,12 +247,38 @@ function get_cron_hooks(): array {
 }
 
 /**
- * Clear every plugin-owned scheduled hook.
+ * Clear every plugin-owned scheduled hook used during disconnect.
+ *
+ * The `atmosphere_revoke_refresh_token` event is intentionally NOT
+ * cleared here. `Client::disconnect()` schedules it AFTER this helper
+ * runs so a slow auth server cannot block the admin click; including
+ * it in the loop would clear the event we just queued. The cron
+ * worker is a one-shot best-effort POST; once it fires (or its
+ * scheduled-event row ages out), there is nothing local to clean up.
+ *
+ * `deactivate()` and uninstall use {@see clear_scheduled_hooks_all()}
+ * instead because at that point the plugin is going away and the
+ * still-queued revoke event would orphan encrypted ciphertexts in
+ * `wp_options['cron']` forever — WP-Cron does not auto-drop rows
+ * whose callbacks are no longer registered.
  */
 function clear_scheduled_hooks(): void {
 	foreach ( get_cron_hooks() as $hook ) {
 		\wp_clear_scheduled_hook( $hook );
 	}
+}
+
+/**
+ * Clear every plugin-owned scheduled hook, including the one-shot
+ * revocation hook `Client::disconnect()` defers cleanup of.
+ *
+ * Use at plugin deactivation / uninstall so a queued revoke event
+ * does not sit in `wp_options['cron']` with encrypted ciphertext
+ * waiting for a callback that no longer exists.
+ */
+function clear_scheduled_hooks_all(): void {
+	clear_scheduled_hooks();
+	\wp_clear_scheduled_hook( 'atmosphere_revoke_refresh_token' );
 }
 
 /**
@@ -190,4 +298,20 @@ function get_supported_post_types(): array {
  */
 function is_supported_post_type( string $post_type ): bool {
 	return Post_Types::supports( $post_type );
+}
+
+/**
+ * Whether a post is currently eligible for AT Protocol publishing.
+ *
+ * Federation output is remote, site-wide state. Do not use
+ * post_password_required() here: it depends on the current visitor's
+ * unlock cookie and can leak protected content into PDS records.
+ *
+ * @param \WP_Post $post Post object.
+ * @return bool
+ */
+function is_post_publishable( \WP_Post $post ): bool {
+	return 'publish' === $post->post_status
+		&& '' === (string) $post->post_password
+		&& is_supported_post_type( $post->post_type );
 }

--- a/bundled/atmosphere/includes/oauth/class-client.php
+++ b/bundled/atmosphere/includes/oauth/class-client.php
@@ -13,6 +13,7 @@ namespace Atmosphere\OAuth;
 \defined( 'ABSPATH' ) || exit;
 
 use function Atmosphere\clear_scheduled_hooks;
+use function Atmosphere\get_connection;
 
 /**
  * OAuth client that manages the authorization lifecycle.
@@ -40,6 +41,16 @@ class Client {
 	private const SCOPES = 'atproto transition:generic identity:handle';
 
 	/**
+	 * `wp_options` row name used as the cross-process refresh lock.
+	 *
+	 * Public so `uninstall.php` and the test suite can refer to the same
+	 * key without drifting from the canonical value used here.
+	 *
+	 * @var string
+	 */
+	public const REFRESH_LOCK_OPTION = '_atmosphere_refresh_lock';
+
+	/**
 	 * Get the client_id URL (= client metadata endpoint).
 	 *
 	 * @return string
@@ -51,21 +62,56 @@ class Client {
 	/**
 	 * OAuth callback URI (admin page with special query param).
 	 *
+	 * The return value of this method is sent to the auth server as
+	 * `redirect_uri` in the PAR / authorize request and also baked into
+	 * the public client metadata document. If a third-party filter
+	 * returns a non-admin URL, the auth server happily redirects the
+	 * authorization code to that destination on completion — which is
+	 * an OAuth token-leak primitive. We validate the filter return is
+	 * a string pointing at this site's admin and fall back to the
+	 * default URI on anything else.
+	 *
 	 * @return string
 	 */
 	public static function redirect_uri(): string {
-		$uri = \admin_url( 'options-general.php?page=atmosphere' );
+		/*
+		 * Force the `https` scheme regardless of what `admin_url()`
+		 * would default to. AT Protocol auth servers will return the
+		 * authorization code by redirecting the browser to this URL;
+		 * on an HTTP-configured admin that code would otherwise travel
+		 * in cleartext. Sites that don't actually serve admin over
+		 * HTTPS will fail to load the redirect, which is the safer
+		 * failure mode.
+		 */
+		$uri = \admin_url( 'options-general.php?page=atmosphere', 'https' );
 
 		/**
 		 * Filters the OAuth redirect URI.
 		 *
 		 * Allows consumers (e.g. wrapper plugins) to set their own callback
 		 * URL so the OAuth flow returns to their admin page instead of the
-		 * default Atmosphere settings page.
+		 * default Atmosphere settings page. The return MUST be a string
+		 * pointing at this site's admin area over HTTPS — anything else is
+		 * rejected to prevent a malicious or buggy filter from redirecting
+		 * OAuth codes off-site or over cleartext.
 		 *
 		 * @param string $uri Default redirect URI.
 		 */
-		return \apply_filters( 'atmosphere_oauth_redirect_uri', $uri );
+		$filtered = \apply_filters( 'atmosphere_oauth_redirect_uri', $uri );
+
+		if ( ! \is_string( $filtered ) || '' === $filtered ) {
+			return $uri;
+		}
+
+		if ( ! \str_starts_with( $filtered, 'https://' ) ) {
+			return $uri;
+		}
+
+		if ( ! \str_starts_with( $filtered, \admin_url( '', 'https' ) ) ) {
+			return $uri;
+		}
+
+		return $filtered;
 	}
 
 	/**
@@ -78,9 +124,25 @@ class Client {
 	 * @return string|\WP_Error Authorization URL or error.
 	 */
 	public static function authorize( string $handle ): string|\WP_Error {
+		/*
+		 * Rate-limit AFTER a successful `Resolver::resolve()`, not
+		 * before. The earlier ordering charged the per-user bucket on
+		 * every handle-typo / DNS-miss / malformed-DID-document path,
+		 * even though those failures never reach the auth server — so
+		 * ten consecutive typos in fifteen minutes locked the admin
+		 * out without any abusive request having occurred. Resolver
+		 * itself is bounded by its own DNS + HTTP timeouts, so the
+		 * pre-resolve flood surface stays narrow even without a
+		 * bucket charge here.
+		 */
 		$resolved = Resolver::resolve( $handle );
 		if ( \is_wp_error( $resolved ) ) {
 			return $resolved;
+		}
+
+		$rate_limit = self::rate_limit_check();
+		if ( \is_wp_error( $rate_limit ) ) {
+			return $rate_limit;
 		}
 
 		$auth_meta = $resolved['auth_server'];
@@ -95,10 +157,27 @@ class Client {
 		// State for CSRF.
 		$state = \wp_generate_password( 40, false );
 
-		// Persist transient data needed for callback.
+		/*
+		 * Persist transient data needed for callback. The DPoP JWK
+		 * contains the ES256 private `d` parameter and must never sit
+		 * in plaintext in `wp_options` — encrypt it the same way the
+		 * persisted connection encrypts the key after callback
+		 * (`Encryption::encrypt()` below at the option write).
+		 *
+		 * Compute the ciphertext BEFORE writing any transients.
+		 * `Encryption::encrypt()` ultimately calls `random_bytes()`
+		 * and `sodium_crypto_secretbox()`, both of which can throw.
+		 * If we wrote verifier + state first and the encrypt then
+		 * threw, those transients would sit orphaned for an hour and
+		 * the user would see `atmosphere_expired` on retry until they
+		 * expired naturally. Doing the encrypt first means a thrown
+		 * exception bubbles up cleanly with no orphans.
+		 */
+		$dpop_jwk_ciphertext = Encryption::encrypt( (string) \wp_json_encode( $dpop_jwk ) );
+
 		\set_transient( 'atmosphere_oauth_verifier', $verifier, HOUR_IN_SECONDS );
 		\set_transient( 'atmosphere_oauth_state', $state, HOUR_IN_SECONDS );
-		\set_transient( 'atmosphere_oauth_dpop_jwk', $dpop_jwk, HOUR_IN_SECONDS );
+		\set_transient( 'atmosphere_oauth_dpop_jwk', $dpop_jwk_ciphertext, HOUR_IN_SECONDS );
 		\set_transient(
 			'atmosphere_oauth_resolved',
 			array(
@@ -175,7 +254,7 @@ class Client {
 			'login_hint'            => $did,
 		);
 
-		$response = \wp_remote_post(
+		$response = \wp_safe_remote_post(
 			$par_url,
 			array(
 				'headers' => array(
@@ -199,6 +278,9 @@ class Client {
 
 		$status = \wp_remote_retrieve_response_code( $response );
 		$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+		if ( ! \is_array( $data ) ) {
+			$data = array();
+		}
 
 		// Retry once with nonce on use_dpop_nonce error.
 		if ( \in_array( $status, array( 400, 401 ), true )
@@ -211,7 +293,7 @@ class Client {
 				return new \WP_Error( 'atmosphere_dpop', \__( 'DPoP nonce retry failed.', 'atmosphere' ) );
 			}
 
-			$response = \wp_remote_post(
+			$response = \wp_safe_remote_post(
 				$par_url,
 				array(
 					'headers' => array(
@@ -234,6 +316,9 @@ class Client {
 
 			$status = \wp_remote_retrieve_response_code( $response );
 			$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+			if ( ! \is_array( $data ) ) {
+				$data = array();
+			}
 		}
 
 		if ( $status >= 400 || empty( $data['request_uri'] ) ) {
@@ -257,6 +342,11 @@ class Client {
 	 * @return true|\WP_Error
 	 */
 	public static function handle_callback( string $code, string $state ): true|\WP_Error {
+		$rate_limit = self::rate_limit_check();
+		if ( \is_wp_error( $rate_limit ) ) {
+			return $rate_limit;
+		}
+
 		// Verify state.
 		$stored_state = \get_transient( 'atmosphere_oauth_state' );
 		if ( ! $stored_state || ! \hash_equals( $stored_state, $state ) ) {
@@ -270,13 +360,40 @@ class Client {
 		}
 		\delete_transient( 'atmosphere_oauth_verifier' );
 
-		$dpop_jwk = \get_transient( 'atmosphere_oauth_dpop_jwk' );
-		$resolved = \get_transient( 'atmosphere_oauth_resolved' );
+		$dpop_jwk_blob = \get_transient( 'atmosphere_oauth_dpop_jwk' );
+		$resolved      = \get_transient( 'atmosphere_oauth_resolved' );
 		\delete_transient( 'atmosphere_oauth_dpop_jwk' );
 		\delete_transient( 'atmosphere_oauth_resolved' );
 
-		if ( ! $dpop_jwk || ! $resolved ) {
+		if ( ! $dpop_jwk_blob || ! $resolved ) {
 			return new \WP_Error( 'atmosphere_expired', \__( 'OAuth session data missing. Please try again.', 'atmosphere' ) );
+		}
+
+		/*
+		 * Pre-encryption versions of the plugin stored the DPoP JWK as
+		 * a plain array in the transient. A user who started OAuth on
+		 * the old code and completes the callback after upgrading
+		 * sees a non-string value here. Distinct error code from
+		 * "transient expired" so support can tell the two cases apart.
+		 */
+		if ( ! \is_string( $dpop_jwk_blob ) ) {
+			return new \WP_Error(
+				'atmosphere_legacy_session',
+				\__( 'OAuth session predates the latest update. Please try connecting again.', 'atmosphere' )
+			);
+		}
+
+		$dpop_jwk_json = Encryption::decrypt( $dpop_jwk_blob );
+		if ( false === $dpop_jwk_json ) {
+			return new \WP_Error( 'atmosphere_decrypt', \__( 'Failed to decrypt OAuth session key.', 'atmosphere' ) );
+		}
+
+		$dpop_jwk = \json_decode( $dpop_jwk_json, true );
+		if ( ! \is_array( $dpop_jwk ) ) {
+			return new \WP_Error(
+				'atmosphere_session_malformed',
+				\__( 'OAuth session key is malformed. Please try again.', 'atmosphere' )
+			);
 		}
 
 		$token_endpoint = $resolved['auth_server']['token_endpoint'];
@@ -295,7 +412,7 @@ class Client {
 			'code_verifier' => $verifier,
 		);
 
-		$response = \wp_remote_post(
+		$response = \wp_safe_remote_post(
 			$token_endpoint,
 			array(
 				'headers' => array(
@@ -315,6 +432,9 @@ class Client {
 		$nonce  = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
 		$status = \wp_remote_retrieve_response_code( $response );
 		$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+		if ( ! \is_array( $data ) ) {
+			$data = array();
+		}
 
 		if ( $nonce ) {
 			DPoP::persist_nonce( $dpop_jwk, $token_endpoint, $nonce );
@@ -329,7 +449,7 @@ class Client {
 				return new \WP_Error( 'atmosphere_dpop', \__( 'DPoP nonce retry failed during token exchange.', 'atmosphere' ) );
 			}
 
-			$response = \wp_remote_post(
+			$response = \wp_safe_remote_post(
 				$token_endpoint,
 				array(
 					'headers' => array(
@@ -345,8 +465,23 @@ class Client {
 				return $response;
 			}
 
+			/*
+			 * Persist the nonce from the retry response too. Auth
+			 * servers rotate nonces per response; without this write
+			 * the stored nonce stays at whatever the first response
+			 * advertised, so the next DPoP-bound request issues a
+			 * stale proof and forces another `use_dpop_nonce` retry.
+			 */
+			$nonce_retry = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
+			if ( $nonce_retry ) {
+				DPoP::persist_nonce( $dpop_jwk, $token_endpoint, $nonce_retry );
+			}
+
 			$status = \wp_remote_retrieve_response_code( $response );
 			$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+			if ( ! \is_array( $data ) ) {
+				$data = array();
+			}
 		}
 
 		if ( $status >= 400 || empty( $data['access_token'] ) ) {
@@ -354,26 +489,88 @@ class Client {
 			return new \WP_Error( 'atmosphere_token', $msg );
 		}
 
-		// Persist connection.
-		$connection = array(
-			'did'            => $resolved['did'],
-			'handle'         => $resolved['handle'],
-			'pds_endpoint'   => $resolved['pds_endpoint'],
-			'auth_server'    => $resolved['auth_server']['issuer_url'],
-			'token_endpoint' => $token_endpoint,
-			'access_token'   => Encryption::encrypt( $data['access_token'] ),
-			'refresh_token'  => ! empty( $data['refresh_token'] ) ? Encryption::encrypt( $data['refresh_token'] ) : '',
-			'dpop_jwk'       => Encryption::encrypt( (string) \wp_json_encode( $dpop_jwk ) ),
-			'expires_at'     => \time() + ( $data['expires_in'] ?? 3600 ),
+		/*
+		 * Persist identity separately from the credentials so a later
+		 * refresh failure can wipe the live session without taking the
+		 * domain's verification headers down with it. The credentials
+		 * option still holds did/handle/pds_endpoint as well for
+		 * backward compatibility with any external consumer reading the
+		 * pre-split shape; the canonical source of truth for identity
+		 * is `atmosphere_identity`.
+		 */
+		\update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => $resolved['did'],
+				'handle'       => $resolved['handle'],
+				'pds_endpoint' => $resolved['pds_endpoint'],
+			),
+			true
 		);
 
-		\update_option( 'atmosphere_connection', $connection );
+		$connection = array(
+			'did'                 => $resolved['did'],
+			'handle'              => $resolved['handle'],
+			'pds_endpoint'        => $resolved['pds_endpoint'],
+			'auth_server'         => $resolved['auth_server']['issuer_url'],
+			'token_endpoint'      => $token_endpoint,
+			'revocation_endpoint' => isset( $resolved['auth_server']['revocation_endpoint'] )
+				? (string) $resolved['auth_server']['revocation_endpoint']
+				: '',
+			'access_token'        => Encryption::encrypt( $data['access_token'] ),
+			'refresh_token'       => ! empty( $data['refresh_token'] ) ? Encryption::encrypt( $data['refresh_token'] ) : '',
+			'dpop_jwk'            => Encryption::encrypt( (string) \wp_json_encode( $dpop_jwk ) ),
+			'expires_at'          => \time() + ( $data['expires_in'] ?? 3600 ),
+			'needs_reauth'        => false,
+		);
+
+		/*
+		 * Encrypted token blobs do not need to ride along in every
+		 * request's `alloptions` payload; they're only read on the
+		 * paths that actually talk to the PDS. WP 6.6+ honours the
+		 * autoload flag on subsequent `update_option` calls too, so
+		 * existing autoloaded rows flip on the next reconnect.
+		 */
+		\update_option( 'atmosphere_connection', $connection, false );
 
 		return true;
 	}
 
 	/**
+	 * Maximum lifetime (seconds) of the refresh lock before it is
+	 * presumed stale and reclaimed.
+	 *
+	 * `refresh_locked()` can issue up to two HTTP POSTs sequentially when
+	 * the auth server requires a `use_dpop_nonce` retry — each with a
+	 * 15-second `wp_safe_remote_post` timeout, plus encryption /
+	 * option I/O overhead. A TTL shorter than that worst case would
+	 * let a second worker reclaim a lock the first worker is still
+	 * legitimately holding, which reintroduces the concurrent-refresh
+	 * race the lock exists to close. 90 seconds covers 2 × 15s
+	 * timeouts plus ample margin.
+	 *
+	 * @var int
+	 */
+	private const REFRESH_LOCK_TTL = 90;
+
+	/**
 	 * Refresh the access token.
+	 *
+	 * Gated by a cross-process coordination lock so a publish event
+	 * firing inline through `access_token()`, the twice-daily refresh
+	 * cron, an admin click, or any combination of those cannot both
+	 * POST the same refresh token to the auth server. The auth server
+	 * consumes the refresh token on first success and the loser would
+	 * otherwise receive `invalid_grant`, which used to delete a
+	 * perfectly-working connection.
+	 *
+	 * Atomicity comes from {@see self::lock()}, which uses
+	 * `INSERT IGNORE` on the `wp_options` UNIQUE index — portable to
+	 * every WP-supported DB and truly cross-process. When the lock is
+	 * already held, this method short-circuits to success if the
+	 * stored token has already been rotated to a fresh value,
+	 * otherwise it returns a soft error and lets the other process
+	 * finish.
 	 *
 	 * @return true|\WP_Error
 	 */
@@ -384,6 +581,52 @@ class Client {
 			return new \WP_Error( 'atmosphere_no_refresh', \__( 'No refresh token available.', 'atmosphere' ) );
 		}
 
+		if ( ! self::lock() ) {
+			$fresh = \get_option( 'atmosphere_connection', array() );
+
+			if ( ! empty( $fresh['access_token'] )
+				&& empty( $fresh['needs_reauth'] )
+				&& ! empty( $fresh['expires_at'] )
+				&& $fresh['expires_at'] > \time() + 300
+			) {
+				return true;
+			}
+
+			return new \WP_Error(
+				'atmosphere_refresh_locked',
+				\__( 'Token refresh is already in progress; another request will pick up the new token.', 'atmosphere' )
+			);
+		}
+
+		try {
+			/*
+			 * Re-read the connection after acquiring the lock. Another
+			 * caller may have completed a refresh between our initial
+			 * read and the lock acquisition; using a stale refresh
+			 * token here would defeat the point of locking.
+			 */
+			$conn = \get_option( 'atmosphere_connection', array() );
+
+			if ( empty( $conn['refresh_token'] ) ) {
+				return new \WP_Error( 'atmosphere_no_refresh', \__( 'No refresh token available.', 'atmosphere' ) );
+			}
+
+			return self::refresh_locked( $conn );
+		} finally {
+			self::unlock();
+		}
+	}
+
+	/**
+	 * Inner refresh routine. Runs under the refresh lock acquired in
+	 * `refresh()`. Do not call directly — concurrent callers will
+	 * burn the refresh token. Always go through `refresh()` which
+	 * holds the lock.
+	 *
+	 * @param array $conn Connection option as read at lock-acquisition time.
+	 * @return true|\WP_Error
+	 */
+	private static function refresh_locked( array $conn ): true|\WP_Error {
 		$refresh_token = Encryption::decrypt( $conn['refresh_token'] );
 		if ( false === $refresh_token ) {
 			return new \WP_Error( 'atmosphere_decrypt', \__( 'Failed to decrypt refresh token.', 'atmosphere' ) );
@@ -408,7 +651,7 @@ class Client {
 			'client_id'     => self::client_id(),
 		);
 
-		$response = \wp_remote_post(
+		$response = \wp_safe_remote_post(
 			$token_endpoint,
 			array(
 				'headers' => array(
@@ -427,6 +670,9 @@ class Client {
 		$nonce  = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
 		$status = \wp_remote_retrieve_response_code( $response );
 		$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+		if ( ! \is_array( $data ) ) {
+			$data = array();
+		}
 
 		if ( $nonce ) {
 			DPoP::persist_nonce( $dpop_jwk, $token_endpoint, $nonce );
@@ -442,7 +688,7 @@ class Client {
 				return new \WP_Error( 'atmosphere_dpop', \__( 'DPoP nonce retry failed during refresh.', 'atmosphere' ) );
 			}
 
-			$response = \wp_remote_post(
+			$response = \wp_safe_remote_post(
 				$token_endpoint,
 				array(
 					'headers' => array(
@@ -458,37 +704,313 @@ class Client {
 				return $response;
 			}
 
+			/*
+			 * Persist the nonce from the retry response too. Auth
+			 * servers rotate nonces per response; without this write
+			 * the stored nonce stays at whatever the first response
+			 * advertised, so the next DPoP-bound refresh issues a
+			 * stale proof and forces another `use_dpop_nonce` retry.
+			 */
+			$nonce_retry = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
+			if ( $nonce_retry ) {
+				DPoP::persist_nonce( $dpop_jwk, $token_endpoint, $nonce_retry );
+			}
+
 			$status = \wp_remote_retrieve_response_code( $response );
 			$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+			if ( ! \is_array( $data ) ) {
+				$data = array();
+			}
 		}
 
 		if ( $status >= 400 || empty( $data['access_token'] ) ) {
 			$msg = $data['error_description'] ?? ( $data['error'] ?? \__( 'Token refresh failed.', 'atmosphere' ) );
 
 			/*
-			 * Only delete the connection for permanent errors where the
-			 * refresh token has been consumed or revoked. Transient errors
-			 * (rate-limiting, server errors) may not have consumed the
-			 * token, so the connection can recover on the next attempt.
+			 * Only mark the connection as needing reauth for permanent
+			 * errors where the refresh token has been consumed or revoked.
+			 * Transient errors (rate-limiting, server errors) may not have
+			 * consumed the token, so the connection can recover on the
+			 * next attempt without operator action.
+			 *
+			 * The connection row itself is preserved (rather than deleted)
+			 * so the durable identity inside it stays available for the
+			 * public verification headers — see `Atmosphere\has_identity()`
+			 * and the gates in `output_document_link()` and the well-known
+			 * endpoints. `is_connected()` returns false while
+			 * `needs_reauth` is set, so the publish, comment, and API
+			 * callers short-circuit until the user re-authorizes.
 			 */
 			$error = $data['error'] ?? '';
 			if ( \in_array( $error, array( 'invalid_grant', 'invalid_client', 'unauthorized_client' ), true ) ) {
-				\delete_option( 'atmosphere_connection' );
+				/*
+				 * Re-read the connection before writing, and only stamp
+				 * `needs_reauth` if the row STILL holds the same
+				 * refresh-token ciphertext we read at lock-acquisition
+				 * time. Two races close here:
+				 *
+				 *   - Admin disconnected mid-flight: the row is gone
+				 *     and the `refresh_token` check below fails.
+				 *   - Admin disconnected + reconnected to a different
+				 *     account mid-flight: the row exists but the
+				 *     `refresh_token` ciphertext is different (libsodium
+				 *     re-encrypts with a fresh nonce). Stamping
+				 *     `needs_reauth` on the NEW account because the
+				 *     OLD account's refresh failed would be wrong.
+				 */
+				$current = \get_option( 'atmosphere_connection', array() );
+				if ( \is_array( $current )
+					&& ! empty( $current['refresh_token'] )
+					&& isset( $conn['refresh_token'] )
+					&& \hash_equals( (string) $conn['refresh_token'], (string) $current['refresh_token'] )
+				) {
+					$current['needs_reauth'] = true;
+					$current['access_token'] = '';
+					unset( $current['expires_at'] );
+					\update_option( 'atmosphere_connection', $current, false );
+				}
 			}
 
 			return new \WP_Error( 'atmosphere_refresh', $msg );
 		}
 
-		$conn['access_token'] = Encryption::encrypt( $data['access_token'] );
-		$conn['expires_at']   = \time() + ( $data['expires_in'] ?? 3600 );
+		/*
+		 * Re-read the connection before persisting the rotated token.
+		 * Two races are possible while the worker is in-flight:
+		 *
+		 *  1. Admin clicks Disconnect — `atmosphere_connection` is
+		 *     deleted. Writing the post-network token back would
+		 *     resurrect the row the admin just removed.
+		 *  2. Admin clicks Disconnect AND immediately reconnects to a
+		 *     different account. The row exists, but `refresh_token`
+		 *     belongs to the NEW account; writing our rotated tokens
+		 *     would overwrite the new account's access_token with
+		 *     credentials minted against the OLD account's session.
+		 *
+		 * Both are closed by comparing the refresh-token ciphertext we
+		 * read at lock-acquisition time against the current row. The
+		 * ciphertexts are random per encryption (libsodium uses a
+		 * fresh nonce on every `encrypt()`), so any change at all —
+		 * delete-then-recreate, reconnect, even an unrelated
+		 * `sync_connection_handle()` write that re-encrypted the row
+		 * — fails the equality check and the worker bails.
+		 */
+		$current = \get_option( 'atmosphere_connection', array() );
 
-		if ( ! empty( $data['refresh_token'] ) ) {
-			$conn['refresh_token'] = Encryption::encrypt( $data['refresh_token'] );
+		if ( ! \is_array( $current )
+			|| empty( $current['refresh_token'] )
+			|| ! isset( $conn['refresh_token'] )
+			|| ! \hash_equals( (string) $conn['refresh_token'], (string) $current['refresh_token'] )
+		) {
+			return new \WP_Error(
+				'atmosphere_disconnected_mid_refresh',
+				\__( 'Connection changed while the refresh was in-flight; new tokens were discarded.', 'atmosphere' )
+			);
 		}
 
-		\update_option( 'atmosphere_connection', $conn );
+		$current['access_token'] = Encryption::encrypt( $data['access_token'] );
+		$current['expires_at']   = \time() + ( $data['expires_in'] ?? 3600 );
+		$current['needs_reauth'] = false;
+
+		if ( ! empty( $data['refresh_token'] ) ) {
+			$current['refresh_token'] = Encryption::encrypt( $data['refresh_token'] );
+		}
+
+		\update_option( 'atmosphere_connection', $current, false );
 
 		return true;
+	}
+
+	/**
+	 * Acquire the refresh-in-progress lock. Returns true if this caller
+	 * now owns the lock; false if another request already holds a
+	 * non-expired lock.
+	 *
+	 * Atomicity comes from the `UNIQUE` index on `wp_options.option_name`:
+	 * `INSERT IGNORE` will succeed for exactly one concurrent caller and
+	 * silently no-op for the rest. The stored value is the expiry
+	 * timestamp; if a holder crashes mid-refresh, the next caller reads
+	 * a past expiry and atomically steals the row via a `UPDATE ... WHERE
+	 * option_value = $previous` compare-and-swap.
+	 *
+	 * Direct `$wpdb` queries are used (rather than `add_option`) because
+	 * `add_option` is itself a check-then-INSERT and is not safe under
+	 * concurrent acquisition. The options cache is invalidated by hand
+	 * on every write so a subsequent `get_option` lookup elsewhere in
+	 * the codebase does not return a cached value.
+	 *
+	 * Note: re-locking by the same caller returns false. The lock has
+	 * no notion of owner identity; pair every successful `lock()` with
+	 * a matching `unlock()` in a `try`/`finally`.
+	 *
+	 * @return bool
+	 */
+	public static function lock(): bool {
+		global $wpdb;
+
+		$key        = self::REFRESH_LOCK_OPTION;
+		$now        = \time();
+		$expires_at = $now + self::REFRESH_LOCK_TTL;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$inserted = $wpdb->query(
+			$wpdb->prepare(
+				"INSERT IGNORE INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %s, %s)",
+				$key,
+				(string) $expires_at,
+				'no'
+			)
+		);
+
+		if ( 1 === (int) $inserted ) {
+			self::invalidate_lock_option_cache( $key );
+			return true;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$existing = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				$key
+			)
+		);
+
+		if ( $existing > 0 && $now < $existing ) {
+			return false;
+		}
+
+		/*
+		 * Compare-and-swap: only steal the lock if the row still holds
+		 * the timestamp we just read. If a third caller stole the row
+		 * between the SELECT and this UPDATE, the WHERE clause filters
+		 * us out and we report failure.
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$stolen = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND option_value = %s",
+				(string) $expires_at,
+				$key,
+				(string) $existing
+			)
+		);
+
+		if ( 1 === (int) $stolen ) {
+			self::invalidate_lock_option_cache( $key );
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Release the refresh-in-progress lock.
+	 *
+	 * Safe to call unconditionally — a missing row is a no-op.
+	 */
+	public static function unlock(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->delete( $wpdb->options, array( 'option_name' => self::REFRESH_LOCK_OPTION ) );
+		self::invalidate_lock_option_cache( self::REFRESH_LOCK_OPTION );
+	}
+
+	/**
+	 * Whether the refresh lock is currently held by any caller.
+	 *
+	 * Returns false when the lock row is absent or its stored expiry is
+	 * in the past — both states indicate the next {@see self::lock()}
+	 * call would succeed. Useful for diagnostics and for tests; the
+	 * production refresh path uses {@see self::lock()}'s return value
+	 * directly to avoid a redundant SELECT.
+	 *
+	 * @return bool
+	 */
+	public static function locked(): bool {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$value = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				self::REFRESH_LOCK_OPTION
+			)
+		);
+
+		if ( null === $value ) {
+			return false;
+		}
+
+		return \time() < (int) $value;
+	}
+
+	/**
+	 * Invalidate the WP options cache for the lock row so a later
+	 * `get_option` call does not see a stale value written by the
+	 * direct `$wpdb` queries above.
+	 *
+	 * @param string $key Option name.
+	 */
+	private static function invalidate_lock_option_cache( string $key ): void {
+		\wp_cache_delete( $key, 'options' );
+		\wp_cache_delete( 'notoptions', 'options' );
+	}
+
+	/**
+	 * Poll the connection option waiting for the concurrent refresh
+	 * holder to write a fresh access token (or to flip
+	 * `needs_reauth` on a permanent failure).
+	 *
+	 * The deadline matches `REFRESH_LOCK_TTL` (90s) rather than a
+	 * conservative few-seconds wait. The previous 5-second budget
+	 * was shorter than the realistic worst case — two sequential
+	 * `wp_safe_remote_post` calls at 15-second timeouts on the
+	 * `use_dpop_nonce` retry path plus encryption overhead — which
+	 * meant single-shot publish / comment cron events that arrived
+	 * mid-refresh would silently drop their content even though the
+	 * holder was about to land a fresh token. Aligning with the
+	 * lock TTL guarantees we either see the holder's result or
+	 * conclude the holder crashed (lock will be reclaimable on the
+	 * next call).
+	 *
+	 * Returns `true` when the stored token has been rotated and is
+	 * safe to use, or a `WP_Error` when the holder either flipped
+	 * `needs_reauth` (permanent failure) or did not finish in time.
+	 * Used by {@see self::access_token()} so that a publish or
+	 * comment cron event does not get silently dropped when it
+	 * arrives mid-refresh.
+	 *
+	 * @return true|\WP_Error
+	 */
+	private static function wait_for_token_refresh(): true|\WP_Error {
+		$deadline = \microtime( true ) + (float) self::REFRESH_LOCK_TTL;
+
+		while ( \microtime( true ) < $deadline ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			\usleep( 100000 );
+
+			$conn = \get_option( 'atmosphere_connection', array() );
+
+			if ( ! empty( $conn['needs_reauth'] ) ) {
+				return new \WP_Error(
+					'atmosphere_needs_reauth',
+					\__( 'AT Protocol session expired during concurrent refresh. Reconnect to resume publishing.', 'atmosphere' )
+				);
+			}
+
+			if ( ! empty( $conn['access_token'] )
+				&& ! empty( $conn['expires_at'] )
+				&& $conn['expires_at'] > \time() + 300
+			) {
+				return true;
+			}
+		}
+
+		return new \WP_Error(
+			'atmosphere_refresh_locked',
+			\__( 'Token refresh did not complete in time.', 'atmosphere' )
+		);
 	}
 
 	/**
@@ -499,6 +1021,13 @@ class Client {
 	public static function access_token(): string|\WP_Error {
 		$conn = \get_option( 'atmosphere_connection', array() );
 
+		if ( ! empty( $conn['needs_reauth'] ) ) {
+			return new \WP_Error(
+				'atmosphere_needs_reauth',
+				\__( 'AT Protocol session expired. Reconnect to resume publishing.', 'atmosphere' )
+			);
+		}
+
 		if ( empty( $conn['access_token'] ) ) {
 			return new \WP_Error( 'atmosphere_not_connected', \__( 'Not connected to AT Protocol.', 'atmosphere' ) );
 		}
@@ -506,9 +1035,28 @@ class Client {
 		// Refresh if expiring within 5 minutes.
 		if ( ! empty( $conn['expires_at'] ) && $conn['expires_at'] < \time() + 300 ) {
 			$result = self::refresh();
+
 			if ( \is_wp_error( $result ) ) {
-				return $result;
+				/*
+				 * Another caller is refreshing right now. Wait briefly
+				 * for them to finish before failing the publish/comment
+				 * cron event we are part of: those events are consumed
+				 * on dispatch and not retried, so propagating the
+				 * `atmosphere_refresh_locked` error would silently drop
+				 * the post or comment even though the other caller is
+				 * about to rotate the token.
+				 */
+				if ( 'atmosphere_refresh_locked' === $result->get_error_code() ) {
+					$waited = self::wait_for_token_refresh();
+
+					if ( \is_wp_error( $waited ) ) {
+						return $waited;
+					}
+				} else {
+					return $result;
+				}
 			}
+
 			$conn = \get_option( 'atmosphere_connection', array() );
 		}
 
@@ -528,10 +1076,418 @@ class Client {
 	 * connection check, so a disconnect→reconnect-to-different-account
 	 * cycle would otherwise fire deletes against the new account's repo.
 	 * Mirrors the cleanup performed on plugin deactivate / uninstall.
+	 *
+	 * Best-effort revokes the refresh token at the auth server (RFC 7009)
+	 * so a leaked refresh token stops working server-side even though
+	 * disconnect already removed it locally. The revocation POST is
+	 * deferred to a single-shot WP-Cron event scheduled AFTER
+	 * `clear_scheduled_hooks()` runs (so the helper does not clear the
+	 * very event we just queued), keeping the admin click responsive:
+	 * a slow or unreachable auth server otherwise blocks disconnect
+	 * for up to ~20 seconds (two synchronous 10-second POSTs).
 	 */
 	public static function disconnect(): void {
+		$conn = \get_option( 'atmosphere_connection', array() );
+
+		/*
+		 * Capture the inputs the revocation worker needs BEFORE we
+		 * wipe the local options. The encrypted ciphertexts are passed
+		 * directly to the cron worker so it can decrypt them later
+		 * without re-reading `atmosphere_connection`, which is about
+		 * to be deleted.
+		 */
+		$revoke_args = null;
+		if ( \is_array( $conn )
+			&& ! empty( $conn['refresh_token'] )
+			&& ! empty( $conn['dpop_jwk'] )
+			&& ! empty( $conn['revocation_endpoint'] )
+			&& ! empty( $conn['auth_server'] )
+		) {
+			/*
+			 * Pass the auth-server issuer URL alongside the revocation
+			 * endpoint. The cron worker binds the two at use time: if
+			 * a tampered or backup-restored `atmosphere_connection`
+			 * row pointed `revocation_endpoint` at an attacker host,
+			 * the refresh token would otherwise be POSTed to that
+			 * host even though `is_safe_https_url()` would not block
+			 * it (the check only confirms HTTPS + safe host, not the
+			 * issuer-binding). Including the issuer here lets the
+			 * worker reject endpoint↔issuer mismatches before the
+			 * decryption step.
+			 */
+			$revoke_args = array(
+				(string) $conn['refresh_token'],
+				(string) $conn['dpop_jwk'],
+				(string) $conn['revocation_endpoint'],
+				(string) $conn['auth_server'],
+			);
+		}
+
 		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( self::REFRESH_LOCK_OPTION );
+
+		/*
+		 * Sweep a stale option from 1.0.0 installs. `atmosphere_publication_uri`
+		 * was cached state that nothing in production ever read — the
+		 * well-known endpoint and the Document transformer's `site`
+		 * reference both derive the publication URI on demand from
+		 * `get_did()` + the publication TID. Drop the row so it does
+		 * not linger on disconnected installs. `atmosphere_publication_tid`
+		 * stays put because that TID is the stable site-level
+		 * identifier that survives reconnects to the same account.
+		 */
+		\delete_option( 'atmosphere_publication_uri' );
+
 		clear_scheduled_hooks();
+
+		if ( null !== $revoke_args ) {
+			\wp_schedule_single_event(
+				\time(),
+				'atmosphere_revoke_refresh_token',
+				$revoke_args
+			);
+		}
+	}
+
+	/**
+	 * Best-effort revoke a refresh token at the auth server.
+	 *
+	 * Invoked by the `atmosphere_revoke_refresh_token` cron hook from
+	 * `disconnect()`. Decrypts the ciphertexts the caller captured
+	 * before the local state was wiped, and POSTs the token to the
+	 * auth server's `revocation_endpoint` per RFC 7009. AT Protocol
+	 * auth servers require DPoP-bound revocation, so the request
+	 * carries a DPoP proof and retries once on `use_dpop_nonce`
+	 * exactly like `refresh()` does. Any failure path returns
+	 * silently after logging — disconnect already succeeded locally
+	 * by the time this fires.
+	 *
+	 * @param string $refresh_token_ciphertext Encrypted refresh token
+	 *                                         captured at disconnect.
+	 * @param string $dpop_jwk_ciphertext      Encrypted DPoP JWK.
+	 * @param string $revocation_endpoint      Auth server revocation URL.
+	 * @param string $auth_server_issuer       Auth server issuer URL the
+	 *                                         revocation endpoint must
+	 *                                         share an origin with.
+	 */
+	public static function revoke_refresh_token(
+		string $refresh_token_ciphertext,
+		string $dpop_jwk_ciphertext,
+		string $revocation_endpoint,
+		string $auth_server_issuer = ''
+	): void {
+		if ( '' === $revocation_endpoint ) {
+			return;
+		}
+
+		/*
+		 * Validate at call time, not just at the resolver during
+		 * connect. The stored option may have been imported from a
+		 * backup, restored from a migration tool, or filtered by a
+		 * misbehaving plugin since the connection was minted. POSTing
+		 * a refresh token to a non-HTTPS or otherwise-unsafe URL on
+		 * disconnect would leak it to whoever controls that endpoint.
+		 */
+		if ( ! Resolver::is_safe_https_url( $revocation_endpoint ) ) {
+			return;
+		}
+
+		/*
+		 * Bind the revocation endpoint to the auth-server issuer
+		 * origin. `is_safe_https_url()` above confirms the URL is
+		 * well-formed HTTPS to a non-private host, but says nothing
+		 * about which host. A tampered `atmosphere_connection` row
+		 * could have swapped `revocation_endpoint` for
+		 * `https://attacker.example/collect` between connect and
+		 * disconnect; without this check the cron worker would
+		 * happily POST the decrypted refresh token there.
+		 *
+		 * The comparison is scheme + host + port (origin in the RFC
+		 * 6454 sense). The auth-server is always HTTPS (the resolver
+		 * already enforces that), so in practice this comes down to
+		 * matching the host plus an explicit port if either side
+		 * declares one. Missing ports normalise to the HTTPS default
+		 * (443) so `auth.example.com` and `auth.example.com:443`
+		 * compare equal.
+		 */
+		if ( '' !== $auth_server_issuer ) {
+			$revoke_host = $revocation_endpoint ? \wp_parse_url( $revocation_endpoint, PHP_URL_HOST ) : '';
+			$issuer_host = \wp_parse_url( $auth_server_issuer, PHP_URL_HOST );
+			$revoke_port = \wp_parse_url( $revocation_endpoint, PHP_URL_PORT );
+			$issuer_port = \wp_parse_url( $auth_server_issuer, PHP_URL_PORT );
+
+			if ( ! \is_string( $revoke_host )
+				|| ! \is_string( $issuer_host )
+				|| '' === $revoke_host
+				|| \strtolower( $revoke_host ) !== \strtolower( $issuer_host )
+				|| ( $revoke_port ?? 443 ) !== ( $issuer_port ?? 443 )
+			) {
+				return;
+			}
+		}
+
+		if ( '' === $refresh_token_ciphertext || '' === $dpop_jwk_ciphertext ) {
+			return;
+		}
+
+		$refresh_token = Encryption::decrypt( $refresh_token_ciphertext );
+		$dpop_jwk_json = Encryption::decrypt( $dpop_jwk_ciphertext );
+		if ( false === $refresh_token || false === $dpop_jwk_json ) {
+			return;
+		}
+
+		$dpop_jwk = \json_decode( $dpop_jwk_json, true );
+		if ( ! \is_array( $dpop_jwk ) ) {
+			return;
+		}
+
+		$body = array(
+			'token'           => $refresh_token,
+			'token_type_hint' => 'refresh_token',
+			'client_id'       => self::client_id(),
+		);
+
+		$dpop_proof = DPoP::create_proof( $dpop_jwk, 'POST', $revocation_endpoint );
+		if ( false === $dpop_proof ) {
+			return;
+		}
+
+		$response = \wp_safe_remote_post(
+			$revocation_endpoint,
+			array(
+				'headers' => array(
+					'Content-Type' => 'application/x-www-form-urlencoded',
+					'DPoP'         => $dpop_proof,
+				),
+				'body'    => $body,
+				'timeout' => 10,
+			)
+		);
+
+		if ( \is_wp_error( $response ) ) {
+			\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				\sprintf(
+					'[atmosphere] refresh-token revocation failed: %s',
+					$response->get_error_message()
+				)
+			);
+			return;
+		}
+
+		$nonce = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
+		if ( $nonce ) {
+			DPoP::persist_nonce( $dpop_jwk, $revocation_endpoint, $nonce );
+		}
+
+		$status = \wp_remote_retrieve_response_code( $response );
+		$data   = \json_decode( \wp_remote_retrieve_body( $response ), true );
+		if ( ! \is_array( $data ) ) {
+			$data = array();
+		}
+
+		if ( \in_array( $status, array( 400, 401 ), true )
+			&& ( $data['error'] ?? '' ) === 'use_dpop_nonce'
+			&& $nonce
+		) {
+			$dpop_proof = DPoP::create_proof( $dpop_jwk, 'POST', $revocation_endpoint, $nonce );
+			if ( false === $dpop_proof ) {
+				return;
+			}
+
+			$response = \wp_safe_remote_post(
+				$revocation_endpoint,
+				array(
+					'headers' => array(
+						'Content-Type' => 'application/x-www-form-urlencoded',
+						'DPoP'         => $dpop_proof,
+					),
+					'body'    => $body,
+					'timeout' => 10,
+				)
+			);
+
+			if ( \is_wp_error( $response ) ) {
+				\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					\sprintf(
+						'[atmosphere] refresh-token revocation retry failed: %s',
+						$response->get_error_message()
+					)
+				);
+				return;
+			}
+
+			$nonce_retry = \wp_remote_retrieve_header( $response, 'dpop-nonce' );
+			if ( $nonce_retry ) {
+				DPoP::persist_nonce( $dpop_jwk, $revocation_endpoint, $nonce_retry );
+			}
+
+			$status = \wp_remote_retrieve_response_code( $response );
+		}
+
+		/*
+		 * RFC 7009 §2.2: revocation responses are 200 even when the
+		 * token is unknown to the auth server. A 4xx/5xx generally
+		 * indicates a misconfigured client or a server outage; either
+		 * way disconnect proceeds.
+		 */
+		if ( $status >= 400 ) {
+			\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				\sprintf(
+					'[atmosphere] refresh-token revocation returned status %d',
+					$status
+				)
+			);
+		}
+	}
+
+	/**
+	 * Maximum OAuth attempts (authorize + callback combined) per user
+	 * inside a single rate-limit window.
+	 *
+	 * @var int
+	 */
+	private const RATE_LIMIT_MAX = 10;
+
+	/**
+	 * Rate-limit window in seconds.
+	 *
+	 * @var int
+	 */
+	private const RATE_LIMIT_WINDOW = 900;
+
+	/**
+	 * Throttle OAuth start and callback per WordPress user.
+	 *
+	 * The admin-only capability gate keeps the surface narrow, but a
+	 * compromised admin or a chain that survives the nonce check (a
+	 * settings-screen XSS in another plugin, for example) could
+	 * otherwise drive unbounded outbound requests to an attacker-chosen
+	 * auth server via the handle field. The counter is cheap, scoped to
+	 * the current user (or a shared `0` bucket for unauthenticated
+	 * callers, which the admin nonce normally rejects anyway), and
+	 * naturally resets when the window expires.
+	 *
+	 * @return true|\WP_Error
+	 */
+	private static function rate_limit_check(): true|\WP_Error {
+		global $wpdb;
+
+		/*
+		 * Why direct $wpdb instead of the options API or a transient?
+		 * The rate-limit semantics require atomicity: two concurrent
+		 * callers at `attempts = N - 1` must not both pass the cap.
+		 * None of the WordPress-idiomatic primitives give us that
+		 * cross-process guarantee on a default install:
+		 *
+		 *   - `set_transient` / `get_transient` is a check-then-set
+		 *     pair; the two callers above both `get` 9, both pass
+		 *     the `>=` check, both `set` 10. The cap silently
+		 *     doubles under contention.
+		 *   - `add_option` does a preflight `SELECT` then an
+		 *     `INSERT ... ON DUPLICATE KEY UPDATE`, so on the second
+		 *     INSERT it overwrites the first caller's value rather
+		 *     than failing — also not atomic for our purpose.
+		 *   - `wp_cache_add` is atomic on installs with a persistent
+		 *     object cache (Redis, Memcached) but degrades to a
+		 *     per-request store on default WP, where it cannot see
+		 *     a concurrent worker's bucket at all.
+		 *
+		 * `INSERT IGNORE` is atomic at the SQL layer because of the
+		 * UNIQUE index on `wp_options.option_name`. Combined with
+		 * the CAS-loop below (`UPDATE ... WHERE option_value = $previous`),
+		 * the entire read-decide-write cycle becomes lock-free and
+		 * cross-process correct. The bespoke SQL is the price of an
+		 * actually-atomic counter; the per-user bucket holds two
+		 * digits and an integer expiry, so the storage is cheap.
+		 *
+		 * The encoded value is `attempts|expires_at` so the whole
+		 * bucket is a single packed payload the CAS can replace
+		 * with one statement. Window expiry is encoded in the value
+		 * itself (rather than relying on transient TTL) so stale
+		 * windows reset themselves on the next CAS-iteration.
+		 */
+		$key        = \sprintf( '_atmosphere_oauth_rate_%d', \get_current_user_id() );
+		$now        = \time();
+		$expires_at = $now + self::RATE_LIMIT_WINDOW;
+
+		/*
+		 * First-in-window race: `INSERT IGNORE` is atomic on the
+		 * `wp_options` UNIQUE index, so exactly one concurrent
+		 * caller writes the initial `1|expires_at` row. Everyone
+		 * else falls through to the CAS-loop below.
+		 */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$inserted = $wpdb->query(
+			$wpdb->prepare(
+				"INSERT IGNORE INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %s, %s)",
+				$key,
+				'1|' . $expires_at,
+				'no'
+			)
+		);
+
+		if ( 1 === (int) $inserted ) {
+			self::invalidate_lock_option_cache( $key );
+			return true;
+		}
+
+		/*
+		 * Row exists. Walk a bounded compare-and-swap loop: read the
+		 * current packed value, decide what the next value should be
+		 * (cap-reached / window-expired-reset / increment), then
+		 * `UPDATE ... WHERE option_value = $previous`. The WHERE
+		 * clause filters out anyone else who beat us between SELECT
+		 * and UPDATE, so the loser retries on a fresh read. Five
+		 * tries is more than enough under realistic contention; if
+		 * we still cannot land an update, fail closed so the
+		 * caller backs off rather than passing in a torn state.
+		 */
+		for ( $i = 0; $i < 5; $i++ ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$current = (string) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+					$key
+				)
+			);
+
+			$parts            = \explode( '|', $current, 2 );
+			$current_attempts = (int) ( $parts[0] ?? 0 );
+			$current_expiry   = (int) ( $parts[1] ?? 0 );
+
+			if ( $now >= $current_expiry ) {
+				// Window has expired; reset to 1 attempt in a fresh window.
+				$next = '1|' . ( $now + self::RATE_LIMIT_WINDOW );
+			} elseif ( $current_attempts >= self::RATE_LIMIT_MAX ) {
+				return new \WP_Error(
+					'atmosphere_rate_limited',
+					\__( 'Too many OAuth attempts. Please wait a few minutes and try again.', 'atmosphere' )
+				);
+			} else {
+				$next = ( $current_attempts + 1 ) . '|' . $current_expiry;
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$updated = (int) $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND option_value = %s",
+					$next,
+					$key,
+					$current
+				)
+			);
+
+			if ( 1 === $updated ) {
+				self::invalidate_lock_option_cache( $key );
+				return true;
+			}
+		}
+
+		return new \WP_Error(
+			'atmosphere_rate_limited',
+			\__( 'Too many OAuth attempts. Please wait a few minutes and try again.', 'atmosphere' )
+		);
 	}
 
 	/**

--- a/bundled/atmosphere/includes/oauth/class-dpop.php
+++ b/bundled/atmosphere/includes/oauth/class-dpop.php
@@ -79,11 +79,20 @@ class DPoP {
 				'jwk' => $public_jwk,
 			);
 
+			$iat = \time();
+
+			/*
+			 * `exp` is OPTIONAL in RFC 9449 but bounds the replay window
+			 * regardless of how lenient the receiving server is about
+			 * proof age. Sixty seconds matches common server-side caps
+			 * and leaves room for clock skew + transport latency.
+			 */
 			$payload = array(
 				'jti' => self::base64url( \random_bytes( 16 ) ),
 				'htm' => \strtoupper( $method ),
 				'htu' => $url,
-				'iat' => \time(),
+				'iat' => $iat,
+				'exp' => $iat + 60,
 			);
 
 			if ( null !== $nonce ) {

--- a/bundled/atmosphere/includes/oauth/class-nonce-storage.php
+++ b/bundled/atmosphere/includes/oauth/class-nonce-storage.php
@@ -13,6 +13,8 @@ namespace Atmosphere\OAuth;
 
 \defined( 'ABSPATH' ) || exit;
 
+use function Atmosphere\get_did;
+
 /**
  * Simple key-value nonce storage via transients.
  */
@@ -55,12 +57,20 @@ class Nonce_Storage {
 	}
 
 	/**
-	 * Hash a URL to a safe transient suffix.
+	 * Hash a URL + current account DID to a safe transient suffix.
+	 *
+	 * The connected DID participates in the key so a future
+	 * multi-account variant of the plugin (or a third-party fork) can't
+	 * silently share a nonce that was issued to account A with a
+	 * request signed by account B. When no DID is connected the URL
+	 * alone is sufficient — the only paths that hit this code without
+	 * a connection are pre-callback resolution requests, which the
+	 * auth server happily issues a fresh nonce for.
 	 *
 	 * @param string $url URL.
 	 * @return string 32-char hex string.
 	 */
 	private static function hash( string $url ): string {
-		return \md5( $url );
+		return \md5( get_did() . '|' . $url );
 	}
 }

--- a/bundled/atmosphere/includes/oauth/class-resolver.php
+++ b/bundled/atmosphere/includes/oauth/class-resolver.php
@@ -24,6 +24,13 @@ class Resolver {
 	 * @return string|\WP_Error DID string or error.
 	 */
 	public static function handle_to_did( string $handle ): string|\WP_Error {
+		if ( ! self::is_valid_handle( $handle ) ) {
+			return new \WP_Error(
+				'atmosphere_invalid_handle',
+				\__( 'Handle is not a valid DNS-style identifier.', 'atmosphere' )
+			);
+		}
+
 		// Try DNS TXT first: _atproto.<handle>.
 		$records = @\dns_get_record( '_atproto.' . $handle, DNS_TXT ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 
@@ -36,7 +43,7 @@ class Resolver {
 		}
 
 		// Fallback: HTTPS well-known.
-		$response = \wp_remote_get(
+		$response = \wp_safe_remote_get(
 			'https://' . $handle . '/.well-known/atproto-did',
 			array( 'timeout' => 10 )
 		);
@@ -71,7 +78,13 @@ class Resolver {
 			$url = 'https://plc.directory/' . $did;
 		} elseif ( \str_starts_with( $did, 'did:web:' ) ) {
 			$domain = \substr( $did, 8 );
-			$url    = 'https://' . $domain . '/.well-known/did.json';
+			if ( ! self::is_valid_handle( $domain ) ) {
+				return new \WP_Error(
+					'atmosphere_invalid_did',
+					\__( 'did:web identifier is not a valid DNS-style host.', 'atmosphere' )
+				);
+			}
+			$url = 'https://' . $domain . '/.well-known/did.json';
 		} else {
 			return new \WP_Error(
 				'atmosphere_unsupported_did',
@@ -79,7 +92,7 @@ class Resolver {
 			);
 		}
 
-		$response = \wp_remote_get( $url, array( 'timeout' => 10 ) );
+		$response = \wp_safe_remote_get( $url, array( 'timeout' => 10 ) );
 
 		if ( \is_wp_error( $response ) ) {
 			return $response;
@@ -100,18 +113,51 @@ class Resolver {
 	/**
 	 * Extract the PDS endpoint from a DID document.
 	 *
-	 * Looks for the #atproto_pds service entry.
+	 * Looks for the #atproto_pds service entry. The serviceEndpoint is
+	 * attacker-controlled (anyone can publish a DID doc on plc.directory
+	 * pointing at any URL), so we reject anything that isn't a plain
+	 * HTTPS URL pointing at a publicly-routable host. `wp_http_validate_url()`
+	 * does the host-reachability gate; the explicit `https` check rules
+	 * out `http://` and exotic schemes that the spec doesn't allow.
 	 *
 	 * @param array $did_doc DID document.
 	 * @return string|\WP_Error PDS URL or error.
 	 */
 	public static function pds_from_did_doc( array $did_doc ): string|\WP_Error {
-		foreach ( $did_doc['service'] ?? array() as $service ) {
+		$services = $did_doc['service'] ?? array();
+
+		/*
+		 * The DID document is remote/untrusted. A malformed `service`
+		 * field that decodes to a scalar (or to a list of scalars
+		 * rather than a list of objects) would TypeError on the
+		 * `$service['id']` offset access below. Bail cleanly instead.
+		 */
+		if ( ! \is_array( $services ) ) {
+			return new \WP_Error(
+				'atmosphere_invalid_did_doc',
+				\__( 'DID document `service` field is malformed.', 'atmosphere' )
+			);
+		}
+
+		foreach ( $services as $service ) {
+			if ( ! \is_array( $service ) ) {
+				continue;
+			}
+
 			$id   = $service['id'] ?? '';
 			$type = $service['type'] ?? '';
 
 			if ( '#atproto_pds' === $id && 'AtprotoPersonalDataServer' === $type && ! empty( $service['serviceEndpoint'] ) ) {
-				return $service['serviceEndpoint'];
+				$endpoint = $service['serviceEndpoint'];
+
+				if ( ! \is_string( $endpoint ) || ! self::is_safe_https_url( $endpoint ) ) {
+					return new \WP_Error(
+						'atmosphere_unsafe_pds',
+						\__( 'PDS endpoint in DID document is not a safe HTTPS URL.', 'atmosphere' )
+					);
+				}
+
+				return $endpoint;
 			}
 		}
 
@@ -126,13 +172,18 @@ class Resolver {
 	 *
 	 * Fetches /.well-known/oauth-protected-resource, then
 	 * /.well-known/oauth-authorization-server from the indicated issuer.
+	 * Every URL produced by the response chain is re-validated before it
+	 * is fetched — the DID-doc PDS endpoint, the issuer URL inside
+	 * `authorization_servers`, and the `token_endpoint` /
+	 * `authorization_endpoint` advertised by the auth server are all
+	 * attacker-controlled in the worst case.
 	 *
 	 * @param string $pds_url PDS base URL.
 	 * @return array|\WP_Error Authorization server metadata or error.
 	 */
 	public static function discover_auth_server( string $pds_url ): array|\WP_Error {
 		$resource_url = \rtrim( $pds_url, '/' ) . '/.well-known/oauth-protected-resource';
-		$response     = \wp_remote_get( $resource_url, array( 'timeout' => 10 ) );
+		$response     = \wp_safe_remote_get( $resource_url, array( 'timeout' => 10 ) );
 
 		if ( \is_wp_error( $response ) ) {
 			return $response;
@@ -140,16 +191,41 @@ class Resolver {
 
 		$resource = \json_decode( \wp_remote_retrieve_body( $response ), true );
 
-		if ( empty( $resource['authorization_servers'][0] ) ) {
+		/*
+		 * Malformed JSON (or a valid scalar/null payload like
+		 * `"foo"` or `null`) decodes to a non-array. Bail before
+		 * indexing so PHP 8 doesn't TypeError on offset access.
+		 *
+		 * Guard the parent `authorization_servers` separately: on
+		 * PHP 8.1+ `empty( $resource['authorization_servers'][0] )`
+		 * still evaluates the inner offset access first, and if the
+		 * value is a scalar (`'foo'`, `42`) the offset read emits a
+		 * warning before `empty()` short-circuits. Checking
+		 * `is_array()` on the parent first sidesteps that.
+		 */
+		if ( ! \is_array( $resource )
+			|| ! isset( $resource['authorization_servers'] )
+			|| ! \is_array( $resource['authorization_servers'] )
+			|| empty( $resource['authorization_servers'][0] )
+			|| ! \is_string( $resource['authorization_servers'][0] )
+		) {
 			return new \WP_Error(
 				'atmosphere_no_auth_server',
 				\__( 'PDS did not advertise an authorization server.', 'atmosphere' )
 			);
 		}
 
-		$issuer   = $resource['authorization_servers'][0];
+		$issuer = $resource['authorization_servers'][0];
+
+		if ( ! self::is_safe_https_url( $issuer ) ) {
+			return new \WP_Error(
+				'atmosphere_unsafe_auth_server',
+				\__( 'Authorization server issuer is not a safe HTTPS URL.', 'atmosphere' )
+			);
+		}
+
 		$meta_url = \rtrim( $issuer, '/' ) . '/.well-known/oauth-authorization-server';
-		$response = \wp_remote_get( $meta_url, array( 'timeout' => 10 ) );
+		$response = \wp_safe_remote_get( $meta_url, array( 'timeout' => 10 ) );
 
 		if ( \is_wp_error( $response ) ) {
 			return $response;
@@ -157,11 +233,56 @@ class Resolver {
 
 		$meta = \json_decode( \wp_remote_retrieve_body( $response ), true );
 
-		if ( empty( $meta['token_endpoint'] ) || empty( $meta['authorization_endpoint'] ) ) {
+		/*
+		 * Same guard as above — a scalar / null payload would
+		 * TypeError on the indexing checks below.
+		 */
+		if ( ! \is_array( $meta )
+			|| empty( $meta['token_endpoint'] )
+			|| empty( $meta['authorization_endpoint'] )
+		) {
 			return new \WP_Error(
 				'atmosphere_incomplete_auth_meta',
 				\__( 'Authorization server metadata is incomplete.', 'atmosphere' )
 			);
+		}
+
+		if ( ! \is_string( $meta['token_endpoint'] ) || ! self::is_safe_https_url( $meta['token_endpoint'] ) ) {
+			return new \WP_Error(
+				'atmosphere_unsafe_token_endpoint',
+				\__( 'Authorization server token endpoint is not a safe HTTPS URL.', 'atmosphere' )
+			);
+		}
+
+		if ( ! \is_string( $meta['authorization_endpoint'] ) || ! self::is_safe_https_url( $meta['authorization_endpoint'] ) ) {
+			return new \WP_Error(
+				'atmosphere_unsafe_auth_endpoint',
+				\__( 'Authorization server authorization endpoint is not a safe HTTPS URL.', 'atmosphere' )
+			);
+		}
+
+		if ( ! empty( $meta['pushed_authorization_request_endpoint'] )
+			&& ( ! \is_string( $meta['pushed_authorization_request_endpoint'] )
+				|| ! self::is_safe_https_url( $meta['pushed_authorization_request_endpoint'] ) )
+		) {
+			return new \WP_Error(
+				'atmosphere_unsafe_par_endpoint',
+				\__( 'Authorization server PAR endpoint is not a safe HTTPS URL.', 'atmosphere' )
+			);
+		}
+
+		/*
+		 * `revocation_endpoint` is optional (RFC 8414 §2). When the auth
+		 * server advertises one we keep it so disconnect can revoke the
+		 * refresh token server-side; a malformed value gets dropped
+		 * rather than failing the whole connect, since revocation is
+		 * best-effort defence-in-depth.
+		 */
+		if ( ! empty( $meta['revocation_endpoint'] )
+			&& ( ! \is_string( $meta['revocation_endpoint'] )
+				|| ! self::is_safe_https_url( $meta['revocation_endpoint'] ) )
+		) {
+			unset( $meta['revocation_endpoint'] );
 		}
 
 		$meta['issuer_url'] = $issuer;
@@ -201,5 +322,149 @@ class Resolver {
 			'pds_endpoint' => $pds,
 			'auth_server'  => $auth_server,
 		);
+	}
+
+	/**
+	 * Reserved TLDs the AT Protocol handle spec explicitly disallows.
+	 *
+	 * Sourced from https://atproto.com/specs/handle — reserved or
+	 * private-use TLDs that cannot resolve publicly and therefore
+	 * cannot host a valid handle.
+	 *
+	 * @var array<int, string>
+	 */
+	private const RESERVED_TLDS = array(
+		'alt',
+		'arpa',
+		'example',
+		'internal',
+		'invalid',
+		'local',
+		'localhost',
+		'onion',
+		'test',
+	);
+
+	/**
+	 * Validate an AT Protocol handle or `did:web` host against the
+	 * AT Protocol handle spec.
+	 *
+	 * Rejects empty strings, oversized labels, leading/trailing
+	 * hyphens, single-label hosts (`localhost`), and characters
+	 * outside `[A-Za-z0-9-]`. Also rejects per the handle spec:
+	 *
+	 *  - TLDs starting with a digit, or composed entirely of digits
+	 *    (numeric-only TLDs aren't real TLDs and overlap with the
+	 *    IP-literal class).
+	 *  - Reserved TLDs (`.local`, `.localhost`, `.arpa`,
+	 *    `.internal`, `.invalid`, `.onion`, `.test`, `.example`,
+	 *    `.alt`) — these are private-use / reserved and can't host
+	 *    a routable handle.
+	 *
+	 * Public so the facet / mention code in `Transformer\Facet` can
+	 * reuse the same validation rules — keeping both paths in lock-step
+	 * avoids the case where the mention path accepts a handle the
+	 * resolver path then rejects (or vice versa).
+	 *
+	 * @param string $host Hostname (handle or did:web domain).
+	 * @return bool
+	 */
+	public static function is_valid_handle( string $host ): bool {
+		if ( '' === $host || \strlen( $host ) > 253 ) {
+			return false;
+		}
+
+		$label = '[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?';
+
+		if ( ! \preg_match( '/^' . $label . '(?:\.' . $label . ')+$/', $host ) ) {
+			return false;
+		}
+
+		$labels = \explode( '.', $host );
+		$tld    = \strtolower( \end( $labels ) );
+
+		// TLD must not start with a digit, must not be all digits.
+		if ( \ctype_digit( $tld[0] ) ) {
+			return false;
+		}
+
+		if ( \in_array( $tld, self::RESERVED_TLDS, true ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate that a URL is well-formed, https-only, and safe to
+	 * persist or hand off downstream.
+	 *
+	 * The actual host-safety gate (private-IP, loopback, link-local)
+	 * lives in `wp_safe_remote_*`, which the resolver uses on every
+	 * outbound request. This helper deliberately does NOT call
+	 * `wp_http_validate_url()` — that function does a `gethostbyname`
+	 * lookup, which is unreliable in CI (test domains like
+	 * `pds.example.com` may not resolve) and redundant with the
+	 * fetch-time check.
+	 *
+	 * What this helper does enforce:
+	 *
+	 *  - non-empty string input
+	 *  - parses as a URL
+	 *  - scheme is exactly `https` (the spec requires HTTPS; we narrow
+	 *    further than WordPress's `http`/`https`/`ssl` allowlist)
+	 *  - has a host
+	 *  - host is NOT a raw IP literal — IPv4 (`127.0.0.1`,
+	 *    `169.254.169.254`), IPv6 (`[::1]`, `[fd00::1]`), and any
+	 *    other `FILTER_VALIDATE_IP`-recognised form. `wp_safe_remote_*`
+	 *    catches RFC1918 and loopback but is IPv4-centric, and the
+	 *    `authorization_endpoint` URL is handed straight to
+	 *    `wp_redirect()` with no host-safety net at all. Rejecting IP
+	 *    literals here closes both gaps in one place.
+	 *  - no embedded `user:pass@` credentials (a known URL-injection
+	 *    vector that would otherwise be carried into the persisted
+	 *    connection)
+	 *
+	 * Public so other components that consume attacker-controlled
+	 * URLs (e.g. facet / mention construction in `Transformer\Facet`)
+	 * can share the same gate.
+	 *
+	 * @param mixed $url URL to validate.
+	 * @return bool
+	 */
+	public static function is_safe_https_url( $url ): bool {
+		if ( ! \is_string( $url ) || '' === $url ) {
+			return false;
+		}
+
+		$parts = \wp_parse_url( $url );
+		if ( ! \is_array( $parts ) ) {
+			return false;
+		}
+
+		if ( \strtolower( $parts['scheme'] ?? '' ) !== 'https' ) {
+			return false;
+		}
+
+		if ( empty( $parts['host'] ) ) {
+			return false;
+		}
+
+		/*
+		 * PHP's parse_url() preserves the brackets around IPv6 hosts
+		 * (host is `[::1]` for `https://[::1]/`), and
+		 * FILTER_VALIDATE_IP rejects bracketed forms — strip them
+		 * before validating.
+		 */
+		$host_candidate = \trim( $parts['host'], '[]' );
+		if ( false !== \filter_var( $host_candidate, FILTER_VALIDATE_IP ) ) {
+			return false;
+		}
+
+		if ( isset( $parts['user'] ) || isset( $parts['pass'] ) ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/bundled/atmosphere/includes/transformer/class-base.php
+++ b/bundled/atmosphere/includes/transformer/class-base.php
@@ -135,6 +135,28 @@ abstract class Base {
 	}
 
 	/**
+	 * Whether post-derived record fields must be redacted.
+	 *
+	 * Transformer output can be written to a remote PDS, so this check
+	 * must not use post_password_required(), which depends on the
+	 * current request's unlock cookie.
+	 *
+	 * Intentionally narrower than `Atmosphere\is_post_publishable()`:
+	 * direct transformer callers may transform unsupported post types,
+	 * but protected/non-published fields still must not be serialized.
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return bool
+	 */
+	protected function is_post_redacted( \WP_Post $post ): bool {
+		if ( '' !== (string) $post->post_password ) {
+			return true;
+		}
+
+		return 'publish' !== \get_post_status( $post );
+	}
+
+	/**
 	 * Cache of `render_post_content_plain()` output keyed by post ID.
 	 *
 	 * Per-instance memoization; `the_content` filter chains can be

--- a/bundled/atmosphere/includes/transformer/class-comment.php
+++ b/bundled/atmosphere/includes/transformer/class-comment.php
@@ -55,6 +55,38 @@ class Comment extends Base {
 	public function transform(): array {
 		$comment = $this->object;
 
+		/*
+		 * Mirror the defense-in-depth `is_post_redacted` check the
+		 * Post and Document transformers apply. If the cron handler's
+		 * cached `WP_Post` is stale and the parent has become
+		 * non-public mid-flight, the reply's `text` is emptied so a
+		 * direct caller (preview, third-party listener of
+		 * `atmosphere_transform_comment`) can't leak comment content
+		 * by federating against a redacted parent.
+		 */
+		$parent_post = \get_post( (int) $comment->comment_post_ID );
+		$redacted    = ! $parent_post instanceof \WP_Post || $this->is_post_redacted( $parent_post );
+
+		if ( $redacted ) {
+			/*
+			 * Skip `build_reply_ref()` entirely on redaction. The
+			 * parent post's `Post::META_URI` / `Post::META_CID` may
+			 * be empty (cleanup already cascaded, or the parent
+			 * never published) which would otherwise emit
+			 * `{ root: { uri:'', cid:'' } }` — an invalid strongRef
+			 * that breaks any direct caller of `Comment::transform()`
+			 * (preview, third-party listener). An empty placeholder
+			 * record signals "do not publish" without a malformed
+			 * sub-structure.
+			 */
+			return array(
+				'$type'     => 'app.bsky.feed.post',
+				'text'      => '',
+				'createdAt' => $this->to_iso8601( $comment->comment_date_gmt ),
+				'langs'     => $this->get_langs(),
+			);
+		}
+
 		$text = truncate_text( sanitize_text( (string) $comment->comment_content ), 300 );
 
 		$record = array(
@@ -73,10 +105,24 @@ class Comment extends Base {
 		/**
 		 * Filters the app.bsky.feed.post comment reply record before publishing.
 		 *
+		 * Filters that return a non-array fall back to the pre-filter
+		 * record.
+		 *
 		 * @param array       $record  Bsky post record.
 		 * @param \WP_Comment $comment WordPress comment.
 		 */
-		return \apply_filters( 'atmosphere_transform_comment', $record, $comment );
+		$filtered = \apply_filters( 'atmosphere_transform_comment', $record, $comment );
+
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_comment must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'1.0.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 
 	/**

--- a/bundled/atmosphere/includes/transformer/class-document.php
+++ b/bundled/atmosphere/includes/transformer/class-document.php
@@ -31,6 +31,18 @@ class Document extends Base {
 	public const META_TID = '_atmosphere_doc_tid';
 
 	/**
+	 * Post meta key for the DID that minted the document TID.
+	 *
+	 * Companion to `META_TID` so cleanup paths can detect when the
+	 * record was written under a different connected account. See
+	 * `\Atmosphere\Transformer\Post::META_DID` for the matching key on
+	 * the bsky side and the rationale.
+	 *
+	 * @var string
+	 */
+	public const META_DID = '_atmosphere_doc_did';
+
+	/**
 	 * Post meta key for the document AT-URI.
 	 *
 	 * @var string
@@ -50,11 +62,21 @@ class Document extends Base {
 	 * @return array site.standard.document record.
 	 */
 	public function transform(): array {
+		$redacted = $this->is_post_redacted( $this->object );
+
+		/*
+		 * Redacted records are defense-in-depth output for authorized
+		 * previews/direct callers. Publisher rejects or deletes
+		 * non-publishable posts before this placeholder reaches the PDS.
+		 */
 		$record = array(
-			'$type'       => 'site.standard.document',
-			'title'       => sanitize_text( \get_the_title( $this->object ) ),
-			'publishedAt' => $this->to_iso8601( $this->object->post_date_gmt ),
+			'$type' => 'site.standard.document',
+			'title' => $redacted ? '' : sanitize_text( \get_the_title( $this->object ) ),
 		);
+
+		if ( ! $redacted ) {
+			$record['publishedAt'] = $this->to_iso8601( $this->object->post_date_gmt );
+		}
 
 		// Publication reference (required by spec).
 		$pub_tid = \get_option( 'atmosphere_publication_tid' );
@@ -65,68 +87,88 @@ class Document extends Base {
 			$record['site'] = \untrailingslashit( \get_home_url() );
 		}
 
-		// Relative path.
-		$permalink = \get_permalink( $this->object );
-		$relative  = \wp_make_link_relative( $permalink );
-		if ( $relative ) {
-			$record['path'] = $relative;
-		}
+		if ( ! $redacted ) {
+			// Relative path.
+			$permalink = \get_permalink( $this->object );
+			$relative  = \wp_make_link_relative( $permalink );
+			if ( $relative ) {
+				$record['path'] = $relative;
+			}
 
-		// Description.
-		$excerpt = $this->get_excerpt( $this->object, 55 );
-		if ( ! empty( $excerpt ) ) {
-			$record['description'] = $excerpt;
-		}
+			// Description.
+			$excerpt = $this->get_excerpt( $this->object, 55 );
+			if ( ! empty( $excerpt ) ) {
+				$record['description'] = $excerpt;
+			}
 
-		// Cover image.
-		$thumb_id = \get_post_thumbnail_id( $this->object );
-		if ( $thumb_id ) {
-			$blob = Post::upload_thumbnail( $thumb_id );
-			if ( $blob ) {
-				$record['coverImage'] = $blob;
+			// Cover image.
+			$thumb_id = \get_post_thumbnail_id( $this->object );
+			if ( $thumb_id ) {
+				$blob = Post::upload_thumbnail( $thumb_id );
+				if ( $blob ) {
+					$record['coverImage'] = $blob;
+				}
+			}
+
+			// Full text content.
+			$text_content = $this->get_text_content();
+			if ( ! empty( $text_content ) ) {
+				$record['textContent'] = $text_content;
+			}
+
+			// Parsed rich content (open union).
+			$content = $this->get_content();
+			if ( ! empty( $content ) ) {
+				$record['content'] = $content;
+			}
+
+			// Tags.
+			$tags = $this->collect_tags( $this->object );
+			if ( ! empty( $tags ) ) {
+				$record['tags'] = $tags;
+			}
+
+			// Bluesky cross-reference (populated after initial publish).
+			$bsky_uri = \get_post_meta( $this->object->ID, Post::META_URI, true );
+			$bsky_cid = \get_post_meta( $this->object->ID, Post::META_CID, true );
+			if ( $bsky_uri && $bsky_cid ) {
+				$record['bskyPostRef'] = array(
+					'uri' => $bsky_uri,
+					'cid' => $bsky_cid,
+				);
+			}
+
+			// Updated timestamp.
+			if ( $this->object->post_modified_gmt !== $this->object->post_date_gmt ) {
+				$record['updatedAt'] = $this->to_iso8601( $this->object->post_modified_gmt );
 			}
 		}
 
-		// Full text content.
-		$text_content = $this->get_text_content();
-		if ( ! empty( $text_content ) ) {
-			$record['textContent'] = $text_content;
-		}
-
-		// Parsed rich content (open union).
-		$content = $this->get_content();
-		if ( ! empty( $content ) ) {
-			$record['content'] = $content;
-		}
-
-		// Tags.
-		$tags = $this->collect_tags( $this->object );
-		if ( ! empty( $tags ) ) {
-			$record['tags'] = $tags;
-		}
-
-		// Bluesky cross-reference (populated after initial publish).
-		$bsky_uri = \get_post_meta( $this->object->ID, Post::META_URI, true );
-		$bsky_cid = \get_post_meta( $this->object->ID, Post::META_CID, true );
-		if ( $bsky_uri && $bsky_cid ) {
-			$record['bskyPostRef'] = array(
-				'uri' => $bsky_uri,
-				'cid' => $bsky_cid,
-			);
-		}
-
-		// Updated timestamp.
-		if ( $this->object->post_modified_gmt !== $this->object->post_date_gmt ) {
-			$record['updatedAt'] = $this->to_iso8601( $this->object->post_modified_gmt );
+		if ( $redacted ) {
+			return $record;
 		}
 
 		/**
 		 * Filters the site.standard.document record before publishing.
 		 *
+		 * Filters that return a non-array fall back to the pre-filter
+		 * record.
+		 *
 		 * @param array    $record Document record.
 		 * @param \WP_Post $post   WordPress post.
 		 */
-		return \apply_filters( 'atmosphere_transform_document', $record, $this->object );
+		$filtered = \apply_filters( 'atmosphere_transform_document', $record, $this->object );
+
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_document must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'1.0.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 
 	/**
@@ -140,6 +182,20 @@ class Document extends Base {
 	 * {@inheritDoc}
 	 */
 	public function get_rkey(): string {
+		/*
+		 * Refresh DID provenance on every call so reconnect-to-a-
+		 * different-account flows update the recorded origin. See the
+		 * full rationale on `\Atmosphere\Transformer\Post::get_rkey()`.
+		 *
+		 * Compare before writing so `wp_head`-time callers don't issue
+		 * a DB write on every pageload.
+		 */
+		$current_did = \Atmosphere\get_did();
+		$stored_did  = (string) \get_post_meta( $this->object->ID, self::META_DID, true );
+		if ( $stored_did !== $current_did ) {
+			\update_post_meta( $this->object->ID, self::META_DID, $current_did );
+		}
+
 		$rkey = \get_post_meta( $this->object->ID, self::META_TID, true );
 
 		if ( empty( $rkey ) ) {

--- a/bundled/atmosphere/includes/transformer/class-facet.php
+++ b/bundled/atmosphere/includes/transformer/class-facet.php
@@ -132,6 +132,16 @@ class Facet {
 
 			$did = self::resolve_mention( $handle );
 
+			/*
+			 * `resolve_mention()` returns an empty string when the
+			 * handle fails its (defence-in-depth) syntax check. Skip
+			 * the facet entirely in that case — sending an empty
+			 * `did` to Bluesky would have the PDS reject the record.
+			 */
+			if ( '' === $did ) {
+				continue;
+			}
+
 			$facets[] = array(
 				'index'    => array(
 					'byteStart' => $start,
@@ -188,15 +198,34 @@ class Facet {
 	/**
 	 * Resolve a handle to a DID for mention facets.
 	 *
-	 * Falls back to did:web if DNS resolution fails.
+	 * Falls back to `did:web` if DNS resolution fails. The
+	 * `is_valid_handle()` gate below ensures only DNS-syntactically
+	 * valid handles reach `dns_get_record()` — that closes the
+	 * "malformed handle as DNS query smuggling" angle (e.g. control
+	 * characters or percent-encoded segments injected through a
+	 * regex relaxation), it does NOT block lookups against
+	 * attacker-controlled but well-formed domains.
+	 *
+	 * That broader exposure is by design: mention resolution requires
+	 * a DNS lookup against the mentioned handle's authoritative server,
+	 * and any user (commenter included) can mention any well-formed
+	 * domain. If that DNS-egress surface becomes a concern, the right
+	 * fix is at the threat-model layer (skip mention resolution on
+	 * the commenter path, allowlist mention authorities, or move to
+	 * DoH with a hard timeout) rather than tightening the syntactic
+	 * gate further.
 	 *
 	 * @param string $handle AT Protocol handle.
-	 * @return string DID string.
+	 * @return string DID string, or empty string if the handle is malformed.
 	 */
 	private static function resolve_mention( string $handle ): string {
 		$conn = get_connection();
 		if ( ! empty( $conn['handle'] ) && \strtolower( $handle ) === \strtolower( $conn['handle'] ) ) {
 			return $conn['did'];
+		}
+
+		if ( ! self::is_valid_handle( $handle ) ) {
+			return '';
 		}
 
 		$records = @\dns_get_record( '_atproto.' . $handle, DNS_TXT ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
@@ -210,5 +239,25 @@ class Facet {
 		}
 
 		return 'did:web:' . $handle;
+	}
+
+	/**
+	 * RFC 1035-style DNS-name validation, mirroring
+	 * `Resolver::is_valid_handle()`. Rejects empty strings, oversized
+	 * labels, leading/trailing hyphens, single-label hosts, and any
+	 * character outside `[A-Za-z0-9-]` — including percent-encoded
+	 * forms.
+	 *
+	 * @param string $host Handle to validate.
+	 * @return bool
+	 */
+	private static function is_valid_handle( string $host ): bool {
+		if ( '' === $host || \strlen( $host ) > 253 ) {
+			return false;
+		}
+
+		$label = '[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?';
+
+		return (bool) \preg_match( '/^' . $label . '(?:\.' . $label . ')+$/', $host );
 	}
 }

--- a/bundled/atmosphere/includes/transformer/class-post.php
+++ b/bundled/atmosphere/includes/transformer/class-post.php
@@ -30,6 +30,22 @@ class Post extends Base {
 	public const META_TID = '_atmosphere_bsky_tid';
 
 	/**
+	 * Post meta key for the DID that minted the bsky TID.
+	 *
+	 * Persisted at the same time as `META_TID` so cleanup paths can
+	 * detect when a post's record was written under a different
+	 * account (disconnect → reconnect-to-different-DID flow,
+	 * `updateHandle` that triggered a migration, atproto account
+	 * migration). Without this, `applyWrites#delete` against the
+	 * currently-connected DID's repo silently succeeds for a TID that
+	 * doesn't exist there — leaving the original record orphaned on
+	 * the previous DID's PDS with no local pointer.
+	 *
+	 * @var string
+	 */
+	public const META_DID = '_atmosphere_bsky_did';
+
+	/**
 	 * Post meta key for the bsky post AT-URI.
 	 *
 	 * @var string
@@ -110,6 +126,8 @@ class Post extends Base {
 	 * @return array app.bsky.feed.post record.
 	 */
 	public function transform(): array {
+		$redacted = $this->is_redacted();
+
 		/**
 		 * Filters whether the post should be treated as short-form for Bluesky.
 		 *
@@ -124,20 +142,27 @@ class Post extends Base {
 		 * @param bool     $is_short Whether the post should be treated as short-form.
 		 * @param \WP_Post $post     The post being transformed.
 		 */
-		$is_short = \wp_validate_boolean(
-			\apply_filters(
-				'atmosphere_is_short_form_post',
-				$this->is_short_form( $this->object ),
-				$this->object
-			)
-		);
+		$is_short = true;
+		if ( ! $redacted ) {
+			$is_short = \wp_validate_boolean(
+				\apply_filters(
+					'atmosphere_is_short_form_post',
+					$this->is_short_form( $this->object ),
+					$this->object
+				)
+			);
+		}
 
-		$text  = $is_short ? $this->build_short_form_text() : '';
+		$text  = $redacted ? '' : ( $is_short ? $this->build_short_form_text() : '' );
 		$embed = null;
 
-		if ( '' === $text ) {
+		if ( ! $redacted && '' === $text ) {
 			$text  = $this->build_text();
 			$embed = $this->build_embed();
+		}
+
+		if ( ! $redacted ) {
+			$embed = $this->apply_post_embed_filter( $embed, $is_short ? 'short-form' : 'link-card' );
 		}
 
 		$record = array(
@@ -152,13 +177,22 @@ class Post extends Base {
 			$record['facets'] = $facets;
 		}
 
-		if ( $embed ) {
+		// `apply_post_embed_filter()` guarantees `$embed` is either null
+		// or a well-formed array with a `$type` key, so this matches
+		// the `null !== $embed` check in `record_for_thread_entry()`.
+		if ( null !== $embed ) {
 			$record['embed'] = $embed;
 		}
 
-		$tags = $this->collect_tags( $this->object );
-		if ( ! empty( $tags ) ) {
-			$record['tags'] = $tags;
+		if ( ! $redacted ) {
+			$tags = $this->collect_tags( $this->object );
+			if ( ! empty( $tags ) ) {
+				$record['tags'] = $tags;
+			}
+		}
+
+		if ( $redacted ) {
+			return $record;
 		}
 
 		/**
@@ -173,11 +207,15 @@ class Post extends Base {
 		 * lint hooks) should use the `$context` array to distinguish
 		 * single-post output from teaser-thread entries.
 		 *
+		 * Filters that return a non-array fall back to the pre-filter
+		 * record — protects the applyWrites batch from a misbehaving
+		 * listener.
+		 *
 		 * @param array    $record Bsky post record.
 		 * @param \WP_Post $post   WordPress post.
 		 * @param array    $context Additional composition context.
 		 */
-		return \apply_filters(
+		$filtered = \apply_filters(
 			'atmosphere_transform_bsky_post',
 			$record,
 			$this->object,
@@ -187,6 +225,17 @@ class Post extends Base {
 				'is_thread_reply' => false,
 			)
 		);
+
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_bsky_post must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'1.0.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 
 	/**
@@ -200,6 +249,31 @@ class Post extends Base {
 	 * {@inheritDoc}
 	 */
 	public function get_rkey(): string {
+		/*
+		 * Persist DID provenance on every call, not only on first
+		 * reservation. After a disconnect+reconnect-to-different-DID,
+		 * `META_TID` already exists from the prior account, so a
+		 * one-shot reservation guard would never refresh `META_DID`
+		 * to the current account — letting the mismatch guard in
+		 * `delete_post()` later block a legitimate cleanup against
+		 * the current account.
+		 *
+		 * Written BEFORE `META_TID` so a partial-failure between the
+		 * two writes leaves the row in "DID set, no TID" state. The
+		 * cleanup gates skip that state cleanly; the inverse ("TID
+		 * set, no DID") would let the mismatch guard fall through to
+		 * `get_did()` and re-open the wrong-repo-delete bypass.
+		 *
+		 * Compare before writing so the read-path callers (the
+		 * `wp_head` document-link renderer) don't issue a DB write on
+		 * every pageload — only on the actual transition.
+		 */
+		$current_did = \Atmosphere\get_did();
+		$stored_did  = (string) \get_post_meta( $this->object->ID, self::META_DID, true );
+		if ( $stored_did !== $current_did ) {
+			\update_post_meta( $this->object->ID, self::META_DID, $current_did );
+		}
+
 		$rkey = \get_post_meta( $this->object->ID, self::META_TID, true );
 
 		if ( empty( $rkey ) ) {
@@ -216,6 +290,10 @@ class Post extends Base {
 	 * @return string
 	 */
 	private function build_text(): string {
+		if ( $this->is_redacted() ) {
+			return '';
+		}
+
 		$title     = sanitize_text( \get_the_title( $this->object ) );
 		$excerpt   = $this->get_excerpt( $this->object );
 		$permalink = \get_permalink( $this->object );
@@ -253,6 +331,10 @@ class Post extends Base {
 	 * @return array|null
 	 */
 	private function build_embed(): ?array {
+		if ( $this->is_redacted() ) {
+			return null;
+		}
+
 		$permalink   = \get_permalink( $this->object );
 		$title       = sanitize_text( \get_the_title( $this->object ) );
 		$description = $this->get_excerpt( $this->object, 55 );
@@ -278,12 +360,22 @@ class Post extends Base {
 	}
 
 	/**
-	 * Upload a thumbnail image and return the blob reference.
+	 * Upload an image attachment and return the blob reference.
+	 *
+	 * Used for any image that needs to land on the PDS — featured-image
+	 * thumbnails for link cards, publication icons, and (downstream)
+	 * native `app.bsky.embed.images` attachments. Blob refs are cached
+	 * in `_atmosphere_blob_ref` postmeta so a re-publish of the same
+	 * attachment skips the upload.
+	 *
+	 * If the original file exceeds AT Protocol's 1 MB blob cap, falls
+	 * back to the `large` intermediate size; returns null if even the
+	 * fallback is too large or unreadable.
 	 *
 	 * @param int $attachment_id WordPress attachment ID.
 	 * @return array|null Blob reference or null.
 	 */
-	public static function upload_thumbnail( int $attachment_id ): ?array {
+	public static function upload_image_blob( int $attachment_id ): ?array {
 		// Check cache first.
 		$cached = \get_post_meta( $attachment_id, '_atmosphere_blob_ref', true );
 		if ( ! empty( $cached ) ) {
@@ -324,6 +416,176 @@ class Post extends Base {
 	}
 
 	/**
+	 * Upload a thumbnail image and return the blob reference.
+	 *
+	 * Alias of `upload_image_blob()` retained so existing callers
+	 * (Publication icons, Document thumbnails, third-party integrations)
+	 * keep working. New call sites should prefer `upload_image_blob()`
+	 * for clarity — the body is attachment-agnostic and works for any
+	 * image, not just post thumbnails.
+	 *
+	 * @param int $attachment_id WordPress attachment ID.
+	 * @return array|null Blob reference or null.
+	 */
+	public static function upload_thumbnail( int $attachment_id ): ?array {
+		return self::upload_image_blob( $attachment_id );
+	}
+
+	/**
+	 * Read an image attachment's intrinsic dimensions.
+	 *
+	 * Returns the integer width / height pair from
+	 * `wp_get_attachment_metadata()`. The AT Protocol `app.bsky.embed.images`
+	 * lexicon expects integer pixel values in its `aspectRatio` field, so
+	 * callers can pass this dict through directly. Returns null when
+	 * metadata is missing or non-numeric — typical for newly-uploaded
+	 * attachments before WordPress has finished generating intermediates,
+	 * or for non-image MIME types.
+	 *
+	 * @param int $attachment_id WordPress attachment ID.
+	 * @return array|null `[ 'width' => int, 'height' => int ]` or null.
+	 */
+	public static function get_attachment_aspect_ratio( int $attachment_id ): ?array {
+		$meta = \wp_get_attachment_metadata( $attachment_id );
+
+		if ( ! \is_array( $meta ) ) {
+			return null;
+		}
+
+		/*
+		 * Validate with `is_numeric` BEFORE casting. The earlier shape
+		 * did `(int) $meta['width']`, which silently accepts strings
+		 * with a leading numeric prefix — `"1600px"` casts to `1600`
+		 * and passes the `> 0` gate. A misbehaving third-party metadata
+		 * filter could otherwise inject a unit-suffixed string and
+		 * have it propagate into the AT Protocol record's
+		 * `aspectRatio` field as a misleading integer. Requiring a
+		 * pure numeric input matches the docblock's "non-numeric"
+		 * contract.
+		 */
+		if ( ! isset( $meta['width'], $meta['height'] )
+			|| ! \is_numeric( $meta['width'] )
+			|| ! \is_numeric( $meta['height'] )
+		) {
+			return null;
+		}
+
+		$width  = (int) $meta['width'];
+		$height = (int) $meta['height'];
+
+		if ( $width <= 0 || $height <= 0 ) {
+			return null;
+		}
+
+		return array(
+			'width'  => $width,
+			'height' => $height,
+		);
+	}
+
+	/**
+	 * Apply the `atmosphere_post_embed` filter to a candidate embed.
+	 *
+	 * Centralizes the filter call so every composition path —
+	 * `transform()` (short-form and default), `record_for_link_card()`,
+	 * and the two teaser-thread embed sites in `build_long_form_records()`
+	 * — gives the same observable seam to downstream consumers.
+	 *
+	 * Valid filter returns: `null` (suppress the embed) or an array with
+	 * a non-empty string `$type` key. Anything else — non-array, empty
+	 * array, or array missing/with a non-string `$type` — is rejected
+	 * with `_doing_it_wrong` and the pre-filter value is used. Failing
+	 * loudly on half-formed returns keeps the three composition call
+	 * sites consistent (all use `null !== $embed`) and protects the
+	 * applyWrites batch from a malformed embed.
+	 *
+	 * @param array|null $embed    Default embed for this strategy
+	 *                             (null for short-form, an
+	 *                             `app.bsky.embed.external` card for the
+	 *                             link-card and teaser-thread strategies).
+	 * @param string     $strategy Composition strategy: 'short-form',
+	 *                             'link-card', or 'teaser-thread'.
+	 * @return array|null Final embed to attach to the record, or null.
+	 */
+	private function apply_post_embed_filter( ?array $embed, string $strategy ): ?array {
+		/**
+		 * Filters the embed attached to a Bluesky post record.
+		 *
+		 * Fires for every composition strategy, including short-form
+		 * (where the default is `null` — short-form posts ship without
+		 * an embed unless something opts in). Consumers can:
+		 *
+		 *   - Replace the default external link card with a richer
+		 *     embed type (`app.bsky.embed.images`, `app.bsky.embed.video`,
+		 *     `app.bsky.embed.record`).
+		 *   - Attach an embed to a short-form post that would otherwise
+		 *     ship plain.
+		 *   - Suppress the default embed by returning null.
+		 *
+		 * Valid returns are `null` or an array with a non-empty string
+		 * `$type` key. Non-array returns, empty arrays, and arrays
+		 * without a non-empty string `$type` are rejected with
+		 * `_doing_it_wrong` and the pre-filter value is restored —
+		 * protects the applyWrites batch from a misbehaving listener
+		 * and keeps every composition strategy treating half-formed
+		 * returns the same way.
+		 *
+		 * The filter is called *after* the default embed has been
+		 * built, so listeners can read the default before deciding to
+		 * replace it (e.g. a photo-projector that wants to fall back to
+		 * the external card when the post has zero image attachments).
+		 *
+		 * Not fired for redacted (password-protected) transforms — the
+		 * record carries no text or tags in that branch and exposing the
+		 * post object to embed filters would leak the protected payload.
+		 *
+		 * @param array|null $embed    Default embed for this strategy
+		 *                             (null for short-form, an
+		 *                             `app.bsky.embed.external` card
+		 *                             otherwise).
+		 * @param \WP_Post   $post     The post being transformed.
+		 * @param string     $strategy Composition strategy: 'short-form',
+		 *                             'link-card', or 'teaser-thread'.
+		 */
+		$filtered = \apply_filters( 'atmosphere_post_embed', $embed, $this->object, $strategy );
+
+		if ( null === $filtered ) {
+			return null;
+		}
+
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_post_embed must return an array or null; falling back to the unfiltered embed.', 'atmosphere' ),
+				'unreleased'
+			);
+			return $embed;
+		}
+
+		/*
+		 * Reject empty arrays and arrays missing the `$type` key.
+		 * Without this gate the three call sites disagreed: the
+		 * `if ( $embed )` truthy checks in `transform()` and
+		 * `record_for_link_card()` silently dropped an empty-array
+		 * return, while `record_for_thread_entry()` used
+		 * `null !== $embed` and attached the malformed embed to the
+		 * record. Failing loudly here means every composition
+		 * strategy treats a half-formed filter return the same way,
+		 * and the call sites can use `null !== $embed` consistently.
+		 */
+		if ( empty( $filtered ) || empty( $filtered['$type'] ) || ! \is_string( $filtered['$type'] ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_post_embed must return an embed array with a non-empty $type string, or null; falling back to the unfiltered embed.', 'atmosphere' ),
+				'unreleased'
+			);
+			return $embed;
+		}
+
+		return $filtered;
+	}
+
+	/**
 	 * Whether the post should be treated as short-form for Bluesky.
 	 *
 	 * Mirrors the ActivityPub plugin's Post::get_type() discriminator so
@@ -355,6 +617,10 @@ class Post extends Base {
 	 * @return string
 	 */
 	private function build_short_form_text(): string {
+		if ( $this->is_redacted() ) {
+			return '';
+		}
+
 		return truncate_text( $this->render_post_content_plain( $this->object ), 300 );
 	}
 
@@ -366,9 +632,17 @@ class Post extends Base {
 	 * Publisher branch on short vs. long without reaching into the
 	 * transformer's private state.
 	 *
+	 * Redacted posts return true without invoking the filter so direct
+	 * transformer callers do not expose protected post objects to
+	 * subscribers.
+	 *
 	 * @return bool
 	 */
 	public function is_short_form_post(): bool {
+		if ( $this->is_redacted() ) {
+			return true;
+		}
+
 		return \wp_validate_boolean(
 			\apply_filters(
 				'atmosphere_is_short_form_post',
@@ -430,6 +704,20 @@ class Post extends Base {
 	 *                 the root / parent of any replies).
 	 */
 	public function build_long_form_records( int $stored_count = 0 ): array {
+		if ( $this->is_redacted() ) {
+			return array(
+				$this->record_for_thread_entry(
+					'',
+					true,
+					array(
+						'strategy'        => 'redacted',
+						'thread_index'    => 0,
+						'is_thread_reply' => false,
+					)
+				),
+			);
+		}
+
 		/**
 		 * Filters the long-form composition strategy for this post.
 		 *
@@ -510,7 +798,7 @@ class Post extends Base {
 								'thread_index'    => 0,
 								'is_thread_reply' => false,
 							),
-							$this->build_embed()
+							$this->apply_post_embed_filter( $this->build_embed(), 'teaser-thread' )
 						),
 					);
 				}
@@ -534,7 +822,7 @@ class Post extends Base {
 							'thread_index'    => $i,
 							'is_thread_reply' => 0 !== $i,
 						),
-						$i === $last ? $this->build_embed() : null
+						$i === $last ? $this->apply_post_embed_filter( $this->build_embed(), 'teaser-thread' ) : null
 					);
 				}
 				return $records;
@@ -779,7 +1067,7 @@ class Post extends Base {
 			\_doing_it_wrong(
 				'atmosphere_teaser_thread_posts',
 				\esc_html__( 'The atmosphere_teaser_thread_posts filter must return a non-empty array of strings; falling back to the default teaser-thread shape.', 'atmosphere' ),
-				'unreleased'
+				'1.0.0'
 			);
 			return $default;
 		}
@@ -801,7 +1089,7 @@ class Post extends Base {
 			\_doing_it_wrong(
 				'atmosphere_teaser_thread_posts',
 				\esc_html__( 'The atmosphere_teaser_thread_posts filter must return at least 2 string entries; falling back to the default teaser-thread shape.', 'atmosphere' ),
-				'unreleased'
+				'1.0.0'
 			);
 			return $default;
 		}
@@ -821,6 +1109,10 @@ class Post extends Base {
 	 * @return bool
 	 */
 	private function has_composable_body(): bool {
+		if ( $this->is_redacted() ) {
+			return false;
+		}
+
 		if ( ! empty( $this->object->post_excerpt )
 			&& \mb_strlen( sanitize_text( $this->object->post_excerpt ) ) >= 10
 		) {
@@ -828,6 +1120,15 @@ class Post extends Base {
 		}
 
 		return \mb_strlen( $this->render_post_content_plain( $this->object ) ) >= 10;
+	}
+
+	/**
+	 * Whether this post's fields must be redacted from AT Protocol records.
+	 *
+	 * @return bool
+	 */
+	private function is_redacted(): bool {
+		return $this->is_post_redacted( $this->object );
 	}
 
 	/**
@@ -983,11 +1284,15 @@ class Post extends Base {
 			$record['embed'] = $embed;
 		}
 
-		if ( $is_root ) {
+		if ( $is_root && ! $this->is_redacted() ) {
 			$tags = $this->collect_tags( $this->object );
 			if ( ! empty( $tags ) ) {
 				$record['tags'] = $tags;
 			}
+		}
+
+		if ( $this->is_redacted() ) {
+			return $record;
 		}
 
 		$context = \wp_parse_args(
@@ -1000,7 +1305,18 @@ class Post extends Base {
 		);
 
 		/** This filter is documented in Post::transform() above. */
-		return \apply_filters( 'atmosphere_transform_bsky_post', $record, $this->object, $context );
+		$filtered = \apply_filters( 'atmosphere_transform_bsky_post', $record, $this->object, $context );
+
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_bsky_post must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'1.0.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 
 	/**
@@ -1014,8 +1330,13 @@ class Post extends Base {
 	 * @return array Bsky post record.
 	 */
 	private function record_for_link_card(): array {
-		$text  = $this->build_text();
-		$embed = $this->build_embed();
+		$text     = $this->build_text();
+		$redacted = $this->is_redacted();
+		$embed    = $this->build_embed();
+
+		if ( ! $redacted ) {
+			$embed = $this->apply_post_embed_filter( $embed, 'link-card' );
+		}
 
 		$record = array(
 			'$type'     => 'app.bsky.feed.post',
@@ -1029,17 +1350,26 @@ class Post extends Base {
 			$record['facets'] = $facets;
 		}
 
-		if ( $embed ) {
+		// `apply_post_embed_filter()` guarantees `$embed` is either null
+		// or a well-formed array with a `$type` key, so this matches
+		// the `null !== $embed` check in `record_for_thread_entry()`.
+		if ( null !== $embed ) {
 			$record['embed'] = $embed;
 		}
 
-		$tags = $this->collect_tags( $this->object );
-		if ( ! empty( $tags ) ) {
-			$record['tags'] = $tags;
+		if ( ! $redacted ) {
+			$tags = $this->collect_tags( $this->object );
+			if ( ! empty( $tags ) ) {
+				$record['tags'] = $tags;
+			}
+		}
+
+		if ( $redacted ) {
+			return $record;
 		}
 
 		/** This filter is documented in Post::transform() above. */
-		return \apply_filters(
+		$filtered = \apply_filters(
 			'atmosphere_transform_bsky_post',
 			$record,
 			$this->object,
@@ -1049,5 +1379,16 @@ class Post extends Base {
 				'is_thread_reply' => false,
 			)
 		);
+
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_bsky_post must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'1.0.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 }

--- a/bundled/atmosphere/includes/transformer/class-publication.php
+++ b/bundled/atmosphere/includes/transformer/class-publication.php
@@ -27,13 +27,6 @@ class Publication extends Base {
 	public const OPTION_TID = 'atmosphere_publication_tid';
 
 	/**
-	 * Option key for the publication AT-URI.
-	 *
-	 * @var string
-	 */
-	public const OPTION_URI = 'atmosphere_publication_uri';
-
-	/**
 	 * Transform site settings into a publication record.
 	 *
 	 * @return array site.standard.publication record.
@@ -65,9 +58,23 @@ class Publication extends Base {
 		/**
 		 * Filters the site.standard.publication record.
 		 *
+		 * Filters that return a non-array fall back to the pre-filter
+		 * record.
+		 *
 		 * @param array $record Publication record.
 		 */
-		return \apply_filters( 'atmosphere_transform_publication', $record );
+		$filtered = \apply_filters( 'atmosphere_transform_publication', $record );
+
+		if ( ! \is_array( $filtered ) ) {
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_transform_publication must return an array; falling back to the unfiltered record.', 'atmosphere' ),
+				'1.0.0'
+			);
+			return $record;
+		}
+
+		return $filtered;
 	}
 
 	/**

--- a/bundled/atmosphere/includes/transformer/class-tid.php
+++ b/bundled/atmosphere/includes/transformer/class-tid.php
@@ -32,6 +32,21 @@ class TID {
 	private const LEN = 13;
 
 	/**
+	 * Option backing the cross-request monotonic counter.
+	 *
+	 * Persisted because the per-process static below only protects
+	 * collisions within one PHP worker. With multiple PHP-FPM workers
+	 * (or load-balanced WordPress instances) two concurrent publishes
+	 * can otherwise mint identical microsecond timestamps. The option
+	 * write costs one extra round-trip per TID; the per-process static
+	 * keeps the hot path tight when a single worker mints many TIDs in
+	 * succession.
+	 *
+	 * @var string
+	 */
+	private const OPTION_LAST_TS = 'atmosphere_tid_last_ts';
+
+	/**
 	 * Monotonic counter to avoid collisions within a single process.
 	 *
 	 * @var int
@@ -40,6 +55,11 @@ class TID {
 
 	/**
 	 * Per-process random 10-bit clock identifier.
+	 *
+	 * Seeded via `random_int` (CSPRNG) so two PHP workers booted from
+	 * the same parent process don't end up with the same `wp_rand`
+	 * sequence; with 1024 possible clock IDs, a CSPRNG draw is the
+	 * cheapest defence against cross-worker TID collisions.
 	 *
 	 * @var int|null
 	 */
@@ -51,16 +71,115 @@ class TID {
 	 * @return string 13-character identifier.
 	 */
 	public static function generate(): string {
+		global $wpdb;
+
 		$ts = (int) ( \microtime( true ) * 1_000_000 );
 
-		if ( $ts <= self::$last_ts ) {
-			$ts = self::$last_ts + 1;
+		/*
+		 * Why direct $wpdb instead of `update_option()` here?
+		 * The whole point of this persisted floor is a cross-worker
+		 * monotonic guarantee: two PHP-FPM workers minting TIDs at
+		 * the same microsecond must end up with distinct rkeys, and
+		 * the persisted value must never regress. `update_option`
+		 * does a read-modify-write at the PHP layer with no
+		 * conditional on the existing row, so the obvious shape —
+		 * read $persisted, compute max, write it back — is racy:
+		 *
+		 *   T0  worker A: get_option = 100
+		 *   T1  worker B: get_option = 100
+		 *   T2  worker A: ts = 105, update_option(105)  -> floor=105
+		 *   T3  worker B: ts = 103, update_option(103)  -> floor=103  ← regress
+		 *
+		 * The slower worker silently regresses the floor and the
+		 * monotonic invariant the docblock promises evaporates.
+		 * Subsequent TIDs fall back to the 10-bit `clock_id` for
+		 * collision avoidance, which is fine 1023/1024 of the time
+		 * but is not "monotonic" in any meaningful sense.
+		 *
+		 * `UPDATE ... WHERE CAST(option_value AS UNSIGNED) < $ts`
+		 * is a single atomic statement: the row is rewritten only
+		 * when the new candidate strictly exceeds the stored one.
+		 * Worker B at T3 above no-ops because 103 < 105 fails the
+		 * WHERE. Combined with the per-process `self::$last_ts`
+		 * for the hot path, this gives us a true monotonic floor
+		 * without an option-write per call (worker B never even
+		 * issues the UPDATE if its candidate is already below the
+		 * static).
+		 */
+		$persisted = (int) \get_option( self::OPTION_LAST_TS, 0 );
+		$floor     = \max( self::$last_ts, $persisted );
+
+		if ( $ts <= $floor ) {
+			$ts = $floor + 1;
 		}
 
 		self::$last_ts = $ts;
 
+		if ( $ts > $persisted ) {
+			/*
+			 * Try the atomic CAS first regardless of whether we think
+			 * the row exists. On steady state this is the only branch
+			 * that runs and it is a single statement. On the very
+			 * first generate() across the whole install the UPDATE
+			 * affects zero rows because the option does not exist
+			 * yet, and we fall through to the INSERT IGNORE below to
+			 * create it.
+			 *
+			 * The previous shape branched on `0 === $persisted` and
+			 * used `update_option` for the first write — which is
+			 * unconditional, so two concurrent first publishers
+			 * could both observe `persisted = 0` and the smaller-
+			 * microtime write would silently regress the floor.
+			 * Going through CAS for every write closes that bootstrap
+			 * race; the INSERT IGNORE below is also atomic on the
+			 * UNIQUE index, so the first concurrent INSERT wins and
+			 * the loser falls back to the CAS path on its next call.
+			 *
+			 * Cast to string for the writes to match how WordPress
+			 * stores `option_value`; the WHERE clause casts back to
+			 * UNSIGNED for a numeric comparison because the column
+			 * is `longtext`. Invalidate the options cache by hand
+			 * because `$wpdb->query` does not (unlike
+			 * `update_option`).
+			 */
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$updated = (int) $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND CAST(option_value AS UNSIGNED) < %d",
+					(string) $ts,
+					self::OPTION_LAST_TS,
+					$ts
+				)
+			);
+
+			if ( 0 === $updated ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->query(
+					$wpdb->prepare(
+						"INSERT IGNORE INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, %s, %s)",
+						self::OPTION_LAST_TS,
+						(string) $ts,
+						'no'
+					)
+				);
+			}
+
+			\wp_cache_delete( self::OPTION_LAST_TS, 'options' );
+		}
+
 		if ( null === self::$clock_id ) {
-			self::$clock_id = \wp_rand( 0, 1023 );
+			/*
+			 * `random_int` throws on systems without a usable CSPRNG
+			 * (essentially never on a working PHP install, but a worth
+			 * a fallback so a missing entropy source can't bring down
+			 * publishing). `wp_rand` is non-cryptographic but the
+			 * collision space is still 1024.
+			 */
+			try {
+				self::$clock_id = \random_int( 0, 1023 );
+			} catch ( \Throwable $e ) {
+				self::$clock_id = \wp_rand( 0, 1023 );
+			}
 		}
 
 		return self::encode( ( $ts << 10 ) | self::$clock_id );

--- a/bundled/atmosphere/includes/wp-admin/class-admin.php
+++ b/bundled/atmosphere/includes/wp-admin/class-admin.php
@@ -16,7 +16,9 @@ use Atmosphere\Post_Types;
 use Atmosphere\Publisher;
 use function Atmosphere\get_connection;
 use function Atmosphere\get_supported_post_types;
+use function Atmosphere\has_identity;
 use function Atmosphere\is_connected;
+use function Atmosphere\needs_reauth;
 
 /**
  * Admin class.
@@ -30,10 +32,11 @@ class Admin {
 		\add_action( 'admin_menu', array( self::class, 'add_menu' ) );
 		\add_action( 'admin_init', array( self::class, 'handle_oauth_callback' ) );
 		\add_action( 'admin_init', array( self::class, 'register_settings' ) );
+		\add_action( 'admin_init', array( self::class, 'maybe_set_domain_handle' ) );
 		\add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_assets' ) );
+		\add_action( 'admin_notices', array( self::class, 'maybe_render_reauth_notice' ) );
 
 		\add_action( 'admin_post_atmosphere_disconnect', array( self::class, 'handle_disconnect' ) );
-		\add_action( 'admin_post_atmosphere_set_domain_handle', array( self::class, 'handle_set_domain_handle' ) );
 
 		// Meta box on syncable post types.
 		\add_action( 'add_meta_boxes', array( self::class, 'add_meta_box' ) );
@@ -134,7 +137,17 @@ class Admin {
 				'atmosphere_connection'
 			);
 
-			return;
+			/*
+			 * Even while the OAuth session is gone, an existing identity
+			 * keeps the publishing-section UI visible so the user does
+			 * not lose sight of their stored auto-publish, long-form,
+			 * and post-type preferences during a reauth round-trip. The
+			 * publish callbacks themselves gate on `is_connected()` and
+			 * stay short-circuited until reauth completes.
+			 */
+			if ( ! has_identity() ) {
+				return;
+			}
 		}
 
 		// Publishing section.
@@ -253,9 +266,8 @@ class Admin {
 	 * {@see Handle::should_offer()} agrees the offer is meaningful.
 	 */
 	public static function render_domain_handle_field(): void {
-		$current  = (string) ( get_connection()['handle'] ?? '' );
-		$target   = Handle::get_target_handle();
-		$post_url = \admin_url( 'admin-post.php?action=atmosphere_set_domain_handle' );
+		$current = (string) ( get_connection()['handle'] ?? '' );
+		$target  = Handle::get_target_handle();
 		?>
 		<p>
 			<?php
@@ -282,23 +294,26 @@ class Admin {
 		<p>
 			<?php
 			/*
-			 * The settings page wraps every field in a single outer
-			 * <form action="options.php" method="post">. A nested form
-			 * would be invalid HTML, so the submit button overrides the
-			 * outer form's destination via formaction/formmethod when —
-			 * and only when — this button is the one clicked. The Save
-			 * button at the bottom of the settings page still posts to
-			 * options.php as normal. This keeps the nonce in the request
-			 * body instead of leaking it through the URL / Referer
-			 * header / link prefetching, which an <a> with
-			 * wp_nonce_url() would do.
+			 * `name`/`value` mark the button so {@see
+			 * self::maybe_set_domain_handle()} (hooked on
+			 * `admin_init`) can detect this specific click. The
+			 * Save Changes button at the bottom of the page does
+			 * not carry this name, so a regular settings save lands
+			 * `$_POST['atmosphere_set_domain_handle']` as empty and
+			 * the trigger handler bails — only an explicit click on
+			 * THIS button reaches `Handle::set_handle()`.
+			 *
+			 * Stays inside the WP Settings form: the click rides on
+			 * the form's own nonce + capability gate and options.php
+			 * issues the normal redirect afterwards, so the settings
+			 * notice posted by `Handle::set_handle()` surfaces on the
+			 * next pageview without any custom redirect path.
 			 */
-			\wp_nonce_field( 'atmosphere_set_domain_handle', 'atmosphere_nonce', false );
 			?>
 			<button
 				type="submit"
-				formaction="<?php echo \esc_url( $post_url ); ?>"
-				formmethod="post"
+				name="atmosphere_set_domain_handle"
+				value="1"
 				class="button">
 				<?php
 				echo \esc_html(
@@ -364,7 +379,43 @@ class Admin {
 			return '';
 		}
 
-		\wp_redirect( $auth_url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+		/*
+		 * `$auth_url` is built from the auth-server metadata returned
+		 * by the resolution chain. The resolver validates each URL it
+		 * persists, but defence-in-depth: re-check the scheme + host
+		 * before redirecting an admin so a misconfigured filter or
+		 * future code path can't slip a `javascript:` / `data:` URI
+		 * through.
+		 *
+		 * `wp_safe_redirect` would normally reject this destination —
+		 * it's intentionally off-site (the AT Protocol auth server).
+		 * Add the auth-server host to `allowed_redirect_hosts` for the
+		 * `wp_safe_redirect` call, then immediately detach the filter
+		 * so it can't affect any subsequent redirect — the `exit`
+		 * makes that production-redundant, but pinning the invariant
+		 * here keeps it intact if a test or a `wp_die()` handler ever
+		 * intercepts the redirect before `exit` fires.
+		 */
+		$auth_host   = \is_string( $auth_url ) ? \wp_parse_url( $auth_url, PHP_URL_HOST ) : '';
+		$auth_scheme = \is_string( $auth_url ) ? \wp_parse_url( $auth_url, PHP_URL_SCHEME ) : '';
+
+		if ( empty( $auth_host ) || 'https' !== $auth_scheme ) {
+			\add_settings_error(
+				'atmosphere',
+				'auth_failed',
+				\__( 'Authorization URL is not a safe HTTPS target.', 'atmosphere' )
+			);
+			return '';
+		}
+
+		$allow_auth_host = static function ( $hosts ) use ( $auth_host ) {
+			$hosts[] = $auth_host;
+			return $hosts;
+		};
+
+		\add_filter( 'allowed_redirect_hosts', $allow_auth_host );
+		\wp_safe_redirect( $auth_url );
+		\remove_filter( 'allowed_redirect_hosts', $allow_auth_host );
 		exit;
 	}
 
@@ -647,23 +698,46 @@ class Admin {
 	}
 
 	/**
-	 * Handle the explicit "use my domain as my Bluesky handle" submission.
+	 * Trigger `Handle::set_handle()` when the settings form is
+	 * submitted with the "Use my domain as my Bluesky handle" button.
 	 *
-	 * Verifies capability + nonce, defers to {@see Handle::set_handle()} for
-	 * the actual call, then redirects back to the Settings page with a notice
-	 * already populated by Handle.
+	 * The button renders inside the WP Settings form and carries
+	 * `name="atmosphere_set_domain_handle" value="1"`. When clicked,
+	 * the form POSTs to `options.php` like any other settings save.
+	 * Routing the trigger through a dedicated `admin-post.php?action=…`
+	 * endpoint instead collides with `settings_fields()`'s hidden
+	 * `<input name="action" value="update">` field — POST wins in
+	 * `$_REQUEST['action']` and the click ends up dispatched to
+	 * `admin_post_update`. Detecting the field here on `admin_init`,
+	 * before options.php runs, keeps the action inside the same
+	 * form-submit lifecycle without conflicting concerns.
+	 *
+	 * Bails silently if the trigger field is absent (normal Save
+	 * Changes path) or if the request fails any of the standard
+	 * settings-form guards (capability, option group, nonce). On
+	 * success `Handle::set_handle()` posts its own settings notice;
+	 * options.php's own redirect surfaces the notice on the next
+	 * pageview without us having to intercept the redirect here.
 	 */
-	public static function handle_set_domain_handle(): void {
-		if ( ! \current_user_can( 'manage_options' ) ) {
-			\wp_die( \esc_html__( 'You do not have permission to do this.', 'atmosphere' ) );
+	public static function maybe_set_domain_handle(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Presence check only; nonce is verified below before any side effect.
+		if ( empty( $_POST['atmosphere_set_domain_handle'] ) ) {
+			return;
 		}
 
-		\check_admin_referer( 'atmosphere_set_domain_handle', 'atmosphere_nonce' );
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Same as above; nonce verified on the next line.
+		$option_page = isset( $_POST['option_page'] ) ? \sanitize_key( \wp_unslash( $_POST['option_page'] ) ) : '';
+		if ( 'atmosphere' !== $option_page ) {
+			return;
+		}
+
+		\check_admin_referer( 'atmosphere-options' );
 
 		Handle::set_handle();
-
-		\wp_safe_redirect( \admin_url( 'options-general.php?page=atmosphere' ) );
-		exit;
 	}
 
 	/**
@@ -741,6 +815,47 @@ class Admin {
 	}
 
 	/**
+	 * Render a global admin notice when the OAuth session needs reauth.
+	 *
+	 * Surfaced on every admin screen (gated on `manage_options`) because
+	 * the publish, comment, and update paths silently no-op until the
+	 * user reconnects — without a visible nudge, an expired refresh
+	 * token can sit unnoticed for days. The notice is dismissible per
+	 * page-load only so the user is reminded again on their next visit.
+	 */
+	public static function maybe_render_reauth_notice(): void {
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! needs_reauth() ) {
+			return;
+		}
+
+		$settings_url = \admin_url( 'options-general.php?page=atmosphere' );
+
+		?>
+		<div class="notice notice-warning is-dismissible">
+			<p>
+				<strong><?php \esc_html_e( 'ATmosphere: reconnection required', 'atmosphere' ); ?></strong>
+			</p>
+			<p>
+				<?php
+				echo \wp_kses(
+					\sprintf(
+						/* translators: %s: URL to the ATmosphere settings page. */
+						\__( 'Your AT Protocol session has expired. New posts and comments will not publish until you <a href="%s">reconnect on the settings page</a>. Your publishing preferences and verification headers stay in place in the meantime.', 'atmosphere' ),
+						\esc_url( $settings_url )
+					),
+					array( 'a' => array( 'href' => array() ) )
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
 	 * Register the client-metadata REST endpoint.
 	 */
 	public static function register_rest_routes(): void {
@@ -771,9 +886,13 @@ class Admin {
 			'grant_types'                => array( 'authorization_code', 'refresh_token' ),
 			'response_types'             => array( 'code' ),
 			'token_endpoint_auth_method' => 'none',
-			// MUST match the scope string requested by Client::authorize().
-			// The auth server validates the request scope against the metadata;
-			// a drift here silently downgrades to the smaller of the two.
+
+			/*
+			 * MUST match the scope string requested by
+			 * Client::authorize(). The auth server validates the
+			 * request scope against the metadata; a drift here
+			 * silently downgrades to the smaller of the two.
+			 */
 			'scope'                      => 'atproto transition:generic identity:handle',
 			'dpop_bound_access_tokens'   => true,
 			'application_type'           => 'web',
@@ -782,9 +901,45 @@ class Admin {
 		/**
 		 * Filters the OAuth client metadata served at the REST endpoint.
 		 *
+		 * Filters MUST return an array containing:
+		 *
+		 *  - `client_id`: non-empty string (advertised as the OAuth client
+		 *    identifier; should match `Client::client_id()`).
+		 *  - `redirect_uris`: non-empty list of non-empty strings, where
+		 *    every entry is rooted at this site's admin over HTTPS
+		 *    (`admin_url('', 'https')` prefix). Off-site / empty /
+		 *    non-string / HTTP-scheme / nested-array entries cause the
+		 *    entire filter result to be rejected.
+		 *
+		 * Anything else falls back to the unfiltered metadata. The
+		 * metadata endpoint is public and the document advertises
+		 * `token_endpoint_auth_method: 'none'` (public client), so an
+		 * attacker-supplied `redirect_uris` entry would let them drive
+		 * this site's `client_id` with their own redirect target. Gate
+		 * entries individually, matching the validation
+		 * {@see \Atmosphere\OAuth\Client::redirect_uri()} applies to
+		 * the inbound `atmosphere_oauth_redirect_uri` filter.
+		 *
 		 * @param array $metadata Client metadata.
 		 */
-		$metadata = \apply_filters( 'atmosphere_client_metadata', $metadata );
+		$filtered = \apply_filters( 'atmosphere_client_metadata', $metadata );
+
+		if ( self::client_metadata_filter_is_valid( $filtered ) ) {
+			$metadata = $filtered;
+		} elseif ( $filtered !== $metadata ) {
+			/*
+			 * Surface only when the filter actually fired and returned
+			 * something that failed validation — without this guard
+			 * every page load on a site with no filter would trip the
+			 * notice because the equality check above is the cheap
+			 * shorthand for "nothing changed".
+			 */
+			\_doing_it_wrong(
+				__METHOD__,
+				\esc_html__( 'atmosphere_client_metadata must return an array with a non-empty string client_id and a redirect_uris list of admin URLs; falling back to the unfiltered metadata.', 'atmosphere' ),
+				'1.0.0'
+			);
+		}
 
 		$response = new \WP_REST_Response( $metadata, 200 );
 
@@ -804,5 +959,70 @@ class Admin {
 		$response->header( 'Cache-Control', 'public, max-age=300' );
 
 		return $response;
+	}
+
+	/**
+	 * Validate the return value of the `atmosphere_client_metadata` filter.
+	 *
+	 * Container shape:
+	 *
+	 *  - Must be an array.
+	 *  - `client_id` present, non-empty string.
+	 *  - `redirect_uris` present, non-empty array (list of strings).
+	 *
+	 * Per-entry `redirect_uris` rules:
+	 *
+	 *  - Each entry is a non-empty string.
+	 *  - Each entry begins with this site's HTTPS admin URL prefix
+	 *    (`admin_url('', 'https')`), the same gate
+	 *    {@see \Atmosphere\OAuth\Client::redirect_uri()} applies to
+	 *    the inbound filter. An off-site / HTTP-scheme /
+	 *    scheme-mismatched / empty entry disqualifies the entire
+	 *    filter result.
+	 *
+	 * Returns true only if every check passes; the caller falls back
+	 * to the unfiltered metadata on false.
+	 *
+	 * @param mixed $filtered Filter return value.
+	 * @return bool
+	 */
+	private static function client_metadata_filter_is_valid( $filtered ): bool {
+		if ( ! \is_array( $filtered ) ) {
+			return false;
+		}
+
+		if ( ! isset( $filtered['client_id'] )
+			|| ! \is_string( $filtered['client_id'] )
+			|| '' === $filtered['client_id']
+		) {
+			return false;
+		}
+
+		if ( ! isset( $filtered['redirect_uris'] )
+			|| ! \is_array( $filtered['redirect_uris'] )
+			|| array() === $filtered['redirect_uris']
+		) {
+			return false;
+		}
+
+		/*
+		 * Match the HTTPS scheme `Client::redirect_uri()` produces. The
+		 * OAuth code is delivered to the browser via this URL and must
+		 * not travel in cleartext, even if `admin_url()` itself defaults
+		 * to HTTP on the host.
+		 */
+		$admin_prefix = \admin_url( '', 'https' );
+
+		foreach ( $filtered['redirect_uris'] as $uri ) {
+			if ( ! \is_string( $uri )
+				|| '' === $uri
+				|| ! \str_starts_with( $uri, 'https://' )
+				|| ! \str_starts_with( $uri, $admin_prefix )
+			) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/bundled/atmosphere/readme.txt
+++ b/bundled/atmosphere/readme.txt
@@ -4,7 +4,7 @@ Tags: at-protocol, bluesky, fediverse, atproto, crossposting
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: unreleased
+Stable tag: 1.0.0
 License: GPL-2.0-or-later
 License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
 
@@ -85,16 +85,64 @@ By default, only new posts are shared. You can publish older ones on demand with
 
 Yes. If you delete or unpublish a WordPress post, the matching Bluesky post and AT Protocol records are removed too. If you trash a post and then restore it, ATmosphere re-publishes it.
 
+= Does ATmosphere support WordPress Multisite? =
+
+Not at this time. ATmosphere is designed for a single WordPress site. On a Network-activated install only the current site's data is read and written, and uninstall only cleans the current site — credentials and records on other sites in the network are left intact.
+
 == Changelog ==
 
-= 0.1.0 =
+### 1.0.0 - 2026-05-20
+#### Security
+- Harden OAuth and PDS HTTP request paths against SSRF, encrypt the temporary DPoP key used during connect, and validate URLs received from third-party servers before they are used or stored.
+- Tighten DPoP proof lifetime when talking to the AT Protocol auth server and PDS, and harden the OAuth and PDS HTTP paths against malformed server responses.
+- Tighten OAuth redirect handling, validate hook return values from third-party plugins, gate DNS lookups for @mentions, and clean up additional plugin data on uninstall.
 
-* Initial release.
-* Native AT Protocol OAuth with PKCE and DPoP.
-* Bluesky cross-posting with facet detection.
-* standard.site publication and document records.
-* Per-post meta box controls.
-* Bulk backfill for existing posts.
+#### Added
+- Add extensible content parser support and a JSON preview endpoint for AT Protocol records.
+- Add `atmosphere_publish_post_result` and `atmosphere_publish_comment_result` actions so subscribers can react to publish success or failure (e.g., for metrics and notifications) without observing internal state.
+- Add `atmosphere_should_sync_reply` filter so consumers can suppress specific incoming replies before they become WordPress comments — primarily useful for teaser-thread publishers that don't want their own follow-up records re-ingested as self-replies.
+- Automatically sync the publication record when the site name, tagline, or site icon changes.
+- Choose how long-form posts publish to Bluesky from the ATmosphere settings page — link card (default), a single post combining body text with the permalink, or a two-post teaser thread.
+- Choose which post types are published to AT Protocol from the ATmosphere settings page. Plugins and themes can also opt their custom post types in directly with `add_post_type_support( 'your_type', 'atmosphere' )`.
+- Liftoff! ATmosphere has cleared the troposphere — version 1.0 is now generally available.
+- Long-form posts can now be published to Bluesky as a short thread that points readers back to the full article. Sites can keep the existing single-post behavior, publish a shortened text version with a link, or use a two-post teaser thread. When a threaded post is edited, ATmosphere updates the existing Bluesky posts when possible so links and replies stay connected. If the publishing format changes, ATmosphere replaces the old Bluesky posts with new ones.
+- Preserve the connection success notice after completing Bluesky setup, and let integrating plugins customize the OAuth callback destination.
+- Publish replies from registered WordPress users to Bluesky as native replies, with edit and unapprove/delete synced back to the AT Protocol record.
+- Request the identity:handle permission when connecting to Bluesky so handle changes can be kept in sync.
+- Short-form posts (untitled or with a post format) now publish as native Bluesky posts instead of link cards, matching the ActivityPub plugin's Note discriminator. Added the `atmosphere_is_short_form_post` filter for downstream override.
+- Sync Bluesky replies, likes, and reposts back as WordPress comments.
+- Use your site domain as your Bluesky handle with one click from the ATmosphere settings page.
+- Use your WordPress domain as your Bluesky handle with automatic domain verification.
+
+#### Changed
+- Always use HTTPS for the AT Protocol OAuth callback URL, and keep encrypted connection tokens out of the always-loaded options cache.
+- Improved Bluesky connection reliability and disconnect speed, fixed a rare duplicate-record issue when publishing simultaneously from multiple workers, and now respects your comment moderation and spam filter settings when importing Bluesky reactions and replies.
+- Improve the development test setup so automated tests can run while another local WordPress environment is already using the default ports.
+- Limit backfill to the 10 most recent unsynced posts to avoid overwhelming the server on large sites.
+- Long-form teaser threads now use a 3-post default (hook, body chunk, "continue reading" reply with a link card), so the thread reliably surfaces on bsky.app profiles and the terminal post offers a clear path back to the WordPress article.
+- Redesign the settings page to use the standard WordPress Settings API for a cleaner, more consistent admin experience.
+- Replace third-party JWT library with native OpenSSL signing and add a custom class autoloader.
+
+#### Fixed
+- Break up large cleanup batches when removing a post and its replies so deletion still completes on threads with many comments.
+- Clear every plugin-owned scheduled event on deactivate and uninstall so leftover jobs don't linger after the plugin is removed.
+- Clear queued sync events on disconnect, deactivation, and uninstall so leftover jobs cannot fire against a different connected account.
+- Editing a WordPress post that was published before connecting to Bluesky no longer creates a new Bluesky post on save. Use the Backfill tool to sync existing posts on purpose.
+- Fix auto-publish being disabled by default after saving settings.
+- Fix PHPCS warnings about unprefixed global variables and hook names.
+- Fix published posts being incorrectly deleted from Bluesky when editing.
+- Fix restoring a trashed post not republishing it to Bluesky.
+- Fix the settings page, meta box, and backfill actions not loading after the previous admin hook change.
+- Keep your AT Protocol verification headers and publishing preferences in place when your session expires. Reconnect is required to resume publishing, but your settings no longer reset and standard.site verification keeps working.
+- Move scheduled action hook registration into the standard plugin initialization flow.
+- Preserve remote cleanup of already-synced posts when their post type is removed from the syncable allowlist.
+- Preserve the OAuth connection when token refresh fails due to temporary server errors.
+- Prevent concurrent token refreshes from racing each other and accidentally disconnecting the plugin.
+- Prevent password-protected or otherwise non-public posts from being published to AT Protocol records, and remove existing records when public posts become protected.
+- Remove a comment reply from Bluesky if the comment was deleted or unapproved while it was being published, instead of leaving an orphan reply behind.
+- Short posts under the long-form teaser-thread strategy no longer ship a redundant "continue reading" reply when the entire body already fits in a single Bluesky post. The link-back is preserved as a card on the same post.
+
+See full Changelog on [GitHub](https://github.com/Automattic/wordpress-atmosphere/blob/trunk/CHANGELOG.md).
 
 == Upgrade Notice ==
 

--- a/bundled/atmosphere/uninstall.php
+++ b/bundled/atmosphere/uninstall.php
@@ -7,37 +7,70 @@
  * @package Atmosphere
  */
 
-use function Atmosphere\clear_scheduled_hooks;
+use function Atmosphere\clear_scheduled_hooks_all;
 
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-// Load helpers so the cron-hook list stays in lock-step with deactivate()
-// and Client::disconnect(). uninstall.php is loaded by WordPress without
-// the plugin itself being booted, so this require is necessary.
+/*
+ * Load helpers so the cron-hook list stays in lock-step with
+ * deactivate() and Client::disconnect(). uninstall.php is loaded by
+ * WordPress without the plugin itself being booted, so this require
+ * is necessary.
+ */
 require_once __DIR__ . '/includes/functions.php';
 
 // Remove options.
-delete_option( 'atmosphere_connection' );
-delete_option( 'atmosphere_publication_tid' );
-delete_option( 'atmosphere_publication_uri' );
-delete_option( 'atmosphere_auto_publish' );
-delete_option( 'atmosphere_previous_handle' );
+$atmosphere_options = array(
+	'atmosphere_connection',
+	'atmosphere_identity',
+	'atmosphere_publication_tid',
+	'atmosphere_publication_uri',
+	'atmosphere_auto_publish',
+	'atmosphere_previous_handle',
+	'atmosphere_long_form_composition',
+	'atmosphere_support_post_types',
+	'atmosphere_last_seen_notification',
+	'atmosphere_tid_last_ts',
+	'atmosphere_visibility_cleanup_migrated',
+	'atmosphere_visibility_cleanup_migrated_offset',
+	'atmosphere_visibility_cleanup_last_id',
+	// Canonical value: `\Atmosphere\OAuth\Client::REFRESH_LOCK_OPTION`.
+	// Hardcoded here because `uninstall.php` runs before the plugin
+	// bootstrap is loaded, so the constant isn't available.
+	'_atmosphere_refresh_lock',
+);
 
-// Remove scheduled events via the canonical helper.
-clear_scheduled_hooks();
+foreach ( $atmosphere_options as $atmosphere_option ) {
+	delete_option( $atmosphere_option );
+}
 
-// Remove post meta.
+// Remove scheduled events via the canonical helper. Use the
+// all-hooks variant so any still-queued one-shot revoke event
+// (scheduled outside the regular hook set by `Client::disconnect()`)
+// is also dropped — uninstall is the final cleanup, the encrypted
+// ciphertexts in `wp_options['cron']` would otherwise outlive the
+// plugin forever.
+clear_scheduled_hooks_all();
+
 global $wpdb;
 
+// Remove post meta written by the publisher and document transformer.
 $atmosphere_meta_keys = array(
 	'_atmosphere_bsky_tid',
+	'_atmosphere_bsky_did',
 	'_atmosphere_bsky_uri',
 	'_atmosphere_bsky_cid',
+	'_atmosphere_bsky_thread_records',
+	'_atmosphere_bsky_uri_index',
+	'_atmosphere_bsky_orphan_records',
 	'_atmosphere_doc_tid',
+	'_atmosphere_doc_did',
 	'_atmosphere_doc_uri',
 	'_atmosphere_doc_cid',
+	'_atmosphere_doc_ref_pending',
+	'_atmosphere_visibility_cleanup',
 	'_atmosphere_blob_ref',
 );
 
@@ -45,20 +78,125 @@ foreach ( $atmosphere_meta_keys as $atmosphere_key ) {
 	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $atmosphere_key ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 }
 
-// Remove comment meta written by the outbound-comment publisher.
+/*
+ * Remove comment meta. Two surfaces here:
+ *  - outbound: comment-publishing TID/URI/CID + attempt counter.
+ *  - inbound:  reaction-sync stamps every imported reaction with a
+ *              protocol marker + author DID + author avatar URL so
+ *              the gravatar override + dedupe-by-protocol checks work.
+ *
+ * The plugin-prefixed keys are safe to wipe by key alone. The
+ * `protocol` key, however, is unprefixed and could conceivably be
+ * written by other plugins for their own purposes, so we scope the
+ * delete to the `'atproto'` value that ATmosphere itself writes.
+ */
 $atmosphere_comment_meta_keys = array(
 	'_atmosphere_bsky_tid',
 	'_atmosphere_bsky_uri',
 	'_atmosphere_bsky_cid',
 	'_atmosphere_publish_attempts',
+	'_atmosphere_author_did',
+	'_atmosphere_author_avatar',
 );
 
 foreach ( $atmosphere_comment_meta_keys as $atmosphere_key ) {
 	$wpdb->delete( $wpdb->commentmeta, array( 'meta_key' => $atmosphere_key ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 }
 
-// Remove transients.
-delete_transient( 'atmosphere_oauth_verifier' );
-delete_transient( 'atmosphere_oauth_state' );
-delete_transient( 'atmosphere_oauth_dpop_jwk' );
-delete_transient( 'atmosphere_oauth_resolved' );
+// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+$wpdb->delete(
+	$wpdb->commentmeta,
+	array(
+		'meta_key'   => 'protocol',
+		'meta_value' => 'atproto',
+	)
+);
+// phpcs:enable
+
+// Remove fixed-key transients.
+$atmosphere_transients = array(
+	'atmosphere_oauth_verifier',
+	'atmosphere_oauth_state',
+	'atmosphere_oauth_dpop_jwk',
+	'atmosphere_oauth_resolved',
+	'atmosphere_invalid_long_form_composition_logged',
+);
+
+foreach ( $atmosphere_transients as $atmosphere_transient ) {
+	delete_transient( $atmosphere_transient );
+}
+
+/*
+ * Remove transient + option families that use dynamic keys:
+ *
+ *  - atmo_dpop_nonce_<md5>          — per-URL DPoP nonces (5 min TTL).
+ *    Wildcard MUST stay in lock-step with `Nonce_Storage::PREFIX`
+ *    ({@see \Atmosphere\OAuth\Nonce_Storage}). uninstall.php runs
+ *    pre-bootstrap, so we can't reference the constant directly
+ *    without loading the autoloader here. Anyone renaming the
+ *    constant should grep for `atmo_dpop_nonce_` and update both.
+ *  - _atmosphere_oauth_rate_<user_id>
+ *    — per-user OAuth rate-limit counter. Stored as a plain option
+ *    (not a transient) so the read+CAS-update loop in
+ *    `Client::rate_limit_check()` can be atomic via INSERT IGNORE +
+ *    UPDATE WHERE option_value = $previous; the window expiry is
+ *    encoded in the value itself rather than relying on transient
+ *    TTL.
+ *  - atmosphere_profile_<md5>       — reaction-sync profile cache
+ *    written by `Reaction_Sync::resolve_author()`. No constant —
+ *    grep for `atmosphere_profile_` in includes/.
+ *  - atmosphere_last_seen_own_<col> — reaction-sync watermarks per
+ *    collection (likes, reposts, posts). Wildcard MUST stay in
+ *    lock-step with `Reaction_Sync::OPTION_LAST_SEEN_OWN_PREFIX`
+ *    ({@see \Atmosphere\Reaction_Sync}).
+ *
+ * Query for matching option names first, then route deletion through
+ * `delete_transient()` / `delete_option()` so the object cache
+ * (Redis, Memcached, `alloptions`) is invalidated alongside the
+ * underlying `wp_options` row. A plain SQL `DELETE` against the
+ * options table would leave stale values in any persistent cache,
+ * so a subsequent reinstall could read them back.
+ *
+ * Persistent-object-cache caveat: on installs with a drop-in object
+ * cache (Redis, Memcached, etc.) `set_transient()` writes to the
+ * object cache and bypasses `wp_options` entirely — so the LIKE
+ * queries below return zero rows on those installs, and the only
+ * dynamic transients that get cleaned are the ones the cache layer
+ * has already evicted to the database. The remaining keys age out
+ * naturally on their TTL (DPoP nonces: 5 min; profile cache: 1 hr)
+ * and contain no decryptable secrets — DPoP nonces are server-issued
+ * opaque tokens, profile data is public — so the residual is
+ * acceptable. If a future dynamic-key transient is long-lived or
+ * holds secret material, switch to a write-time registry pattern.
+ */
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+$atmosphere_transient_rows = $wpdb->get_col(
+	"SELECT option_name FROM {$wpdb->options}
+	 WHERE option_name LIKE '\_transient\_atmo\_dpop\_nonce\_%'
+	    OR option_name LIKE '\_transient\_timeout\_atmo\_dpop\_nonce\_%'
+	    OR option_name LIKE '\_transient\_atmosphere\_profile\_%'
+	    OR option_name LIKE '\_transient\_timeout\_atmosphere\_profile\_%'
+	    OR option_name LIKE '\_transient\_atmosphere\_oauth\_%'
+	    OR option_name LIKE '\_transient\_timeout\_atmosphere\_oauth\_%'"
+);
+
+$atmosphere_option_rows = $wpdb->get_col(
+	"SELECT option_name FROM {$wpdb->options}
+	 WHERE option_name LIKE 'atmosphere\_last\_seen\_own\_%'
+	    OR option_name LIKE '\_atmosphere\_oauth\_rate\_%'"
+);
+// phpcs:enable
+
+foreach ( $atmosphere_transient_rows as $atmosphere_row ) {
+	// Strip `_transient_` or `_transient_timeout_` prefix to feed
+	// `delete_transient()` the bare key.
+	if ( 0 === strpos( $atmosphere_row, '_transient_timeout_' ) ) {
+		delete_transient( substr( $atmosphere_row, strlen( '_transient_timeout_' ) ) );
+	} elseif ( 0 === strpos( $atmosphere_row, '_transient_' ) ) {
+		delete_transient( substr( $atmosphere_row, strlen( '_transient_' ) ) );
+	}
+}
+
+foreach ( $atmosphere_option_rows as $atmosphere_row ) {
+	delete_option( $atmosphere_row );
+}

--- a/bundled/atmosphere/vendor/composer/installed.php
+++ b/bundled/atmosphere/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'automattic/atmosphere',
         'pretty_version' => 'dev-trunk',
         'version' => 'dev-trunk',
-        'reference' => 'b9b32fe5e57711b86c487d55a715791f3c2c56dc',
+        'reference' => '2a0383a66a5633b981277b29ebfef768f430aeda',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'automattic/atmosphere' => array(
             'pretty_version' => 'dev-trunk',
             'version' => 'dev-trunk',
-            'reference' => 'b9b32fe5e57711b86c487d55a715791f3c2c56dc',
+            'reference' => '2a0383a66a5633b981277b29ebfef768f430aeda',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/src/class-photo-post-atmosphere.php
+++ b/src/class-photo-post-atmosphere.php
@@ -215,10 +215,10 @@ class Photo_Post_Atmosphere {
 		$budget_deadline = $budget_seconds > 0 ? \microtime( true ) + (float) $budget_seconds : null;
 		$attached        = array();
 		$overflow        = array();
-		$attempted       = 0;
+		$index           = 0;
 
 		foreach ( $image_ids as $attachment_id ) {
-			if ( $attempted >= self::MAX_IMAGES ) {
+			if ( count( $attached ) >= self::MAX_IMAGES ) {
 				$overflow[] = $attachment_id;
 				continue;
 			}
@@ -238,7 +238,7 @@ class Photo_Post_Atmosphere {
 			$blob = self::upload_blob( $attachment_id );
 
 			if ( null === $blob ) {
-				if ( $has_featured && 0 === $attempted ) {
+				if ( $has_featured && 0 === $index ) {
 					// Featured image is the hero shot — refuse to ship
 					// a gallery missing it. Return `$embed` unchanged so
 					// Atmosphere falls back to short-form text and the
@@ -262,7 +262,7 @@ class Photo_Post_Atmosphere {
 					)
 				);
 
-				++$attempted;
+				++$index;
 				continue;
 			}
 
@@ -277,7 +277,7 @@ class Photo_Post_Atmosphere {
 			}
 
 			$attached[] = $image;
-			++$attempted;
+			++$index;
 		}
 
 		if ( empty( $attached ) ) {

--- a/src/class-photo-post-atmosphere.php
+++ b/src/class-photo-post-atmosphere.php
@@ -23,44 +23,43 @@ use WP_Post;
  * projection, the AT counterpart of `Photo_Post::register()`'s AP
  * hooks.
  *
- * Two filter callbacks do the work:
+ * Three filter callbacks do the work:
  *
  *   1. `atmosphere_is_short_form_post` — for photo posts, force the
  *      short-form path so Atmosphere skips link-card / teaser-thread
  *      composition entirely. The transformer's "short-form" path is
  *      already "post body becomes the text, no external card" — the
  *      shape closest to a native Bluesky photo post.
- *   2. `atmosphere_transform_bsky_post` — on the short-form root
- *      record for a photo post, rewrite `text` to the caption-only
- *      plain text (same stripping the AP `activitypub_the_content`
- *      filter does) and replace `embed` with `app.bsky.embed.images`
+ *   2. `atmosphere_post_embed` — Atmosphere's focused embed seam.
+ *      Receives the default embed for the strategy (`null` for
+ *      short-form) and returns the `app.bsky.embed.images` envelope
  *      built from up to {@see self::MAX_IMAGES} uploaded blob refs.
- *
- * Upstream Atmosphere
- * (`Automattic/wordpress-atmosphere` PR 72) adds a focused
- * `atmosphere_post_embed` seam and a public `upload_image_blob()`
- * rename. This projector deliberately targets the *shipped*
- * Atmosphere surface (`atmosphere_transform_bsky_post` + the
- * already-public `Post::upload_thumbnail()`) so the photo-post AT
- * federation works as soon as this PR lands, with or without that
- * upstream change. When PR 72 lands and the bundled copy resyncs,
- * see the class docblock notes below for the cleaner two-line
- * switchover.
+ *      All upload / overflow / featured-image-bail logic lives here so
+ *      a failed projection cleanly results in "no embed attached" and
+ *      Atmosphere ships its default short-form text without further
+ *      intervention from this projector.
+ *   3. `atmosphere_transform_bsky_post` — rewrite the record's `text`
+ *      to the caption-only plain text and re-extract facets so byte
+ *      offsets line up. Gated on "the images embed actually attached"
+ *      so a fully-failed upload pass leaves Atmosphere's default text
+ *      in place; rewriting to a caption when no images shipped would
+ *      strip useful body content for no benefit.
  *
  * Failure-mode posture:
  *
- *   - If the *featured image* upload fails, the projector returns
- *     the record unchanged. Featured Image is the post's hero shot;
- *     silently shipping a gallery missing its hero shot is the
- *     worst failure mode for a photo feature.
+ *   - If the *featured image* upload fails, the embed filter returns
+ *     the input `$embed` unchanged (null for short-form). Featured
+ *     Image is the post's hero shot; silently shipping a gallery
+ *     missing its hero shot is the worst failure mode for a photo
+ *     feature.
  *   - If a non-featured image upload fails, that one attachment is
  *     dropped from the embed and an `error_log` line is written so
  *     operators can correlate with PDS errors.
- *   - If *every* upload fails, the projector returns the record
+ *   - If *every* upload fails, the embed filter returns the input
  *     unchanged so Atmosphere ships short-form text with no embed.
  *     When the post body is also empty (the canonical Featured-Image-
- *     only photo post), the projector additionally logs the empty-
- *     record outcome so a publish failure isn't silent.
+ *     only photo post), the filter additionally logs the empty-record
+ *     outcome so a publish failure isn't silent.
  *   - Filter / upload exceptions are caught per-attachment so one
  *     misbehaving listener can't crater the entire federation event.
  *   - Synchronous blob uploads are bounded by
@@ -137,6 +136,7 @@ class Photo_Post_Atmosphere {
 	 */
 	public static function register(): void {
 		\add_filter( 'atmosphere_is_short_form_post', array( self::class, 'filter_is_short_form_post' ), 10, 2 );
+		\add_filter( 'atmosphere_post_embed', array( self::class, 'filter_post_embed' ), 10, 3 );
 		\add_filter( 'atmosphere_transform_bsky_post', array( self::class, 'filter_transform_bsky_post' ), 10, 3 );
 	}
 
@@ -161,63 +161,47 @@ class Photo_Post_Atmosphere {
 	}
 
 	/**
-	 * Replace the record's `text` and `embed` for photo posts.
+	 * Replace the default short-form embed with `app.bsky.embed.images`
+	 * for photo posts.
 	 *
 	 * Only acts when:
+	 *   - `$strategy === 'short-form'` (the path photo posts are
+	 *     forced onto by {@see self::filter_is_short_form_post()}),
 	 *   - `$post` is a `WP_Post`,
-	 *   - it's a photo post per the shared discriminator,
-	 *   - Atmosphere's composition context indicates a short-form
-	 *     root record (`strategy === 'short-form'` and not a thread
-	 *     reply).
-	 *
-	 * The strategy / thread-reply gate is defensive: a photo post
-	 * forces `is_short_form_post() === true` via
-	 * {@see self::filter_is_short_form_post()}, so the long-form
-	 * branches never run. If a future Atmosphere change reroutes
-	 * short-form through a thread shape, this gate prevents us from
-	 * rewriting every entry in that thread.
-	 *
-	 * When at least one image blob uploads cleanly, the record's
-	 * `text` is replaced with the plain-text caption
-	 * ({@see Photo_Post::caption_text()}), facets are re-extracted
-	 * against the new text, and `embed` becomes
-	 * `app.bsky.embed.images` with up to {@see self::MAX_IMAGES}
-	 * entries. Each image carries `alt` (from
-	 * `_wp_attachment_image_alt` postmeta) and `aspectRatio` (from
-	 * `wp_get_attachment_metadata()`).
+	 *   - the discriminator says photo post,
+	 *   - at least one image attachment uploads cleanly.
 	 *
 	 * Failure handling — see class docblock for the full rationale:
-	 *   - Featured-image upload failure → return unchanged. A
-	 *     gallery missing its hero shot is worse than no gallery.
+	 *   - Featured-image upload failure → return `$embed` unchanged
+	 *     so Atmosphere ships short-form text with no embed. A gallery
+	 *     missing its hero shot is worse than no gallery.
 	 *   - Non-featured upload failure → drop that attachment, log,
 	 *     keep going.
-	 *   - Every upload failed → return unchanged so Atmosphere ships
-	 *     short-form text; if the body is also empty, log it.
+	 *   - Every upload failed → return `$embed` unchanged; if the post
+	 *     body is also empty, log it so the silent "user federated
+	 *     literally nothing" outcome surfaces.
 	 *
-	 * @param array $record  Bsky post record under construction.
-	 * @param mixed $post    The post being transformed.
-	 * @param mixed $context Atmosphere's composition context.
-	 * @return array Mutated record (or the input unchanged when no projection applies).
+	 * @param mixed $embed    Default embed for the strategy (null for short-form).
+	 * @param mixed $post     The post being transformed.
+	 * @param mixed $strategy Composition strategy ('short-form', 'link-card', 'teaser-thread').
+	 * @return array|null Replacement embed, or the input unchanged.
 	 */
-	public static function filter_transform_bsky_post( array $record, $post, $context = array() ): array {
+	public static function filter_post_embed( $embed, $post, $strategy ) {
+		if ( 'short-form' !== $strategy ) {
+			return $embed;
+		}
+
 		if ( ! $post instanceof WP_Post ) {
-			return $record;
+			return $embed;
 		}
 
 		if ( ! Photo_Post::is_photo_post( $post ) ) {
-			return $record;
-		}
-
-		$strategy        = \is_array( $context ) && isset( $context['strategy'] ) ? (string) $context['strategy'] : '';
-		$is_thread_reply = \is_array( $context ) && ! empty( $context['is_thread_reply'] );
-
-		if ( 'short-form' !== $strategy || $is_thread_reply ) {
-			return $record;
+			return $embed;
 		}
 
 		$image_ids = Photo_Post::collect_image_attachment_ids( $post );
 		if ( empty( $image_ids ) ) {
-			return $record;
+			return $embed;
 		}
 
 		// `collect_image_attachment_ids()` contractually orders the
@@ -225,14 +209,13 @@ class Photo_Post_Atmosphere {
 		// here so an early upload failure on the hero shot can bail
 		// the whole projection rather than ship a gallery with the
 		// canonical image silently missing.
-		$featured_id      = (int) \get_post_thumbnail_id( $post );
-		$has_featured     = $featured_id > 0 && ! empty( $image_ids ) && $image_ids[0] === $featured_id;
-		$budget_seconds   = self::upload_budget_seconds( $post );
-		$budget_deadline  = $budget_seconds > 0 ? \microtime( true ) + (float) $budget_seconds : null;
-		$attached         = array();
-		$overflow         = array();
-		$attempted        = 0;
-		$budget_exhausted = false;
+		$featured_id     = (int) \get_post_thumbnail_id( $post );
+		$has_featured    = $featured_id > 0 && $image_ids[0] === $featured_id;
+		$budget_seconds  = self::upload_budget_seconds( $post );
+		$budget_deadline = $budget_seconds > 0 ? \microtime( true ) + (float) $budget_seconds : null;
+		$attached        = array();
+		$overflow        = array();
+		$attempted       = 0;
 
 		foreach ( $image_ids as $attachment_id ) {
 			if ( $attempted >= self::MAX_IMAGES ) {
@@ -241,7 +224,6 @@ class Photo_Post_Atmosphere {
 			}
 
 			if ( null !== $budget_deadline && \microtime( true ) >= $budget_deadline ) {
-				$budget_exhausted = true;
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal for operators; behind a budget that defaults to 30s.
 				\error_log(
 					\sprintf(
@@ -258,7 +240,7 @@ class Photo_Post_Atmosphere {
 			if ( null === $blob ) {
 				if ( $has_featured && 0 === $attempted ) {
 					// Featured image is the hero shot — refuse to ship
-					// a gallery missing it. Return unchanged so
+					// a gallery missing it. Return `$embed` unchanged so
 					// Atmosphere falls back to short-form text and the
 					// operator gets a log line to act on.
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal for operators.
@@ -268,7 +250,7 @@ class Photo_Post_Atmosphere {
 							$post->ID
 						)
 					);
-					return $record;
+					return $embed;
 				}
 
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal for operators.
@@ -299,11 +281,12 @@ class Photo_Post_Atmosphere {
 		}
 
 		if ( empty( $attached ) ) {
-			// Every upload failed. Return unchanged so Atmosphere ships
-			// the caption with no embed (better than a malformed
-			// embed); if the body is also empty, log so the silent
-			// "user federated literally nothing" outcome surfaces.
-			if ( '' === \trim( (string) ( $record['text'] ?? '' ) ) ) {
+			// Every upload failed. Return `$embed` unchanged so
+			// Atmosphere ships the caption with no embed (better than a
+			// malformed embed); if the body is also empty, log so the
+			// silent "user federated literally nothing" outcome
+			// surfaces.
+			if ( '' === \trim( (string) $post->post_content ) ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal for operators.
 				\error_log(
 					\sprintf(
@@ -312,28 +295,67 @@ class Photo_Post_Atmosphere {
 					)
 				);
 			}
-			return $record;
+			return $embed;
 		}
-
-		// Budget-exhausted attachments aren't surfaced via the overflow
-		// action — overflow is documented as "more images than the
-		// lexicon cap" and a downstream listener can't usefully retry
-		// budget drops in the same federation event. The error_log
-		// line above is the operator-facing signal.
-		unset( $budget_exhausted );
 
 		if ( ! empty( $overflow ) ) {
 			self::fire_overflow_action( $post, $overflow );
 		}
 
-		$caption        = Photo_Post::caption_text( $post );
-		$text           = self::truncate_text( $caption );
-		$record['text'] = $text;
-
-		$record['embed'] = array(
+		return array(
 			'$type'  => 'app.bsky.embed.images',
 			'images' => $attached,
 		);
+	}
+
+	/**
+	 * Replace the record's `text` and `facets` for photo posts.
+	 *
+	 * Runs after `atmosphere_post_embed` so we can read the embed the
+	 * pipeline ultimately attached. Only rewrites when:
+	 *
+	 *   - `$post` is a `WP_Post`,
+	 *   - the discriminator says photo post,
+	 *   - the composition context is a short-form root record
+	 *     (`strategy === 'short-form'`, not a thread reply), and
+	 *   - the record carries our `app.bsky.embed.images` envelope.
+	 *
+	 * The embed-type gate is load-bearing: if every upload failed,
+	 * {@see self::filter_post_embed()} returned the input embed
+	 * (null) and Atmosphere will ship plain short-form text. Rewriting
+	 * to a caption-only string in that case would strip useful body
+	 * content from a record that has no image to caption.
+	 *
+	 * @param array $record  Bsky post record under construction.
+	 * @param mixed $post    The post being transformed.
+	 * @param mixed $context Atmosphere's composition context.
+	 * @return array Mutated record (or the input unchanged when no projection applies).
+	 */
+	public static function filter_transform_bsky_post( array $record, $post, $context = array() ): array {
+		if ( ! $post instanceof WP_Post ) {
+			return $record;
+		}
+
+		if ( ! Photo_Post::is_photo_post( $post ) ) {
+			return $record;
+		}
+
+		$strategy        = \is_array( $context ) && isset( $context['strategy'] ) ? (string) $context['strategy'] : '';
+		$is_thread_reply = \is_array( $context ) && ! empty( $context['is_thread_reply'] );
+
+		if ( 'short-form' !== $strategy || $is_thread_reply ) {
+			return $record;
+		}
+
+		$embed      = $record['embed'] ?? null;
+		$embed_type = \is_array( $embed ) ? ( $embed['$type'] ?? '' ) : '';
+		if ( 'app.bsky.embed.images' !== $embed_type ) {
+			return $record;
+		}
+
+		$caption        = Photo_Post::caption_text( $post );
+		$text           = self::truncate_text( $caption );
+		$record['text'] = $text;
 
 		// Re-extract facets against the rewritten caption so byte
 		// offsets line up with the new text. Extract against the
@@ -354,18 +376,16 @@ class Photo_Post_Atmosphere {
 	 * Upload an image attachment to the AT Protocol PDS and return the
 	 * blob reference.
 	 *
-	 * Delegates to Atmosphere's `Post::upload_thumbnail()` —
-	 * misleadingly-named today (the body is attachment-agnostic), but
-	 * the only public blob-upload surface on shipped Atmosphere.
-	 * Upstream PR 72 (`Automattic/wordpress-atmosphere`) renames this
-	 * to `upload_image_blob()`; once that lands and the bundled copy
-	 * resyncs, switch the call site below to the new name.
+	 * Delegates to Atmosphere's `Post::upload_image_blob()` — the
+	 * attachment-agnostic blob-upload surface introduced upstream as
+	 * the documented successor to `Post::upload_thumbnail()` (which
+	 * remains as a backward-compatible alias for legacy callers).
 	 *
 	 * The `fosse_photo_post_atmosphere_upload_blob` filter is the
 	 * extension seam. Three return shapes are honored:
 	 *
 	 *   - `null` (default): fall through to Atmosphere's
-	 *     `upload_thumbnail()`.
+	 *     `upload_image_blob()`.
 	 *   - A validly-shaped blob-ref array: short-circuit with a
 	 *     successful upload. The structure is validated before use.
 	 *   - Anything else (`false`, `WP_Error`, string, int, malformed
@@ -390,7 +410,7 @@ class Photo_Post_Atmosphere {
 			 * Three return shapes are honored:
 			 *
 			 *   - `null` (default): fall through to Atmosphere's
-			 *     `upload_thumbnail()`.
+			 *     `upload_image_blob()`.
 			 *   - A validly-shaped blob-ref array (`$type === 'blob'`,
 			 *     `ref`, `mimeType` like `image/jpeg`, `size`):
 			 *     short-circuit with a successful upload. The return
@@ -437,12 +457,12 @@ class Photo_Post_Atmosphere {
 		}
 
 		try {
-			$blob = \Atmosphere\Transformer\Post::upload_thumbnail( $attachment_id );
+			$blob = \Atmosphere\Transformer\Post::upload_image_blob( $attachment_id );
 		} catch ( \Throwable $e ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal: surface unexpected upload-pipeline crashes.
 			\error_log(
 				\sprintf(
-					'[fosse:photo-post-atmosphere] Atmosphere upload_thumbnail threw for attachment %d: %s',
+					'[fosse:photo-post-atmosphere] Atmosphere upload_image_blob threw for attachment %d: %s',
 					$attachment_id,
 					$e->getMessage()
 				)
@@ -523,50 +543,31 @@ class Photo_Post_Atmosphere {
 	/**
 	 * Read an image attachment's intrinsic pixel dimensions.
 	 *
-	 * Returns `[ 'width' => int, 'height' => int ]` for use as
-	 * `aspectRatio` in `app.bsky.embed.images`. The lexicon's
-	 * `aspectRatio` is documented as "intended display aspect" — AT
-	 * clients use it for layout before the blob downloads, so
-	 * approximate is fine; pixel-perfect intrinsic dims (from
-	 * `wp_get_attachment_metadata()`) are the most reliable source.
-	 *
-	 * Returns null when metadata is missing or non-positive — a
-	 * newly-uploaded attachment whose subsizes haven't been generated
-	 * yet, or a non-image attachment that slipped through somehow.
-	 *
-	 * Once Atmosphere PR 72 lands and the bundled copy resyncs, this
-	 * delegate can be replaced with `Post::get_attachment_aspect_ratio()`.
+	 * Delegates to Atmosphere's `Post::get_attachment_aspect_ratio()`
+	 * so every downstream image-embed consumer reads dimensions the
+	 * same way (including the unit-suffix sanitation that helper
+	 * applies to `wp_get_attachment_metadata()` output). Returns null
+	 * when Atmosphere isn't loaded — defensive only; the projector
+	 * registers itself behind a `class_exists` check.
 	 *
 	 * @param int $attachment_id WordPress attachment ID.
 	 * @return array|null `[ 'width' => int, 'height' => int ]` or null.
 	 */
 	private static function get_aspect_ratio( int $attachment_id ): ?array {
-		$meta = \wp_get_attachment_metadata( $attachment_id );
-
-		if ( ! \is_array( $meta ) ) {
+		if ( ! \class_exists( '\Atmosphere\Transformer\Post' ) ) {
 			return null;
 		}
 
-		$width  = isset( $meta['width'] ) ? (int) $meta['width'] : 0;
-		$height = isset( $meta['height'] ) ? (int) $meta['height'] : 0;
-
-		if ( $width <= 0 || $height <= 0 ) {
-			return null;
-		}
-
-		return array(
-			'width'  => $width,
-			'height' => $height,
-		);
+		return \Atmosphere\Transformer\Post::get_attachment_aspect_ratio( $attachment_id );
 	}
 
 	/**
 	 * Resolve the wall-time budget for synchronous blob uploads.
 	 *
-	 * Each `Post::upload_thumbnail()` call can take up to 60s on a
+	 * Each `Post::upload_image_blob()` call can take up to 60s on a
 	 * degraded PDS; four of those in a row exceed typical PHP
-	 * execution-time limits. The default 30s budget keeps the
-	 * publish request from hanging when the PDS is slow.
+	 * execution-time limits. The default 30s budget keeps the publish
+	 * request from hanging when the PDS is slow.
 	 *
 	 * Filter return is coerced to non-negative int. Zero disables
 	 * the budget (uploads run to completion regardless of wall

--- a/src/class-photo-post-atmosphere.php
+++ b/src/class-photo-post-atmosphere.php
@@ -215,9 +215,8 @@ class Photo_Post_Atmosphere {
 		$budget_deadline = $budget_seconds > 0 ? \microtime( true ) + (float) $budget_seconds : null;
 		$attached        = array();
 		$overflow        = array();
-		$index           = 0;
 
-		foreach ( $image_ids as $attachment_id ) {
+		foreach ( $image_ids as $position => $attachment_id ) {
 			if ( count( $attached ) >= self::MAX_IMAGES ) {
 				$overflow[] = $attachment_id;
 				continue;
@@ -238,7 +237,7 @@ class Photo_Post_Atmosphere {
 			$blob = self::upload_blob( $attachment_id );
 
 			if ( null === $blob ) {
-				if ( $has_featured && 0 === $index ) {
+				if ( $has_featured && 0 === $position ) {
 					// Featured image is the hero shot — refuse to ship
 					// a gallery missing it. Return `$embed` unchanged so
 					// Atmosphere falls back to short-form text and the
@@ -262,7 +261,6 @@ class Photo_Post_Atmosphere {
 					)
 				);
 
-				++$index;
 				continue;
 			}
 
@@ -277,16 +275,18 @@ class Photo_Post_Atmosphere {
 			}
 
 			$attached[] = $image;
-			++$index;
 		}
 
 		if ( empty( $attached ) ) {
 			// Every upload failed. Return `$embed` unchanged so
 			// Atmosphere ships the caption with no embed (better than a
-			// malformed embed); if the body is also empty, log so the
-			// silent "user federated literally nothing" outcome
-			// surfaces.
-			if ( '' === \trim( (string) $post->post_content ) ) {
+			// malformed embed); if the rendered caption is also empty,
+			// log so the silent "user federated literally nothing"
+			// outcome surfaces. We check the caption (not raw
+			// `post_content`) because a pure Rule-2 photo post is just
+			// `<!-- wp:image -->` blocks — non-empty `post_content` but
+			// empty federated text once image markup is stripped.
+			if ( '' === \trim( Photo_Post::caption_text( $post ) ) ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Reliability signal for operators.
 				\error_log(
 					\sprintf(
@@ -347,9 +347,16 @@ class Photo_Post_Atmosphere {
 			return $record;
 		}
 
-		$embed      = $record['embed'] ?? null;
-		$embed_type = \is_array( $embed ) ? ( $embed['$type'] ?? '' ) : '';
-		if ( 'app.bsky.embed.images' !== $embed_type ) {
+		// Gate on a fully-formed images embed, not just the `$type`
+		// string — a third-party `atmosphere_post_embed` listener could
+		// forge `$type === 'app.bsky.embed.images'` with no images
+		// array, which would otherwise trip the caption rewrite on a
+		// record that has no gallery to caption.
+		$embed       = $record['embed'] ?? null;
+		$embed_type  = \is_array( $embed ) ? ( $embed['$type'] ?? '' ) : '';
+		$images      = \is_array( $embed ) ? ( $embed['images'] ?? null ) : null;
+		$has_gallery = \is_array( $images ) && ! empty( $images );
+		if ( 'app.bsky.embed.images' !== $embed_type || ! $has_gallery ) {
 			return $record;
 		}
 
@@ -612,9 +619,13 @@ class Photo_Post_Atmosphere {
 			 * thread, fall back to a link card, surface a notice to
 			 * the user) without modifying this projector.
 			 *
-			 * Listeners must be fast and non-throwing — exceptions
-			 * are caught here so a misbehaving subscriber can't
-			 * crater the already-built embed.
+			 * Listeners must be fast, non-throwing, and non-mutating
+			 * with respect to `$post`. Exceptions are caught here so a
+			 * misbehaving subscriber can't crater the already-built
+			 * embed; mutation cannot be intercepted the same way and
+			 * would desync the caption that
+			 * {@see self::filter_transform_bsky_post()} computes from
+			 * `$post->post_content` later in the same composition pass.
 			 *
 			 * @param WP_Post $post     The post being projected.
 			 * @param int[]   $overflow Attachment ids dropped from the embed.

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -2385,7 +2385,13 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	): void {
 		set_transient( 'atmosphere_oauth_state', $state, HOUR_IN_SECONDS );
 		set_transient( 'atmosphere_oauth_verifier', 'test-verifier-' . uniqid( '', true ), HOUR_IN_SECONDS );
-		set_transient( 'atmosphere_oauth_dpop_jwk', \Atmosphere\OAuth\DPoP::generate_key(), HOUR_IN_SECONDS );
+		set_transient(
+			'atmosphere_oauth_dpop_jwk',
+			\Atmosphere\OAuth\Encryption::encrypt(
+				(string) wp_json_encode( \Atmosphere\OAuth\DPoP::generate_key() ) // phpcs:ignore Jetpack.Functions.JsonEncodeFlags.Missing -- test fixture.
+			),
+			HOUR_IN_SECONDS
+		);
 		set_transient(
 			'atmosphere_oauth_resolved',
 			array(

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1599,6 +1599,18 @@ class Onboarding_WizardTest extends BaseTestCase {
 				'access_token' => Encryption::encrypt( 'token' ),
 			)
 		);
+		// Seed identity directly so Atmosphere\get_identity() short-circuits
+		// instead of running its lazy migration (which would cast the corrupt
+		// array handle to string and emit an "Array to string conversion"
+		// warning — the wizard's own defenses kick in further downstream).
+		update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:alice123',
+				'handle'       => '',
+				'pds_endpoint' => 'https://bsky.social',
+			)
+		);
 
 		$output = $this->render_wizard_step( 'complete' );
 

--- a/tests/php/Photo_Post_AtmosphereTest.php
+++ b/tests/php/Photo_Post_AtmosphereTest.php
@@ -462,6 +462,13 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 
 		$this->assertCount( Photo_Post_Atmosphere::MAX_IMAGES, $record['embed']['images'] );
 		$this->assertSame( array( $image_ids[5] ), $overflow_payload );
+		// Lock down which blobs landed (and in what order): the failed
+		// upload at index 2 should be skipped, not occupy a slot.
+		$cids = array_map(
+			static fn( array $image ) => $image['image']['ref']['$link'],
+			$record['embed']['images']
+		);
+		$this->assertSame( array( 'bafy0', 'bafy1', 'bafy3', 'bafy4' ), $cids );
 	}
 
 	/**
@@ -710,6 +717,78 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 
 		$this->assertSame( 'cta text', $record['text'] );
 		$this->assertArrayNotHasKey( 'embed', $record );
+	}
+
+	/**
+	 * Defensive: when a third-party `atmosphere_post_embed` listener
+	 * wins and attaches a non-images embed (e.g. `app.bsky.embed.external`
+	 * for a link card), the text-rewrite filter must NOT replace the
+	 * caption — the embed-type gate is the only thing standing between
+	 * a photo-post discriminator match and a record whose text has been
+	 * caption-stripped but whose embed is a link card.
+	 */
+	public function test_transform_filter_skips_when_embed_type_is_not_images(): void {
+		$this->stub_blob_for( $this->image_id );
+		$post = $this->make_post( 'some prose body', $this->image_id );
+
+		$record = apply_filters(
+			'atmosphere_transform_bsky_post',
+			array(
+				'$type'     => 'app.bsky.feed.post',
+				'text'      => 'some prose body',
+				'createdAt' => '2026-05-19T00:00:00Z',
+				'langs'     => array( 'en' ),
+				'embed'     => array(
+					'$type'    => 'app.bsky.embed.external',
+					'external' => array(
+						'uri'   => 'https://example.test/',
+						'title' => 'forged',
+					),
+				),
+			),
+			$post,
+			array(
+				'strategy'        => 'short-form',
+				'thread_index'    => 0,
+				'is_thread_reply' => false,
+			)
+		);
+
+		$this->assertSame( 'some prose body', $record['text'] );
+		$this->assertSame( 'app.bsky.embed.external', $record['embed']['$type'] );
+	}
+
+	/**
+	 * Defensive: a forged `$type === 'app.bsky.embed.images'` envelope
+	 * with no actual images array must NOT trip the caption rewrite —
+	 * the gate has to look at the whole embed shape, not just the type
+	 * string. Protects against a third-party listener returning a
+	 * skeleton embed that lies about what shipped.
+	 */
+	public function test_transform_filter_skips_when_images_embed_has_no_images(): void {
+		$post = $this->make_post( 'narrative body', $this->image_id );
+
+		$record = apply_filters(
+			'atmosphere_transform_bsky_post',
+			array(
+				'$type'     => 'app.bsky.feed.post',
+				'text'      => 'narrative body',
+				'createdAt' => '2026-05-19T00:00:00Z',
+				'langs'     => array( 'en' ),
+				'embed'     => array(
+					'$type'  => 'app.bsky.embed.images',
+					'images' => array(),
+				),
+			),
+			$post,
+			array(
+				'strategy'        => 'short-form',
+				'thread_index'    => 0,
+				'is_thread_reply' => false,
+			)
+		);
+
+		$this->assertSame( 'narrative body', $record['text'] );
 	}
 
 	/**

--- a/tests/php/Photo_Post_AtmosphereTest.php
+++ b/tests/php/Photo_Post_AtmosphereTest.php
@@ -15,11 +15,17 @@ use WorDBless\BaseTestCase;
 use WP_Post;
 
 /**
- * Covers `Photo_Post_Atmosphere::filter_is_short_form_post()` and
- * `filter_transform_bsky_post()` through `apply_filters` round-trips
- * — keeps the contract "FOSSE projects onto Atmosphere's filters"
- * load-bearing in the tests, the same posture {@see Photo_PostTest}
- * uses for the AP-side hooks.
+ * Covers `Photo_Post_Atmosphere::filter_is_short_form_post()`,
+ * `filter_post_embed()`, and `filter_transform_bsky_post()` through
+ * `apply_filters` round-trips — keeps the contract "FOSSE projects onto
+ * Atmosphere's filters" load-bearing in the tests, the same posture
+ * {@see Photo_PostTest} uses for the AP-side hooks.
+ *
+ * The {@see self::apply_transform_filter()} helper simulates Atmosphere's
+ * own composition order — run `atmosphere_post_embed` first, attach
+ * the result onto the record, then run `atmosphere_transform_bsky_post`
+ * — so the embed-attached → text-rewritten chain mirrors what shipped
+ * Atmosphere actually does inside `Post::transform()`.
  *
  * Blob uploads are intercepted via the
  * `fosse_photo_post_atmosphere_upload_blob` extension filter so tests
@@ -79,6 +85,7 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 	#[Before]
 	public function reset_state(): void {
 		remove_all_filters( 'atmosphere_is_short_form_post' );
+		remove_all_filters( 'atmosphere_post_embed' );
 		remove_all_filters( 'atmosphere_transform_bsky_post' );
 		remove_all_filters( 'fosse_pre_is_photo_post' );
 		remove_all_filters( 'fosse_is_photo_post' );
@@ -110,8 +117,8 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 		// Reset stub state and install the interception filter.
 		// Unstubbed attachments return `false` so the projector
 		// treats them as failed uploads without falling through to
-		// Atmosphere's real `upload_thumbnail()` (which would try to
-		// read a real file and warn).
+		// Atmosphere's real `upload_image_blob()` (which would try
+		// to read a real file and warn).
 		$this->blob_stubs = array();
 		add_filter(
 			'fosse_photo_post_atmosphere_upload_blob',
@@ -225,12 +232,16 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 	}
 
 	/**
-	 * Apply the `atmosphere_transform_bsky_post` filter against a
-	 * short-form record envelope.
+	 * Simulate Atmosphere's short-form composition: run
+	 * `atmosphere_post_embed` to build the embed, attach the result
+	 * onto the record if non-null, then run
+	 * `atmosphere_transform_bsky_post`. Mirrors the call order inside
+	 * shipped `Post::transform()` so the test pipeline exercises both
+	 * projector filters end-to-end the same way Atmosphere does.
 	 *
 	 * @param WP_Post $post      The post being transformed.
 	 * @param array   $overrides Optional record overrides.
-	 * @return array Filtered record.
+	 * @return array Final record after both filters.
 	 */
 	private function apply_transform_filter( WP_Post $post, array $overrides = array() ): array {
 		$record = array_merge(
@@ -242,6 +253,11 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 			),
 			$overrides
 		);
+
+		$embed = apply_filters( 'atmosphere_post_embed', null, $post, 'short-form' );
+		if ( null !== $embed ) {
+			$record['embed'] = $embed;
+		}
 
 		return apply_filters(
 			'atmosphere_transform_bsky_post',
@@ -562,6 +578,58 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 		$this->assertArrayHasKey( 'embed', $record );
 		$this->assertCount( 1, $record['embed']['images'] );
 		$this->assertSame( array( '$link' => 'bafyhero' ), $record['embed']['images'][0]['image']['ref'] );
+	}
+
+	/**
+	 * Defensive: a non-`short-form` strategy on the embed filter must
+	 * leave the input embed alone. Photo posts force
+	 * `is_short_form_post()` true so the link-card / teaser-thread
+	 * paths never see a photo post in practice, but if a third-party
+	 * filter forces a photo post off the short-form path we must not
+	 * attach `app.bsky.embed.images` to a teaser thread (which still
+	 * expects an external card on its terminal entry).
+	 */
+	public function test_post_embed_filter_passes_through_for_non_short_form_strategy(): void {
+		$this->stub_blob_for( $this->image_id );
+		$post = $this->make_post( '', $this->image_id );
+
+		$default_external = array(
+			'$type'    => 'app.bsky.embed.external',
+			'external' => array(
+				'uri'         => 'https://example.test/p/1',
+				'title'       => 'fallback',
+				'description' => '',
+			),
+		);
+
+		$this->assertSame(
+			$default_external,
+			apply_filters( 'atmosphere_post_embed', $default_external, $post, 'teaser-thread' )
+		);
+		$this->assertSame(
+			$default_external,
+			apply_filters( 'atmosphere_post_embed', $default_external, $post, 'link-card' )
+		);
+	}
+
+	/**
+	 * Defensive: a non-WP_Post second arg to the embed filter must
+	 * pass the input through unchanged. Same posture as the
+	 * `is_short_form` filter — a stray hook call (third-party plugin
+	 * that re-fires `atmosphere_post_embed` with the wrong shape) must
+	 * not crash the federation event.
+	 */
+	public function test_post_embed_filter_passes_through_on_non_wp_post(): void {
+		$this->assertNull( apply_filters( 'atmosphere_post_embed', null, null, 'short-form' ) );
+		$this->assertSame(
+			array( '$type' => 'app.bsky.embed.external' ),
+			apply_filters(
+				'atmosphere_post_embed',
+				array( '$type' => 'app.bsky.embed.external' ),
+				'not-a-post',
+				'short-form'
+			)
+		);
 	}
 
 	/**

--- a/tests/php/Photo_Post_AtmosphereTest.php
+++ b/tests/php/Photo_Post_AtmosphereTest.php
@@ -417,6 +417,54 @@ class Photo_Post_AtmosphereTest extends BaseTestCase {
 	}
 
 	/**
+	 * A non-featured mid-list upload failure must not eat one of the
+	 * MAX_IMAGES slots: when more uploadable attachments are available
+	 * the embed should still ship `MAX_IMAGES` successful blobs.
+	 * Counts successful attachments toward the cap, not raw attempts.
+	 */
+	public function test_transform_filter_fills_cap_after_non_featured_failure(): void {
+		add_filter( 'activitypub_max_image_attachments', static fn() => 6 );
+
+		// Six resolvable images: featured + five gallery children.
+		// We'll fail the second gallery image (index 2 in $image_ids)
+		// and expect the projector to still ship MAX_IMAGES = 4
+		// successful uploads, with the trailing attachment as overflow.
+		$image_ids = array( $this->image_id, $this->image_id_alt );
+		for ( $i = 0; $i < 4; $i++ ) {
+			$image_ids[] = $this->insert_image_attachment( "extra-{$i}.jpg", 1000, 1000 );
+		}
+		foreach ( $image_ids as $i => $id ) {
+			if ( 2 === $i ) {
+				continue;
+			}
+			$this->stub_blob_for( $id, 'bafy' . $i );
+		}
+
+		$inner = '';
+		foreach ( array_slice( $image_ids, 1 ) as $id ) {
+			$inner .= '<!-- wp:image {"id":' . $id . '} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->';
+		}
+		$content = '<!-- wp:gallery -->' . $inner . '<!-- /wp:gallery -->';
+
+		$overflow_payload = null;
+		add_action(
+			'fosse_photo_post_atmosphere_overflow',
+			static function ( $post, $overflow ) use ( &$overflow_payload ) {
+				$overflow_payload = $overflow;
+			},
+			10,
+			2
+		);
+
+		$post = $this->make_post( $content, $this->image_id );
+
+		$record = $this->apply_transform_filter( $post );
+
+		$this->assertCount( Photo_Post_Atmosphere::MAX_IMAGES, $record['embed']['images'] );
+		$this->assertSame( array( $image_ids[5] ), $overflow_payload );
+	}
+
+	/**
 	 * Aspect ratio is omitted when metadata is unavailable — the
 	 * `images` entry must still carry `image` + `alt`.
 	 */


### PR DESCRIPTION
Refs [DOTCOM-17143](https://linear.app/a8c/issue/DOTCOM-17143).

Resyncs both bundled backends to current upstream trunk and refactors `Photo_Post_Atmosphere` onto the focused embed seam introduced upstream by [wordpress-atmosphere PR 72](https://github.com/Automattic/wordpress-atmosphere/pull/72).

## Upstream SHAs

- **wordpress-activitypub** trunk → `31cdcd0a` (Add blurhash term to JSON-LD context)
- **wordpress-atmosphere** trunk → `2a0383a` (Re-sync publication on theme and site-URL changes)

## Notable upstream changes brought in

**Atmosphere:**

- **`atmosphere_post_embed` filter + `Post::upload_image_blob()` / `Post::get_attachment_aspect_ratio()` helpers** ([wordpress-atmosphere PR 72](https://github.com/Automattic/wordpress-atmosphere/pull/72)) — the surface the second commit targets. `Post::upload_thumbnail()` remains as a back-compat alias for Publication / Document callers.
- Re-sync publication on theme / site-URL changes ([PR 76](https://github.com/Automattic/wordpress-atmosphere/pull/76)) and publication link tag for standard.site discovery ([PR 75](https://github.com/Automattic/wordpress-atmosphere/pull/75)).
- Publishing classifier, publication URI staleness, and handle-button hang fixes after the 1.0.0 cut ([PR 74](https://github.com/Automattic/wordpress-atmosphere/pull/74)).
- Atmosphere 1.0.0 release ([PR 73](https://github.com/Automattic/wordpress-atmosphere/pull/73)). The bundled copy still reports `ATMOSPHERE_VERSION = 'unreleased'` because we vendor trunk, not the release tag.

**ActivityPub:**

- `toot:blurhash` declared in the JSON-LD context ([PR 3327](https://github.com/Automattic/wordpress-activitypub/pull/3327)). Pairs with FOSSE's own [Blurhash injection](https://github.com/Automattic/fosse/pull/159) so the field validates against Mastodon's schema without a FOSSE-side `@context` shim.
- SWICG basic-profile conformance improvements for C2S ([PR 3328](https://github.com/Automattic/wordpress-activitypub/pull/3328)) and supporting OAuth scope / token refactors.
- Tombstone migration and post-types helper changes.

## Photo-post projector refactor

The previous shape ([PR 156](https://github.com/Automattic/fosse/pull/156)) deliberately targeted the *shipped* Atmosphere surface — `atmosphere_transform_bsky_post` plus `Post::upload_thumbnail()` — so the photo-post AT federation worked the moment that PR landed, with or without [PR 72](https://github.com/Automattic/wordpress-atmosphere/pull/72) upstream. The class docblock called out the cleaner two-line switchover for when PR 72 made it into the bundled copy. That's this commit.

Three filter callbacks now do the work:

| Filter | Role |
| -- | -- |
| `atmosphere_is_short_form_post` | Force the short-form path for photo posts. Unchanged. |
| `atmosphere_post_embed` (new) | Build `app.bsky.embed.images` from up to 4 uploaded blob refs. All upload / overflow / featured-image-bail logic lives here. |
| `atmosphere_transform_bsky_post` (slimmed) | Rewrite the record's `text` and re-extract facets. Now gated on `record.embed.$type === 'app.bsky.embed.images'` so a fully-failed upload pass leaves Atmosphere's default short-form text in place. |

Other cleanups:

- `upload_blob()` calls `Post::upload_image_blob()` (the documented successor). Functional behavior unchanged.
- `get_aspect_ratio()` delegates to `Post::get_attachment_aspect_ratio()` so every downstream image-embed consumer reads dimensions the same way (including the `is_numeric()` sanitation that helper applies — protects against a unit-suffixed string like `"1600px"` propagating as a misleading integer).

### Failure-mode posture (unchanged from PR 156)

- Featured-image upload failure → embed filter returns input unchanged (null for short-form). Atmosphere ships text-only. A gallery missing its hero shot is worse than no gallery.
- Non-featured upload failure → drop that attachment, log, keep going.
- Every upload failed → embed filter returns input unchanged; if the post body is also empty, log so the silent "user federated literally nothing" outcome surfaces.
- Filter / upload exceptions caught per-attachment so one misbehaving listener can't crater the federation event.
- Synchronous blob uploads bounded by `fosse_photo_post_atmosphere_upload_budget_seconds` (default 30s).

## Tests

- 28 photo-post tests pass (the existing 26 plus 2 new ones covering the embed-filter contract directly: non-short-form strategy pass-through and non-`WP_Post` second-arg pass-through).
- The `apply_transform_filter()` helper now simulates Atmosphere's full composition order — run `atmosphere_post_embed`, attach result, then run `atmosphere_transform_bsky_post` — so the embed-attached → text-rewritten chain is exercised end-to-end the way shipped Atmosphere does it inside `Post::transform()`.

## Known regressions from the bundled resync

Three OAuth callback tests in `Admin\Bluesky_ProviderTest` started failing with the Atmosphere resync (not introduced by the photo-post refactor):

- `test_handle_oauth_callback_success_emits_success_notice`
- `test_handle_oauth_callback_warns_when_connection_not_persisted`
- `test_handle_oauth_callback_warns_when_sync_publication_fails`

Atmosphere's OAuth client was substantially rewritten upstream (~1000 lines changed in `includes/oauth/class-client.php`). The FOSSE-side stubs in `fake_atmosphere_oauth_environment()` / `intercept_token_endpoint_success()` need to be refreshed against the new request flow. Filing as a separate follow-up so this resync isn't held up — flagging here so it isn't a surprise on the next test run.

The pre-existing BlurhashTest and Blurhash_CLITest failures on `trunk` are unchanged by this PR.

## Testing instructions

- `composer test-php -- --filter Photo_Post_Atmosphere` — 28/28 pass.
- `composer lint-php -- src/class-photo-post-atmosphere.php tests/php/Photo_Post_AtmosphereTest.php` — clean.
- Manual: publish a WP post with post format = Image and a single image + caption. Confirm the federated Bluesky record carries `embed.$type === "app.bsky.embed.images"` (Flashes / Pinksky render it as a native image post; web bsky.app shows it inline). Toggle off `Photo_Post::is_photo_post()` via the `fosse_is_photo_post` filter and confirm the record reverts to `embed.$type === "app.bsky.embed.external"` (today's default link card).
