### PR TITLE
fix: PR 27 code-review follow-ups (autoload notice, followers description, registry diagnostics, is_connected interface)

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -29,6 +29,35 @@ define( 'FOSSE_VERSION', '0.1.2-alpha' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload_packages.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload_packages.php';
+} else {
+	/*
+	 * Composer autoload missing. The rest of `fosse.php` already degrades
+	 * cleanly via `class_exists` guards (no menu, no projectors, no
+	 * provider boot), but that leaves an admin staring at silence. Surface
+	 * a `manage_options`-only notice so the operator knows the deploy is
+	 * incomplete instead of assuming FOSSE is broken or inactive.
+	 */
+	add_action(
+		'admin_notices',
+		static function () {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+			}
+			?>
+			<div class="notice notice-error">
+				<p>
+					<strong><?php esc_html_e( 'FOSSE is missing its Composer dependencies.', 'fosse' ); ?></strong>
+					<?php
+					esc_html_e(
+						'Run `composer install` inside the FOSSE plugin directory, or redeploy a release build that includes the `vendor/` directory. Most FOSSE features are disabled until this is resolved.',
+						'fosse'
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		}
+	);
 }
 
 /*

--- a/src/Admin/class-ap-provider.php
+++ b/src/Admin/class-ap-provider.php
@@ -113,6 +113,19 @@ class AP_Provider implements Connection_Provider {
 	}
 
 	/**
+	 * Whether ActivityPub is connected.
+	 *
+	 * AP has no external auth step — the bundled/standalone plugin is
+	 * either loaded (connected) or not. Mirrors the `connected` key of
+	 * {@see self::get_status()}.
+	 *
+	 * @return bool
+	 */
+	public function is_connected(): bool {
+		return (bool) $this->get_status()['connected'];
+	}
+
+	/**
 	 * Per-request memo for {@see self::get_status()}. The Status page
 	 * renders each provider's status twice in the same request — once
 	 * filtering on `connected`, once inside `render_status_card()` —
@@ -637,7 +650,10 @@ class AP_Provider implements Connection_Provider {
 			$count = \Activitypub\Collection\Followers::count( get_current_user_id() );
 			?>
 			<dt class="fosse-detail-list__term"><?php esc_html_e( 'Your Followers', 'fosse' ); ?></dt>
-			<dd class="fosse-detail-list__description"><?php echo esc_html( number_format_i18n( $count ) ); ?></dd>
+			<dd class="fosse-detail-list__description">
+				<?php echo esc_html( number_format_i18n( $count ) ); ?>
+				<p class="description"><?php esc_html_e( 'This count reflects your own author profile, not a site-wide total.', 'fosse' ); ?></p>
+			</dd>
 			<?php
 		}
 	}

--- a/src/Admin/class-bluesky-provider.php
+++ b/src/Admin/class-bluesky-provider.php
@@ -189,6 +189,20 @@ class Bluesky_Provider implements Connection_Provider {
 	}
 
 	/**
+	 * Whether Bluesky currently has a working connection.
+	 *
+	 * Mirrors the `connected` key of {@see self::get_status()}. Reads
+	 * through the memoized status so the token-health probe in
+	 * {@see self::get_status()} still runs and clears stale connections
+	 * before the answer is returned.
+	 *
+	 * @return bool
+	 */
+	public function is_connected(): bool {
+		return (bool) $this->get_status()['connected'];
+	}
+
+	/**
 	 * Whether Bluesky auto-publishing is enabled for this site.
 	 *
 	 * Centralizes the "absent option reads as enabled" rule that
@@ -1552,7 +1566,7 @@ class Bluesky_Provider implements Connection_Provider {
 
 		// Only show for connected sites — a disconnected site has nothing
 		// to publish to anyway, so the notice would be noise.
-		if ( ! $this->get_status()['connected'] ) {
+		if ( ! $this->is_connected() ) {
 			return;
 		}
 

--- a/src/Admin/class-connection-provider-registry.php
+++ b/src/Admin/class-connection-provider-registry.php
@@ -23,7 +23,9 @@ class Connection_Provider_Registry {
 	private static array $providers = array();
 
 	/**
-	 * Register a provider. Duplicate slugs are silently ignored (first wins).
+	 * Register a provider. Duplicate slugs are rejected — first registration
+	 * wins — and surface a `_doing_it_wrong()` so the caller knows the
+	 * duplicate didn't take effect instead of debugging a phantom no-op.
 	 *
 	 * @param Connection_Provider $provider Provider instance.
 	 * @return void
@@ -32,6 +34,11 @@ class Connection_Provider_Registry {
 		$slug = $provider->get_slug();
 
 		if ( isset( self::$providers[ $slug ] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf( 'Connection provider "%s" is already registered.', esc_html( $slug ) ),
+				'0.1.0'
+			);
 			return;
 		}
 

--- a/src/Admin/class-connection-provider-registry.php
+++ b/src/Admin/class-connection-provider-registry.php
@@ -37,7 +37,7 @@ class Connection_Provider_Registry {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf( 'Connection provider "%s" is already registered.', esc_html( $slug ) ),
-				esc_html( FOSSE_VERSION )
+				'0.1.2'
 			);
 			return;
 		}

--- a/src/Admin/class-connection-provider-registry.php
+++ b/src/Admin/class-connection-provider-registry.php
@@ -37,7 +37,7 @@ class Connection_Provider_Registry {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf( 'Connection provider "%s" is already registered.', esc_html( $slug ) ),
-				'0.1.0'
+				esc_html( FOSSE_VERSION )
 			);
 			return;
 		}

--- a/src/Admin/interface-connection-provider.php
+++ b/src/Admin/interface-connection-provider.php
@@ -75,6 +75,18 @@ interface Connection_Provider {
 	public function get_status(): array;
 
 	/**
+	 * Whether the provider currently has a working connection.
+	 *
+	 * Mirrors `get_status()['connected']` as a typed shortcut so callers
+	 * don't have to inspect a loosely-typed array just to ask a yes/no
+	 * question. Implementations should keep this in lockstep with the
+	 * `connected` key of {@see self::get_status()}.
+	 *
+	 * @return bool
+	 */
+	public function is_connected(): bool;
+
+	/**
 	 * Render this provider's settings fields inside the unified Settings form.
 	 *
 	 * Implementations render protocol-specific form rows only — no opening

--- a/src/Admin/templates/status-page.php
+++ b/src/Admin/templates/status-page.php
@@ -16,7 +16,7 @@ $available       = array_filter(
 );
 $connected       = array_filter(
 	$available,
-	static fn( $p ) => ! empty( $p->get_status()['connected'] )
+	static fn( $p ) => $p->is_connected()
 );
 $available_count = count( $available );
 $connected_count = count( $connected );

--- a/tests/php/Admin/AP_ProviderTest.php
+++ b/tests/php/Admin/AP_ProviderTest.php
@@ -104,6 +104,16 @@ class AP_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * `is_connected()` mirrors the `connected` key of `get_status()`.
+	 */
+	public function test_is_connected_matches_status() {
+		$this->assertSame(
+			(bool) $this->provider->get_status()['connected'],
+			$this->provider->is_connected()
+		);
+	}
+
+	/**
 	 * Default actor mode is 'actor'.
 	 */
 	public function test_status_default_actor_mode() {

--- a/tests/php/Admin/Bluesky_ProviderTest.php
+++ b/tests/php/Admin/Bluesky_ProviderTest.php
@@ -168,6 +168,37 @@ class Bluesky_ProviderTest extends BaseTestCase {
 	}
 
 	/**
+	 * `is_connected()` mirrors the `connected` key of `get_status()`,
+	 * both when disconnected and connected.
+	 */
+	public function test_is_connected_matches_status() {
+		// Fresh provider, no Atmosphere connection seeded -> disconnected.
+		$disconnected = new Bluesky_Provider();
+		$this->assertSame(
+			(bool) $disconnected->get_status()['connected'],
+			$disconnected->is_connected()
+		);
+		$this->assertFalse( $disconnected->is_connected() );
+
+		update_option(
+			'atmosphere_connection',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'alice.bsky.social',
+				'pds_endpoint' => 'https://bsky.social',
+				'access_token' => Encryption::encrypt( 'token' ),
+			)
+		);
+
+		$connected = new Bluesky_Provider();
+		$this->assertSame(
+			(bool) $connected->get_status()['connected'],
+			$connected->is_connected()
+		);
+		$this->assertTrue( $connected->is_connected() );
+	}
+
+	/**
 	 * Connected status reflects the Atmosphere connection option.
 	 */
 	public function test_status_connected_reflects_connection() {

--- a/tests/php/Admin/Connection_Provider_RegistryTest.php
+++ b/tests/php/Admin/Connection_Provider_RegistryTest.php
@@ -56,17 +56,63 @@ class Connection_Provider_RegistryTest extends BaseTestCase {
 	}
 
 	/**
-	 * Registering a duplicate slug is silently ignored; first registration wins.
+	 * Registering a duplicate slug is rejected; first registration wins.
+	 *
+	 * Suppresses the `_doing_it_wrong()` warning via the
+	 * `doing_it_wrong_trigger_error` filter so PHPUnit's `failOnWarning`
+	 * doesn't trip — the firing of the warning itself is asserted
+	 * separately in {@see self::test_duplicate_slug_triggers_doing_it_wrong()}.
 	 */
 	public function test_duplicate_slug_is_ignored() {
-		$first  = $this->make_provider( 'dupe' );
-		$second = $this->make_provider( 'dupe' );
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
 
-		Connection_Provider_Registry::register( $first );
-		Connection_Provider_Registry::register( $second );
+		try {
+			$first  = $this->make_provider( 'dupe' );
+			$second = $this->make_provider( 'dupe' );
 
-		$this->assertSame( $first, Connection_Provider_Registry::get_provider( 'dupe' ) );
-		$this->assertCount( 1, Connection_Provider_Registry::get_providers() );
+			Connection_Provider_Registry::register( $first );
+			Connection_Provider_Registry::register( $second );
+
+			$this->assertSame( $first, Connection_Provider_Registry::get_provider( 'dupe' ) );
+			$this->assertCount( 1, Connection_Provider_Registry::get_providers() );
+		} finally {
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
+	}
+
+	/**
+	 * Registering a duplicate slug fires `_doing_it_wrong` so callers can
+	 * see the conflict instead of debugging a silent no-op.
+	 *
+	 * Hooks `doing_it_wrong_run` to capture the call and filters
+	 * `doing_it_wrong_trigger_error` to false so PHPUnit's failOnWarning
+	 * doesn't trip on the E_USER_NOTICE — WorDBless's BaseTestCase
+	 * extends Yoast's polyfill TestCase, neither of which exposes
+	 * `setExpectedIncorrectUsage()`.
+	 */
+	public function test_duplicate_slug_triggers_doing_it_wrong() {
+		$captured = array();
+		$listener = static function ( $function_name, $message ) use ( &$captured ) {
+			$captured[] = array(
+				'function' => $function_name,
+				'message'  => $message,
+			);
+		};
+
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		add_action( 'doing_it_wrong_run', $listener, 10, 2 );
+
+		try {
+			Connection_Provider_Registry::register( $this->make_provider( 'dupe' ) );
+			Connection_Provider_Registry::register( $this->make_provider( 'dupe' ) );
+		} finally {
+			remove_action( 'doing_it_wrong_run', $listener, 10 );
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
+
+		$this->assertCount( 1, $captured );
+		$this->assertStringContainsString( 'Connection_Provider_Registry::register', $captured[0]['function'] );
+		$this->assertStringContainsString( 'dupe', $captured[0]['message'] );
 	}
 
 	/**
@@ -118,6 +164,9 @@ class Connection_Provider_RegistryTest extends BaseTestCase {
 			}
 			public function get_status(): array {
 				return array( 'connected' => true );
+			}
+			public function is_connected(): bool {
+				return true;
 			}
 			public function render_setup_section(): void {}
 			public function render_connection_actions(): void {}

--- a/tests/php/Admin/Onboarding_WizardTest.php
+++ b/tests/php/Admin/Onboarding_WizardTest.php
@@ -1266,6 +1266,15 @@ class Onboarding_WizardTest extends BaseTestCase {
 				}
 
 				/**
+				 * Whether the provider is connected.
+				 *
+				 * @return bool
+				 */
+				public function is_connected(): bool {
+					return false;
+				}
+
+				/**
 				 * Render setup UI.
 				 *
 				 * @return void

--- a/tests/php/Provider_LoaderTest.php
+++ b/tests/php/Provider_LoaderTest.php
@@ -196,6 +196,9 @@ class Provider_LoaderTest extends BaseTestCase {
 			public function get_status(): array {
 				return array( 'connected' => true );
 			}
+			public function is_connected(): bool {
+				return true;
+			}
 			public function render_setup_section(): void {}
 			public function render_connection_actions(): void {}
 			public function render_status_card(): void {}


### PR DESCRIPTION
## Summary

Four small polish items deferred from the [PR 27](https://github.com/Automattic/fosse/pull/27) onboarding-UX code review (DOTCOM-16910). They're independent and small, so they land together.

## What this PR ships

### Item 2 — Admin notice when Composer autoload is missing

If `vendor/autoload_packages.php` is missing (bare clone, broken deploy), FOSSE was silently doing nothing — no menu, no projection, no admin notice. Added an `else` branch in `fosse.php` that registers an `admin_notices` callback explaining the deploy is incomplete. Gated on `current_user_can( 'manage_options' )` so non-admins don't see the diagnostic. Translatable, `fosse` text domain.

### Item 3 — Followers card description in pure actor mode

The `else` branch in `AP_Provider::render_follower_count_row()` (the per-user actor-mode branch) now adds a one-sentence `<p class="description">` clarifying that the count reflects the viewing admin's own author profile, not a site-wide total. The blog and `actor_blog` modes already disambiguate via their own labels, so the description only renders in the per-user branch.

### Item 4 — `_doing_it_wrong()` on duplicate registry slugs

`Connection_Provider_Registry::register()` used to silently return when a slug was already registered. It now fires `_doing_it_wrong()` first so the caller knows their second registration didn't take effect — first registration still wins, the surface change is observability.

### Item 5 — `is_connected(): bool` on the Connection_Provider interface

Added `public function is_connected(): bool;` to the interface. Concrete implementations on `AP_Provider` (always true when AP is loaded) and `Bluesky_Provider` (mirrors the token-probed `connected` key, so the cache-deletion semantics in `get_status()` are preserved). Switched two clean one-line consumers — `Bluesky_Provider::maybe_render_auto_publish_disabled_notice()` and the Status page template — onto the typed shortcut. Updated the three anonymous-class test mocks (`Connection_Provider_RegistryTest`, `Provider_LoaderTest`, `Onboarding_WizardTest`) to satisfy the new contract.

## Test plan

- [x] `composer run-script lint-php` — clean (71/71 files).
- [x] `composer run-script test-php` — 785 tests pass (4 new/modified: the new `_doing_it_wrong` assertion, the existing silent-duplicate test now wrapped in a `doing_it_wrong_trigger_error` filter, and two `is_connected_matches_status` smoke tests for AP and Bluesky).
- [ ] Item 2 smoke test: rename `vendor/autoload_packages.php` aside, visit any admin page as a `manage_options` user. Expect the FOSSE-missing-deps notice. Revert.
- [ ] Item 3 smoke test: with `activitypub_actor_mode` set to `actor` (the default), open FOSSE Setup, scroll to "Your Followers". Expect the count line plus the new "This count reflects your own author profile, not a site-wide total." description directly below.
- [ ] Item 4 smoke test: in a debug-on environment, register the same provider slug twice. Expect a `_doing_it_wrong` notice naming `Connection_Provider_Registry::register` and the duplicate slug.
- [ ] Item 5 smoke test: connect Bluesky, then disconnect. The auto-publish-off recovery notice and the Status page "X of Y providers connected" summary continue to render correctly — they now reach `is_connected()` instead of `get_status()['connected']`.

Items 2 and 3 don't get dedicated PHPUnit coverage — the rendering paths are exercised indirectly by the existing follower-count and admin-screen smoke tests, and a hooks-only assertion on notice registration would be noisy without proportional value.

## Related

- Fixes DOTCOM-16910
- Follow-up to PR 27 (onboarding UX)
