### PR TITLE
Fix Bluesky reconnect lockout after disconnect on domain-handle sites

### DIFF
--- a/bundled/atmosphere/includes/oauth/class-client.php
+++ b/bundled/atmosphere/includes/oauth/class-client.php
@@ -1069,7 +1069,23 @@ class Client {
 	}
 
 	/**
-	 * Disconnect: remove all stored credentials and clear queued cron events.
+	 * Disconnect: remove stored credentials and clear queued cron events.
+	 *
+	 * Drops `atmosphere_connection` (the OAuth session) but deliberately
+	 * preserves `atmosphere_identity`. Identity holds the DID, handle, and
+	 * PDS endpoint that drive the bidirectional verification headers
+	 * (`/.well-known/atproto-did` and the publication link tag). Sites that
+	 * adopted a custom domain handle (e.g. `example.com` instead of
+	 * `alice.bsky.social`) depend on that route to resolve their handle
+	 * back to a DID during reconnect — wiping identity here breaks the
+	 * chain: `Resolver::handle_to_did()` then 404s on both DNS TXT and the
+	 * HTTPS well-known, and the user is locked out of reconnecting with
+	 * their domain handle. The split between identity and credentials was
+	 * introduced precisely so a failed token refresh would not break this
+	 * route (see `get_identity()`); explicit disconnect must honor the
+	 * same invariant. A reconnect overwrites identity in place; sites that
+	 * truly want to forget the DID should clear `atmosphere_identity`
+	 * separately.
 	 *
 	 * Queued events (`atmosphere_delete_records`,
 	 * `atmosphere_delete_comment_record`) issue applyWrites without a
@@ -1124,7 +1140,6 @@ class Client {
 		}
 
 		\delete_option( 'atmosphere_connection' );
-		\delete_option( 'atmosphere_identity' );
 		\delete_option( self::REFRESH_LOCK_OPTION );
 
 		/*

--- a/bundled/atmosphere/vendor/composer/installed.php
+++ b/bundled/atmosphere/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'automattic/atmosphere',
         'pretty_version' => 'dev-trunk',
         'version' => 'dev-trunk',
-        'reference' => '11f3992944a48e9dd0fcef4e083d9e005559b11d',
+        'reference' => 'c03581874229f5a20f22489653fc4bb974078e20',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'automattic/atmosphere' => array(
             'pretty_version' => 'dev-trunk',
             'version' => 'dev-trunk',
-            'reference' => '11f3992944a48e9dd0fcef4e083d9e005559b11d',
+            'reference' => 'c03581874229f5a20f22489653fc4bb974078e20',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -475,6 +475,64 @@
 	margin-top: 12px;
 }
 
+.fosse-identity-recovery {
+	border-top: 1px solid var(--fosse-ui-border-soft);
+	background: var(--fosse-ui-surface);
+}
+
+.fosse-identity-recovery__summary {
+	box-sizing: border-box;
+	padding: 14px 24px;
+	cursor: pointer;
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 1.45;
+	color: var(--fosse-ui-accent);
+}
+
+.fosse-identity-recovery__summary:hover {
+	text-decoration: underline;
+	text-decoration-thickness: from-font;
+	text-underline-offset: 2px;
+}
+
+.fosse-identity-recovery__summary:focus-visible {
+	outline: 2px solid var(--fosse-ui-accent);
+	outline-offset: -2px;
+}
+
+.fosse-identity-recovery__body {
+	padding: 0 24px 20px;
+}
+
+.fosse-identity-recovery__body > :first-child {
+	margin-top: 0;
+}
+
+.fosse-identity-recovery__body > :last-child {
+	margin-bottom: 0;
+}
+
+.fosse-identity-recovery__body p {
+	max-width: 720px;
+	color: var(--fosse-ui-muted);
+}
+
+.fosse-identity-recovery__form {
+	max-width: 720px;
+	margin-top: 14px;
+	padding: 14px 16px;
+	border: 1px solid var(--fosse-ui-border-soft);
+	border-radius: var(--fosse-ui-radius);
+	background: var(--fosse-ui-surface-muted);
+}
+
+.fosse-identity-recovery__actions {
+	margin-top: 14px;
+	padding-top: 14px;
+	border-top: 1px solid var(--fosse-ui-border-soft);
+}
+
 .fosse-settings-actions {
 	display: flex;
 	align-items: center;
@@ -908,6 +966,16 @@
 	.fosse-card-body,
 	.fosse-card-footer {
 		padding: 18px;
+	}
+
+	.fosse-identity-recovery__summary {
+		padding-right: 18px;
+		padding-left: 18px;
+	}
+
+	.fosse-identity-recovery__body {
+		padding-right: 18px;
+		padding-left: 18px;
 	}
 
 	.fosse-card-header,

--- a/src/Admin/class-bluesky-domain-handle.php
+++ b/src/Admin/class-bluesky-domain-handle.php
@@ -585,6 +585,19 @@ class Bluesky_Domain_Handle {
 		delete_option( self::OPTION_PREVIOUS_HANDLE );
 		self::sync_local_connection_handle( $previous );
 
+		// Clear the persisted Atmosphere identity (DID + handle + PDS) when
+		// the revert succeeded. Without this, `/.well-known/atproto-did`
+		// keeps serving the DID against a domain the account no longer
+		// claims — the PDS-side handle was just reverted away from this
+		// site, so the DID's `alsoKnownAs` no longer lists `at://<host>`,
+		// and the well-known route becomes a stale public claim that fails
+		// bidirectional verification. The disconnect-preserves-identity
+		// contract only makes sense when the binding still holds; once
+		// the revert removes it, the verification anchor should go with
+		// it. A reconnect with the original (now-restored) handle
+		// rebuilds identity from the token exchange, so nothing is lost.
+		delete_option( 'atmosphere_identity' );
+
 		self::add_settings_notice(
 			sprintf(
 				/* translators: %s: the handle that was restored (e.g. alice.bsky.social). */

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -1484,6 +1484,14 @@ class Bluesky_Provider implements Connection_Provider {
 
 		check_admin_referer( 'fosse_forget_bluesky_identity' );
 
+		if ( function_exists( '\Atmosphere\is_connected' ) && \Atmosphere\is_connected() ) {
+			$this->redirect_with_notice(
+				__( 'Disconnect Bluesky before forgetting this site\'s identity. You can forget the saved identity after the Bluesky account is disconnected.', 'fosse' ),
+				'error'
+			);
+			return;
+		}
+
 		// Capture the DID before deletion so the notice can confirm what
 		// just went away (and so a "did nothing" double-click on a fresh
 		// install doesn't read as success).

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -610,22 +610,22 @@ class Bluesky_Provider implements Connection_Provider {
 		}
 		?>
 		<details class="fosse-identity-recovery">
-			<summary>
-				<?php esc_html_e( 'Trouble reconnecting with your domain as a handle? Restore from a DID.', 'fosse' ); ?>
+			<summary class="fosse-identity-recovery__summary">
+				<?php esc_html_e( 'Trouble reconnecting a domain handle?', 'fosse' ); ?>
 			</summary>
-			<div class="fosse-card-body">
+			<div class="fosse-identity-recovery__body">
 				<p>
 					<?php
 					echo esc_html(
 						sprintf(
 							/* translators: %s: WordPress site host (e.g. example.com). */
-							__( 'Use this if you previously used FOSSE to set %s as your Bluesky handle and the Connect step now fails with "Could not resolve handle to a DID". Paste your Bluesky DID (find it in bsky.app under Settings → Account, or in the profile URL once logged in). FOSSE fetches the DID document, verifies it lists this site as one of your handles, and restores the verification endpoint so reconnect works.', 'fosse' ),
+							__( 'Use this if you previously used %s as your Bluesky handle and reconnecting no longer works. Paste your Bluesky DID below. FOSSE will check that the DID still points back to this site before restoring the identity needed to reconnect.', 'fosse' ),
 							$site_host
 						)
 					);
 					?>
 				</p>
-				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<form class="fosse-identity-recovery__form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 					<input type="hidden" name="action" value="fosse_restore_bluesky_identity" />
 					<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_restore_bluesky_identity' ) ); ?>" />
 
@@ -637,18 +637,29 @@ class Bluesky_Provider implements Connection_Provider {
 								class="regular-text"
 								name="bluesky_did"
 								id="fosse_bluesky_did"
+								aria-describedby="fosse_bluesky_did_description"
 								placeholder="did:plc:..."
 								autocomplete="off"
+								autocapitalize="none"
 								spellcheck="false"
 							/>
-							<p class="description">
-								<?php esc_html_e( 'Format: did:plc: followed by 24 lowercase letters or digits, or did:web: followed by a hostname.', 'fosse' ); ?>
+							<p class="description" id="fosse_bluesky_did_description">
+								<?php
+								echo wp_kses_post(
+									sprintf(
+										/* translators: 1: opening anchor tag to Bluesky account settings, 2: closing anchor tag. */
+										__( 'Starts with did:plc: or did:web:. You can find it in %1$sBluesky account settings%2$s or your profile URL.', 'fosse' ),
+										'<a href="' . esc_url( 'https://bsky.app/settings/account' ) . '" target="_blank" rel="noopener noreferrer">',
+										'</a>'
+									)
+								);
+								?>
 							</p>
 						</div>
 					</div>
 
-					<div class="fosse-card-footer fosse-action-bar">
-						<?php submit_button( __( 'Restore identity from DID', 'fosse' ), 'secondary', 'submit', false ); ?>
+					<div class="fosse-identity-recovery__actions fosse-action-bar">
+						<?php submit_button( __( 'Restore identity', 'fosse' ), 'secondary', 'submit', false ); ?>
 					</div>
 				</form>
 			</div>
@@ -1353,15 +1364,20 @@ class Bluesky_Provider implements Connection_Provider {
 			return;
 		}
 
-		// autoload=true matches Atmosphere\get_identity()'s lazy-migration write
-		// so subsequent get_option() calls hit the autoloaded cache rather than
-		// re-fetching from the options table.
 		$identity = array(
 			'did'          => $did,
 			'handle'       => $site_host,
 			'pds_endpoint' => $pds,
 		);
-		update_option( 'atmosphere_identity', $identity, true );
+
+		// autoload=true matches Atmosphere\get_identity()'s lazy-migration write
+		// so subsequent get_option() calls hit the autoloaded cache rather than
+		// re-fetching from the options table.
+		update_option(
+			'atmosphere_identity',
+			$identity,
+			true
+		);
 
 		// `update_option()` returns false both on DB write failure AND on
 		// "value didn't change" (e.g. a hostile filter pinning the option,

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -385,6 +385,7 @@ class Bluesky_Provider implements Connection_Provider {
 					</div>
 				</form>
 				<?php $this->render_identity_recovery_panel(); ?>
+				<?php $this->render_identity_forget_panel(); ?>
 			<?php else : ?>
 				<div class="fosse-card-body">
 					<p>
@@ -586,12 +587,25 @@ class Bluesky_Provider implements Connection_Provider {
 	 * @return void
 	 */
 	private function render_identity_recovery_panel(): void {
-		if ( function_exists( '\Atmosphere\has_identity' ) && \Atmosphere\has_identity() ) {
+		// Mirror the handler's resolver-API check so the panel doesn't
+		// invite a submission the handler will immediately reject. The
+		// missing-Atmosphere case is rare in shipped FOSSE but reachable
+		// in custom builds and CI; either way, a hidden panel is a better
+		// UX than a paste-then-fail loop.
+		if ( ! function_exists( '\Atmosphere\has_identity' )
+			|| ! class_exists( '\Atmosphere\OAuth\Resolver' )
+			|| ! method_exists( '\Atmosphere\OAuth\Resolver', 'resolve_did' )
+			|| ! method_exists( '\Atmosphere\OAuth\Resolver', 'pds_from_did_doc' )
+		) {
 			return;
 		}
 
-		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
-		if ( ! is_string( $site_host ) || '' === $site_host ) {
+		if ( \Atmosphere\has_identity() ) {
+			return;
+		}
+
+		$site_host = $this->get_eligible_canonical_site_host();
+		if ( '' === $site_host ) {
 			return;
 		}
 		?>
@@ -635,6 +649,78 @@ class Bluesky_Provider implements Connection_Provider {
 
 					<div class="fosse-card-footer fosse-action-bar">
 						<?php submit_button( __( 'Restore identity from DID', 'fosse' ), 'secondary', 'submit', false ); ?>
+					</div>
+				</form>
+			</div>
+		</details>
+		<?php
+	}
+
+	/**
+	 * Render the "Forget Bluesky identity" disclosure panel.
+	 *
+	 * Counterpart to {@see self::render_identity_recovery_panel()}. Renders
+	 * only on the disconnected state when an identity is still on file —
+	 * the case where the admin disconnected but Disconnect deliberately
+	 * preserved the verification anchor, and they now want to fully sever
+	 * the link (selling the site, switching accounts entirely, undoing a
+	 * wrong restore). Connected sites don't see this — the natural flow is
+	 * Disconnect, then Forget if they want a clean slate.
+	 *
+	 * Shows the persisted DID + handle + PDS as plain text inside the
+	 * disclosure body so the admin can verify what they're about to delete
+	 * before clicking through. Collapsed by default because the typical
+	 * disconnect → reconnect cycle shouldn't surface this as the primary
+	 * action.
+	 *
+	 * @return void
+	 */
+	private function render_identity_forget_panel(): void {
+		if ( ! function_exists( '\Atmosphere\get_identity' ) || ! function_exists( '\Atmosphere\has_identity' ) ) {
+			return;
+		}
+
+		if ( ! \Atmosphere\has_identity() ) {
+			return;
+		}
+
+		$identity = \Atmosphere\get_identity();
+		$did      = isset( $identity['did'] ) ? (string) $identity['did'] : '';
+		$handle   = isset( $identity['handle'] ) ? (string) $identity['handle'] : '';
+		$pds      = isset( $identity['pds_endpoint'] ) ? (string) $identity['pds_endpoint'] : '';
+		?>
+		<details class="fosse-identity-forget">
+			<summary>
+				<?php esc_html_e( 'Forget this site\'s Bluesky identity entirely.', 'fosse' ); ?>
+			</summary>
+			<div class="fosse-card-body">
+				<p>
+					<?php
+					esc_html_e(
+						'Disconnect keeps the persisted DID so a domain-handle site can reconnect cleanly. Use this if you instead want to fully sever the link — selling the site, switching to a different Bluesky account, or undoing a wrong restore. Once cleared, the .well-known/atproto-did route on this domain stops serving the DID, and external resolvers stop trusting any cached binding.',
+						'fosse'
+					);
+					?>
+				</p>
+				<dl class="fosse-detail-list">
+					<?php if ( '' !== $did ) : ?>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'DID', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description"><code><?php echo esc_html( $did ); ?></code></dd>
+					<?php endif; ?>
+					<?php if ( '' !== $handle ) : ?>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'Handle', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description"><code><?php echo esc_html( $handle ); ?></code></dd>
+					<?php endif; ?>
+					<?php if ( '' !== $pds ) : ?>
+						<dt class="fosse-detail-list__term"><?php esc_html_e( 'PDS endpoint', 'fosse' ); ?></dt>
+						<dd class="fosse-detail-list__description"><code><?php echo esc_html( $pds ); ?></code></dd>
+					<?php endif; ?>
+				</dl>
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="fosse_forget_bluesky_identity" />
+					<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_forget_bluesky_identity' ) ); ?>" />
+					<div class="fosse-card-footer fosse-action-bar">
+						<?php submit_button( __( 'Forget Bluesky identity', 'fosse' ), 'secondary', 'submit', false ); ?>
 					</div>
 				</form>
 			</div>
@@ -743,6 +829,7 @@ class Bluesky_Provider implements Connection_Provider {
 		add_action( 'admin_post_fosse_disconnect_bluesky', array( $this, 'handle_disconnect' ) );
 		add_action( 'admin_post_fosse_set_bluesky_domain_handle', array( $this, 'handle_set_domain_handle' ) );
 		add_action( 'admin_post_fosse_restore_bluesky_identity', array( $this, 'handle_restore_identity' ) );
+		add_action( 'admin_post_fosse_forget_bluesky_identity', array( $this, 'handle_forget_identity' ) );
 		add_action( 'admin_post_fosse_enable_bluesky_auto_publish', array( $this, 'handle_enable_auto_publish' ) );
 		add_action( 'admin_init', array( $this, 'handle_oauth_callback' ) );
 		add_action( 'admin_notices', array( $this, 'maybe_render_auto_publish_disabled_notice' ) );
@@ -1147,6 +1234,22 @@ class Bluesky_Provider implements Connection_Provider {
 
 		check_admin_referer( 'fosse_restore_bluesky_identity' );
 
+		// Mirror the renderer's gate at the handler level. The recovery panel
+		// only renders when has_identity() is false, but the admin-post hook
+		// is still wired up regardless — a stale form tab from a prior
+		// disconnected state, or a direct POST with a valid nonce, could
+		// otherwise overwrite identity on a site that has since reconnected.
+		// That would produce split-brain state: get_status() reports the
+		// connected DID from atmosphere_connection while the well-known
+		// route serves the overwritten DID from atmosphere_identity.
+		if ( function_exists( '\Atmosphere\has_identity' ) && \Atmosphere\has_identity() ) {
+			$this->redirect_with_notice(
+				__( 'A Bluesky identity is already on file for this site. Use Disconnect or "Forget Bluesky identity" first if you want to replace it.', 'fosse' ),
+				'error'
+			);
+			return;
+		}
+
 		$did = trim( sanitize_text_field( wp_unslash( $_POST['bluesky_did'] ?? '' ) ) );
 
 		if ( '' === $did ) {
@@ -1183,6 +1286,21 @@ class Bluesky_Provider implements Connection_Provider {
 			return;
 		}
 
+		// Use the same eligibility + canonical-form helper that the
+		// domain-handle SET path uses. Without this, the recovery flow can
+		// claim a domain handle on a site that's not actually eligible
+		// (subdirectory install, non-routable host, etc.), or reject a
+		// legitimate IDN site by comparing the raw UTF-8 form against the
+		// punycoded `at://xn--…` entry the DID document actually stores.
+		$site_host = $this->get_eligible_canonical_site_host();
+		if ( '' === $site_host ) {
+			$this->redirect_with_notice(
+				__( 'This site\'s WordPress Address (URL) is not eligible to be a Bluesky handle (subdirectory install, non-routable host, or an internationalized name this server can\'t encode). Fix the Site URL in Settings → General, or set up the handle on a different installation first.', 'fosse' ),
+				'error'
+			);
+			return;
+		}
+
 		$did_doc = \Atmosphere\OAuth\Resolver::resolve_did( $did );
 		if ( is_wp_error( $did_doc ) ) {
 			$this->redirect_with_notice(
@@ -1195,16 +1313,6 @@ class Bluesky_Provider implements Connection_Provider {
 			);
 			return;
 		}
-
-		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
-		if ( ! is_string( $site_host ) || '' === $site_host ) {
-			$this->redirect_with_notice(
-				__( 'Could not determine this site\'s hostname. Check the WordPress Address (URL) in Settings → General.', 'fosse' ),
-				'error'
-			);
-			return;
-		}
-		$site_host = strtolower( $site_host );
 
 		$expected_aka = 'at://' . $site_host;
 		$also_known   = array();
@@ -1259,11 +1367,18 @@ class Bluesky_Provider implements Connection_Provider {
 		// "value didn't change" (e.g. a hostile filter pinning the option,
 		// or a stale autoloaded row that matches), so the return value
 		// alone isn't a reliable success signal. Re-read the option and
-		// verify the DID landed — if it didn't, surface the failure
-		// instead of cheerfully telling the admin recovery succeeded
-		// while the well-known route stays dark.
+		// verify the full identity trio landed — not just the DID. A
+		// hostile `pre_option_atmosphere_identity` filter could pin the
+		// option with the same DID but a different handle or PDS endpoint,
+		// which would silently route the well-known route's handle field
+		// and Atmosphere\get_pds_endpoint() against attacker-controlled
+		// values while the handler reports success.
 		$persisted = get_option( 'atmosphere_identity', array() );
-		if ( ! is_array( $persisted ) || ( $persisted['did'] ?? '' ) !== $did ) {
+		if ( ! is_array( $persisted )
+			|| ( $persisted['did'] ?? '' ) !== $identity['did']
+			|| ( $persisted['handle'] ?? '' ) !== $identity['handle']
+			|| ( $persisted['pds_endpoint'] ?? '' ) !== $identity['pds_endpoint']
+		) {
 			$this->redirect_with_notice(
 				__( 'Could not persist the restored Bluesky identity. The option write failed or was overridden by a filter. Check database write access and try again.', 'fosse' ),
 				'error'
@@ -1271,11 +1386,123 @@ class Bluesky_Provider implements Connection_Provider {
 			return;
 		}
 
+		// Echo the persisted values into the success notice. The admin pasted
+		// the DID by hand and is still on the page that triggered the action;
+		// surfacing the resolved DID + PDS at the moment of commit gives them
+		// the last opportunity to spot a wrong paste (e.g. from a phishing
+		// support thread) before they continue on to the OAuth handoff. The
+		// adjacent "Forget Bluesky identity" panel is the undo if it does
+		// look wrong.
 		$this->redirect_with_notice(
 			sprintf(
-				/* translators: %s: site host the user can now reconnect with (e.g. example.com). */
-				__( 'Restored Bluesky identity. You can now reconnect using %s as your handle.', 'fosse' ),
-				$site_host
+				/* translators: 1: site host the user can now reconnect with (e.g. example.com); 2: persisted DID (did:plc:…); 3: persisted PDS endpoint URL. */
+				__( 'Restored Bluesky identity for %1$s. DID: %2$s. PDS: %3$s. Click Connect Bluesky to reauthorize. If anything looks wrong, scroll down to "Forget Bluesky identity" to clear it.', 'fosse' ),
+				$site_host,
+				$identity['did'],
+				$identity['pds_endpoint']
+			),
+			'success'
+		);
+	}
+
+	/**
+	 * Eligible, canonical Bluesky-handle form of the current site's host.
+	 *
+	 * Returns `''` when the site is not in a shape that can legally host a
+	 * Bluesky domain handle — subdirectory install, non-routable host, or
+	 * an internationalized name that this server can't encode to punycode
+	 * (`intl` extension missing). Returns the lowercased ASCII handle
+	 * otherwise — punycoded for IDN sites, exactly as the AT Protocol
+	 * handle lexicon expects and as Bluesky_Domain_Handle::set_handle()
+	 * would store it.
+	 *
+	 * Shared by the recovery handler and renderer so the gate, the
+	 * alsoKnownAs comparison, and the persisted handle string all agree
+	 * about what "this site's handle" is. Diverging here is how the panel
+	 * ends up either offered on an ineligible install or comparing a
+	 * raw IDN host against the DID's punycoded entry.
+	 *
+	 * @return string
+	 */
+	private function get_eligible_canonical_site_host(): string {
+		if ( ! class_exists( Bluesky_Domain_Handle::class ) ) {
+			return '';
+		}
+		if ( ! Bluesky_Domain_Handle::is_root_install() ) {
+			return '';
+		}
+		if ( ! Bluesky_Domain_Handle::is_resolvable_host() ) {
+			return '';
+		}
+		return Bluesky_Domain_Handle::get_target_handle();
+	}
+
+	/**
+	 * Clear the persisted Bluesky identity from this site.
+	 *
+	 * Counterpart to {@see self::handle_restore_identity()}. Disconnect now
+	 * preserves `atmosphere_identity` so a domain-handle site can reconnect
+	 * without losing the bidirectional verification anchor. That contract
+	 * leaves no in-product path to fully sever the DID link in two real
+	 * cases:
+	 *
+	 *  1. Site transfer / ownership change. The previous owner's DID stays
+	 *     advertised by `/.well-known/atproto-did` and the publication
+	 *     link tag until somebody clears it.
+	 *  2. Recovery undo. The admin pastes the wrong DID into the recovery
+	 *     panel (phish, support thread mix-up). The success notice echoes
+	 *     the persisted DID/PDS as a sanity check, but the admin still
+	 *     needs a button to revert if it looks wrong.
+	 *
+	 * The action is deliberately destructive — once cleared, the
+	 * well-known route 404s and external resolvers stop trusting any
+	 * cached binding. Capability + nonce gated like every other admin-post
+	 * handler in this class.
+	 *
+	 * @return void
+	 */
+	public function handle_forget_identity(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'fosse' ) );
+		}
+
+		check_admin_referer( 'fosse_forget_bluesky_identity' );
+
+		// Capture the DID before deletion so the notice can confirm what
+		// just went away (and so a "did nothing" double-click on a fresh
+		// install doesn't read as success).
+		$cleared_did = '';
+		if ( function_exists( '\Atmosphere\get_did' ) ) {
+			$cleared_did = (string) \Atmosphere\get_did();
+		}
+
+		if ( '' === $cleared_did ) {
+			$this->redirect_with_notice(
+				__( 'There is no Bluesky identity on file to forget.', 'fosse' ),
+				'info'
+			);
+			return;
+		}
+
+		delete_option( 'atmosphere_identity' );
+
+		// Re-read to verify the delete landed. A hostile
+		// `pre_option_atmosphere_identity` filter or a sticky autoloaded
+		// row could otherwise leave the option in place while the handler
+		// reports success.
+		if ( function_exists( '\Atmosphere\has_identity' ) && \Atmosphere\has_identity() ) {
+			$this->redirect_with_notice(
+				__( 'Could not clear the Bluesky identity. The option may be pinned by a filter or stuck in autoload. Check database write access and try again.', 'fosse' ),
+				'error'
+			);
+			return;
+		}
+
+		$this->redirect_with_notice(
+			sprintf(
+				/* translators: %s: DID that was cleared (e.g. did:plc:abcdef…). */
+				__( 'Forgot Bluesky identity %s. This site no longer claims that DID; the .well-known/atproto-did route now returns 404.', 'fosse' ),
+				$cleared_did
 			),
 			'success'
 		);

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -1248,15 +1248,28 @@ class Bluesky_Provider implements Connection_Provider {
 		// autoload=true matches Atmosphere\get_identity()'s lazy-migration write
 		// so subsequent get_option() calls hit the autoloaded cache rather than
 		// re-fetching from the options table.
-		update_option(
-			'atmosphere_identity',
-			array(
-				'did'          => $did,
-				'handle'       => $site_host,
-				'pds_endpoint' => $pds,
-			),
-			true
+		$identity = array(
+			'did'          => $did,
+			'handle'       => $site_host,
+			'pds_endpoint' => $pds,
 		);
+		update_option( 'atmosphere_identity', $identity, true );
+
+		// `update_option()` returns false both on DB write failure AND on
+		// "value didn't change" (e.g. a hostile filter pinning the option,
+		// or a stale autoloaded row that matches), so the return value
+		// alone isn't a reliable success signal. Re-read the option and
+		// verify the DID landed — if it didn't, surface the failure
+		// instead of cheerfully telling the admin recovery succeeded
+		// while the well-known route stays dark.
+		$persisted = get_option( 'atmosphere_identity', array() );
+		if ( ! is_array( $persisted ) || ( $persisted['did'] ?? '' ) !== $did ) {
+			$this->redirect_with_notice(
+				__( 'Could not persist the restored Bluesky identity. The option write failed or was overridden by a filter. Check database write access and try again.', 'fosse' ),
+				'error'
+			);
+			return;
+		}
 
 		$this->redirect_with_notice(
 			sprintf(

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -384,6 +384,7 @@ class Bluesky_Provider implements Connection_Provider {
 						<?php submit_button( __( 'Connect Bluesky', 'fosse' ), 'primary', 'submit', false ); ?>
 					</div>
 				</form>
+				<?php $this->render_identity_recovery_panel(); ?>
 			<?php else : ?>
 				<div class="fosse-card-body">
 					<p>
@@ -565,6 +566,83 @@ class Bluesky_Provider implements Connection_Provider {
 	}
 
 	/**
+	 * Render the collapsed "Restore from DID" recovery panel.
+	 *
+	 * Surfaces below the primary Connect form on the disconnected state.
+	 * Collapsed by default — most users never need it. The escape hatch
+	 * is for sites that adopted the site domain as their Bluesky handle
+	 * and lost `atmosphere_identity` (older Atmosphere disconnects wiped
+	 * it; a backup restore that excluded the option does the same). With
+	 * identity empty, `/.well-known/atproto-did` 404s, the handle
+	 * resolver finds nothing, and reconnect with the domain handle is
+	 * impossible — `handle_restore_identity()` rebuilds the verification
+	 * anchor from a DID the user can read off bsky.app.
+	 *
+	 * Only renders when there's no persisted identity at all. A site
+	 * with a previously-persisted identity that just needs reauth has
+	 * the normal Connect path; this panel would only be a confusing
+	 * second option for them.
+	 *
+	 * @return void
+	 */
+	private function render_identity_recovery_panel(): void {
+		if ( function_exists( '\Atmosphere\has_identity' ) && \Atmosphere\has_identity() ) {
+			return;
+		}
+
+		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
+		if ( ! is_string( $site_host ) || '' === $site_host ) {
+			return;
+		}
+		?>
+		<details class="fosse-identity-recovery">
+			<summary>
+				<?php esc_html_e( 'Trouble reconnecting with your domain as a handle? Restore from a DID.', 'fosse' ); ?>
+			</summary>
+			<div class="fosse-card-body">
+				<p>
+					<?php
+					echo esc_html(
+						sprintf(
+							/* translators: %s: WordPress site host (e.g. example.com). */
+							__( 'Use this if you previously used FOSSE to set %s as your Bluesky handle and the Connect step now fails with "Could not resolve handle to a DID". Paste your Bluesky DID (find it in bsky.app under Settings → Account, or in the profile URL once logged in). FOSSE fetches the DID document, verifies it lists this site as one of your handles, and restores the verification endpoint so reconnect works.', 'fosse' ),
+							$site_host
+						)
+					);
+					?>
+				</p>
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="fosse_restore_bluesky_identity" />
+					<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'fosse_restore_bluesky_identity' ) ); ?>" />
+
+					<div class="fosse-field">
+						<label class="fosse-field__label" for="fosse_bluesky_did"><?php esc_html_e( 'Bluesky DID', 'fosse' ); ?></label>
+						<div class="fosse-field__control">
+							<input
+								type="text"
+								class="regular-text"
+								name="bluesky_did"
+								id="fosse_bluesky_did"
+								placeholder="did:plc:..."
+								autocomplete="off"
+								spellcheck="false"
+							/>
+							<p class="description">
+								<?php esc_html_e( 'Format: did:plc: followed by 24 lowercase letters or digits, or did:web: followed by a hostname.', 'fosse' ); ?>
+							</p>
+						</div>
+					</div>
+
+					<div class="fosse-card-footer fosse-action-bar">
+						<?php submit_button( __( 'Restore identity from DID', 'fosse' ), 'secondary', 'submit', false ); ?>
+					</div>
+				</form>
+			</div>
+		</details>
+		<?php
+	}
+
+	/**
 	 * Render the Bluesky status card on the FOSSE Status page.
 	 *
 	 * @return void
@@ -664,6 +742,7 @@ class Bluesky_Provider implements Connection_Provider {
 		add_action( 'admin_post_fosse_connect_bluesky', array( $this, 'handle_connect' ) );
 		add_action( 'admin_post_fosse_disconnect_bluesky', array( $this, 'handle_disconnect' ) );
 		add_action( 'admin_post_fosse_set_bluesky_domain_handle', array( $this, 'handle_set_domain_handle' ) );
+		add_action( 'admin_post_fosse_restore_bluesky_identity', array( $this, 'handle_restore_identity' ) );
 		add_action( 'admin_post_fosse_enable_bluesky_auto_publish', array( $this, 'handle_enable_auto_publish' ) );
 		add_action( 'admin_init', array( $this, 'handle_oauth_callback' ) );
 		add_action( 'admin_notices', array( $this, 'maybe_render_auto_publish_disabled_notice' ) );
@@ -1027,6 +1106,166 @@ class Bluesky_Provider implements Connection_Provider {
 
 		wp_safe_redirect( $this->get_redirect_url( $return_context ) );
 		exit;
+	}
+
+	/**
+	 * Restore `atmosphere_identity` from a DID submitted by the admin.
+	 *
+	 * Recovery escape hatch for sites that previously adopted the site
+	 * domain as their Bluesky handle and lost the persisted identity (e.g.
+	 * disconnected on a pre-fix Atmosphere release that wiped
+	 * `atmosphere_identity`, or restored from a backup that excluded the
+	 * option). With identity gone, `/.well-known/atproto-did` 404s and the
+	 * AT Protocol handle resolver has nothing to find — `handle_to_did()`
+	 * fails on both DNS TXT and HTTPS well-known, so reconnect with the
+	 * domain handle is impossible without first restoring the option.
+	 *
+	 * Flow:
+	 *  1. Capability + nonce gate.
+	 *  2. Validate DID syntax (`did:plc:<24 lowercase alnum>` or `did:web:<host>`).
+	 *  3. Fetch the DID document via {@see \Atmosphere\OAuth\Resolver::resolve_did()}.
+	 *  4. Bind to the site: the document's `alsoKnownAs` MUST include
+	 *     `at://<site-host>`. This is the integrity gate that blocks both
+	 *     accidental wrong-DID entry and deliberate impersonation — only a
+	 *     DID that already lists this WordPress site as one of its handles
+	 *     can attach itself here.
+	 *  5. Extract the PDS endpoint via {@see \Atmosphere\OAuth\Resolver::pds_from_did_doc()}.
+	 *  6. Write `atmosphere_identity` with the trio FOSSE/Atmosphere
+	 *     expect (`did`, `handle`, `pds_endpoint`), `autoload=true` to
+	 *     match {@see \Atmosphere\get_identity()}.
+	 *
+	 * The user still has to complete a fresh OAuth flow afterwards — this
+	 * only restores the bidirectional verification anchor so the resolver
+	 * chain works.
+	 *
+	 * @return void
+	 */
+	public function handle_restore_identity(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'fosse' ) );
+		}
+
+		check_admin_referer( 'fosse_restore_bluesky_identity' );
+
+		$did = trim( sanitize_text_field( wp_unslash( $_POST['bluesky_did'] ?? '' ) ) );
+
+		if ( '' === $did ) {
+			$this->redirect_with_notice(
+				__( 'Enter your Bluesky DID to restore the connection.', 'fosse' ),
+				'error'
+			);
+			return;
+		}
+
+		// Strict DID syntax: did:plc with a 24-char base32-ish suffix (the
+		// canonical PLC identifier shape) or did:web with a DNS-style host.
+		// Anything outside these two methods isn't supported by the resolver
+		// downstream, so rejecting here gives a clearer error than letting
+		// resolve_did() fall through to "Unsupported DID method".
+		if ( ! preg_match( '/^did:plc:[a-z0-9]{24}$/', $did )
+			&& ! preg_match( '/^did:web:[a-z0-9.-]+$/', $did )
+		) {
+			$this->redirect_with_notice(
+				__( 'That doesn\'t look like a valid AT Protocol DID. It should start with did:plc: or did:web:.', 'fosse' ),
+				'error'
+			);
+			return;
+		}
+
+		if ( ! class_exists( '\Atmosphere\OAuth\Resolver' )
+			|| ! method_exists( '\Atmosphere\OAuth\Resolver', 'resolve_did' )
+			|| ! method_exists( '\Atmosphere\OAuth\Resolver', 'pds_from_did_doc' )
+		) {
+			$this->redirect_with_notice(
+				__( 'Identity recovery is unavailable: the bundled Atmosphere is missing the resolver API.', 'fosse' ),
+				'error'
+			);
+			return;
+		}
+
+		$did_doc = \Atmosphere\OAuth\Resolver::resolve_did( $did );
+		if ( is_wp_error( $did_doc ) ) {
+			$this->redirect_with_notice(
+				sprintf(
+					/* translators: %s: upstream error message from DID document lookup. */
+					__( 'Could not fetch the DID document: %s', 'fosse' ),
+					$did_doc->get_error_message()
+				),
+				'error'
+			);
+			return;
+		}
+
+		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
+		if ( ! is_string( $site_host ) || '' === $site_host ) {
+			$this->redirect_with_notice(
+				__( 'Could not determine this site\'s hostname. Check the WordPress Address (URL) in Settings → General.', 'fosse' ),
+				'error'
+			);
+			return;
+		}
+		$site_host = strtolower( $site_host );
+
+		$expected_aka = 'at://' . $site_host;
+		$also_known   = array();
+		if ( isset( $did_doc['alsoKnownAs'] ) && is_array( $did_doc['alsoKnownAs'] ) ) {
+			foreach ( $did_doc['alsoKnownAs'] as $aka ) {
+				if ( is_string( $aka ) ) {
+					$also_known[] = strtolower( $aka );
+				}
+			}
+		}
+
+		if ( ! in_array( $expected_aka, $also_known, true ) ) {
+			$listed = empty( $also_known )
+				? __( '(none)', 'fosse' )
+				: implode( ', ', array_slice( $also_known, 0, 3 ) );
+			$this->redirect_with_notice(
+				sprintf(
+					/* translators: 1: WordPress site host (e.g. example.com); 2: comma-separated list of at:// handles the DID document actually lists. */
+					__( 'This DID does not list %1$s as one of its handles (its document claims: %2$s). FOSSE only restores identity for a DID whose document lists this site.', 'fosse' ),
+					$site_host,
+					$listed
+				),
+				'error'
+			);
+			return;
+		}
+
+		$pds = \Atmosphere\OAuth\Resolver::pds_from_did_doc( $did_doc );
+		if ( is_wp_error( $pds ) ) {
+			$this->redirect_with_notice(
+				sprintf(
+					/* translators: %s: upstream error message from PDS extraction. */
+					__( 'Could not find a PDS endpoint in the DID document: %s', 'fosse' ),
+					$pds->get_error_message()
+				),
+				'error'
+			);
+			return;
+		}
+
+		// autoload=true matches Atmosphere\get_identity()'s lazy-migration write
+		// so subsequent get_option() calls hit the autoloaded cache rather than
+		// re-fetching from the options table.
+		update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => $did,
+				'handle'       => $site_host,
+				'pds_endpoint' => $pds,
+			),
+			true
+		);
+
+		$this->redirect_with_notice(
+			sprintf(
+				/* translators: %s: site host the user can now reconnect with (e.g. example.com). */
+				__( 'Restored Bluesky identity. You can now reconnect using %s as your handle.', 'fosse' ),
+				$site_host
+			),
+			'success'
+		);
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_Domain_HandleTest.php
+++ b/tests/php/Admin/Bluesky_Domain_HandleTest.php
@@ -38,6 +38,7 @@ class Bluesky_Domain_HandleTest extends BaseTestCase {
 		$this->reset_filters();
 		delete_option( Bluesky_Domain_Handle::OPTION_PREVIOUS_HANDLE );
 		delete_option( 'atmosphere_connection' );
+		delete_option( 'atmosphere_identity' );
 		delete_option( 'home' );
 		delete_option( 'siteurl' );
 
@@ -693,11 +694,25 @@ class Bluesky_Domain_HandleTest extends BaseTestCase {
 
 	/**
 	 * Successful revert clears the snapshot, syncs the locally-cached
-	 * connection handle, and posts an info notice.
+	 * connection handle, clears `atmosphere_identity` (so the well-known
+	 * route stops advertising a DID the PDS-side handle no longer claims),
+	 * and posts an info notice.
 	 */
 	public function test_maybe_revert_on_disconnect_success_clears_option(): void {
 		$this->seed_connection( 'example.com' );
 		$this->seed_snapshot( 'did:plc:test123', 'alice.bsky.social' );
+		// Seed identity so we can assert it gets cleared. Without the
+		// clear, /.well-known/atproto-did keeps serving did:plc:test123
+		// against a domain the account no longer claims.
+		update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://bsky.social',
+			),
+			true
+		);
 
 		$received = null;
 		add_filter(
@@ -720,6 +735,13 @@ class Bluesky_Domain_HandleTest extends BaseTestCase {
 		$connection = get_option( 'atmosphere_connection' );
 		$this->assertSame( 'alice.bsky.social', $connection['handle'] );
 
+		// Identity must be cleared on a successful revert so the
+		// well-known route stops advertising a now-orphaned binding.
+		$this->assertFalse(
+			get_option( 'atmosphere_identity' ),
+			'Successful revert must clear atmosphere_identity so .well-known/atproto-did stops serving the now-orphaned DID.'
+		);
+
 		$messages = wp_list_pluck( get_settings_errors( 'atmosphere' ), 'message' );
 		$this->assertNotEmpty(
 			array_filter(
@@ -739,6 +761,16 @@ class Bluesky_Domain_HandleTest extends BaseTestCase {
 	public function test_maybe_revert_on_disconnect_failure_preserves_option_without_notice(): void {
 		$this->seed_connection( 'example.com' );
 		$this->seed_snapshot( 'did:plc:test123', 'alice.bsky.social' );
+		// Seed identity so we can assert it is preserved across a failed
+		// revert. The PDS-side handle is still `example.com` (the revert
+		// didn't land), so the well-known route should keep serving the
+		// DID — exactly the state the recovery panel exists to preserve.
+		$seeded_identity = array(
+			'did'          => 'did:plc:test123',
+			'handle'       => 'example.com',
+			'pds_endpoint' => 'https://bsky.social',
+		);
+		update_option( 'atmosphere_identity', $seeded_identity, true );
 
 		add_filter(
 			Bluesky_Domain_Handle::FILTER_PRE_UPDATE,
@@ -754,6 +786,17 @@ class Bluesky_Domain_HandleTest extends BaseTestCase {
 				'handle' => 'alice.bsky.social',
 			),
 			get_option( Bluesky_Domain_Handle::OPTION_PREVIOUS_HANDLE )
+		);
+
+		// Failed revert must preserve atmosphere_identity. The PDS-side
+		// handle is still the site's domain, so the well-known anchor
+		// remains accurate; clearing it here would break reconnect for a
+		// user whose revert temporarily failed (token issue, network
+		// hiccup) but who still has a valid domain-handle binding.
+		$this->assertSame(
+			$seeded_identity,
+			get_option( 'atmosphere_identity' ),
+			'Failed revert must preserve atmosphere_identity — the PDS-side handle binding still holds.'
 		);
 
 		$this->assertEmpty(

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -78,6 +78,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'pre_option_atmosphere_connection' );
 		remove_all_filters( 'pre_option_atmosphere_identity' );
+		remove_all_filters( 'pre_update_option_atmosphere_identity' );
 		remove_all_filters( Bluesky_Domain_Handle::FILTER_ENABLED );
 		remove_all_filters( Bluesky_Domain_Handle::FILTER_PRE_UPDATE );
 		remove_all_filters( 'home_url' );
@@ -102,6 +103,8 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		remove_all_filters( 'wp_die_handler' );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'pre_option_atmosphere_connection' );
+		remove_all_filters( 'pre_option_atmosphere_identity' );
+		remove_all_filters( 'pre_update_option_atmosphere_identity' );
 	}
 
 	/**
@@ -333,6 +336,56 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$this->assertStringContainsString( 'Connect Bluesky', $output );
 		$this->assertStringContainsString( 'Disconnected', $output );
 		$this->assertStringNotContainsString( 'class="form-table"', $output );
+	}
+
+	/**
+	 * Disconnected sites without a persisted AT Protocol identity get a
+	 * quiet secondary recovery disclosure after the primary Connect action.
+	 */
+	public function test_render_connection_actions_disconnected_shows_identity_recovery_when_identity_missing(): void {
+		$this->force_home_url( 'https://example.com' );
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		$output = ob_get_clean();
+
+		$connect_position  = strpos( $output, 'Connect Bluesky' );
+		$recovery_position = strpos( $output, 'Trouble reconnecting a domain handle?' );
+
+		$this->assertStringContainsString( 'class="fosse-identity-recovery"', $output );
+		$this->assertStringContainsString( 'class="fosse-identity-recovery__summary"', $output );
+		$this->assertStringContainsString( 'Trouble reconnecting a domain handle?', $output );
+		$this->assertStringContainsString( 'fosse_restore_bluesky_identity', $output );
+		$this->assertStringContainsString( 'name="bluesky_did"', $output );
+		$this->assertStringContainsString( 'aria-describedby="fosse_bluesky_did_description"', $output );
+		$this->assertStringContainsString( 'https://bsky.app/settings/account', $output );
+		$this->assertIsInt( $connect_position );
+		$this->assertIsInt( $recovery_position );
+		$this->assertGreaterThan( $connect_position, $recovery_position );
+		$this->assertStringNotContainsString( 'Trouble reconnecting with your domain as a handle? Restore from a DID.', $output );
+	}
+
+	/**
+	 * Disconnected-but-identified sites should use the normal reconnect form
+	 * only; showing DID recovery there would create a second path for users
+	 * who already have the verification anchor needed for reconnect.
+	 */
+	public function test_render_connection_actions_disconnected_omits_identity_recovery_when_identity_exists(): void {
+		update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://bsky.social',
+			)
+		);
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'fosse-identity-recovery', $output );
+		$this->assertStringNotContainsString( 'fosse_restore_bluesky_identity', $output );
 	}
 
 	/**
@@ -2506,6 +2559,36 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * Mock a plc.directory DID document lookup.
+	 *
+	 * @param string               $did      DID to match in the request URL.
+	 * @param array<string, mixed> $document Decoded DID document response.
+	 * @return void
+	 */
+	private function mock_did_document_response( string $did, array $document ): void {
+		$body = (string) wp_json_encode(
+			$document,
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( $did, $body ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, 'plc.directory/' . $did ) ) {
+					return $preempt;
+				}
+
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $body,
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
 	 * Seed the OAuth transients Atmosphere\OAuth\Client::handle_callback()
 	 * expects to find when validating an inbound callback.
 	 *
@@ -3280,9 +3363,9 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	 * .well-known/atproto-did route starts serving again.
 	 */
 	public function test_handle_restore_identity_writes_atmosphere_identity(): void {
-		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature requires the URL arg even though we always return the override.
-
-		$body = (string) wp_json_encode(
+		$this->force_home_url( 'https://example.com' );
+		$this->mock_did_document_response(
+			'did:plc:abcdefghij1234567890wxyz',
 			array(
 				'id'          => 'did:plc:abcdefghij1234567890wxyz',
 				'alsoKnownAs' => array( 'at://example.com' ),
@@ -3293,22 +3376,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 						'serviceEndpoint' => 'https://pds.example.com',
 					),
 				),
-			),
-			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
-		);
-		add_filter(
-			'pre_http_request',
-			static function ( $preempt, $parsed_args, $url ) use ( $body ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
-				if ( false === strpos( (string) $url, 'plc.directory/did:plc:abcdefghij1234567890wxyz' ) ) {
-					return $preempt;
-				}
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => $body,
-				);
-			},
-			10,
-			3
+			)
 		);
 
 		$this->become_admin();
@@ -3347,6 +3415,74 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$errors = get_settings_errors( 'atmosphere' );
 		$types  = wp_list_pluck( $errors, 'type' );
 		$this->assertContains( 'success', $types );
+	}
+
+	/**
+	 * Restore identity must not report success unless the option write
+	 * actually converges on the desired identity payload.
+	 */
+	public function test_handle_restore_identity_reports_error_when_identity_write_fails(): void {
+		$this->force_home_url( 'https://example.com' );
+		$this->mock_did_document_response(
+			'did:plc:abcdefghij1234567890wxyz',
+			array(
+				'id'          => 'did:plc:abcdefghij1234567890wxyz',
+				'alsoKnownAs' => array( 'at://example.com' ),
+				'service'     => array(
+					array(
+						'id'              => '#atproto_pds',
+						'type'            => 'AtprotoPersonalDataServer',
+						'serviceEndpoint' => 'https://pds.example.com',
+					),
+				),
+			)
+		);
+		add_filter(
+			'pre_update_option_atmosphere_identity',
+			static function ( $value, $old_value ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature.
+				return $old_value;
+			},
+			10,
+			2
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( get_option( 'atmosphere_identity', false ) );
+
+		$errors   = get_settings_errors( 'atmosphere' );
+		$types    = wp_list_pluck( $errors, 'type' );
+		$messages = wp_list_pluck( $errors, 'message' );
+
+		$this->assertContains( 'error', $types );
+		$this->assertNotContains( 'success', $types );
+		$this->assertNotEmpty(
+			array_filter(
+				$messages,
+				static fn( $message ) => false !== strpos( (string) $message, 'Could not persist the restored Bluesky identity' )
+			)
+		);
 	}
 
 	/**
@@ -3402,9 +3538,9 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	 * would start serving a DID that doesn't actually belong to this site.
 	 */
 	public function test_handle_restore_identity_rejects_did_with_mismatched_aka(): void {
-		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature requires the URL arg even though we always return the override.
-
-		$body = (string) wp_json_encode(
+		$this->force_home_url( 'https://example.com' );
+		$this->mock_did_document_response(
+			'did:plc:abcdefghij1234567890wxyz',
 			array(
 				'id'          => 'did:plc:abcdefghij1234567890wxyz',
 				'alsoKnownAs' => array( 'at://someone-else.test' ),
@@ -3415,22 +3551,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 						'serviceEndpoint' => 'https://pds.example.com',
 					),
 				),
-			),
-			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
-		);
-		add_filter(
-			'pre_http_request',
-			static function ( $preempt, $parsed_args, $url ) use ( $body ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
-				if ( false === strpos( (string) $url, 'plc.directory/did:plc:abcdefghij1234567890wxyz' ) ) {
-					return $preempt;
-				}
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => $body,
-				);
-			},
-			10,
-			3
+			)
 		);
 
 		$this->become_admin();

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -4314,6 +4314,60 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * A stale Forget form from a disconnected tab must not clear identity
+	 * after the admin reconnects in another tab. Otherwise the site keeps
+	 * valid OAuth credentials while its DID verification anchor disappears.
+	 */
+	public function test_handle_forget_identity_rejects_while_connected(): void {
+		$this->seed_connected_atmosphere_connection();
+
+		$identity = array(
+			'did'          => 'did:plc:abcdefghij1234567890wxyz',
+			'handle'       => 'example.com',
+			'pds_endpoint' => 'https://pds.example.com',
+		);
+		update_option( 'atmosphere_identity', $identity, true );
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => wp_create_nonce( 'fosse_forget_bluesky_identity' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_forget_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( $identity, get_option( 'atmosphere_identity' ), 'Forget must not clear identity while the site is connected.' );
+		$this->assertTrue( \Atmosphere\is_connected(), 'Forget must not disconnect or orphan the OAuth connection.' );
+
+		$errors   = get_settings_errors( 'atmosphere' );
+		$types    = wp_list_pluck( $errors, 'type' );
+		$messages = wp_list_pluck( $errors, 'message' );
+
+		$this->assertContains( 'error', $types );
+		$this->assertNotContains( 'success', $types );
+		$this->assertNotEmpty(
+			array_filter(
+				$messages,
+				static fn( $message ) => false !== strpos( (string) $message, 'Disconnect Bluesky before forgetting this site' )
+			)
+		);
+	}
+
+	/**
 	 * Forget on a site with no identity on file returns an info notice,
 	 * not an error — a double-click on a fresh install shouldn't read as
 	 * a failure.

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -3279,7 +3279,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	 * .well-known/atproto-did route starts serving again.
 	 */
 	public function test_handle_restore_identity_writes_atmosphere_identity(): void {
-		add_filter( 'home_url', static fn() => 'https://example.com', 10, 1 );
+		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature requires the URL arg even though we always return the override.
 
 		$body = (string) wp_json_encode(
 			array(
@@ -3401,7 +3401,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	 * would start serving a DID that doesn't actually belong to this site.
 	 */
 	public function test_handle_restore_identity_rejects_did_with_mismatched_aka(): void {
-		add_filter( 'home_url', static fn() => 'https://example.com', 10, 1 );
+		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature requires the URL arg even though we always return the override.
 
 		$body = (string) wp_json_encode(
 			array(
@@ -3463,6 +3463,146 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		$errors = get_settings_errors( 'atmosphere' );
 		$types  = wp_list_pluck( $errors, 'type' );
 		$this->assertContains( 'error', $types );
+	}
+
+	/**
+	 * Restore identity: a successful DID-doc fetch followed by an option
+	 * write that gets reverted by a hostile filter must surface an error,
+	 * not a cheerful success. update_option's return value is ambiguous
+	 * (false means either "DB failure" or "value didn't change"), so the
+	 * handler re-reads the option and verifies the DID landed before
+	 * declaring victory.
+	 */
+	public function test_handle_restore_identity_surfaces_persist_failure(): void {
+		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature requires the URL arg.
+
+		$body = (string) wp_json_encode(
+			array(
+				'id'          => 'did:plc:abcdefghij1234567890wxyz',
+				'alsoKnownAs' => array( 'at://example.com' ),
+				'service'     => array(
+					array(
+						'id'              => '#atproto_pds',
+						'type'            => 'AtprotoPersonalDataServer',
+						'serviceEndpoint' => 'https://pds.example.com',
+					),
+				),
+			),
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( $body ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, 'plc.directory/did:plc:abcdefghij1234567890wxyz' ) ) {
+					return $preempt;
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $body,
+				);
+			},
+			10,
+			3
+		);
+
+		// Pin the option to a sentinel that won't match the DID we're
+		// trying to write. Simulates either a DB write failure or a
+		// hostile filter overriding the option.
+		add_filter(
+			'pre_option_atmosphere_identity',
+			static fn() => array( 'did' => 'did:plc:different0000000000wxyz' )
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = wp_list_pluck( $errors, 'type' );
+		$this->assertContains( 'error', $types, 'Handler must surface an error when the option write does not persist.' );
+		$this->assertNotContains( 'success', $types, 'Handler must NOT tell the admin recovery succeeded if the option write failed.' );
+	}
+
+	/**
+	 * Recovery panel visibility: render_connection_actions surfaces the
+	 * "Restore from DID" disclosure ONLY when there's no persisted
+	 * identity. A site with a healthy connection or a previously-set
+	 * identity (reauth-needed but identity intact) must not see the
+	 * panel — it would be confusing noise on screens where the normal
+	 * Connect path already works.
+	 */
+	public function test_render_connection_actions_shows_recovery_panel_when_identity_missing(): void {
+		// Disconnected AND no identity — the stuck state the panel targets.
+		delete_option( 'atmosphere_connection' );
+		delete_option( 'atmosphere_identity' );
+
+		$this->become_admin();
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		$html = (string) ob_get_clean();
+
+		$this->assertStringContainsString(
+			'fosse-identity-recovery',
+			$html,
+			'Recovery panel must render on the disconnected state when has_identity() is false.'
+		);
+		$this->assertStringContainsString(
+			'fosse_restore_bluesky_identity',
+			$html,
+			'Recovery panel form must wire to the fosse_restore_bluesky_identity admin-post action.'
+		);
+	}
+
+	/**
+	 * Recovery panel visibility: suppressed when an identity is on file,
+	 * even though the connection is gone. This is the reauth-needed state
+	 * — identity is intact, the user just needs to reconnect. Showing the
+	 * recovery panel there would offer a confusing second path for a
+	 * problem the normal Connect button already solves.
+	 */
+	public function test_render_connection_actions_hides_recovery_panel_when_identity_present(): void {
+		delete_option( 'atmosphere_connection' );
+		update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:abcdefghij1234567890wxyz',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+			),
+			true
+		);
+
+		$this->become_admin();
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		$html = (string) ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'fosse-identity-recovery',
+			$html,
+			'Recovery panel must NOT render when has_identity() is true — Connect handles the reauth case.'
+		);
 	}
 
 	/**

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -77,6 +77,7 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		remove_all_filters( 'status_header' );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'pre_option_atmosphere_connection' );
+		remove_all_filters( 'pre_option_atmosphere_identity' );
 		remove_all_filters( Bluesky_Domain_Handle::FILTER_ENABLED );
 		remove_all_filters( Bluesky_Domain_Handle::FILTER_PRE_UPDATE );
 		remove_all_filters( 'home_url' );
@@ -3636,5 +3637,737 @@ class Bluesky_ProviderTest extends BaseTestCase {
 
 		$this->assertTrue( $threw, 'Non-admin must be blocked with wp_die().' );
 		$this->assertFalse( get_option( 'atmosphere_identity', false ) );
+	}
+
+	/**
+	 * Bundled-atmosphere regression: `Client::disconnect()` must not delete
+	 * `atmosphere_identity`. The whole PR is built on this invariant; a
+	 * future resync that re-introduced the delete would break every
+	 * domain-handle site without any FOSSE-side test catching it.
+	 */
+	public function test_disconnect_preserves_atmosphere_identity(): void {
+		$identity = array(
+			'did'          => 'did:plc:testidentity1234567890',
+			'handle'       => 'example.com',
+			'pds_endpoint' => 'https://pds.example.com',
+		);
+		update_option( 'atmosphere_identity', $identity, true );
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:testidentity1234567890',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		\Atmosphere\OAuth\Client::disconnect();
+
+		$this->assertSame( array(), get_option( 'atmosphere_connection', array() ), 'Disconnect must clear atmosphere_connection.' );
+		$this->assertSame(
+			$identity,
+			get_option( 'atmosphere_identity' ),
+			'Disconnect must preserve atmosphere_identity so .well-known/atproto-did keeps serving and the user can reconnect with a domain handle.'
+		);
+	}
+
+	/**
+	 * Recovery handler rejects when identity is already on file. The
+	 * renderer hides the panel in that case, but the admin-post hook
+	 * stays wired up — a stale form tab or a direct POST with a valid
+	 * nonce could otherwise overwrite identity on a connected site,
+	 * producing split-brain state where get_status() reports the
+	 * connected DID while the well-known route serves the overwritten
+	 * DID.
+	 */
+	public function test_handle_restore_identity_rejects_when_identity_already_present(): void {
+		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature.
+
+		$existing = array(
+			'did'          => 'did:plc:existing0000000000000',
+			'handle'       => 'example.com',
+			'pds_endpoint' => 'https://pds.example.com',
+		);
+		update_option( 'atmosphere_identity', $existing, true );
+
+		$http_called = false;
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt ) use ( &$http_called ) {
+				$http_called = true;
+				return $preempt;
+			}
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:attacker00000000000000',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertSame( $existing, get_option( 'atmosphere_identity' ), 'Existing identity must not be overwritten.' );
+		$this->assertFalse( $http_called, 'Handler must short-circuit before fetching the DID document when identity already exists.' );
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = wp_list_pluck( $errors, 'type' );
+		$this->assertContains( 'error', $types );
+	}
+
+	/**
+	 * Recovery handler refuses to run when the site isn't in an eligible
+	 * shape to host a Bluesky domain handle (subdirectory install,
+	 * non-routable host, port-bearing URL). Without this, the panel can
+	 * report success on `example.com/blog` and then the user discovers
+	 * reconnect still fails because the well-known route can't actually
+	 * serve from the subpath. Mirrors the eligibility checks
+	 * `Bluesky_Domain_Handle::set_handle()` already enforces.
+	 */
+	public function test_handle_restore_identity_rejects_when_site_ineligible(): void {
+		// Subdirectory install — is_root_install() returns false.
+		add_filter( 'home_url', static fn( $url ) => 'https://example.com/blog', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature.
+
+		$http_called = false;
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt ) use ( &$http_called ) {
+				$http_called = true;
+				return $preempt;
+			}
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( get_option( 'atmosphere_identity', false ) );
+		$this->assertFalse( $http_called, 'Handler must short-circuit before any HTTP call when the site is ineligible.' );
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = wp_list_pluck( $errors, 'type' );
+		$this->assertContains( 'error', $types );
+	}
+
+	/**
+	 * Tightened persist re-check catches handle drift, not just DID drift.
+	 * A hostile `pre_option_atmosphere_identity` filter could pin the
+	 * same DID but a different handle — the well-known route stays
+	 * correct (DID matches) but `Atmosphere\get_identity()['handle']`
+	 * and the publication link tag silently operate on the attacker
+	 * value. Handler must refuse.
+	 */
+	public function test_handle_restore_identity_persist_check_catches_handle_drift(): void {
+		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature.
+
+		$body = (string) wp_json_encode(
+			array(
+				'id'          => 'did:plc:abcdefghij1234567890wxyz',
+				'alsoKnownAs' => array( 'at://example.com' ),
+				'service'     => array(
+					array(
+						'id'              => '#atproto_pds',
+						'type'            => 'AtprotoPersonalDataServer',
+						'serviceEndpoint' => 'https://pds.example.com',
+					),
+				),
+			),
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( $body ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, 'plc.directory/did:plc:abcdefghij1234567890wxyz' ) ) {
+					return $preempt;
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $body,
+				);
+			},
+			10,
+			3
+		);
+
+		// Pin to same DID + same PDS but ATTACKER handle.
+		add_filter(
+			'pre_option_atmosphere_identity',
+			static fn() => array(
+				'did'          => 'did:plc:abcdefghij1234567890wxyz',
+				'handle'       => 'attacker.example',
+				'pds_endpoint' => 'https://pds.example.com',
+			)
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = wp_list_pluck( $errors, 'type' );
+		$this->assertContains( 'error', $types, 'Handler must report failure when the persisted handle differs from what was written.' );
+		$this->assertNotContains( 'success', $types );
+	}
+
+	/**
+	 * Recovery success after writing must make `Atmosphere\has_identity()`
+	 * return true. The raw-option assertion alone could pass through a
+	 * lazy-migration or filter quirk that leaves `has_identity()` still
+	 * false, in which case the well-known route stays dark and recovery
+	 * is meaningless.
+	 */
+	public function test_handle_restore_identity_success_makes_has_identity_true(): void {
+		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature.
+
+		$body = (string) wp_json_encode(
+			array(
+				'id'          => 'did:plc:abcdefghij1234567890wxyz',
+				'alsoKnownAs' => array( 'at://example.com' ),
+				'service'     => array(
+					array(
+						'id'              => '#atproto_pds',
+						'type'            => 'AtprotoPersonalDataServer',
+						'serviceEndpoint' => 'https://pds.example.com',
+					),
+				),
+			),
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( $body ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, 'plc.directory' ) ) {
+					return $preempt;
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $body,
+				);
+			},
+			10,
+			3
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertTrue(
+			\Atmosphere\has_identity(),
+			'After a successful restore, has_identity() must return true so .well-known/atproto-did starts serving the DID.'
+		);
+
+		$messages = wp_list_pluck( get_settings_errors( 'atmosphere' ), 'message' );
+		$this->assertNotEmpty(
+			array_filter(
+				$messages,
+				static fn( $m ) => false !== strpos( $m, 'did:plc:abcdefghij1234567890wxyz' )
+					&& false !== strpos( $m, 'https://pds.example.com' )
+			),
+			'Success notice must echo the persisted DID and PDS so the admin can verify before reauthorizing.'
+		);
+	}
+
+	/**
+	 * Empty / missing DID submission short-circuits with a clear error
+	 * before any HTTP traffic.
+	 */
+	public function test_handle_restore_identity_rejects_empty_did(): void {
+		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature.
+
+		$http_called = false;
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt ) use ( &$http_called ) {
+				$http_called = true;
+				return $preempt;
+			}
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => '   ',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( get_option( 'atmosphere_identity', false ) );
+		$this->assertFalse( $http_called );
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = wp_list_pluck( $errors, 'type' );
+		$this->assertContains( 'error', $types );
+	}
+
+	/**
+	 * Resolver returning WP_Error (network failure, plc.directory 5xx) is
+	 * surfaced to the admin with the upstream message, not collapsed into
+	 * a generic success/failure.
+	 */
+	public function test_handle_restore_identity_surfaces_resolver_wp_error(): void {
+		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature.
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, 'plc.directory' ) ) {
+					return $preempt;
+				}
+				return new \WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' );
+			},
+			10,
+			3
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( get_option( 'atmosphere_identity', false ) );
+
+		$messages = wp_list_pluck( get_settings_errors( 'atmosphere' ), 'message' );
+		$this->assertNotEmpty(
+			array_filter(
+				$messages,
+				static fn( $m ) => false !== strpos( $m, 'Could not fetch the DID document' )
+			)
+		);
+	}
+
+	/**
+	 * DID document missing the required `service` entry must surface as a
+	 * concrete error from `pds_from_did_doc()` rather than silently
+	 * passing through.
+	 */
+	public function test_handle_restore_identity_surfaces_pds_extraction_error(): void {
+		add_filter( 'home_url', static fn( $url ) => 'https://example.com', 10, 1 ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- filter signature.
+
+		$body = (string) wp_json_encode(
+			array(
+				'id'          => 'did:plc:abcdefghij1234567890wxyz',
+				'alsoKnownAs' => array( 'at://example.com' ),
+				// Intentionally no `service` array — pds_from_did_doc()
+				// returns atmosphere_no_pds.
+			),
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( $body ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, 'plc.directory' ) ) {
+					return $preempt;
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $body,
+				);
+			},
+			10,
+			3
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( get_option( 'atmosphere_identity', false ) );
+
+		$messages = wp_list_pluck( get_settings_errors( 'atmosphere' ), 'message' );
+		$this->assertNotEmpty(
+			array_filter(
+				$messages,
+				static fn( $m ) => false !== strpos( $m, 'PDS endpoint' )
+			)
+		);
+	}
+
+	/**
+	 * Bad nonce → wp_die. Same pattern as every other admin-post handler
+	 * in this class; missing on `handle_restore_identity` was a coverage
+	 * gap previously surfaced in review.
+	 */
+	public function test_handle_restore_identity_rejects_bad_nonce(): void {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => 'invalid-nonce',
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_die_handler',
+			static fn() => static function () {
+				throw new \RuntimeException( 'wp_die' );
+			}
+		);
+
+		$threw = false;
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( \RuntimeException $e ) {
+			$threw = 'wp_die' === $e->getMessage();
+		}
+
+		$this->assertTrue( $threw, 'Bad nonce must be blocked with wp_die().' );
+		$this->assertFalse( get_option( 'atmosphere_identity', false ) );
+	}
+
+	// ---------- handle_forget_identity ----------
+
+	/**
+	 * Forget identity clears `atmosphere_identity` and surfaces a success
+	 * notice that echoes the cleared DID so the admin sees exactly what
+	 * was removed.
+	 */
+	public function test_handle_forget_identity_clears_persisted_identity(): void {
+		$cleared = array(
+			'did'          => 'did:plc:abcdefghij1234567890wxyz',
+			'handle'       => 'example.com',
+			'pds_endpoint' => 'https://pds.example.com',
+		);
+		update_option( 'atmosphere_identity', $cleared, true );
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => wp_create_nonce( 'fosse_forget_bluesky_identity' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_forget_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( get_option( 'atmosphere_identity', false ), 'Forget must delete atmosphere_identity.' );
+		$this->assertFalse( \Atmosphere\has_identity(), 'has_identity() must return false after forget.' );
+
+		$messages = wp_list_pluck( get_settings_errors( 'atmosphere' ), 'message' );
+		$this->assertNotEmpty(
+			array_filter(
+				$messages,
+				static fn( $m ) => false !== strpos( $m, 'did:plc:abcdefghij1234567890wxyz' )
+			),
+			'Success notice must echo the cleared DID for audit visibility.'
+		);
+	}
+
+	/**
+	 * Forget on a site with no identity on file returns an info notice,
+	 * not an error — a double-click on a fresh install shouldn't read as
+	 * a failure.
+	 */
+	public function test_handle_forget_identity_when_no_identity_present(): void {
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => wp_create_nonce( 'fosse_forget_bluesky_identity' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_forget_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = wp_list_pluck( $errors, 'type' );
+		$this->assertContains( 'info', $types );
+		$this->assertNotContains( 'error', $types, 'No-op forget must not read as a failure.' );
+	}
+
+	/**
+	 * Forget is a destructive admin-only action — subscribers are blocked
+	 * with wp_die just like every other admin-post handler in this class.
+	 */
+	public function test_handle_forget_identity_rejects_subscriber(): void {
+		update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:abcdefghij1234567890wxyz',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+			),
+			true
+		);
+
+		$this->become_subscriber();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => wp_create_nonce( 'fosse_forget_bluesky_identity' ),
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_die_handler',
+			static fn() => static function () {
+				throw new \RuntimeException( 'wp_die' );
+			}
+		);
+
+		$threw = false;
+		try {
+			$this->provider->handle_forget_identity();
+		} catch ( \RuntimeException $e ) {
+			$threw = 'wp_die' === $e->getMessage();
+		}
+
+		$this->assertTrue( $threw, 'Subscriber must be blocked with wp_die().' );
+		$this->assertNotFalse( get_option( 'atmosphere_identity', false ), 'Identity must NOT be cleared when subscriber attempt is blocked.' );
+	}
+
+	/**
+	 * Forget with a bad nonce → wp_die. CSRF defense.
+	 */
+	public function test_handle_forget_identity_rejects_bad_nonce(): void {
+		update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:abcdefghij1234567890wxyz',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+			),
+			true
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce' => 'invalid-nonce',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_die_handler',
+			static fn() => static function () {
+				throw new \RuntimeException( 'wp_die' );
+			}
+		);
+
+		$threw = false;
+		try {
+			$this->provider->handle_forget_identity();
+		} catch ( \RuntimeException $e ) {
+			$threw = 'wp_die' === $e->getMessage();
+		}
+
+		$this->assertTrue( $threw );
+		$this->assertNotFalse( get_option( 'atmosphere_identity', false ) );
+	}
+
+	/**
+	 * Forget panel renders on the disconnected state when identity is on
+	 * file — the case where the admin wants to fully sever the link.
+	 * The recovery panel does NOT render in this state (identity exists);
+	 * the Forget panel is the visible action.
+	 */
+	public function test_render_connection_actions_shows_forget_panel_when_disconnected_with_identity(): void {
+		delete_option( 'atmosphere_connection' );
+		update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:abcdefghij1234567890wxyz',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+			),
+			true
+		);
+
+		$this->become_admin();
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		$html = (string) ob_get_clean();
+
+		$this->assertStringContainsString(
+			'fosse-identity-forget',
+			$html,
+			'Forget panel must render when disconnected with identity on file.'
+		);
+		$this->assertStringContainsString(
+			'fosse_forget_bluesky_identity',
+			$html,
+			'Forget form must wire to the fosse_forget_bluesky_identity admin-post action.'
+		);
+		$this->assertStringNotContainsString(
+			'fosse-identity-recovery',
+			$html,
+			'Recovery panel must NOT render when identity already exists.'
+		);
+	}
+
+	/**
+	 * Forget panel is suppressed when no identity is on file (nothing to
+	 * forget). The recovery panel is the one that renders in this state.
+	 */
+	public function test_render_connection_actions_hides_forget_panel_when_no_identity(): void {
+		delete_option( 'atmosphere_connection' );
+		delete_option( 'atmosphere_identity' );
+
+		$this->become_admin();
+
+		ob_start();
+		$this->provider->render_connection_actions();
+		$html = (string) ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'fosse-identity-forget',
+			$html,
+			'Forget panel must NOT render when there is no identity to forget.'
+		);
 	}
 }

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -3267,4 +3267,234 @@ class Bluesky_ProviderTest extends BaseTestCase {
 		// Snapshot is preserved — the legitimate account may reconnect later.
 		$this->assertNotFalse( get_option( Bluesky_Domain_Handle::OPTION_PREVIOUS_HANDLE ) );
 	}
+
+	/**
+	 * Restore identity: success path writes atmosphere_identity from a DID
+	 * whose document lists the site host in alsoKnownAs.
+	 *
+	 * Recovery escape hatch for sites that lost identity (e.g. pre-fix
+	 * disconnect that wiped it). The handler fetches the DID document via
+	 * Resolver::resolve_did, verifies the bidirectional claim, extracts
+	 * the PDS endpoint, and persists the identity trio so the
+	 * .well-known/atproto-did route starts serving again.
+	 */
+	public function test_handle_restore_identity_writes_atmosphere_identity(): void {
+		add_filter( 'home_url', static fn() => 'https://example.com', 10, 1 );
+
+		$body = (string) wp_json_encode(
+			array(
+				'id'          => 'did:plc:abcdefghij1234567890wxyz',
+				'alsoKnownAs' => array( 'at://example.com' ),
+				'service'     => array(
+					array(
+						'id'              => '#atproto_pds',
+						'type'            => 'AtprotoPersonalDataServer',
+						'serviceEndpoint' => 'https://pds.example.com',
+					),
+				),
+			),
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( $body ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, 'plc.directory/did:plc:abcdefghij1234567890wxyz' ) ) {
+					return $preempt;
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $body,
+				);
+			},
+			10,
+			3
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$identity = get_option( 'atmosphere_identity' );
+		$this->assertSame(
+			array(
+				'did'          => 'did:plc:abcdefghij1234567890wxyz',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+			),
+			$identity
+		);
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = wp_list_pluck( $errors, 'type' );
+		$this->assertContains( 'success', $types );
+	}
+
+	/**
+	 * Restore identity: malformed DID is rejected before any HTTP traffic.
+	 * The user gets an actionable hint rather than a confusing upstream
+	 * "Unsupported DID method" error from the resolver.
+	 */
+	public function test_handle_restore_identity_rejects_malformed_did(): void {
+		$http_called = false;
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt ) use ( &$http_called ) {
+				$http_called = true;
+				return $preempt;
+			}
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'not-a-did',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse( get_option( 'atmosphere_identity', false ) );
+		$this->assertFalse( $http_called, 'Malformed DID must short-circuit before any HTTP call to plc.directory.' );
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = wp_list_pluck( $errors, 'type' );
+		$this->assertContains( 'error', $types );
+	}
+
+	/**
+	 * Restore identity: a DID whose document does NOT list this site in
+	 * alsoKnownAs is rejected. This is the integrity gate — without it, a
+	 * site admin could claim someone else's DID and the well-known route
+	 * would start serving a DID that doesn't actually belong to this site.
+	 */
+	public function test_handle_restore_identity_rejects_did_with_mismatched_aka(): void {
+		add_filter( 'home_url', static fn() => 'https://example.com', 10, 1 );
+
+		$body = (string) wp_json_encode(
+			array(
+				'id'          => 'did:plc:abcdefghij1234567890wxyz',
+				'alsoKnownAs' => array( 'at://someone-else.test' ),
+				'service'     => array(
+					array(
+						'id'              => '#atproto_pds',
+						'type'            => 'AtprotoPersonalDataServer',
+						'serviceEndpoint' => 'https://pds.example.com',
+					),
+				),
+			),
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( $body ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- pre_http_request signature.
+				if ( false === strpos( (string) $url, 'plc.directory/did:plc:abcdefghij1234567890wxyz' ) ) {
+					return $preempt;
+				}
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => $body,
+				);
+			},
+			10,
+			3
+		);
+
+		$this->become_admin();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_redirect',
+			static function () {
+				throw new RedirectFired( 'redirect' );
+			}
+		);
+
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( RedirectFired $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- redirect is expected.
+			unset( $e );
+		}
+
+		$this->assertFalse(
+			get_option( 'atmosphere_identity', false ),
+			'Identity must NOT be written when the DID document does not list this site.'
+		);
+
+		$errors = get_settings_errors( 'atmosphere' );
+		$types  = wp_list_pluck( $errors, 'type' );
+		$this->assertContains( 'error', $types );
+	}
+
+	/**
+	 * Restore identity: non-admin subscriber is blocked with wp_die. This
+	 * is an option-write endpoint; only manage_options users may invoke it.
+	 */
+	public function test_handle_restore_identity_rejects_subscriber(): void {
+		$this->become_subscriber();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- test setup.
+		$_POST    = array(
+			'_wpnonce'    => wp_create_nonce( 'fosse_restore_bluesky_identity' ),
+			'bluesky_did' => 'did:plc:abcdefghij1234567890wxyz',
+		);
+		$_REQUEST = $_POST;
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		add_filter(
+			'wp_die_handler',
+			static fn() => static function () {
+				throw new \RuntimeException( 'wp_die' );
+			}
+		);
+
+		$threw = false;
+		try {
+			$this->provider->handle_restore_identity();
+		} catch ( \RuntimeException $e ) {
+			$threw = 'wp_die' === $e->getMessage();
+		}
+
+		$this->assertTrue( $threw, 'Non-admin must be blocked with wp_die().' );
+		$this->assertFalse( get_option( 'atmosphere_identity', false ) );
+	}
 }

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -3665,69 +3665,6 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
-	 * Recovery panel visibility: render_connection_actions surfaces the
-	 * "Restore from DID" disclosure ONLY when there's no persisted
-	 * identity. A site with a healthy connection or a previously-set
-	 * identity (reauth-needed but identity intact) must not see the
-	 * panel — it would be confusing noise on screens where the normal
-	 * Connect path already works.
-	 */
-	public function test_render_connection_actions_shows_recovery_panel_when_identity_missing(): void {
-		// Disconnected AND no identity — the stuck state the panel targets.
-		delete_option( 'atmosphere_connection' );
-		delete_option( 'atmosphere_identity' );
-
-		$this->become_admin();
-
-		ob_start();
-		$this->provider->render_connection_actions();
-		$html = (string) ob_get_clean();
-
-		$this->assertStringContainsString(
-			'fosse-identity-recovery',
-			$html,
-			'Recovery panel must render on the disconnected state when has_identity() is false.'
-		);
-		$this->assertStringContainsString(
-			'fosse_restore_bluesky_identity',
-			$html,
-			'Recovery panel form must wire to the fosse_restore_bluesky_identity admin-post action.'
-		);
-	}
-
-	/**
-	 * Recovery panel visibility: suppressed when an identity is on file,
-	 * even though the connection is gone. This is the reauth-needed state
-	 * — identity is intact, the user just needs to reconnect. Showing the
-	 * recovery panel there would offer a confusing second path for a
-	 * problem the normal Connect button already solves.
-	 */
-	public function test_render_connection_actions_hides_recovery_panel_when_identity_present(): void {
-		delete_option( 'atmosphere_connection' );
-		update_option(
-			'atmosphere_identity',
-			array(
-				'did'          => 'did:plc:abcdefghij1234567890wxyz',
-				'handle'       => 'example.com',
-				'pds_endpoint' => 'https://pds.example.com',
-			),
-			true
-		);
-
-		$this->become_admin();
-
-		ob_start();
-		$this->provider->render_connection_actions();
-		$html = (string) ob_get_clean();
-
-		$this->assertStringNotContainsString(
-			'fosse-identity-recovery',
-			$html,
-			'Recovery panel must NOT render when has_identity() is true — Connect handles the reauth case.'
-		);
-	}
-
-	/**
 	 * Restore identity: non-admin subscriber is blocked with wp_die. This
 	 * is an option-write endpoint; only manage_options users may invoke it.
 	 */


### PR DESCRIPTION
## Summary

Sites that adopted their own domain as a Bluesky handle (via FOSSE's "Use my domain as my Bluesky handle" panel) could get permanently locked out of reconnecting after a disconnect. Two changes fix the bug and add a recovery path for sites already stuck.

## The bug

`OAuth\Client::disconnect()` in bundled Atmosphere was deleting `atmosphere_identity` alongside the OAuth session. That option drives the bidirectional verification headers — `/.well-known/atproto-did` and the publication link tag. Once the option is gone:

1. The well-known route 404s on the site.
2. `Resolver::handle_to_did()` tries DNS TXT for `_atproto.<domain>` (typically not set) and the HTTPS well-known (now 404), and returns `Could not resolve handle <domain> to a DID.`
3. The user is stuck — the PDS-side handle is still their domain, but no public mechanism publishes the DID anymore.

Bluesky's own `resolveHandle` AppView depends on the same resolution chain, so even the bsky.app frontend can't find the user via their domain handle while in this state.

## What this PR ships

### 1. Upstream fix, resynced into bundled Atmosphere

Removed `delete_option( 'atmosphere_identity' )` from `OAuth\Client::disconnect()`. Identity is the bidirectional-verification anchor; the identity/connection split (see `get_identity()` docstring) was designed specifically so token failures wouldn't break verification headers — explicit disconnect was violating that same invariant. The OAuth session still drops cleanly; reconnecting refreshes identity in place.

Upstream PR: Automattic/wordpress-atmosphere#85
Commit: `fix: preserve atmosphere_identity across OAuth disconnect`

### 2. FOSSE-side recovery escape hatch for already-stuck sites

For sites running an older Atmosphere release (or restored from a backup that excluded `atmosphere_identity`), the fix above doesn't help — identity is already gone. Added a "Restore from DID" recovery panel in the Bluesky admin card.

- Collapsed `<details>` disclosure under the Connect form, only rendered when `! \Atmosphere\has_identity()` (no noise for healthy installs)
- Single field: paste a `did:plc:...` or `did:web:...`
- Handler `Bluesky_Provider::handle_restore_identity()` (admin-post, nonce + `manage_options` gated):
  1. Validates DID syntax
  2. Fetches the DID document via `Resolver::resolve_did()`
  3. **Safety gate:** the document's `alsoKnownAs` MUST include `at://<this-site-host>` — refuses to claim a DID that doesn't list this site (blocks both accidental wrong-DID entry and deliberate impersonation)
  4. Extracts the PDS endpoint via `Resolver::pds_from_did_doc()`
  5. Writes `atmosphere_identity` with `did`, `handle`, `pds_endpoint` (autoload=true, matching `get_identity()`)
- 4 new tests in `Bluesky_ProviderTest`: success path, malformed DID short-circuit, alsoKnownAs mismatch, subscriber rejection

Commit: `add: restore-identity admin escape hatch for stuck domain-handle sites`

## Test plan

- [ ] **Regression coverage on the disconnect fix.** With the bundled fix applied:
  1. Connect via OAuth → confirm `wp option get atmosphere_identity` returns a DID/handle/pds_endpoint trio.
  2. `curl https://<site>/.well-known/atproto-did` returns the DID.
  3. Disconnect. `atmosphere_identity` is **still present**; `atmosphere_connection` is gone.
  4. `curl` the well-known route — still returns the DID.
  5. Reconnect with the same handle. Resolver succeeds; OAuth completes; identity overwrites in place.
- [ ] **Recovery panel — happy path.** On a site with no `atmosphere_identity` (delete via `wp option delete atmosphere_identity` if needed):
  1. Visit FOSSE settings; Bluesky panel shows disconnected state.
  2. Below the Connect form, the "Trouble reconnecting with your domain as a handle?" disclosure is visible. Expand it.
  3. Paste your DID (the one whose document lists this site in `alsoKnownAs`), click "Restore identity from DID".
  4. Success notice appears; `wp option get atmosphere_identity` now returns the full trio.
  5. `curl` the well-known — returns the DID.
  6. Click Connect Bluesky with your domain handle — OAuth proceeds normally.
- [ ] **Recovery panel — safety gate.** Paste a DID that does NOT list this site in `alsoKnownAs` (e.g. someone else's DID like `did:plc:z72i7hdynmk6r22z27h6tvur`). Expect an error notice naming the alsoKnownAs values the document actually claims, and `atmosphere_identity` remains unset.
- [ ] **Recovery panel — bad input.** Paste `not-a-did`. Expect an error notice; no HTTP request to plc.directory is made; `atmosphere_identity` remains unset.
- [ ] **Recovery panel visibility.** Connect normally. Reload FOSSE settings — the disclosure must NOT render (`has_identity()` is true).
- [ ] **Test suite.** `composer test-php` — 761 tests pass. `tools/vendor/bin/phpcs` — clean.

## Related

- Upstream PR Automattic/wordpress-atmosphere#85
- Recent FOSSE PR 166 switched the well-known route from `is_connected()` to `has_identity()` (same family of bug, same anchor option); this PR completes the design intent by ensuring `has_identity()` actually remains true across disconnect.