### PR TITLE
Admin: fix Bluesky domain handle resolution during reauth

### DIFF
--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -754,33 +754,22 @@ class Bluesky_Provider implements Connection_Provider {
 			return null;
 		}
 
-		$did = '';
-
-		if ( function_exists( '\Atmosphere\has_identity' ) && function_exists( '\Atmosphere\get_did' ) ) {
-			if ( ! \Atmosphere\has_identity() ) {
-				return array(
-					'status' => 404,
-					'did'    => '',
-				);
-			}
-
-			$did = \Atmosphere\get_did();
-		} elseif ( function_exists( '\Atmosphere\is_connected' ) && function_exists( '\Atmosphere\get_connection' ) ) {
-			if ( ! \Atmosphere\is_connected() ) {
-				return array(
-					'status' => 404,
-					'did'    => '',
-				);
-			}
-
-			$connection = \Atmosphere\get_connection();
-			$did        = isset( $connection['did'] ) ? (string) $connection['did'] : '';
-		} else {
-			// Atmosphere isn't loaded. That's a structural error, not a
-			// user-facing "no connection" state. Decline to handle so a
-			// normal 404 happens via WordPress's main request flow.
+		if ( ! function_exists( '\Atmosphere\has_identity' ) || ! function_exists( '\Atmosphere\get_did' ) ) {
+			// Atmosphere isn't loaded, or is too old to expose the persisted
+			// identity contract. That's a structural error, not a user-facing
+			// "no connection" state. Decline to handle so a normal 404 happens
+			// via WordPress's main request flow.
 			return null;
 		}
+
+		if ( ! \Atmosphere\has_identity() ) {
+			return array(
+				'status' => 404,
+				'did'    => '',
+			);
+		}
+
+		$did = \Atmosphere\get_did();
 
 		// Validate the DID against AT Proto syntax before promising to serve it.
 		// The response is plain text and a malformed value (newlines, control chars,

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -984,7 +984,12 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return string Normalized handle.
 	 */
 	private static function normalize_submitted_handle( string $handle ): string {
-		$edge_pattern = '/^[\s\p{Cf}]+|[\s\p{Cf}]+$/u';
+		// ASCII whitespace is listed explicitly rather than via `\s` so the
+		// pattern doesn't quietly grow if PCRE2 is ever compiled with UCP
+		// (PHP's bundled build isn't, but the explicit class removes the
+		// dependency on that). Non-ASCII whitespace stays intact and falls
+		// through to the AT Protocol ASCII validator downstream.
+		$edge_pattern = '/^[ \t\n\r\f\v\p{Cf}]+|[ \t\n\r\f\v\p{Cf}]+$/u';
 
 		$handle = (string) preg_replace( $edge_pattern, '', $handle );
 		$handle = ltrim( $handle, '@' );

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -971,25 +971,24 @@ class Bluesky_Provider implements Connection_Provider {
 	/**
 	 * Normalize a submitted Bluesky handle before validation.
 	 *
+	 * Peels ASCII whitespace and invisible Unicode formatting bytes
+	 * (`\p{Cf}`: BOM, ZWSP, bidi marks, etc.) from both edges of the
+	 * handle, then strips a leading `@`. Formatting bytes in the
+	 * interior of the handle are intentionally left in place — they
+	 * change the semantic shape of what the user typed and the
+	 * downstream ASCII validation should surface that as an
+	 * `invalid_handle` error rather than silently coercing the input
+	 * into a different valid handle.
+	 *
 	 * @param string $handle Raw sanitized handle from the form submission.
 	 * @return string Normalized handle.
 	 */
 	private static function normalize_submitted_handle( string $handle ): string {
-		$handle = preg_replace( '/\p{Cf}+/u', '', $handle );
-		if ( ! is_string( $handle ) ) {
-			return '';
-		}
+		$edge_pattern = '/^[\s\p{Cf}]+|[\s\p{Cf}]+$/u';
 
-		$handle = preg_replace( '/^\s+|\s+$/u', '', $handle );
-		if ( ! is_string( $handle ) ) {
-			return '';
-		}
-
+		$handle = (string) preg_replace( $edge_pattern, '', $handle );
 		$handle = ltrim( $handle, '@' );
-		$handle = preg_replace( '/^\s+|\s+$/u', '', $handle );
-		if ( ! is_string( $handle ) ) {
-			return '';
-		}
+		$handle = (string) preg_replace( $edge_pattern, '', $handle );
 
 		return strtolower( $handle );
 	}

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -702,8 +702,8 @@ class Bluesky_Provider implements Connection_Provider {
 	 * Returns silently for unrelated paths, when the
 	 * `fosse_serve_atproto_did_well_known` filter opts out, and when
 	 * Atmosphere isn't loaded. Sends a 404 and exits when Atmosphere is
-	 * loaded but no DID is available; otherwise sends a `text/plain` body
-	 * containing the connected DID and exits.
+	 * loaded but no identity DID is available; otherwise sends a
+	 * `text/plain` body containing the DID and exits.
 	 *
 	 * @return void
 	 */
@@ -754,22 +754,33 @@ class Bluesky_Provider implements Connection_Provider {
 			return null;
 		}
 
-		if ( ! function_exists( '\Atmosphere\is_connected' ) ) {
+		$did = '';
+
+		if ( function_exists( '\Atmosphere\has_identity' ) && function_exists( '\Atmosphere\get_did' ) ) {
+			if ( ! \Atmosphere\has_identity() ) {
+				return array(
+					'status' => 404,
+					'did'    => '',
+				);
+			}
+
+			$did = \Atmosphere\get_did();
+		} elseif ( function_exists( '\Atmosphere\is_connected' ) && function_exists( '\Atmosphere\get_connection' ) ) {
+			if ( ! \Atmosphere\is_connected() ) {
+				return array(
+					'status' => 404,
+					'did'    => '',
+				);
+			}
+
+			$connection = \Atmosphere\get_connection();
+			$did        = isset( $connection['did'] ) ? (string) $connection['did'] : '';
+		} else {
 			// Atmosphere isn't loaded. That's a structural error, not a
 			// user-facing "no connection" state. Decline to handle so a
 			// normal 404 happens via WordPress's main request flow.
 			return null;
 		}
-
-		if ( ! \Atmosphere\is_connected() ) {
-			return array(
-				'status' => 404,
-				'did'    => '',
-			);
-		}
-
-		$connection = \Atmosphere\get_connection();
-		$did        = isset( $connection['did'] ) ? (string) $connection['did'] : '';
 
 		// Validate the DID against AT Proto syntax before promising to serve it.
 		// The response is plain text and a malformed value (newlines, control chars,

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -864,7 +864,7 @@ class Bluesky_Provider implements Connection_Provider {
 		);
 
 		$handle = sanitize_text_field( wp_unslash( $_POST['bluesky_handle'] ?? '' ) );
-		$handle = strtolower( trim( ltrim( trim( $handle ), '@' ) ) );
+		$handle = self::normalize_submitted_handle( $handle );
 
 		if ( empty( $handle ) ) {
 			self::record_connection_failed( 'bluesky', $source, 'invalid_handle' );
@@ -977,6 +977,32 @@ class Bluesky_Provider implements Connection_Provider {
 		}
 
 		$this->redirect_with_notice( __( 'Disconnected from Bluesky.', 'fosse' ), 'info' );
+	}
+
+	/**
+	 * Normalize a submitted Bluesky handle before validation.
+	 *
+	 * @param string $handle Raw sanitized handle from the form submission.
+	 * @return string Normalized handle.
+	 */
+	private static function normalize_submitted_handle( string $handle ): string {
+		$handle = preg_replace( '/\p{Cf}+/u', '', $handle );
+		if ( ! is_string( $handle ) ) {
+			return '';
+		}
+
+		$handle = preg_replace( '/^\s+|\s+$/u', '', $handle );
+		if ( ! is_string( $handle ) ) {
+			return '';
+		}
+
+		$handle = ltrim( $handle, '@' );
+		$handle = preg_replace( '/^\s+|\s+$/u', '', $handle );
+		if ( ! is_string( $handle ) ) {
+			return '';
+		}
+
+		return strtolower( $handle );
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -54,6 +54,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		// invocation in the same PHP process if the static `$booted` flag leaked.
 		Provider_Loader::reset();
 		delete_option( 'atmosphere_connection' );
+		delete_option( 'atmosphere_identity' );
 		delete_option( 'atmosphere_auto_publish' );
 		delete_option( Bluesky_Domain_Handle::OPTION_PREVIOUS_HANDLE );
 		delete_transient( 'fosse_bluesky_profile_' . sanitize_key( 'did:plc:test123' ) );
@@ -881,9 +882,48 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * A stored DID is not enough to serve the well-known route without a connection.
+	 * The well-known route must keep serving the DID while a stored identity
+	 * needs OAuth reauthorization. Domain handles depend on this endpoint to
+	 * resolve before the reconnect flow can even redirect to the auth server.
 	 */
-	public function test_atproto_did_well_known_response_requires_connected_atmosphere() {
+	public function test_atproto_did_well_known_response_uses_identity_during_reauth() {
+		update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://bsky.social',
+			)
+		);
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => '',
+				'needs_reauth' => true,
+			)
+		);
+
+		$this->assertFalse( \Atmosphere\is_connected() );
+		$this->assertTrue( \Atmosphere\has_identity() );
+
+		$this->assertSame(
+			array(
+				'status' => 200,
+				'did'    => 'did:plc:test123',
+			),
+			$this->get_atproto_did_well_known_response( '/.well-known/atproto-did' )
+		);
+	}
+
+	/**
+	 * A legacy connection row with identity data still serves the DID even
+	 * without a live access token. Atmosphere lazily migrates this shape into
+	 * `atmosphere_identity`, and FOSSE should follow that source of truth.
+	 */
+	public function test_atproto_did_well_known_response_migrates_legacy_identity_without_live_connection() {
 		update_option(
 			'atmosphere_connection',
 			array(
@@ -892,6 +932,19 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			)
 		);
 
+		$this->assertSame(
+			array(
+				'status' => 200,
+				'did'    => 'did:plc:test123',
+			),
+			$this->get_atproto_did_well_known_response( '/.well-known/atproto-did' )
+		);
+	}
+
+	/**
+	 * Sites without any persisted AT Protocol identity return 404.
+	 */
+	public function test_atproto_did_well_known_response_returns_404_without_identity() {
 		$this->assertSame(
 			array(
 				'status' => 404,

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -1943,7 +1943,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 			'Expected pre_http_request to fire from Client::authorize() after removing invisible formatting bytes.'
 		);
 		$this->assertSame(
-			'devdotdev.bsky.social',
+			'fosse.example.com',
 			wp_parse_url( (string) $captured_url, PHP_URL_HOST ),
 			'Normalized handle should be the resolved host of the authorize lookup URL.'
 		);
@@ -1952,13 +1952,20 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	/**
 	 * Data provider for edge-placed invisible Unicode formatting bytes.
 	 *
+	 * Uses an `example.com` subdomain (IANA-owned per RFC 2606) so the
+	 * DNS TXT probe in `Resolver::handle_to_did()` deterministically misses
+	 * and falls through to the HTTPS well-known path the `pre_http_request`
+	 * filter intercepts. Reserved TLDs (`.invalid`, `.test`, `.example`,
+	 * `.localhost`) are not usable here — Atmosphere's `is_valid_handle()`
+	 * rejects them before resolution.
+	 *
 	 * @return array<string, array{0: string}>
 	 */
 	public static function boundary_invisible_handle_provider(): array {
 		return array(
-			'trailing pop directional formatting (U+202C)' => array( "devdotdev.bsky.social\u{202C}" ),
-			'leading byte-order mark (U+FEFF)'             => array( "\u{FEFF}devdotdev.bsky.social" ),
-			'leading and trailing zero-width space (U+200B)' => array( "\u{200B}devdotdev.bsky.social\u{200B}" ),
+			'trailing pop directional formatting (U+202C)' => array( "fosse.example.com\u{202C}" ),
+			'leading byte-order mark (U+FEFF)'             => array( "\u{FEFF}fosse.example.com" ),
+			'leading and trailing zero-width space (U+200B)' => array( "\u{200B}fosse.example.com\u{200B}" ),
 		);
 	}
 

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -1460,13 +1460,15 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	 */
 	public static function invalid_handle_provider(): array {
 		return array(
-			'no dot, single label' => array( 'alice' ),
-			'leading dot'          => array( '.bsky.social' ),
-			'trailing dot'         => array( 'alice.bsky.social.' ),
-			'space inside'         => array( 'alice bsky.social' ),
-			'underscore'           => array( 'al_ice.bsky.social' ),
-			'mastodon style'       => array( '@alice@host.example' ),
-			'leading hyphen label' => array( '-alice.bsky.social' ),
+			'no dot, single label'                 => array( 'alice' ),
+			'leading dot'                          => array( '.bsky.social' ),
+			'trailing dot'                         => array( 'alice.bsky.social.' ),
+			'space inside'                         => array( 'alice bsky.social' ),
+			'underscore'                           => array( 'al_ice.bsky.social' ),
+			'mastodon style'                       => array( '@alice@host.example' ),
+			'leading hyphen label'                 => array( '-alice.bsky.social' ),
+			'interior zero-width space (U+200B)'   => array( "alice\u{200B}.bsky.social" ),
+			'interior left-to-right mark (U+200E)' => array( "alice.bsky\u{200E}.social" ),
 		);
 	}
 
@@ -1890,26 +1892,33 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Invisible Unicode formatting bytes from copied handles are stripped
-	 * before validation. They are visually indistinguishable from a valid
-	 * handle, but the ASCII handle regex rejects them if they survive.
+	 * Invisible Unicode formatting bytes at the edges of a copied handle
+	 * are stripped before validation. They are visually indistinguishable
+	 * from a valid handle, but the ASCII handle regex would reject them if
+	 * they survived. Interior formatting bytes are NOT stripped — see
+	 * {@see self::invalid_handle_provider()} for those cases.
+	 *
+	 * @dataProvider boundary_invisible_handle_provider
+	 *
+	 * @param string $raw_handle Raw user input.
 	 */
-	public function test_handle_connect_strips_invisible_unicode_formatting() {
+	#[DataProvider( 'boundary_invisible_handle_provider' )]
+	public function test_handle_connect_strips_edge_invisible_unicode_formatting( string $raw_handle ) {
 		$this->become_admin();
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
 		$_POST    = array(
 			'_wpnonce'       => wp_create_nonce( 'fosse_connect_bluesky' ),
-			'bluesky_handle' => "devdotdev.bsky.social\u{202C}",
+			'bluesky_handle' => $raw_handle,
 		);
 		$_REQUEST = $_POST;
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
-		$captured_handle = null;
+		$captured_url = null;
 		add_filter(
 			'pre_http_request',
-			static function ( $preempt, $args, $url ) use ( &$captured_handle ) {
-				$captured_handle = $url;
+			static function ( $preempt, $args, $url ) use ( &$captured_url ) {
+				$captured_url = $url;
 				return new \WP_Error( 'fosse_test_intercept', 'intercepted' );
 			},
 			10,
@@ -1930,11 +1939,27 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		}
 
 		$this->assertNotNull(
-			$captured_handle,
+			$captured_url,
 			'Expected pre_http_request to fire from Client::authorize() after removing invisible formatting bytes.'
 		);
-		$this->assertStringContainsString( 'devdotdev.bsky.social', $captured_handle );
-		$this->assertStringNotContainsString( '%E2%80%AC', $captured_handle );
+		$this->assertSame(
+			'devdotdev.bsky.social',
+			wp_parse_url( (string) $captured_url, PHP_URL_HOST ),
+			'Normalized handle should be the resolved host of the authorize lookup URL.'
+		);
+	}
+
+	/**
+	 * Data provider for edge-placed invisible Unicode formatting bytes.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function boundary_invisible_handle_provider(): array {
+		return array(
+			'trailing pop directional formatting (U+202C)' => array( "devdotdev.bsky.social\u{202C}" ),
+			'leading byte-order mark (U+FEFF)'             => array( "\u{FEFF}devdotdev.bsky.social" ),
+			'leading and trailing zero-width space (U+200B)' => array( "\u{200B}devdotdev.bsky.social\u{200B}" ),
+		);
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -1890,6 +1890,54 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Invisible Unicode formatting bytes from copied handles are stripped
+	 * before validation. They are visually indistinguishable from a valid
+	 * handle, but the ASCII handle regex rejects them if they survive.
+	 */
+	public function test_handle_connect_strips_invisible_unicode_formatting() {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'       => wp_create_nonce( 'fosse_connect_bluesky' ),
+			'bluesky_handle' => "devdotdev.bsky.social\u{202C}",
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$captured_handle = null;
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$captured_handle ) {
+				$captured_handle = $url;
+				return new \WP_Error( 'fosse_test_intercept', 'intercepted' );
+			},
+			10,
+			3
+		);
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_connect();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertNotNull(
+			$captured_handle,
+			'Expected pre_http_request to fire from Client::authorize() after removing invisible formatting bytes.'
+		);
+		$this->assertStringContainsString( 'devdotdev.bsky.social', $captured_handle );
+		$this->assertStringNotContainsString( '%E2%80%AC', $captured_handle );
+	}
+
+	/**
 	 * Provider registers the expected hooks. Settings save is centralized
 	 * in {@see Setup_Page::handle_save()} so the provider's own
 	 * `register_hooks()` does NOT register an admin-post handler for it.

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -923,7 +923,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	 * without a live access token. Atmosphere lazily migrates this shape into
 	 * `atmosphere_identity`, and FOSSE should follow that source of truth.
 	 */
-	public function test_atproto_did_well_known_response_migrates_legacy_identity_without_live_connection() {
+	public function test_atproto_did_well_known_response_serves_did_from_legacy_connection_row() {
 		update_option(
 			'atmosphere_connection',
 			array(


### PR DESCRIPTION
## Summary
- Serve FOSSE's `/.well-known/atproto-did` route from Atmosphere's persisted identity when available, matching the new bundled Atmosphere contract during reauth. The endpoint now returns the DID whenever a stored identity exists, not only while a live OAuth session is held.
- Normalize copied Bluesky handles by stripping ASCII whitespace and invisible Unicode formatting bytes (`\p{Cf}`: BOM, ZWSP, bidi marks) **at the edges only**. Interior formatting bytes are left in place so the downstream ASCII validator rejects them with a meaningful `invalid_handle` error rather than silently coercing the input into a different valid handle.
- Add regression coverage: needs_reauth, legacy `atmosphere_connection` row, no-identity 404, edge BOM/PDF/ZWSP, and interior ZWSP / LRM rejection.

## Behavior change
- `/.well-known/atproto-did` used to return 404 whenever `\Atmosphere\is_connected()` was false (expired token, `needs_reauth`, missing `access_token`). It now returns 200+DID whenever `\Atmosphere\has_identity()` is true, regardless of OAuth session state. Anyone polling the route as a "live session" health signal will see 404→200 during reauth; AT Protocol handle resolution per spec only requires the DID, not a live token.

## Test Plan
- [x] `./vendor/bin/phpunit --colors=always --do-not-cache-result tests/php/Admin/Bluesky_ProviderTest.php`
- [x] `composer run-script lint-php -- src/Admin/class-bluesky-provider.php tests/php/Admin/Bluesky_ProviderTest.php`
- [x] `pnpm run format:check`
- [x] `pnpm run lint`

## Follow-up
- See https://github.com/Automattic/fosse/issues/169 — consolidating FOSSE's well-known handler with Atmosphere's so this contract drift can't recur.