### PR TITLE
Admin: refine onboarding wizard theme styles

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ export default [
 			'test-results/**',
 			'coverage/**',
 			'.claude/**',
+			'.worktrees/**',
 		],
 	},
 	...wp.configs.recommended,

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -761,6 +761,24 @@
 	overflow-wrap: anywhere;
 }
 
+.fosse-token--ap-address,
+.fosse-token--handle,
+.fosse-token--host,
+.fosse-admin-token--ap-address,
+.fosse-admin-token--handle,
+.fosse-admin-token--host,
+.fosse-status-card__token--ap-address,
+.fosse-status-card__token--handle,
+.fosse-status-card__token--host {
+	overflow-wrap: anywhere;
+}
+
+.fosse-token--host,
+.fosse-admin-token--host,
+.fosse-status-card__token--host {
+	font-weight: 500;
+}
+
 .fosse-callout {
 	margin: 18px 0;
 	padding: 16px;
@@ -1863,6 +1881,8 @@
 	--fosse-ui-muted: #405334;
 	--fosse-wizard-warm: #fff2b8;
 	--fosse-wizard-warm-text: #604d00;
+	--fosse-wizard-spot: rgba(49, 93, 18, 0.09);
+	--fosse-wizard-spot-soft: rgba(120, 152, 58, 0.12);
 	isolation: isolate;
 }
 
@@ -1875,7 +1895,28 @@
 	content: "";
 	border: 1px solid rgba(137, 168, 75, 0.24);
 	border-radius: var(--fosse-ui-radius);
-	background: #f8fce8;
+	background: radial-gradient(
+			ellipse 46px 30px at 8% 18%,
+			var(--fosse-wizard-spot) 0 48%,
+			transparent 52%
+		),
+		radial-gradient(
+			ellipse 38px 24px at 88% 14%,
+			var(--fosse-wizard-spot-soft) 0 46%,
+			transparent 50%
+		),
+		radial-gradient(
+			ellipse 42px 27px at 15% 78%,
+			var(--fosse-wizard-spot-soft) 0 45%,
+			transparent 50%
+		),
+		radial-gradient(
+			ellipse 30px 19px at 93% 72%,
+			var(--fosse-wizard-spot) 0 46%,
+			transparent 51%
+		),
+		#f8fce8;
+	background-repeat: no-repeat;
 }
 
 .fosse-wizard.is-lizard-themed .fosse-wizard__progress,
@@ -1980,6 +2021,32 @@
 }
 
 .fosse-wizard.is-lizard-themed .fosse-wizard__card,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-wizard__card {
+	background: radial-gradient(
+			ellipse 52px 32px at 92% 16%,
+			var(--fosse-wizard-spot) 0 45%,
+			transparent 50%
+		),
+		radial-gradient(
+			ellipse 42px 26px at 12% 66%,
+			var(--fosse-wizard-spot-soft) 0 44%,
+			transparent 49%
+		),
+		radial-gradient(
+			ellipse 30px 19px at 78% 84%,
+			var(--fosse-wizard-spot) 0 46%,
+			transparent 51%
+		),
+		var(--fosse-ui-surface);
+	background-repeat: no-repeat;
+}
+
+.fosse-wizard.is-lizard-themed .fosse-wizard__card-header,
+.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-wizard__card-header {
+	background: transparent;
+}
+
+.fosse-wizard.is-lizard-themed .fosse-wizard__card,
 .has-fosse-wizard-lizard-theme .fosse-wizard .fosse-wizard__card,
 .fosse-wizard.is-lizard-themed .fosse-destination-card,
 .has-fosse-wizard-lizard-theme .fosse-wizard .fosse-destination-card,
@@ -2004,6 +2071,40 @@
 .has-fosse-wizard-lizard-theme .fosse-wizard .button-primary:focus {
 	background: var(--fosse-wizard-accent-button-hover);
 	border-color: var(--fosse-wizard-accent-button-hover-border);
+	box-shadow:
+		0 0 0 1px #fff,
+		0 0 0 3px var(--fosse-ui-accent);
+	color: #fff;
+}
+
+.fosse-wizard.is-lizard-themed .button:not(.button-primary),
+.has-fosse-wizard-lizard-theme .fosse-wizard .button:not(.button-primary) {
+	border-color: var(--fosse-ui-accent);
+	color: var(--fosse-ui-accent);
+}
+
+.fosse-wizard.is-lizard-themed .button:not(.button-primary):hover,
+.has-fosse-wizard-lizard-theme .fosse-wizard .button:not(.button-primary):hover,
+.fosse-wizard.is-lizard-themed .button:not(.button-primary):focus,
+.has-fosse-wizard-lizard-theme
+	.fosse-wizard
+	.button:not(.button-primary):focus {
+	border-color: var(--fosse-wizard-accent-button-hover-border);
+	box-shadow: 0 0 0 1px var(--fosse-wizard-accent-button-hover-border);
+	color: var(--fosse-wizard-accent-button-hover);
+}
+
+.fosse-wizard.is-lizard-themed a:not(.button),
+.has-fosse-wizard-lizard-theme .fosse-wizard a:not(.button) {
+	color: var(--fosse-ui-accent);
+}
+
+.fosse-wizard.is-lizard-themed a:not(.button):hover,
+.has-fosse-wizard-lizard-theme .fosse-wizard a:not(.button):hover,
+.fosse-wizard.is-lizard-themed a:not(.button):focus,
+.has-fosse-wizard-lizard-theme .fosse-wizard a:not(.button):focus {
+	box-shadow: 0 0 0 1px var(--fosse-wizard-accent-button-hover);
+	color: var(--fosse-wizard-accent-button-hover);
 }
 
 .fosse-wizard.is-lizard-themed .fosse-wizard__lizard,

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -747,35 +747,13 @@
 	color: var(--fosse-ui-text);
 	word-break: normal;
 	white-space: normal;
-	overflow-wrap: break-word;
+	overflow-wrap: anywhere;
 	box-decoration-break: clone;
 	-webkit-box-decoration-break: clone;
 }
 
-.fosse-token--did,
-.fosse-token--url,
-.fosse-admin-token--did,
-.fosse-admin-token--url,
-.fosse-status-card__token--did,
-.fosse-status-card__token--url {
-	overflow-wrap: anywhere;
-}
-
-.fosse-token--ap-address,
-.fosse-token--handle,
 .fosse-token--host,
-.fosse-admin-token--ap-address,
-.fosse-admin-token--handle,
-.fosse-admin-token--host,
-.fosse-status-card__token--ap-address,
-.fosse-status-card__token--handle,
-.fosse-status-card__token--host {
-	overflow-wrap: anywhere;
-}
-
-.fosse-token--host,
-.fosse-admin-token--host,
-.fosse-status-card__token--host {
+.fosse-admin-token--host {
 	font-weight: 500;
 }
 
@@ -2039,6 +2017,9 @@
 		),
 		var(--fosse-ui-surface);
 	background-repeat: no-repeat;
+	box-shadow:
+		0 10px 24px rgba(63, 111, 29, 0.08),
+		inset 0 1px 0 rgba(255, 255, 255, 0.72);
 }
 
 .fosse-wizard.is-lizard-themed .fosse-wizard__card-header,
@@ -2046,8 +2027,6 @@
 	background: transparent;
 }
 
-.fosse-wizard.is-lizard-themed .fosse-wizard__card,
-.has-fosse-wizard-lizard-theme .fosse-wizard .fosse-wizard__card,
 .fosse-wizard.is-lizard-themed .fosse-destination-card,
 .has-fosse-wizard-lizard-theme .fosse-wizard .fosse-destination-card,
 .fosse-wizard.is-lizard-themed .fosse-mode-card,

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -180,8 +180,8 @@ class Bluesky_Provider implements Connection_Provider {
 		$this->status_cache = array(
 			'connected'    => $connected,
 			'handle'       => is_string( $connection['handle'] ?? null ) ? $connection['handle'] : '',
-			'did'          => $connection['did'] ?? '',
-			'pds_endpoint' => $connection['pds_endpoint'] ?? '',
+			'did'          => is_string( $connection['did'] ?? null ) ? $connection['did'] : '',
+			'pds_endpoint' => is_string( $connection['pds_endpoint'] ?? null ) ? $connection['pds_endpoint'] : '',
 			'token_error'  => $token_error,
 		);
 

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -179,7 +179,7 @@ class Bluesky_Provider implements Connection_Provider {
 
 		$this->status_cache = array(
 			'connected'    => $connected,
-			'handle'       => $connection['handle'] ?? '',
+			'handle'       => is_string( $connection['handle'] ?? null ) ? $connection['handle'] : '',
 			'did'          => $connection['did'] ?? '',
 			'pds_endpoint' => $connection['pds_endpoint'] ?? '',
 			'token_error'  => $token_error,

--- a/src/Admin/class-onboarding-wizard.php
+++ b/src/Admin/class-onboarding-wizard.php
@@ -1700,7 +1700,7 @@ class Onboarding_Wizard {
 		);
 
 		if ( $bluesky['connected'] ) {
-			$bluesky_handle     = is_string( $bluesky['handle'] ?? null ) ? $bluesky['handle'] : '';
+			$bluesky_handle     = $bluesky['handle'];
 			$bluesky_normalized = ltrim( $bluesky_handle, '@' );
 
 			if ( '' !== $bluesky_normalized ) {

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -874,6 +874,11 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Your fediverse address', $output );
 		$this->assertStringContainsString( 'Site fediverse address', $output );
 		$this->assertStringContainsString( 'name="activitypub_blog_identifier"', $output );
+
+		// CSS-contract: the AP-address tokens emitted here must match the
+		// modifier classes asserted in Admin_CSS_Test.
+		$this->assertStringContainsString( 'fosse-token--ap-address', $output );
+		$this->assertStringContainsString( 'fosse-admin-token--ap-address', $output );
 	}
 
 	/**
@@ -890,5 +895,21 @@ class AP_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( '<dd', $output );
 		$this->assertStringContainsString( 'ActivityPub profile', $output );
 		$this->assertStringNotContainsString( 'widefat striped', $output );
+	}
+
+	/**
+	 * Status card emits the AP-address token with the
+	 * `fosse-status-card__token--ap-address` modifier so the CSS rule
+	 * in `admin.css` targets a real DOM node.
+	 */
+	public function test_render_status_card_emits_status_card_ap_address_token() {
+		update_option( 'activitypub_actor_mode', 'blog' );
+		update_option( 'activitypub_blog_identifier', 'my-site' );
+
+		ob_start();
+		$this->provider->render_status_card();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'fosse-status-card__token--ap-address', $output );
 	}
 }

--- a/tests/php/Admin/Admin_CSS_Test.php
+++ b/tests/php/Admin/Admin_CSS_Test.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Tests for admin stylesheet contracts.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests\Admin;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+
+/**
+ * Verifies that emitted admin CSS hooks have matching stylesheet rules.
+ */
+class Admin_CSS_Test extends BaseTestCase {
+
+	/**
+	 * Identity token modifiers emitted by admin renderers should be real
+	 * styling hooks, not test-only marker classes.
+	 *
+	 * @dataProvider provide_identity_token_modifier_selectors
+	 *
+	 * @param string $selector CSS selector expected in the admin stylesheet.
+	 */
+	#[DataProvider( 'provide_identity_token_modifier_selectors' )]
+	public function test_identity_token_modifiers_have_css_rules( string $selector ): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local fixture read; assert below fails clearly if unreadable.
+		$css = file_get_contents( dirname( __DIR__, 3 ) . '/src/Admin/assets/css/admin.css' );
+
+		$this->assertIsString( $css );
+		$this->assertStringContainsString( $selector, $css );
+	}
+
+	/**
+	 * Selectors for emitted identity token modifier classes.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public static function provide_identity_token_modifier_selectors(): array {
+		return array(
+			'completion ap address token' => array( '.fosse-token--ap-address' ),
+			'admin ap address token'      => array( '.fosse-admin-token--ap-address' ),
+			'status ap address token'     => array( '.fosse-status-card__token--ap-address' ),
+			'completion handle token'     => array( '.fosse-token--handle' ),
+			'admin handle token'          => array( '.fosse-admin-token--handle' ),
+			'status handle token'         => array( '.fosse-status-card__token--handle' ),
+			'completion host token'       => array( '.fosse-token--host' ),
+			'admin host token'            => array( '.fosse-admin-token--host' ),
+			'status host token'           => array( '.fosse-status-card__token--host' ),
+		);
+	}
+}

--- a/tests/php/Admin/Admin_CSS_Test.php
+++ b/tests/php/Admin/Admin_CSS_Test.php
@@ -16,8 +16,46 @@ use WorDBless\BaseTestCase;
 class Admin_CSS_Test extends BaseTestCase {
 
 	/**
-	 * Identity token modifiers emitted by admin renderers should be real
-	 * styling hooks, not test-only marker classes.
+	 * Read the admin stylesheet with block comments stripped so an
+	 * assertion can't be satisfied by a selector mentioned only in a
+	 * comment.
+	 *
+	 * @return string Stylesheet contents minus block comments.
+	 */
+	private function load_stylesheet_without_comments(): string {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local fixture read; assert below fails clearly if unreadable.
+		$css = file_get_contents( dirname( __DIR__, 3 ) . '/src/Admin/assets/css/admin.css' );
+
+		$this->assertIsString( $css );
+
+		return (string) preg_replace( '#/\*.*?\*/#s', '', $css );
+	}
+
+	/**
+	 * The base identity token classes wrap long, unbreakable strings
+	 * (DIDs, URLs, AP addresses, handles, hosts) by character instead
+	 * of overflowing their container. Modifier-specific rules were
+	 * consolidated onto the base classes, so this base contract is
+	 * what keeps every modifier laid out correctly.
+	 */
+	public function test_identity_token_base_classes_break_long_strings(): void {
+		$css = $this->load_stylesheet_without_comments();
+
+		$this->assertMatchesRegularExpression(
+			'/\.fosse-token\s*,\s*\.fosse-admin-token\s*,\s*\.fosse-status-card__token\s*\{[^}]*overflow-wrap:\s*anywhere/s',
+			$css,
+			'Base identity-token classes should declare `overflow-wrap: anywhere` so long unbreakable strings wrap.'
+		);
+	}
+
+	/**
+	 * Identity token modifiers with their own dedicated styling
+	 * (rather than relying on the base classes) should appear as
+	 * real CSS rules. Only modifiers that carry modifier-specific
+	 * declarations are listed here; modifiers that inherit everything
+	 * from the base classes are covered by
+	 * {@see self::test_identity_token_base_classes_break_long_strings()}
+	 * and the renderer tests that assert the class is emitted.
 	 *
 	 * @dataProvider provide_identity_token_modifier_selectors
 	 *
@@ -25,33 +63,19 @@ class Admin_CSS_Test extends BaseTestCase {
 	 */
 	#[DataProvider( 'provide_identity_token_modifier_selectors' )]
 	public function test_identity_token_modifiers_have_css_rules( string $selector ): void {
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local fixture read; assert below fails clearly if unreadable.
-		$css = file_get_contents( dirname( __DIR__, 3 ) . '/src/Admin/assets/css/admin.css' );
-
-		$this->assertIsString( $css );
-
-		// Strip block comments so a selector mentioned in a CSS comment
-		// can't satisfy the contract — only real rules should count.
-		$css_without_comments = preg_replace( '#/\*.*?\*/#s', '', $css );
-
-		$this->assertStringContainsString( $selector, $css_without_comments );
+		$this->assertStringContainsString( $selector, $this->load_stylesheet_without_comments() );
 	}
 
 	/**
-	 * Selectors for emitted identity token modifier classes.
+	 * Selectors for emitted identity token modifier classes that carry
+	 * their own modifier-specific declarations.
 	 *
 	 * @return array<string, array{string}>
 	 */
 	public static function provide_identity_token_modifier_selectors(): array {
 		return array(
-			'completion ap address token' => array( '.fosse-token--ap-address' ),
-			'admin ap address token'      => array( '.fosse-admin-token--ap-address' ),
-			'status ap address token'     => array( '.fosse-status-card__token--ap-address' ),
-			'completion handle token'     => array( '.fosse-token--handle' ),
-			'admin handle token'          => array( '.fosse-admin-token--handle' ),
-			'status handle token'         => array( '.fosse-status-card__token--handle' ),
-			'completion host token'       => array( '.fosse-token--host' ),
-			'admin host token'            => array( '.fosse-admin-token--host' ),
+			'completion host token' => array( '.fosse-token--host' ),
+			'admin host token'      => array( '.fosse-admin-token--host' ),
 		);
 	}
 }

--- a/tests/php/Admin/Admin_CSS_Test.php
+++ b/tests/php/Admin/Admin_CSS_Test.php
@@ -29,7 +29,12 @@ class Admin_CSS_Test extends BaseTestCase {
 		$css = file_get_contents( dirname( __DIR__, 3 ) . '/src/Admin/assets/css/admin.css' );
 
 		$this->assertIsString( $css );
-		$this->assertStringContainsString( $selector, $css );
+
+		// Strip block comments so a selector mentioned in a CSS comment
+		// can't satisfy the contract — only real rules should count.
+		$css_without_comments = preg_replace( '#/\*.*?\*/#s', '', $css );
+
+		$this->assertStringContainsString( $selector, $css_without_comments );
 	}
 
 	/**
@@ -47,7 +52,6 @@ class Admin_CSS_Test extends BaseTestCase {
 			'status handle token'         => array( '.fosse-status-card__token--handle' ),
 			'completion host token'       => array( '.fosse-token--host' ),
 			'admin host token'            => array( '.fosse-admin-token--host' ),
-			'status host token'           => array( '.fosse-status-card__token--host' ),
 		);
 	}
 }

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -187,6 +187,39 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Non-string handles in the raw Atmosphere connection are normalized at
+	 * the status boundary so every status consumer can treat `handle` as a
+	 * string.
+	 */
+	public function test_status_normalizes_non_string_connection_handle(): void {
+		// Seed identity so `Atmosphere\is_connected()` does not enter the
+		// legacy connection-to-identity migration path and cast the malformed
+		// connection handle before FOSSE's status boundary can normalize it.
+		update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+			)
+		);
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => array( 'alice.bsky.social' ),
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		$status = $this->provider->get_status();
+
+		$this->assertTrue( $status['connected'] );
+		$this->assertSame( '', $status['handle'] );
+	}
+
+	/**
 	 * `get_status()` re-reads the connection state after the token-health
 	 * probe so a refresh that deletes `atmosphere_connection` mid-call
 	 * (e.g. permanent OAuth failure: `invalid_grant`, `invalid_client`,


### PR DESCRIPTION
## Summary
- Refine the alternate onboarding wizard theme so secondary buttons and wizard links use the theme accent color.
- Add a subtle background treatment to the wizard surface without expanding UI behavior.
- Normalize Bluesky status handles at the provider boundary and cover emitted token CSS hooks.

## Test Plan
- [x] git diff --check
- [x] pnpm run format:check
- [x] pnpm run lint
- [x] pnpm test
- [x] composer run-script lint-php
- [x] composer run-script test-php