### PR TITLE
Admin: delegate /.well-known/atproto-did to Atmosphere

### DIFF
--- a/sdd/bluesky-handle-setup/implementation-notes.md
+++ b/sdd/bluesky-handle-setup/implementation-notes.md
@@ -14,7 +14,7 @@ Task 1 is implemented on this branch: `/.well-known/atproto-did` is served from 
 - **Decision**: When Bluesky is connected, FOSSE serves `/.well-known/atproto-did` automatically. A `fosse_serve_atproto_did_well_known` filter (default `true`) lets users disable it.
 - **Reason**: The whole point of this feature is to make the verification step disappear for the common case. Most WordPress sites don't have anything else competing for `.well-known/atproto-did`. The filter exists for the edge cases (managed hosts that intercept `.well-known`, sites running multiple ATProto identities, etc.) so users have an out without us needing a settings toggle.
 
-### FOSSE re-serves a route Atmosphere also serves
+### FOSSE re-serves a route Atmosphere also serves (superseded — see deviations below)
 - **Decision**: FOSSE serves the well-known response itself and suppresses Atmosphere's handler when `fosse_serve_atproto_did_well_known` returns false.
 - **Reason**: FOSSE owns the unified setup experience and its opt-out filter must mean "FOSSE will not serve this route, and the bundled fallback will not silently serve it either." This behavior is FOSSE-shaped, so it stays out of `bundled/`. A generic upstream Atmosphere opt-out hook can replace the suppression shim later if it becomes useful outside FOSSE.
 
@@ -45,6 +45,10 @@ The implementation that actually shipped (Automattic/fosse#97 and follow-ups on 
 ### Prerequisite: PR 115 brought the `identity:handle` OAuth scope upstream
 - **Decision**: This branch depends on `bundled/wordpress-atmosphere/` already declaring `identity:handle` in its requested OAuth scopes. PR 115 (bundled plugin sync) merged in upstream wordpress-atmosphere PR #53 which added the scope; without that prerequisite, the `updateHandle` call would 401 even though FOSSE's code path is correct.
 - **Reason**: The OAuth client is bundled, not vendored. Scope changes flow through wordpress-atmosphere, then into FOSSE via the bundled-mirror sync. This dependency is invisible at the FOSSE call site, so it's worth documenting.
+
+### Well-known route delegated to Atmosphere (issue #169)
+- **Decision**: FOSSE no longer serves `/.well-known/atproto-did` itself. Atmosphere's `serve_wellknown_atproto_did()` owns the route end-to-end; FOSSE only retains a `template_redirect` priority-1 suppression hook that fires when the `fosse_serve_atproto_did_well_known` filter returns false (clearing Atmosphere's query var and forcing a 404 so the opt-out contract still means "neither plugin responds").
+- **Reason**: The duplicated handler kept silently drifting from Atmosphere's identity contract (the original `is_connected()` gate broke domain-handle reconnect; PR 166 fixed it by mirroring `has_identity()`). Atmosphere's bundled handler already gates on `has_identity()`, validates the DID via `get_did()`, and emits the same `text/plain` body — there's no FOSSE-specific shape worth maintaining a parallel implementation for. See issue #169.
 
 ### Snapshot-and-revert on disconnect (`OPTION_PREVIOUS_HANDLE`)
 - **Decision**: When `set_handle()` succeeds, FOSSE snapshots the previous handle to `OPTION_PREVIOUS_HANDLE`, keyed by the connected DID. On disconnect, `Bluesky_Domain_Handle::maybe_revert_on_disconnect()` runs BEFORE Atmosphere's OAuth revoke (so the access token is still valid) and restores the snapshotted handle when the snapshot's DID matches the currently-connected DID.

--- a/sdd/bluesky-handle-setup/implementation-notes.md
+++ b/sdd/bluesky-handle-setup/implementation-notes.md
@@ -2,7 +2,7 @@
 
 ## Status Snapshot
 
-Task 1 is implemented on this branch: `/.well-known/atproto-did` is served from `Bluesky_Provider` only when Atmosphere reports a connected account, the FOSSE opt-out filter is honored, and the bundled Atmosphere fallback is suppressed when FOSSE opts out. The resolver, UI, DNS fallback, admin-post handlers, and broader feature tests remain planned work.
+Task 1's deliverable is in place but the implementation shape changed in PR 170 (issue 169): FOSSE no longer serves `/.well-known/atproto-did` itself — the bundled Atmosphere plugin serves it via `serve_wellknown_atproto_did()` (`template_redirect` priority 10, gated on `\Atmosphere\has_identity()`). FOSSE retains a `template_redirect` priority-1 suppression hook so the `fosse_serve_atproto_did_well_known` filter still means "neither plugin responds" when set to false. The resolver, UI, DNS fallback, admin-post handlers, and broader feature tests remain planned work.
 
 ## Design Decisions
 
@@ -11,7 +11,7 @@ Task 1 is implemented on this branch: `/.well-known/atproto-did` is served from 
 - **Reason**: The user's actual question is "does Bluesky see my domain as my handle?" — only Bluesky's resolver can answer that authoritatively. Local DNS could resolve correctly while Bluesky's cache is still warm with the old answer, producing a green status that turns out wrong. Plus, PHP DNS extensions aren't guaranteed on managed hosts.
 
 ### Well-known route is default-on with an opt-out filter
-- **Decision**: When Bluesky is connected, FOSSE serves `/.well-known/atproto-did` automatically. A `fosse_serve_atproto_did_well_known` filter (default `true`) lets users disable it.
+- **Decision**: When Bluesky is connected, `/.well-known/atproto-did` resolves automatically (via bundled Atmosphere since PR 170 — see deviations below). A `fosse_serve_atproto_did_well_known` filter (default `true`) lets users disable it; when false, FOSSE clears Atmosphere's query var and forces a 404 so neither plugin responds.
 - **Reason**: The whole point of this feature is to make the verification step disappear for the common case. Most WordPress sites don't have anything else competing for `.well-known/atproto-did`. The filter exists for the edge cases (managed hosts that intercept `.well-known`, sites running multiple ATProto identities, etc.) so users have an out without us needing a settings toggle.
 
 ### FOSSE re-serves a route Atmosphere also serves (superseded — see deviations below)
@@ -46,9 +46,9 @@ The implementation that actually shipped (Automattic/fosse#97 and follow-ups on 
 - **Decision**: This branch depends on `bundled/wordpress-atmosphere/` already declaring `identity:handle` in its requested OAuth scopes. PR 115 (bundled plugin sync) merged in upstream wordpress-atmosphere PR #53 which added the scope; without that prerequisite, the `updateHandle` call would 401 even though FOSSE's code path is correct.
 - **Reason**: The OAuth client is bundled, not vendored. Scope changes flow through wordpress-atmosphere, then into FOSSE via the bundled-mirror sync. This dependency is invisible at the FOSSE call site, so it's worth documenting.
 
-### Well-known route delegated to Atmosphere (issue #169)
+### Well-known route delegated to Atmosphere (issue 169)
 - **Decision**: FOSSE no longer serves `/.well-known/atproto-did` itself. Atmosphere's `serve_wellknown_atproto_did()` owns the route end-to-end; FOSSE only retains a `template_redirect` priority-1 suppression hook that fires when the `fosse_serve_atproto_did_well_known` filter returns false (clearing Atmosphere's query var and forcing a 404 so the opt-out contract still means "neither plugin responds").
-- **Reason**: The duplicated handler kept silently drifting from Atmosphere's identity contract (the original `is_connected()` gate broke domain-handle reconnect; PR 166 fixed it by mirroring `has_identity()`). Atmosphere's bundled handler already gates on `has_identity()`, validates the DID via `get_did()`, and emits the same `text/plain` body — there's no FOSSE-specific shape worth maintaining a parallel implementation for. See issue #169.
+- **Reason**: The duplicated handler kept silently drifting from Atmosphere's identity contract (the original `is_connected()` gate broke domain-handle reconnect; PR 166 fixed it by mirroring `has_identity()`). Atmosphere's bundled handler gates on `has_identity()` and emits a `text/plain` body via `esc_html( get_did() )` — equivalent surface for the common case where Atmosphere is the sole writer of `atmosphere_identity` (the OAuth client persists only PDS-resolved DIDs, never request input). The deleted FOSSE-side regex (`/\Adid:[a-z]+:.../`) provided a defense-in-depth layer against a poisoned `atmosphere_identity` option that no longer applies; correctness now relies on upstream Atmosphere persisting well-formed DIDs. If that ever becomes load-bearing, restore the validation upstream in Atmosphere rather than locally in FOSSE.
 
 ### Snapshot-and-revert on disconnect (`OPTION_PREVIOUS_HANDLE`)
 - **Decision**: When `set_handle()` succeeds, FOSSE snapshots the previous handle to `OPTION_PREVIOUS_HANDLE`, keyed by the connected DID. On disconnect, `Bluesky_Domain_Handle::maybe_revert_on_disconnect()` runs BEFORE Atmosphere's OAuth revoke (so the access token is still valid) and restores the snapshotted handle when the snapshot's DID matches the currently-connected DID.

--- a/sdd/bluesky-handle-setup/plan.md
+++ b/sdd/bluesky-handle-setup/plan.md
@@ -4,7 +4,7 @@ Based on: sdd/bluesky-handle-setup/spec.md
 
 ## Progress
 
-- [x] Task 1: Add `/.well-known/atproto-did` route handler
+- [~] Task 1: Add `/.well-known/atproto-did` route handler — superseded by delegation to bundled Atmosphere (see Task 1 below)
 - [~] Task 2: Add verification check method — superseded by direct `updateHandle` flow (see below)
 - [~] Task 2.5: Add `fetch_current_handle($did)` helper — superseded by direct `updateHandle` flow
 - [x] Task 3: Add domain-handle UI to Bluesky_Provider setup section
@@ -19,9 +19,9 @@ Based on: sdd/bluesky-handle-setup/spec.md
 ## Tasks
 
 ### Task 1: Add `/.well-known/atproto-did` route handler
-- **Status**: ✅ Done (396985f, 138404f, bc43461)
+- **Status**: Superseded by PR 170 (issue 169). FOSSE no longer serves the route; bundled Atmosphere's `serve_wellknown_atproto_did()` (`template_redirect` priority 10, gated on `\Atmosphere\has_identity()`) owns it. FOSSE retains only `Bluesky_Provider::maybe_suppress_atmosphere_well_known()` at `template_redirect` priority 1, which clears Atmosphere's `atmosphere_wellknown` query var and forces a 404 when the `fosse_serve_atproto_did_well_known` filter returns false. See `implementation-notes.md` § "Well-known route delegated to Atmosphere (issue 169)" for rationale; the original commits (396985f, 138404f, bc43461) introduced the deleted handler.
 - **Files**: `src/Admin/class-bluesky-provider.php`
-- **Do**:
+- **Do** (historical, no longer in scope):
   1. Add `serve_atproto_did_well_known()` method. Hook to `init` priority 1 inside `register_hooks()`.
   2. Parse `$_SERVER['REQUEST_URI']` with `wp_parse_url( ..., PHP_URL_PATH )` and match strict equality against `/.well-known/atproto-did`. If no match, return early.
   3. Apply `fosse_serve_atproto_did_well_known` filter (default `true`). If false, return.

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -667,7 +667,6 @@ class Bluesky_Provider implements Connection_Provider {
 		add_action( 'admin_post_fosse_enable_bluesky_auto_publish', array( $this, 'handle_enable_auto_publish' ) );
 		add_action( 'admin_init', array( $this, 'handle_oauth_callback' ) );
 		add_action( 'admin_notices', array( $this, 'maybe_render_auto_publish_disabled_notice' ) );
-		add_action( 'init', array( $this, 'serve_atproto_did_well_known' ), 1 );
 		add_action( 'template_redirect', array( $this, 'maybe_suppress_atmosphere_well_known' ), 1 );
 
 		// Override Atmosphere's OAuth redirect URI so the auth server callback
@@ -697,107 +696,19 @@ class Bluesky_Provider implements Connection_Provider {
 	}
 
 	/**
-	 * Serve /.well-known/atproto-did when FOSSE owns the route.
-	 *
-	 * Returns silently for unrelated paths, when the
-	 * `fosse_serve_atproto_did_well_known` filter opts out, and when
-	 * Atmosphere isn't loaded. Sends a 404 and exits when Atmosphere is
-	 * loaded but no DID is available; otherwise sends a `text/plain` body
-	 * containing the connected DID and exits.
-	 *
-	 * @return void
-	 */
-	public function serve_atproto_did_well_known(): void {
-		// Path-match below uses strict equality; sanitize_text_field can normalize
-		// encoded characters in surprising ways, so read raw.
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? (string) wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
-		$response    = $this->get_atproto_did_well_known_response( $request_uri );
-
-		if ( null === $response ) {
-			return;
-		}
-
-		if ( 404 === $response['status'] ) {
-			status_header( 404 );
-			nocache_headers();
-			exit;
-		}
-
-		header( 'Content-Type: text/plain; charset=utf-8' );
-		nocache_headers();
-		echo $response['did']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- text/plain response; DID syntax validated in get_atproto_did_well_known_response().
-		exit;
-	}
-
-	/**
-	 * Resolve the response data for FOSSE's /.well-known/atproto-did handler.
-	 *
-	 * @param string $request_uri Request URI.
-	 * @return array{status:200|404,did:string}|null Null when FOSSE should not handle the request; otherwise a status code and the DID (empty for 404).
-	 */
-	private function get_atproto_did_well_known_response( string $request_uri ): ?array {
-		$path = wp_parse_url( $request_uri, PHP_URL_PATH );
-
-		if ( '/.well-known/atproto-did' !== $path ) {
-			return null;
-		}
-
-		/**
-		 * Filter whether FOSSE serves the /.well-known/atproto-did route.
-		 *
-		 * Disable to let another component (CDN, custom rewrite, etc.) own the path.
-		 *
-		 * @param bool $serve Default true.
-		 */
-		if ( ! apply_filters( 'fosse_serve_atproto_did_well_known', true ) ) {
-			return null;
-		}
-
-		if ( ! function_exists( '\Atmosphere\is_connected' ) ) {
-			// Atmosphere isn't loaded. That's a structural error, not a
-			// user-facing "no connection" state. Decline to handle so a
-			// normal 404 happens via WordPress's main request flow.
-			return null;
-		}
-
-		if ( ! \Atmosphere\is_connected() ) {
-			return array(
-				'status' => 404,
-				'did'    => '',
-			);
-		}
-
-		$connection = \Atmosphere\get_connection();
-		$did        = isset( $connection['did'] ) ? (string) $connection['did'] : '';
-
-		// Validate the DID against AT Proto syntax before promising to serve it.
-		// The response is plain text and a malformed value (newlines, control chars,
-		// HTML bytes) would corrupt the body or worse. Valid AT Proto DIDs are
-		// "did:" + method + ":" + ASCII alphanumerics with a small punctuation set.
-		// \A and \z anchor strictly so a stored DID with a trailing newline (which
-		// PHP's $ anchor permits) doesn't slip a stray byte into the response.
-		if ( ! preg_match( '/\Adid:[a-z]+:[A-Za-z0-9._:%\-]*[A-Za-z0-9._\-]\z/', $did ) ) {
-			return array(
-				'status' => 404,
-				'did'    => '',
-			);
-		}
-
-		return array(
-			'status' => 200,
-			'did'    => $did,
-		);
-	}
-
-	/**
 	 * Suppress bundled Atmosphere's /.well-known/atproto-did handler when FOSSE opts out.
 	 *
-	 * The fosse_serve_atproto_did_well_known filter only controls FOSSE's own handler.
-	 * Atmosphere registers an independent template_redirect handler that would otherwise
-	 * still serve the route, defeating the opt-out. Clearing Atmosphere's query var
-	 * makes its handler return early so neither plugin serves the route. Also flags the
-	 * request 404 so WordPress doesn't render the front page for the well-known URL.
+	 * Atmosphere owns the route end-to-end now: its `serve_wellknown_atproto_did()`
+	 * runs on `template_redirect` priority 10 and gates the response on
+	 * `\Atmosphere\has_identity()`, which is the contract FOSSE was previously
+	 * mirroring. The `fosse_serve_atproto_did_well_known` filter remains as a
+	 * site-level opt-out: when it returns false, this hook (priority 1) clears
+	 * Atmosphere's query var so its handler returns early and marks the request
+	 * 404 so WordPress doesn't render the front page for the well-known URL.
+	 *
+	 * Third-party handlers attached at `template_redirect` priority > 1 can still
+	 * take over by calling `status_header( 200 )`, `$wp_query->set_404( false )`,
+	 * and `exit()`.
 	 *
 	 * @return void
 	 */
@@ -806,6 +717,15 @@ class Bluesky_Provider implements Connection_Provider {
 			return;
 		}
 
+		/**
+		 * Filter whether the bundled Atmosphere handler serves /.well-known/atproto-did.
+		 *
+		 * Return false to let another component (CDN, custom rewrite, etc.) own the path.
+		 * When false, FOSSE clears Atmosphere's query var and forces a 404 so neither
+		 * plugin responds to the request.
+		 *
+		 * @param bool $serve Default true.
+		 */
 		if ( apply_filters( 'fosse_serve_atproto_did_well_known', true ) ) {
 			return;
 		}

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -668,6 +668,7 @@ class Bluesky_Provider implements Connection_Provider {
 		add_action( 'admin_init', array( $this, 'handle_oauth_callback' ) );
 		add_action( 'admin_notices', array( $this, 'maybe_render_auto_publish_disabled_notice' ) );
 		add_action( 'template_redirect', array( $this, 'maybe_suppress_atmosphere_well_known' ), 1 );
+		add_action( 'template_redirect', array( $this, 'send_atproto_did_nocache_headers' ), 2 );
 
 		// Override Atmosphere's OAuth redirect URI so the auth server callback
 		// and the client-metadata REST endpoint both advertise FOSSE's page.
@@ -693,6 +694,38 @@ class Bluesky_Provider implements Connection_Provider {
 	 */
 	public function save_settings( array $post_data ): bool { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Connection_Provider interface contract; no Bluesky-side fields to persist after the auto-publish toggle removal.
 		return true;
+	}
+
+	/**
+	 * Apply `nocache_headers()` to `/.well-known/atproto-did` responses before
+	 * Atmosphere's handler sends the body.
+	 *
+	 * The deleted FOSSE handler sent `nocache_headers()` on both 200 and 404
+	 * responses; Atmosphere's `serve_wellknown_atproto_did()` doesn't. Without
+	 * the headers, fronting page/CDN caches can keep a pre-connect 404 after
+	 * OAuth completes, or keep a stale 200 DID after disconnect — either
+	 * defeats Bluesky's bidirectional handle resolution. This shim runs at
+	 * `template_redirect` priority 2 (after the opt-out suppression at
+	 * priority 1, before Atmosphere's serve at priority 10) so the headers
+	 * are queued before any body is sent. The opt-out path already calls
+	 * `nocache_headers()` directly, so this hook short-circuits when the
+	 * filter is false.
+	 *
+	 * Track wordpress-atmosphere#83 — once upstream sends `nocache_headers()`
+	 * itself, this shim can be deleted.
+	 *
+	 * @return void
+	 */
+	public function send_atproto_did_nocache_headers(): void {
+		if ( 'atproto-did' !== get_query_var( 'atmosphere_wellknown' ) ) {
+			return;
+		}
+
+		if ( ! apply_filters( 'fosse_serve_atproto_did_well_known', true ) ) {
+			return;
+		}
+
+		nocache_headers();
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -886,6 +886,61 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Tripwire: Atmosphere's bundled well-known handler must stay hooked at
+	 * `template_redirect` priority > 1.
+	 *
+	 * FOSSE's suppression hook runs at priority 1 and clears
+	 * `atmosphere_wellknown` before Atmosphere's handler reads it. If a
+	 * future bundled resync moves the handler to priority 0 or 1 (or
+	 * removes it entirely), the opt-out contract silently breaks and the
+	 * existing direct-call suppression tests stay green. Catch the drift
+	 * at the registration layer instead.
+	 */
+	public function test_atmosphere_serves_wellknown_after_fosse_suppression_priority() {
+		// `plugins_loaded` may not have fired in WorDBless's minimal boot;
+		// run it now so Atmosphere's `init()` registers its hooks.
+		do_action( 'plugins_loaded' );
+
+		global $wp_filter;
+		$this->assertArrayHasKey(
+			'template_redirect',
+			$wp_filter,
+			'No template_redirect callbacks registered — Atmosphere did not boot in this test context.'
+		);
+
+		$atmosphere_priority = null;
+		foreach ( $wp_filter['template_redirect']->callbacks as $priority => $callbacks ) {
+			foreach ( $callbacks as $info ) {
+				$cb = $info['function'];
+				if (
+					is_array( $cb )
+					&& isset( $cb[0] )
+					&& isset( $cb[1] )
+					&& is_object( $cb[0] )
+					&& 'Atmosphere\\Atmosphere' === get_class( $cb[0] )
+					&& 'serve_wellknown_atproto_did' === $cb[1]
+				) {
+					$atmosphere_priority = $priority;
+					break 2;
+				}
+			}
+		}
+
+		$this->assertNotNull(
+			$atmosphere_priority,
+			'Atmosphere\\Atmosphere::serve_wellknown_atproto_did is not hooked on template_redirect. '
+				. 'FOSSE delegates the well-known route to Atmosphere; if the handler moved or was renamed in a bundled resync, '
+				. '/.well-known/atproto-did will silently 404.'
+		);
+		$this->assertGreaterThan(
+			1,
+			$atmosphere_priority,
+			'Atmosphere\\Atmosphere::serve_wellknown_atproto_did is hooked at template_redirect priority ' . $atmosphere_priority
+				. ' but FOSSE\'s suppression hook runs at priority 1. The opt-out filter will not work.'
+		);
+	}
+
+	/**
 	 * Opting out via filter clears Atmosphere's query var and forces a 404.
 	 */
 	public function test_maybe_suppress_atmosphere_well_known_clears_query_var_and_404s_when_opted_out() {

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -851,122 +851,6 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * The well-known route helper ignores unrelated request paths.
-	 */
-	public function test_atproto_did_well_known_response_ignores_other_paths() {
-		$this->assertNull( $this->get_atproto_did_well_known_response( '/about' ) );
-	}
-
-	/**
-	 * The well-known route helper returns the connected DID as plain response data.
-	 */
-	public function test_atproto_did_well_known_response_returns_connected_did() {
-		update_option(
-			'atmosphere_connection',
-			array(
-				'did'          => 'did:plc:test123',
-				'handle'       => 'alice.bsky.social',
-				'pds_endpoint' => 'https://bsky.social',
-				'access_token' => Encryption::encrypt( 'token' ),
-			)
-		);
-
-		$this->assertSame(
-			array(
-				'status' => 200,
-				'did'    => 'did:plc:test123',
-			),
-			$this->get_atproto_did_well_known_response( '/.well-known/atproto-did?ignored=1' )
-		);
-	}
-
-	/**
-	 * A stored DID is not enough to serve the well-known route without a connection.
-	 */
-	public function test_atproto_did_well_known_response_requires_connected_atmosphere() {
-		update_option(
-			'atmosphere_connection',
-			array(
-				'did'    => 'did:plc:test123',
-				'handle' => 'alice.bsky.social',
-			)
-		);
-
-		$this->assertSame(
-			array(
-				'status' => 404,
-				'did'    => '',
-			),
-			$this->get_atproto_did_well_known_response( '/.well-known/atproto-did' )
-		);
-	}
-
-	/**
-	 * The FOSSE opt-out filter prevents FOSSE from serving the well-known route.
-	 */
-	public function test_atproto_did_well_known_response_respects_opt_out_filter() {
-		update_option(
-			'atmosphere_connection',
-			array(
-				'did'          => 'did:plc:test123',
-				'handle'       => 'alice.bsky.social',
-				'pds_endpoint' => 'https://bsky.social',
-				'access_token' => Encryption::encrypt( 'token' ),
-			)
-		);
-
-		add_filter( 'fosse_serve_atproto_did_well_known', '__return_false' );
-
-		$this->assertNull( $this->get_atproto_did_well_known_response( '/.well-known/atproto-did' ) );
-	}
-
-	/**
-	 * A stored DID that doesn't match AT Proto syntax is rejected with a 404.
-	 */
-	public function test_atproto_did_well_known_response_rejects_malformed_did() {
-		update_option(
-			'atmosphere_connection',
-			array(
-				'did'          => "did:plc:abc\n<script>alert(1)</script>",
-				'handle'       => 'alice.bsky.social',
-				'pds_endpoint' => 'https://bsky.social',
-				'access_token' => Encryption::encrypt( 'token' ),
-			)
-		);
-
-		$this->assertSame(
-			array(
-				'status' => 404,
-				'did'    => '',
-			),
-			$this->get_atproto_did_well_known_response( '/.well-known/atproto-did' )
-		);
-	}
-
-	/**
-	 * A stored DID with a single trailing newline is rejected (PHP's $ would have allowed it).
-	 */
-	public function test_atproto_did_well_known_response_rejects_did_with_trailing_newline() {
-		update_option(
-			'atmosphere_connection',
-			array(
-				'did'          => "did:plc:test123\n",
-				'handle'       => 'alice.bsky.social',
-				'pds_endpoint' => 'https://bsky.social',
-				'access_token' => Encryption::encrypt( 'token' ),
-			)
-		);
-
-		$this->assertSame(
-			array(
-				'status' => 404,
-				'did'    => '',
-			),
-			$this->get_atproto_did_well_known_response( '/.well-known/atproto-did' )
-		);
-	}
-
-	/**
 	 * The suppression hook is a no-op for unrelated atmosphere_wellknown query vars.
 	 */
 	public function test_maybe_suppress_atmosphere_well_known_no_op_for_other_query_vars() {
@@ -1849,7 +1733,6 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertNotFalse( has_action( 'admin_post_fosse_enable_bluesky_auto_publish', array( $this->provider, 'handle_enable_auto_publish' ) ) );
 		$this->assertNotFalse( has_action( 'admin_init', array( $this->provider, 'handle_oauth_callback' ) ) );
 		$this->assertNotFalse( has_action( 'admin_notices', array( $this->provider, 'maybe_render_auto_publish_disabled_notice' ) ) );
-		$this->assertSame( 1, has_action( 'init', array( $this->provider, 'serve_atproto_did_well_known' ) ) );
 		$this->assertSame( 1, has_action( 'template_redirect', array( $this->provider, 'maybe_suppress_atmosphere_well_known' ) ) );
 		$this->assertNotFalse( has_filter( 'atmosphere_oauth_redirect_uri', array( $this->provider, 'filter_oauth_redirect_uri' ) ) );
 	}
@@ -2139,17 +2022,6 @@ class Bluesky_ProviderTest extends BaseTestCase {
 				'Subscriber must not be able to flip the option.'
 			);
 		}
-	}
-
-	/**
-	 * Invoke the private well-known response helper via reflection.
-	 *
-	 * @param string $request_uri Request URI.
-	 * @return array{status:int,did:string}|null
-	 */
-	private function get_atproto_did_well_known_response( string $request_uri ): ?array {
-		$method = new ReflectionMethod( Bluesky_Provider::class, 'get_atproto_did_well_known_response' );
-		return $method->invoke( $this->provider, $request_uri );
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -852,6 +852,79 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * The nocache shim sends cache-busting headers for the atproto-did route.
+	 *
+	 * Atmosphere's upstream `serve_wellknown_atproto_did()` doesn't call
+	 * `nocache_headers()`; the deleted FOSSE handler did. The shim restores
+	 * that behavior until wordpress-atmosphere#83 lands upstream.
+	 */
+	public function test_send_atproto_did_nocache_headers_sends_headers_for_atproto_did_query_var() {
+		set_query_var( 'atmosphere_wellknown', 'atproto-did' );
+
+		$nocache_called = false;
+		add_action(
+			'nocache_headers',
+			static function ( $headers ) use ( &$nocache_called ) {
+				$nocache_called = true;
+				return $headers;
+			}
+		);
+
+		$this->provider->send_atproto_did_nocache_headers();
+
+		$this->assertTrue( $nocache_called, 'nocache_headers() should fire for atproto-did query var when filter is true.' );
+	}
+
+	/**
+	 * The nocache shim is a no-op for unrelated atmosphere_wellknown query vars.
+	 *
+	 * It must not pollute cache headers on the publication well-known route
+	 * (or any other Atmosphere-served route) — only the atproto-did response
+	 * needed `nocache_headers()` parity with the deleted FOSSE handler.
+	 */
+	public function test_send_atproto_did_nocache_headers_no_op_for_other_query_vars() {
+		set_query_var( 'atmosphere_wellknown', 'publication' );
+
+		$nocache_called = false;
+		add_action(
+			'nocache_headers',
+			static function ( $headers ) use ( &$nocache_called ) {
+				$nocache_called = true;
+				return $headers;
+			}
+		);
+
+		$this->provider->send_atproto_did_nocache_headers();
+
+		$this->assertFalse( $nocache_called, 'nocache_headers() should not fire for unrelated query vars.' );
+	}
+
+	/**
+	 * The nocache shim short-circuits on opt-out so the suppression hook owns
+	 * the no-cache headers in that path (which it already sends).
+	 */
+	public function test_send_atproto_did_nocache_headers_no_op_when_opted_out() {
+		set_query_var( 'atmosphere_wellknown', 'atproto-did' );
+		add_filter( 'fosse_serve_atproto_did_well_known', '__return_false' );
+
+		$nocache_called = false;
+		add_action(
+			'nocache_headers',
+			static function ( $headers ) use ( &$nocache_called ) {
+				$nocache_called = true;
+				return $headers;
+			}
+		);
+
+		$this->provider->send_atproto_did_nocache_headers();
+
+		$this->assertFalse(
+			$nocache_called,
+			'nocache_headers() should not fire from the shim when opted out — the suppression hook handles that path.'
+		);
+	}
+
+	/**
 	 * The suppression hook is a no-op for unrelated atmosphere_wellknown query vars.
 	 */
 	public function test_maybe_suppress_atmosphere_well_known_no_op_for_other_query_vars() {
@@ -898,33 +971,40 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	 * at the registration layer instead.
 	 */
 	public function test_atmosphere_serves_wellknown_after_fosse_suppression_priority() {
-		// `plugins_loaded` may not have fired in WorDBless's minimal boot;
-		// run it now so Atmosphere's `init()` registers its hooks.
-		do_action( 'plugins_loaded' );
-
+		// Atmosphere registers its `template_redirect` hook from its
+		// `plugins_loaded` callback. WorDBless may fire `plugins_loaded`
+		// before `fosse.php` registers Atmosphere's callback, so check
+		// whether Atmosphere's hook is already present and only re-fire
+		// `plugins_loaded` if not. Guarding against the hook directly (not
+		// via `did_action()`) avoids both the "Atmosphere never booted" and
+		// "re-firing stacks duplicate callbacks across tests" failure modes.
 		global $wp_filter;
-		$this->assertArrayHasKey(
-			'template_redirect',
-			$wp_filter,
-			'No template_redirect callbacks registered — Atmosphere did not boot in this test context.'
-		);
-
-		$atmosphere_priority = null;
-		foreach ( $wp_filter['template_redirect']->callbacks as $priority => $callbacks ) {
-			foreach ( $callbacks as $info ) {
-				$cb = $info['function'];
-				if (
-					is_array( $cb )
-					&& isset( $cb[0] )
-					&& isset( $cb[1] )
-					&& is_object( $cb[0] )
-					&& 'Atmosphere\\Atmosphere' === get_class( $cb[0] )
-					&& 'serve_wellknown_atproto_did' === $cb[1]
-				) {
-					$atmosphere_priority = $priority;
-					break 2;
+		$find_atmosphere_priority = static function () use ( &$wp_filter ): ?int {
+			if ( ! isset( $wp_filter['template_redirect'] ) ) {
+				return null;
+			}
+			foreach ( $wp_filter['template_redirect']->callbacks as $priority => $callbacks ) {
+				foreach ( $callbacks as $info ) {
+					$cb = $info['function'];
+					if (
+						is_array( $cb )
+						&& isset( $cb[0] )
+						&& isset( $cb[1] )
+						&& is_object( $cb[0] )
+						&& 'Atmosphere\\Atmosphere' === get_class( $cb[0] )
+						&& 'serve_wellknown_atproto_did' === $cb[1]
+					) {
+						return (int) $priority;
+					}
 				}
 			}
+			return null;
+		};
+
+		$atmosphere_priority = $find_atmosphere_priority();
+		if ( null === $atmosphere_priority ) {
+			do_action( 'plugins_loaded' );
+			$atmosphere_priority = $find_atmosphere_priority();
 		}
 
 		$this->assertNotNull(
@@ -933,11 +1013,15 @@ class Bluesky_ProviderTest extends BaseTestCase {
 				. 'FOSSE delegates the well-known route to Atmosphere; if the handler moved or was renamed in a bundled resync, '
 				. '/.well-known/atproto-did will silently 404.'
 		);
+		// > 2 (not just > 1) because FOSSE now also hooks
+		// `send_atproto_did_nocache_headers` at priority 2 — if Atmosphere
+		// moves to priority 2, the shim's `nocache_headers()` would queue
+		// after Atmosphere's `exit` and never reach the response.
 		$this->assertGreaterThan(
-			1,
+			2,
 			$atmosphere_priority,
 			'Atmosphere\\Atmosphere::serve_wellknown_atproto_did is hooked at template_redirect priority ' . $atmosphere_priority
-				. ' but FOSSE\'s suppression hook runs at priority 1. The opt-out filter will not work.'
+				. ' but FOSSE\'s suppression hook runs at priority 1 and the nocache shim runs at priority 2. The opt-out filter or nocache headers will not work.'
 		);
 	}
 
@@ -1870,6 +1954,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertNotFalse( has_action( 'admin_init', array( $this->provider, 'handle_oauth_callback' ) ) );
 		$this->assertNotFalse( has_action( 'admin_notices', array( $this->provider, 'maybe_render_auto_publish_disabled_notice' ) ) );
 		$this->assertSame( 1, has_action( 'template_redirect', array( $this->provider, 'maybe_suppress_atmosphere_well_known' ) ) );
+		$this->assertSame( 2, has_action( 'template_redirect', array( $this->provider, 'send_atproto_did_nocache_headers' ) ) );
 		$this->assertNotFalse( has_filter( 'atmosphere_oauth_redirect_uri', array( $this->provider, 'filter_oauth_redirect_uri' ) ) );
 	}
 


### PR DESCRIPTION
## Summary
- FOSSE's `/.well-known/atproto-did` handler has been a mirror of Atmosphere's identity contract since the start, and it has now broken twice — once on the original `is_connected()` gate (404'd during reauth) and again on the follow-up in PR 166. Atmosphere's bundled handler already gates on `has_identity()`, validates the DID via `get_did()`, and returns the same `text/plain` body, so there's no FOSSE-specific behavior worth maintaining a parallel implementation for.
- Delete `serve_atproto_did_well_known()` and the `init` priority-1 registration in `Bluesky_Provider`. Atmosphere now owns the route end-to-end at `template_redirect` priority 10.
- Keep the `template_redirect` priority-1 suppression hook so the existing `fosse_serve_atproto_did_well_known` filter still means "neither plugin responds": when it returns false, the hook clears Atmosphere's `atmosphere_wellknown` query var and forces a 404.
- Drop the now-dead well-known response tests; keep the suppression-hook tests.
- Update `sdd/bluesky-handle-setup/implementation-notes.md` to record the delegation decision.

Fixes #169.

## Behavior change
No user-facing behavior change for the default-on case. Atmosphere's handler already gates on `has_identity()`, which is the contract PR 166 made FOSSE adopt; the response shape (200 + DID body, 404 otherwise) is identical. Sites that filter `fosse_serve_atproto_did_well_known` to `false` continue to get a 404 from neither plugin.

## Test Plan
- [x] `./vendor/bin/phpunit --colors=always --do-not-cache-result tests/php/Admin/Bluesky_ProviderTest.php` (96 passing)
- [x] `composer run-script lint-php -- src/Admin/class-bluesky-provider.php tests/php/Admin/Bluesky_ProviderTest.php`