### PR TITLE
fix: Photo_Post detect() correctness edges from PR 155 review

### DIFF
--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -420,12 +420,6 @@ class Photo_Post {
 
 			if ( 'core/paragraph' === $name ) {
 				$inner_html = $block['innerHTML'] ?? '';
-				// An empty paragraph block ("<p></p>") is structural
-				// padding from the editor, not a real caption.
-				$inner = \trim( \wp_strip_all_tags( $inner_html ) );
-				if ( '' === $inner ) {
-					continue;
-				}
 				// Inline `<img>` / `<figure>` inside a paragraph
 				// block lands in the same cascade as the freeform
 				// branch above: `filter_content()`'s orphan-img
@@ -437,9 +431,21 @@ class Photo_Post {
 				// Treat as unresolvable so Rule 1's format bypass
 				// disqualifies the post and the figure stays
 				// inline in the article body.
+				//
+				// Check the raw innerHTML BEFORE the empty-text
+				// guard below: a paragraph whose only content is
+				// `<img>` strips to empty text but still carries an
+				// image that would vanish on federation. Reversing
+				// the order would `continue` past this case.
 				if ( \preg_match( '#<(?:img|figure)\b#i', $inner_html ) ) {
 					++$other_count;
 					++$unresolvable_image_count;
+					continue;
+				}
+				// An empty paragraph block ("<p></p>") is structural
+				// padding from the editor, not a real caption.
+				$inner = \trim( \wp_strip_all_tags( $inner_html ) );
+				if ( '' === $inner ) {
 					continue;
 				}
 				++$paragraph_count;

--- a/src/class-photo-post.php
+++ b/src/class-photo-post.php
@@ -257,9 +257,23 @@ class Photo_Post {
 	 * @return bool True if the post matches one of the built-in rules.
 	 */
 	private static function detect( WP_Post $post ): bool {
+		// Bundled AP supports disabling attachments entirely via
+		// `activitypub_max_image_attachments = 0`. Photo treatment
+		// makes no sense in that mode — the content stripper would
+		// remove every image figure while AP emits zero attachments,
+		// leaving a caption-only Note with no image. Reject before
+		// ANY rule fires (including the empty-body / featured-image
+		// early return below) so the cap-zero contract holds for
+		// the "set thumbnail, hit publish" flow too.
+		$max_attachments = self::get_max_image_attachments( $post );
+		if ( $max_attachments <= 0 ) {
+			return false;
+		}
+
 		$format        = \get_post_format( $post );
 		$has_format    = 'image' === $format || 'gallery' === $format;
 		$has_thumbnail = self::has_image_thumbnail( $post );
+		$thumbnail_id  = $has_thumbnail ? (int) \get_post_thumbnail_id( $post ) : 0;
 
 		// Empty body + featured image = "Set thumbnail, hit publish"
 		// flow (Rule 3 with zero paragraphs). Catch this before the
@@ -298,20 +312,20 @@ class Photo_Post {
 		$paragraph_count          = 0;
 		$other_count              = 0;
 		$unresolvable_image_count = 0;
-		// Flattened count of individual images that would actually
-		// federate as attachments. `image_count` counts image-like
-		// BLOCKS for Rule 2's shape check ("exactly one image-like
-		// block"), but `total_image_count` counts gallery children
-		// individually so the `max_image_attachments` cap can be
-		// compared against what bundled AP will really emit.
-		$total_image_count = 0;
-		// True when a `core/post-featured-image` block is present in
-		// the body. Bundled AP unshifts the post thumbnail into the
-		// media list AND extracts the featured-image block via
-		// `get_block_attachments`, then dedupes by id — both resolve
-		// to the same attachment. Tracking this lets the cap check
-		// avoid double-counting one image as two.
-		$has_featured_image_block = false;
+		// Resolvable attachment ids contributed by image-like blocks
+		// in document order (`core/image` ids and `core/gallery`
+		// inner `core/image` ids; `core/post-featured-image` blocks
+		// contribute nothing here because their resolved id is the
+		// thumbnail id, which is appended once after the loop). The
+		// `activitypub_max_image_attachments` cap compares against
+		// `count( array_unique( … ) )` of this list plus the
+		// thumbnail id — bundled AP dedupes by id before applying
+		// the cap, so any attachment that appears via multiple
+		// paths (featured-image block + thumbnail, or `core/image`
+		// block carrying the same id as the thumbnail) must count
+		// once. Tracking ids rather than a flat count means the
+		// dedup happens naturally on the cap comparison.
+		$attachment_ids = array();
 
 		foreach ( $blocks as $block ) {
 			$name = $block['blockName'] ?? null;
@@ -385,9 +399,17 @@ class Photo_Post {
 				// the external URL stays in the body.
 				if ( self::block_resolves_locally( $block, $post ) ) {
 					++$image_count;
-					$total_image_count += self::count_resolvable_images( $block, $post );
-					if ( 'core/post-featured-image' === $name ) {
-						$has_featured_image_block = true;
+					// Collect attachment ids contributed by this
+					// block. `block_image_ids()` returns the
+					// resolvable `core/image` and gallery-child
+					// ids; `core/post-featured-image` blocks
+					// contribute nothing here because the thumbnail
+					// id is appended once after the loop. Deduping
+					// the combined list against the cap matches
+					// what bundled AP actually emits after its own
+					// id-based dedup.
+					foreach ( self::block_image_ids( $block, $post ) as $id ) {
+						$attachment_ids[] = $id;
 					}
 				} else {
 					++$other_count;
@@ -397,10 +419,27 @@ class Photo_Post {
 			}
 
 			if ( 'core/paragraph' === $name ) {
+				$inner_html = $block['innerHTML'] ?? '';
 				// An empty paragraph block ("<p></p>") is structural
 				// padding from the editor, not a real caption.
-				$inner = \trim( \wp_strip_all_tags( $block['innerHTML'] ?? '' ) );
+				$inner = \trim( \wp_strip_all_tags( $inner_html ) );
 				if ( '' === $inner ) {
+					continue;
+				}
+				// Inline `<img>` / `<figure>` inside a paragraph
+				// block lands in the same cascade as the freeform
+				// branch above: `filter_content()`'s orphan-img
+				// pass strips the image, but bundled AP's block
+				// extractor only walks `core/image` /
+				// `core/gallery` / `core/cover` — it doesn't scan
+				// paragraph innerHTML — so the inline image
+				// disappears entirely from the federated post.
+				// Treat as unresolvable so Rule 1's format bypass
+				// disqualifies the post and the figure stays
+				// inline in the article body.
+				if ( \preg_match( '#<(?:img|figure)\b#i', $inner_html ) ) {
+					++$other_count;
+					++$unresolvable_image_count;
 					continue;
 				}
 				++$paragraph_count;
@@ -419,30 +458,19 @@ class Photo_Post {
 		// every figure inline AND still emits the first `cap`
 		// images as supplementary attachments, so receivers never
 		// see fewer images than the body declares.
-		// Effective attachment count: resolvable images in the body
-		// PLUS the featured image when set (bundled AP unshifts the
-		// thumbnail into the media list before walking blocks).
-		// Skip the thumbnail bump when a `core/post-featured-image`
-		// block is already in the body — that block resolves to the
-		// same attachment id, and bundled AP dedupes by id before
-		// emitting attachments. Counting it twice would over-report
-		// against the cap and reject otherwise-valid single-photo
-		// posts when the cap is set tight (e.g., 1).
-		$effective_image_count = $total_image_count;
-		if ( $has_thumbnail && ! $has_featured_image_block ) {
-			++$effective_image_count;
+		// Effective attachment count: unique resolvable ids across
+		// every source bundled AP considers — the post thumbnail
+		// (unshifted into the media list) plus every id contributed
+		// by image-like blocks. Deduping by id mirrors bundled AP's
+		// own pre-cap dedup, so an attachment that appears via
+		// multiple paths (featured image + matching `core/image`
+		// block, or `core/post-featured-image` block + thumbnail)
+		// counts once instead of inflating the cap comparison.
+		if ( $thumbnail_id > 0 ) {
+			$attachment_ids[] = $thumbnail_id;
 		}
+		$effective_image_count = \count( \array_unique( $attachment_ids ) );
 
-		// Bundled AP supports disabling attachments entirely via
-		// `activitypub_max_image_attachments = 0`. Photo treatment
-		// makes no sense in that mode — the content stripper would
-		// remove every image figure while AP emits zero attachments,
-		// leaving a caption-only Note with no image. Reject before
-		// any rule fires.
-		$max_attachments = self::get_max_image_attachments( $post );
-		if ( $max_attachments <= 0 ) {
-			return false;
-		}
 		if ( $effective_image_count > $max_attachments ) {
 			return false;
 		}
@@ -601,46 +629,6 @@ class Photo_Post {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Flattened count of individual resolvable images an image-like
-	 * block would contribute as AP attachments. For `core/image` and
-	 * `core/post-featured-image` that's 1; for `core/gallery` it's
-	 * the count of resolvable inner `core/image` children. Used for
-	 * the `activitypub_max_image_attachments` cap check — that cap
-	 * operates on individual images, not on image-bearing blocks.
-	 *
-	 * @param array<string, mixed> $block The parsed block.
-	 * @param \WP_Post             $post  The post being evaluated.
-	 * @return int Count of resolvable images contributed by the block.
-	 */
-	private static function count_resolvable_images( array $block, WP_Post $post ): int {
-		$name = $block['blockName'] ?? '';
-
-		if ( 'core/post-featured-image' === $name ) {
-			return self::has_image_thumbnail( $post ) ? 1 : 0;
-		}
-
-		if ( 'core/image' === $name ) {
-			$id = (int) ( $block['attrs']['id'] ?? 0 );
-			return $id > 0 && \wp_attachment_is_image( $id ) ? 1 : 0;
-		}
-
-		if ( 'core/gallery' === $name ) {
-			$count        = 0;
-			$inner_blocks = $block['innerBlocks'] ?? array();
-			if ( \is_array( $inner_blocks ) ) {
-				foreach ( $inner_blocks as $sub_block ) {
-					if ( \is_array( $sub_block ) ) {
-						$count += self::count_resolvable_images( $sub_block, $post );
-					}
-				}
-			}
-			return $count;
-		}
-
-		return 0;
 	}
 
 	/**

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -584,6 +584,48 @@ class Photo_PostTest extends BaseTestCase {
 	}
 
 	/**
+	 * `core/image` block carrying the same attachment id as the
+	 * post's Featured Image is one image to bundled AP — its
+	 * extraction pipeline dedupes by attachment id before applying
+	 * the cap. FOSSE's cap math must agree: count the unique
+	 * resolvable ids across every source (thumbnail + block ids),
+	 * not the sum of separate counts. With cap=1, a post that
+	 * embeds its featured image as a `core/image` block in the
+	 * body must still detect as a photo post — pre-fix this
+	 * incorrectly counted 2 (1 from the block + 1 from the
+	 * thumbnail bump) and rejected the post even though AP would
+	 * emit exactly one attachment.
+	 */
+	public function test_core_image_block_matching_thumbnail_id_does_not_double_count_against_cap(): void {
+		add_filter(
+			'activitypub_max_image_attachments',
+			static function () {
+				return 1;
+			}
+		);
+
+		// Build a post whose Featured Image AND inline `core/image`
+		// block both point at the same attachment id. The fixture
+		// attachment from setUp (`$this->image_id`) doubles as the
+		// thumbnail so the block markup and `_thumbnail_id` postmeta
+		// agree.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => '',
+				'post_content' => $this->resolve_image_placeholders(
+					'<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+				),
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		update_post_meta( $post_id, '_thumbnail_id', $this->image_id );
+		$post = get_post( $post_id );
+
+		$this->assertTrue( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
 	 * `activitypub_max_image_attachments = 0` disables attachments
 	 * entirely in bundled AP. Photo treatment in that mode would
 	 * strip image figures while AP emits nothing — caption-only
@@ -607,6 +649,30 @@ class Photo_PostTest extends BaseTestCase {
 	}
 
 	/**
+	 * Regression: an empty body + Featured Image normally triggers
+	 * Rule 3's "set thumbnail, hit publish" early return at the top
+	 * of `detect()`. With `activitypub_max_image_attachments = 0` the
+	 * cap-zero rejection must fire FIRST — otherwise photo treatment
+	 * strips the (empty) body to caption-only Note while bundled AP
+	 * emits zero attachments, leaving a Note with neither caption
+	 * nor image. Mirrors the
+	 * `test_zero_attachment_cap_rejects_photo_treatment` regression
+	 * for the empty-body / featured-image entry path.
+	 */
+	public function test_zero_attachment_cap_rejects_empty_body_with_thumbnail(): void {
+		add_filter(
+			'activitypub_max_image_attachments',
+			static function () {
+				return 0;
+			}
+		);
+
+		$post = $this->make_post( '', '', '', 1 );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
 	 * Freeform / classic-editor body with an inline `<img>` (no
 	 * block wrapper, no `attrs.id` — typically an external URL)
 	 * must NOT pass Rule 1 even when a Featured Image anchors
@@ -617,6 +683,27 @@ class Photo_PostTest extends BaseTestCase {
 	 */
 	public function test_image_format_with_thumbnail_plus_freeform_inline_img_does_not_detect(): void {
 		$post = $this->make_post( '<p>See <img src="https://elsewhere.test/inline.jpg"/> the photo.</p>', '', 'image', 1 );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
+	 * Same cascade as the freeform-inline-`<img>` case, but for a
+	 * proper `core/paragraph` block whose innerHTML embeds an
+	 * inline `<img>` (e.g. an editor that pasted an external image
+	 * into a paragraph rather than wrapping it in a `core/image`
+	 * block). `filter_content()`'s orphan-img pass strips the
+	 * image, bundled AP's block extractor only walks
+	 * `core/image` / `core/gallery` / `core/cover` — it doesn't
+	 * scan paragraph innerHTML — so the inline image disappears
+	 * entirely from the federated post if Rule 1 fires. Detection
+	 * must treat the inline `<img>` as unresolvable so Rule 1's
+	 * format bypass disqualifies the post and the figure stays
+	 * inline in the article body.
+	 */
+	public function test_image_format_with_thumbnail_plus_paragraph_block_inline_img_does_not_detect(): void {
+		$paragraph_with_img = '<!-- wp:paragraph --><p>Look at <img src="https://elsewhere.test/inline.jpg"/> the photo.</p><!-- /wp:paragraph -->';
+		$post               = $this->make_post( $paragraph_with_img, '', 'image', 1 );
 
 		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
 	}

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -710,6 +710,27 @@ class Photo_PostTest extends BaseTestCase {
 	}
 
 	/**
+	 * Same cascade as the paragraph-block-with-text-and-img case
+	 * above, but the paragraph's innerHTML is just `<p><img/></p>` —
+	 * no surrounding text. `wp_strip_all_tags()` reduces this to an
+	 * empty string, so a check on stripped text would treat the
+	 * block as editor padding and skip it; the inline `<img>` then
+	 * vanishes on federation while detection still sees a single
+	 * resolvable `core/image` block and fires Rule 2. The raw-HTML
+	 * `<img>` / `<figure>` guard must run before the empty-text
+	 * skip so this case is treated as unresolvable.
+	 */
+	public function test_image_only_paragraph_block_treated_as_unresolvable(): void {
+		$image     = $this->resolve_image_placeholders(
+			'<!-- wp:image {"id":PHOTO_ID} --><figure class="wp-block-image"><img/></figure><!-- /wp:image -->'
+		);
+		$paragraph = '<!-- wp:paragraph --><p><img src="https://elsewhere.test/only.jpg"/></p><!-- /wp:paragraph -->';
+		$post      = $this->make_post( $image . $paragraph );
+
+		$this->assertFalse( Photo_Post::is_photo_post( $post ) );
+	}
+
+	/**
 	 * Per-post `activitypub_max_image_attachments` postmeta wins
 	 * over the site-level option/filter (mirrors bundled AP's read
 	 * order). A two-image gallery passes when the per-post override

--- a/tests/php/Photo_PostTest.php
+++ b/tests/php/Photo_PostTest.php
@@ -77,6 +77,7 @@ class Photo_PostTest extends BaseTestCase {
 		remove_all_filters( 'activitypub_attachment' );
 		remove_all_filters( 'fosse_pre_is_photo_post' );
 		remove_all_filters( 'fosse_is_photo_post' );
+		remove_all_filters( 'activitypub_max_image_attachments' );
 		remove_all_filters( 'get_the_terms' );
 		remove_all_filters( 'wp_insert_post_empty_content' );
 


### PR DESCRIPTION
## Summary

Three narrow misclassifications in `Photo_Post::detect()` surfaced by PR 155's final Copilot review (DOTCOM-17158). Each one cascades into the same shape: photo treatment fires, `filter_content()` strips image markup from the body, and bundled AP either emits zero attachments (caption-only Note with no image), drops the overflow (silently lost inline image), or — for the inverse case — rejects a single-photo post that AP would otherwise accept.

## What this PR ships

### Finding 1: empty body + Featured Image + cap=0 bypassed the cap-zero rejection

The empty-body + has-thumbnail early return at the top of `detect()` fired BEFORE the `activitypub_max_image_attachments <= 0` check further down, so the "set thumbnail, hit publish" flow with attachments disabled still classified as a photo. `filter_content()` then stripped the (empty) body to a caption-only Note while bundled AP emitted zero attachments — a Note with neither caption nor image.

**Fix:** move the cap-zero rejection to the very top of `detect()`, ahead of all classification rules including the empty-body early return.

### Finding 2: same attachment id double-counted across thumbnail + `core/image`

When a user dropped their featured image into the body as a `core/image` block (same attachment id as the thumbnail), the detector counted it twice: once from the block's contribution to `$total_image_count`, once from the thumbnail bump. Bundled AP dedupes by id before applying the cap, so the detector's math overshot — a tight cap (e.g. `activitypub_max_image_attachments = 1`) rejected single-photo posts AP would have happily emitted.

**Fix:** track resolvable attachment IDs across all sources (block IDs + thumbnail ID) and compare `count( array_unique( $attachment_ids ) )` against the cap. The dedup mirrors bundled AP's own pre-cap dedup. The previous `$total_image_count` / `$has_featured_image_block` bookkeeping collapses into the unique-id set, and `count_resolvable_images()` becomes dead code (removed).

### Finding 3: `core/paragraph` block with inline `<img>` not counted as unresolvable

Round 8 of PR 155's review closed the freeform / null-blockName branch's handling of inline `<img>` / `<figure>` (it bumps `$unresolvable_image_count` so Rule 1's format bypass disqualifies the post). The same logic was missing from the `core/paragraph` branch — a paragraph block like `<!-- wp:paragraph --><p>Look at <img src="..."/> the photo.</p><!-- /wp:paragraph -->` passed Rule 1 unchallenged. Then `filter_content()` stripped the orphan `<img>`, bundled AP's block extractor didn't scan paragraph innerHTML, and the inline image vanished entirely from the federated post.

**Fix:** mirror the freeform branch's `preg_match( '#<(?:img|figure)\b#i', ... )` guard inside the `core/paragraph` handling.

## Test plan

- [x] `composer run-script lint-php` — clean.
- [x] `composer run-script test-php` — 785 tests / 1780 assertions pass.
- [x] Three new regression tests in `Photo_PostTest` fail on trunk and pass after the fix:
  - `test_zero_attachment_cap_rejects_empty_body_with_thumbnail` (finding 1)
  - `test_core_image_block_matching_thumbnail_id_does_not_double_count_against_cap` (finding 2)
  - `test_image_format_with_thumbnail_plus_paragraph_block_inline_img_does_not_detect` (finding 3)
- [x] Verified by stashing only the source change and re-running the three filters — all three fail without the fix, all pass with it.
- [x] Existing PR 155 regression suite still passes (`test_zero_attachment_cap_rejects_photo_treatment`, `test_featured_image_block_with_thumbnail_does_not_double_count_against_cap`, `test_image_format_with_thumbnail_plus_freeform_inline_img_does_not_detect`, plus the broader Photo_Post coverage).

## Related

- Original PR 155 review thread (DOTCOM-17143) for context on the deferred findings.
- Fixes DOTCOM-17158.