### PR TITLE
chore: resync bundled Atmosphere to 1.1.0

### DIFF
--- a/bundled/atmosphere/atmosphere.php
+++ b/bundled/atmosphere/atmosphere.php
@@ -3,7 +3,7 @@
  * Plugin Name: ATmosphere
  * Plugin URI: https://github.com/pfefferle/atmosphere
  * Description: Publish WordPress posts to AT Protocol (Bluesky + standard.site) via native OAuth.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL-2.0-or-later

--- a/bundled/atmosphere/includes/class-atmosphere.php
+++ b/bundled/atmosphere/includes/class-atmosphere.php
@@ -70,8 +70,10 @@ class Atmosphere {
 	/**
 	 * Maximum re-schedule hops for a child comment waiting on a
 	 * not-yet-published parent. After this many deferrals the child
-	 * publishes as a top-level reply on the post (current fallback
-	 * behavior) so a stuck parent does not block it forever.
+	 * is skipped if the parent still lacks a threadable strongRef so a
+	 * stuck parent does not block it forever — see
+	 * {@see Atmosphere::parent_has_bsky_representation()} for the
+	 * skip rule.
 	 *
 	 * @var int
 	 */
@@ -1236,6 +1238,21 @@ class Atmosphere {
 				if ( self::defer_when_parent_pending( $comment ) ) {
 					return;
 				}
+				if ( ! self::parent_has_bsky_representation( $comment ) ) {
+					/*
+					 * Parent is local-only: anonymous WP commenter, an
+					 * ineligible comment that will never publish, or a
+					 * federation source other than bsky. Publishing the
+					 * reply anyway would either fail at strongRef
+					 * construction or fall back to a top-level reply on
+					 * the post (losing the WP thread context). Skip
+					 * instead, and clear the deferral counter so a
+					 * future re-publish (e.g. if the parent gains a URI
+					 * later) gets a fresh budget.
+					 */
+					\delete_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS );
+					return;
+				}
 				\delete_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS );
 
 				$result = Publisher::publish_comment( $comment );
@@ -1315,13 +1332,14 @@ class Atmosphere {
 	 *
 	 * Comments are scheduled as independent single events with no
 	 * dependency ordering: if a user approves a parent and its reply
-	 * together, the child's cron event can fire first, see
-	 * resolve_parent_ref() return null, and publish flat as a
-	 * top-level reply on the root post. This defers the child a short
-	 * interval (up to PARENT_DEFER_MAX_ATTEMPTS hops) to give the
-	 * parent time to publish first. After the cap the child publishes
-	 * anyway using the root fallback — a stuck parent must not block
-	 * the child forever.
+	 * together, the child's cron event can fire first and see
+	 * `resolve_parent_ref()` return null. This defers the child a
+	 * short interval (up to PARENT_DEFER_MAX_ATTEMPTS hops) so the
+	 * parent has time to publish first. After the cap the cron
+	 * handler's {@see Atmosphere::parent_has_bsky_representation()}
+	 * check skips the child entirely rather than letting
+	 * {@see Comment::build_reply_ref()} fall back to a top-level
+	 * reply on the post — losing the WP thread context.
 	 *
 	 * @param \WP_Comment $comment Comment being published.
 	 * @return bool True when the publish was deferred, false to proceed now.
@@ -1340,8 +1358,12 @@ class Atmosphere {
 		}
 
 		if ( ! self::should_publish_comment( $parent ) ) {
-			// Parent is ineligible (anon, rejected, etc.); resolve_parent_ref
-			// will fall back to root, which is the correct behavior.
+			// Parent is ineligible (anon, rejected, etc.). No reason to
+			// defer — it will never gain a bsky URI. The subsequent
+			// `parent_has_bsky_representation()` check in the cron
+			// handler will skip the publish entirely so we don't
+			// promote a nested WP reply into a confusing top-level
+			// bsky reply on the post.
 			return false;
 		}
 
@@ -1354,8 +1376,12 @@ class Atmosphere {
 		$attempts   = (int) \get_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS, true );
 
 		if ( $attempts >= self::PARENT_DEFER_MAX_ATTEMPTS ) {
-			// Give up and publish with root as parent; clear the counter
-			// so a future re-publish gets a fresh deferral budget.
+			// Give up on the deferral budget; clear the counter so a
+			// future re-publish gets a fresh budget. The subsequent
+			// `parent_has_bsky_representation()` check skips the publish
+			// rather than letting `build_reply_ref()` fall back to a
+			// top-level reply on the post, which would lose the WP
+			// thread context.
 			\delete_comment_meta( $comment_id, self::META_PUBLISH_ATTEMPTS );
 			return false;
 		}
@@ -1368,6 +1394,72 @@ class Atmosphere {
 		);
 
 		return true;
+	}
+
+	/**
+	 * Whether the comment's immediate WP parent has an AT Protocol
+	 * strongRef the reply record can thread under.
+	 *
+	 * Mirrors the exact requirements of {@see Comment::resolve_parent_ref()}:
+	 * a strongRef needs BOTH `uri` and `cid`. Half-state rows (URI
+	 * present but CID missing, or `META_PROTOCOL = atproto` without
+	 * the federated CID alongside) would let `resolve_parent_ref()`
+	 * fall through and `build_reply_ref()` substitute the post root,
+	 * silently promoting the nested reply to a top-level post — the
+	 * exact bug this check is here to prevent.
+	 *
+	 * Returns true when:
+	 *
+	 * - The comment has no parent (top-level reply to the post). The
+	 *   post itself has a bsky record; the publish path threads against
+	 *   that root.
+	 * - The parent comment carries both {@see Comment::META_URI} and
+	 *   {@see Comment::META_CID} — the plugin already published the
+	 *   parent to the PDS.
+	 * - The parent comment is marked as ingested by
+	 *   {@see Reaction_Sync} (`META_PROTOCOL = atproto`) AND carries
+	 *   both `META_SOURCE_ID` (URI) and `META_BSKY_CID`.
+	 *
+	 * Only the immediate parent is checked: any comment that passes
+	 * this gate was itself only publishable through the same gate, so
+	 * by induction every WP ancestor is also threadable.
+	 *
+	 * Known legacy edge case: sites that ran a pre-fix version of the
+	 * plugin may have "demoted" comments on bsky — comments whose
+	 * original WP parent was local-only but which the old root-fallback
+	 * still pushed to bsky as top-level replies under the post. Their
+	 * rows now carry valid `META_URI` / `META_CID`, so new replies to
+	 * them pass this gate even though the deeper WP ancestor chain is
+	 * incomplete. The strongRef itself is still valid (the demoted
+	 * comment is on bsky); the bsky-side view simply omits the
+	 * pre-existing local-only ancestor, which mirrors what the WP user
+	 * sees with the local-only commenter anyway. No further migration
+	 * is planned for those legacy rows.
+	 *
+	 * @param \WP_Comment $comment Comment about to be published.
+	 * @return bool
+	 */
+	private static function parent_has_bsky_representation( \WP_Comment $comment ): bool {
+		$parent_id = (int) $comment->comment_parent;
+
+		if ( $parent_id <= 0 ) {
+			return true;
+		}
+
+		$local_uri = \get_comment_meta( $parent_id, Comment::META_URI, true );
+		$local_cid = \get_comment_meta( $parent_id, Comment::META_CID, true );
+		if ( ! empty( $local_uri ) && ! empty( $local_cid ) ) {
+			return true;
+		}
+
+		if ( 'atproto' !== \get_comment_meta( $parent_id, Reaction_Sync::META_PROTOCOL, true ) ) {
+			return false;
+		}
+
+		$federated_uri = \get_comment_meta( $parent_id, Reaction_Sync::META_SOURCE_ID, true );
+		$federated_cid = \get_comment_meta( $parent_id, Reaction_Sync::META_BSKY_CID, true );
+
+		return ! empty( $federated_uri ) && ! empty( $federated_cid );
 	}
 
 	/**

--- a/bundled/atmosphere/readme.txt
+++ b/bundled/atmosphere/readme.txt
@@ -4,7 +4,7 @@ Tags: at-protocol, bluesky, fediverse, atproto, crossposting
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: 1.0.0
+Stable tag: 1.1.0
 License: GPL-2.0-or-later
 License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
 
@@ -91,6 +91,18 @@ Not at this time. ATmosphere is designed for a single WordPress site. On a Netwo
 
 == Changelog ==
 
+### 1.1.0 - 2026-05-21
+#### Added
+- Add `atmosphere_post_embed` filter so downstream code can swap the default external link card for a richer embed (`app.bsky.embed.images`, `app.bsky.embed.video`, …) or attach an embed to a short-form post that would otherwise ship with none. The filter accepts `null` (suppress) or an array with a non-empty string `$type` key; non-array, empty-array, or missing-`$type` returns are rejected with `_doing_it_wrong` and the pre-filter value is restored. `Post::upload_thumbnail()` becomes a backward-compatible alias for the new generic `Post::upload_image_blob()`; a new `Post::get_attachment_aspect_ratio()` helper exposes the pixel dimensions consumers need for `embed.images`.
+- Advertise the site's standard.site publication record from the front page and from each published post via a new `<link rel="site.standard.publication">` tag, alongside the existing document link.
+
+#### Changed
+- Refresh the site's publication record when the site URL, the active theme, or the theme's colours change, so the published record always reflects the current site state.
+
+#### Fixed
+- Fix posts not appearing on Bluesky after a frontend visit lazily stamped the post, restore standard.site verification after reconnecting to a different account, and let the "use my domain as my Bluesky handle" button complete reliably without timing out.
+- Stop publishing replies to local-only WordPress comments to Bluesky. Previously such replies were demoted to a top-level reply on the post; they are now skipped so the Bluesky thread only mirrors comments whose ancestors are also on Bluesky.
+
 ### 1.0.0 - 2026-05-20
 #### Security
 - Harden OAuth and PDS HTTP request paths against SSRF, encrypt the temporary DPoP key used during connect, and validate URLs received from third-party servers before they are used or stored.
@@ -141,6 +153,9 @@ Not at this time. ATmosphere is designed for a single WordPress site. On a Netwo
 - Prevent password-protected or otherwise non-public posts from being published to AT Protocol records, and remove existing records when public posts become protected.
 - Remove a comment reply from Bluesky if the comment was deleted or unapproved while it was being published, instead of leaving an orphan reply behind.
 - Short posts under the long-form teaser-thread strategy no longer ship a redundant "continue reading" reply when the entire body already fits in a single Bluesky post. The link-back is preserved as a card on the same post.
+
+[1.1.0]: https://github.com/Automattic/wordpress-atmosphere/compare/1.0.0...1.1.0
+[1.0.0]: https://github.com/Automattic/wordpress-atmosphere/releases
 
 See full Changelog on [GitHub](https://github.com/Automattic/wordpress-atmosphere/blob/trunk/CHANGELOG.md).
 

--- a/bundled/atmosphere/vendor/composer/installed.php
+++ b/bundled/atmosphere/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'automattic/atmosphere',
         'pretty_version' => 'dev-trunk',
         'version' => 'dev-trunk',
-        'reference' => '2a0383a66a5633b981277b29ebfef768f430aeda',
+        'reference' => '11f3992944a48e9dd0fcef4e083d9e005559b11d',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'automattic/atmosphere' => array(
             'pretty_version' => 'dev-trunk',
             'version' => 'dev-trunk',
-            'reference' => '2a0383a66a5633b981277b29ebfef768f430aeda',
+            'reference' => '11f3992944a48e9dd0fcef4e083d9e005559b11d',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary

Re-vendors `bundled/atmosphere/` from upstream trunk at `11f3992` (tagged [`1.1.0`](https://github.com/Automattic/wordpress-atmosphere/releases/tag/1.1.0)).

ActivityPub trunk advanced from `31cdcd0a` to `424eb987` but the only commit was a `@types/react` devDependency bump that's excluded from the bundle, so `bundled/activitypub/` is unchanged.

## Upstream SHAs

- ActivityPub: `424eb987` (no bundle delta)
- Atmosphere:  `11f3992`  (tagged `1.1.0`)

## Notable upstream changes

From the Atmosphere 1.1.0 changelog:

- **Added** — `atmosphere_post_embed` filter so downstream code can swap the default external link card for a richer embed (`app.bsky.embed.images`, etc.). FOSSE already consumes this filter (landed in PR 164).
- **Added** — site advertises its standard.site publication record from the front page and each published post via a new `<link rel="site.standard.publication">` tag.
- **Changed** — publication record refreshes when the site URL, active theme, or theme colours change.
- **Fixed** — posts not appearing on Bluesky after a frontend visit lazily stamped the post; standard.site verification after reconnecting; "use my domain as my Bluesky handle" button reliability.
- **Fixed** — stop publishing replies to local-only WordPress comments to Bluesky (previously demoted to a top-level reply).

## Test plan

- [ ] CI is green (`tests.yml`, `linting.yml`, `e2e.yml`, `build-zip.yml`)
- [ ] FOSSE's `atmosphere_post_embed` consumer still behaves as expected against the bumped Atmosphere (no functional change expected — this filter shipped in 1.1.0 and FOSSE already targets it)