### PR TITLE
add: Playwright teaser-thread e2e via atmosphere_pre_apply_writes capture

### DIFF
--- a/tests/e2e/long-form-link-card.spec.ts
+++ b/tests/e2e/long-form-link-card.spec.ts
@@ -150,7 +150,11 @@ test.describe( 'pass-through long-form link-card path', () => {
 		// Publisher emits and runs the publish inline on
 		// transition_post_status (so we don't need to wait on
 		// Playground's cron loop). Poll briefly in case the REST
-		// request returns before the option write has flushed.
+		// request returns before the option write has flushed. The
+		// link-card path publishes via `publish_single`, which emits
+		// exactly one batch — asserting the count is `1` (not `>= 1`)
+		// catches future regressions where the Publisher accidentally
+		// fans out to extra batches on the pass-through long-form path.
 		const headers = await nonceHeaders( page );
 		let captured: CapturedCalls | null = null;
 		await expect
@@ -168,7 +172,7 @@ test.describe( 'pass-through long-form link-card path', () => {
 				},
 				{ timeout: 5_000, intervals: [ 100, 250, 500 ] }
 			)
-			.toBeGreaterThanOrEqual( 1 );
+			.toBe( 1 );
 
 		// link-card path: one applyWrites call, two writes
 		// (app.bsky.feed.post root + site.standard.document).

--- a/tests/e2e/long-form-link-card.spec.ts
+++ b/tests/e2e/long-form-link-card.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+import { resetBlueskyState, setBlueskyState } from './test-helpers';
 
 type BskyRecord = {
 	$type?: string;
@@ -12,112 +13,202 @@ type BskyRecord = {
 	[ key: string ]: unknown;
 };
 
-type Capture = {
-	post_id: number;
-	bsky_record: BskyRecord;
-	doc_record: { $type: string; [ key: string ]: unknown };
+type Write = {
+	$type: string;
+	collection: string;
+	rkey: string;
+	value: Record< string, unknown >;
 };
+
+type Call = {
+	writes: Write[];
+	did: string;
+};
+
+type CapturedCalls = {
+	calls: Call[];
+};
+
+const nonceHeaders = async ( page: Page ) => ( {
+	'Content-Type': 'application/json',
+	'X-WP-Nonce': await page.evaluate(
+		() => ( window as any ).wpApiSettings.nonce
+	),
+} );
 
 /**
  * Complements short-form-facets.spec.ts by exercising the *pass-through*
  * branch of the Object_Type bridge. When activitypub_object_type is set
  * to 'wordpress-post-format', the bridge returns its input unchanged, so
  * Atmosphere's native is_short_form() classification drives the composition.
- * A titled post with no post format is the classic long-form case:
- * Atmosphere builds a teaser + app.bsky.embed.external link card.
+ * A titled post with no post format is the classic long-form case; with
+ * `atmosphere_long_form_composition` pinned to `link-card`, Atmosphere
+ * builds a teaser + app.bsky.embed.external link card.
  *
  * This spec proves that the bridge doesn't accidentally force
  * short-form on the pass-through path, which would silently break the
  * long-form composition for existing Atmosphere users.
  */
-test( 'pass-through mode: titled post still takes the long-form link-card path', async ( {
-	page,
-} ) => {
-	await page.goto( '/wp-admin/post-new.php' );
+test.describe( 'pass-through long-form link-card path', () => {
+	test.afterAll( async ( { browser }, testInfo ) => {
+		const baseURL = testInfo.project.use.baseURL;
+		if ( ! baseURL ) {
+			throw new Error(
+				'baseURL must be configured in playwright.config.ts'
+			);
+		}
+		await resetBlueskyState( browser, baseURL );
+	} );
 
-	await page.waitForFunction(
-		() => !! ( window as any ).wpApiSettings?.nonce
-	);
+	test( 'pass-through mode: titled post still takes the long-form link-card path', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/post-new.php' );
 
-	// Flip activitypub_object_type to pass-through mode. Blueprint seeds
-	// 'note'; this test wants the bridge to defer to Atmosphere's own
-	// detection.
-	const flipResult = await page.evaluate( async () => {
-		const res = await fetch( '/wp-json/fosse-e2e/v1/object-type', {
-			method: 'POST',
-			headers: {
+		await page.waitForFunction(
+			() => !! ( window as any ).wpApiSettings?.nonce
+		);
+
+		// Flip activitypub_object_type to pass-through mode AND pin the
+		// long-form composition to 'link-card' so this spec stays focused
+		// on the bridge's pass-through path even though FOSSE's canonical-
+		// options migrator seeds 'teaser-thread' as the default.
+		const flipResult = await page.evaluate( async () => {
+			const headers = {
 				'Content-Type': 'application/json',
 				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
-			},
-			body: JSON.stringify( { value: 'wordpress-post-format' } ),
-		} );
-		return { status: res.status, text: await res.text() };
-	} );
-	expect(
-		flipResult.status,
-		`fosse-e2e/v1/object-type returned: ${ flipResult.text.slice(
-			0,
-			300
-		) }`
-	).toBe( 200 );
-
-	const postTitle = 'A long-form post that should become a link card';
-	const body = 'This is the full body content of a long-form blog post.';
-
-	const created = await page.evaluate(
-		async ( { title, content } ) => {
-			const res = await fetch( '/wp-json/wp/v2/posts', {
+			};
+			const otype = await fetch( '/wp-json/fosse-e2e/v1/object-type', {
 				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
-				},
+				headers,
 				body: JSON.stringify( {
-					title,
-					content,
-					status: 'publish',
+					value: 'wordpress-post-format',
 				} ),
 			} );
-			return { status: res.status, text: await res.text() };
-		},
-		{ title: postTitle, content: body }
-	);
-
-	expect(
-		created.status,
-		`POST /posts returned: ${ created.text.slice( 0, 300 ) }`
-	).toBe( 201 );
-	const postId = ( JSON.parse( created.text ) as { id: number } ).id;
-
-	const captureUrl = '/wp-content/uploads/fosse-bsky-capture.json';
-	let captured: Capture | null = null;
-	await expect
-		.poll(
-			async () => {
-				const r = await page.request.get( captureUrl );
-				if ( ! r.ok() ) {
-					return false;
+			const strategy = await fetch(
+				'/wp-json/fosse-e2e/v1/long-form-strategy',
+				{
+					method: 'POST',
+					headers,
+					body: JSON.stringify( { value: 'link-card' } ),
 				}
-				captured = ( await r.json() ) as Capture;
-				return captured.post_id === postId;
+			);
+			return {
+				otypeStatus: otype.status,
+				otypeText: await otype.text(),
+				strategyStatus: strategy.status,
+				strategyText: await strategy.text(),
+			};
+		} );
+		expect(
+			flipResult.otypeStatus,
+			`object-type returned: ${ flipResult.otypeText.slice( 0, 300 ) }`
+		).toBe( 200 );
+		expect(
+			flipResult.strategyStatus,
+			`long-form-strategy returned: ${ flipResult.strategyText.slice(
+				0,
+				300
+			) }`
+		).toBe( 200 );
+
+		// Connect Bluesky and reset the capture so only this test's
+		// publish populates it.
+		await setBlueskyState( page, { connected: true } );
+		await page.evaluate( async () => {
+			await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
+				method: 'DELETE',
+				headers: {
+					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+				},
+			} );
+		} );
+
+		const postTitle = 'A long-form post that should become a link card';
+		const body = 'This is the full body content of a long-form blog post.';
+
+		const created = await page.evaluate(
+			async ( { title, content } ) => {
+				const res = await fetch( '/wp-json/wp/v2/posts', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+					},
+					body: JSON.stringify( {
+						title,
+						content,
+						status: 'publish',
+					} ),
+				} );
+				return { status: res.status, text: await res.text() };
 			},
-			{ timeout: 5_000, intervals: [ 100, 250, 500 ] }
-		)
-		.toBe( true );
+			{ title: postTitle, content: body }
+		);
 
-	const bsky = captured!.bsky_record;
+		expect(
+			created.status,
+			`POST /posts returned: ${ created.text.slice( 0, 300 ) }`
+		).toBe( 201 );
+		const postId = ( JSON.parse( created.text ) as { id: number } ).id;
+		expect( postId ).toBeGreaterThan( 0 );
 
-	// Long-form path: external embed card with the permalink.
-	expect( bsky.embed ).toBeDefined();
-	expect( bsky.embed!.$type ).toBe( 'app.bsky.embed.external' );
-	expect( bsky.embed!.external?.uri ).toMatch( /^https?:\/\// );
+		// The capture mu-plugin records every applyWrites batch the
+		// Publisher emits and runs the publish inline on
+		// transition_post_status (so we don't need to wait on
+		// Playground's cron loop). Poll briefly in case the REST
+		// request returns before the option write has flushed.
+		const headers = await nonceHeaders( page );
+		let captured: CapturedCalls | null = null;
+		await expect
+			.poll(
+				async () => {
+					const r = await page.request.get(
+						'/wp-json/fosse-e2e/v1/apply-writes',
+						{ headers }
+					);
+					if ( ! r.ok() ) {
+						return 0;
+					}
+					captured = ( await r.json() ) as CapturedCalls;
+					return captured.calls.length;
+				},
+				{ timeout: 5_000, intervals: [ 100, 250, 500 ] }
+			)
+			.toBeGreaterThanOrEqual( 1 );
 
-	// Text should contain the title — Atmosphere's long-form build_text()
-	// composes title + excerpt + permalink. We don't assert exact composition
-	// (that's upstream's concern); we just prove the title made it through,
-	// which short-form composition would have dropped.
-	expect( bsky.text ).toContain( postTitle );
+		// link-card path: one applyWrites call, two writes
+		// (app.bsky.feed.post root + site.standard.document).
+		const writes = captured!.calls[ 0 ].writes;
+		const bskyWrite = writes.find(
+			( w ) => w.collection === 'app.bsky.feed.post'
+		);
+		expect( bskyWrite, 'app.bsky.feed.post write present' ).toBeTruthy();
+		const docWrite = writes.find(
+			( w ) => w.collection === 'site.standard.document'
+		);
+		expect(
+			docWrite,
+			'site.standard.document write present (DOTCOM-16809 guard)'
+		).toBeTruthy();
 
-	// Document record still written on the long-form path (DOTCOM-16809 guard).
-	expect( captured!.doc_record.$type ).toBe( 'site.standard.document' );
+		const bsky = bskyWrite!.value as BskyRecord;
+
+		// Long-form path: external embed card with the permalink.
+		expect( bsky.embed ).toBeDefined();
+		expect( bsky.embed!.$type ).toBe( 'app.bsky.embed.external' );
+		expect( bsky.embed!.external?.uri ).toMatch( /^https?:\/\// );
+
+		// Text should contain the title — Atmosphere's long-form
+		// build_text() composes title + excerpt + permalink. We don't
+		// assert exact composition (that's upstream's concern); we
+		// just prove the title made it through, which short-form
+		// composition would have dropped.
+		expect( bsky.text ).toContain( postTitle );
+
+		// Document record still written on the long-form path
+		// (DOTCOM-16809 guard).
+		const doc = docWrite!.value as { $type: string };
+		expect( doc.$type ).toBe( 'site.standard.document' );
+	} );
 } );

--- a/tests/e2e/long-form-link-card.spec.ts
+++ b/tests/e2e/long-form-link-card.spec.ts
@@ -113,16 +113,21 @@ test.describe( 'pass-through long-form link-card path', () => {
 		).toBe( 200 );
 
 		// Connect Bluesky and reset the capture so only this test's
-		// publish populates it.
+		// publish populates it. Assert the DELETE succeeded — a silent
+		// failure would let prior runs' stale calls leak into the
+		// later "captured.calls" assertions and make this spec
+		// order-dependent.
 		await setBlueskyState( page, { connected: true } );
-		await page.evaluate( async () => {
-			await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
+		const resetStatus = await page.evaluate( async () => {
+			const res = await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
 				method: 'DELETE',
 				headers: {
 					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
 				},
 			} );
+			return res.status;
 		} );
+		expect( resetStatus, 'apply-writes DELETE succeeded' ).toBe( 200 );
 
 		const postTitle = 'A long-form post that should become a link card';
 		const body = 'This is the full body content of a long-form blog post.';

--- a/tests/e2e/long-form-link-card.spec.ts
+++ b/tests/e2e/long-form-link-card.spec.ts
@@ -1,5 +1,10 @@
-import { test, expect, type Page } from '@playwright/test';
-import { resetBlueskyState, setBlueskyState } from './test-helpers';
+import { test, expect } from '@playwright/test';
+import {
+	nonceHeaders,
+	resetApplyWritesCapture,
+	resetBlueskyState,
+	setBlueskyState,
+} from './test-helpers';
 
 type BskyRecord = {
 	$type?: string;
@@ -28,13 +33,6 @@ type Call = {
 type CapturedCalls = {
 	calls: Call[];
 };
-
-const nonceHeaders = async ( page: Page ) => ( {
-	'Content-Type': 'application/json',
-	'X-WP-Nonce': await page.evaluate(
-		() => ( window as any ).wpApiSettings.nonce
-	),
-} );
 
 /**
  * Complements short-form-facets.spec.ts by exercising the *pass-through*
@@ -113,21 +111,11 @@ test.describe( 'pass-through long-form link-card path', () => {
 		).toBe( 200 );
 
 		// Connect Bluesky and reset the capture so only this test's
-		// publish populates it. Assert the DELETE succeeded — a silent
-		// failure would let prior runs' stale calls leak into the
-		// later "captured.calls" assertions and make this spec
-		// order-dependent.
+		// publish populates it. The helper asserts the DELETE succeeded
+		// so a silent failure can't let prior runs' stale calls leak
+		// into the later "captured.calls" assertions.
 		await setBlueskyState( page, { connected: true } );
-		const resetStatus = await page.evaluate( async () => {
-			const res = await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
-				method: 'DELETE',
-				headers: {
-					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
-				},
-			} );
-			return res.status;
-		} );
-		expect( resetStatus, 'apply-writes DELETE succeeded' ).toBe( 200 );
+		await resetApplyWritesCapture( page );
 
 		const postTitle = 'A long-form post that should become a link card';
 		const body = 'This is the full body content of a long-form blog post.';

--- a/tests/e2e/long-form-teaser-thread.spec.ts
+++ b/tests/e2e/long-form-teaser-thread.spec.ts
@@ -1,5 +1,10 @@
-import { test, expect, type Page } from '@playwright/test';
-import { resetBlueskyState, setBlueskyState } from './test-helpers';
+import { test, expect } from '@playwright/test';
+import {
+	nonceHeaders,
+	resetApplyWritesCapture,
+	resetBlueskyState,
+	setBlueskyState,
+} from './test-helpers';
 
 type BskyRecord = {
 	$type?: string;
@@ -38,13 +43,6 @@ type PostMetaResponse = {
 	post_id: number;
 	meta: Record< string, unknown >;
 };
-
-const nonceHeaders = async ( page: Page ) => ( {
-	'Content-Type': 'application/json',
-	'X-WP-Nonce': await page.evaluate(
-		() => ( window as any ).wpApiSettings.nonce
-	),
-} );
 
 /**
  * Exercise the long-form `teaser-thread` strategy end-to-end.
@@ -133,21 +131,11 @@ test.describe( 'long-form teaser-thread path', () => {
 		).toBe( 200 );
 
 		// Connect Bluesky and reset the capture so only this test's
-		// publish populates it. Assert the DELETE succeeded — the
-		// "exactly 3 applyWrites calls" assertion below is especially
-		// sensitive to stale state, since a leaked call from a prior
-		// run would push the count past 3 and fail in a confusing way.
+		// publish populates it. The helper asserts the DELETE succeeded
+		// so a silent failure can't let stale calls from a prior run
+		// leak in and push the "exactly 3 calls" assertion past 3.
 		await setBlueskyState( page, { connected: true } );
-		const resetStatus = await page.evaluate( async () => {
-			const res = await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
-				method: 'DELETE',
-				headers: {
-					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
-				},
-			} );
-			return res.status;
-		} );
-		expect( resetStatus, 'apply-writes DELETE succeeded' ).toBe( 200 );
+		await resetApplyWritesCapture( page );
 
 		const postTitle = 'Long-form post composed as a teaser thread';
 		// Curated excerpt drives the hook (≥ 10 chars triggers the

--- a/tests/e2e/long-form-teaser-thread.spec.ts
+++ b/tests/e2e/long-form-teaser-thread.spec.ts
@@ -133,16 +133,21 @@ test.describe( 'long-form teaser-thread path', () => {
 		).toBe( 200 );
 
 		// Connect Bluesky and reset the capture so only this test's
-		// publish populates it.
+		// publish populates it. Assert the DELETE succeeded — the
+		// "exactly 3 applyWrites calls" assertion below is especially
+		// sensitive to stale state, since a leaked call from a prior
+		// run would push the count past 3 and fail in a confusing way.
 		await setBlueskyState( page, { connected: true } );
-		await page.evaluate( async () => {
-			await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
+		const resetStatus = await page.evaluate( async () => {
+			const res = await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
 				method: 'DELETE',
 				headers: {
 					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
 				},
 			} );
+			return res.status;
 		} );
+		expect( resetStatus, 'apply-writes DELETE succeeded' ).toBe( 200 );
 
 		const postTitle = 'Long-form post composed as a teaser thread';
 		// Curated excerpt drives the hook (≥ 10 chars triggers the

--- a/tests/e2e/long-form-teaser-thread.spec.ts
+++ b/tests/e2e/long-form-teaser-thread.spec.ts
@@ -1,0 +1,299 @@
+import { test, expect, type Page } from '@playwright/test';
+import { resetBlueskyState, setBlueskyState } from './test-helpers';
+
+type BskyRecord = {
+	$type?: string;
+	text: string;
+	embed?: {
+		$type?: string;
+		external?: { uri?: string; title?: string };
+		[ key: string ]: unknown;
+	};
+	reply?: {
+		root: { uri: string; cid: string };
+		parent: { uri: string; cid: string };
+	};
+	[ key: string ]: unknown;
+};
+
+type Write = {
+	$type: string;
+	collection: string;
+	rkey: string;
+	value: Record< string, unknown >;
+};
+
+type Call = {
+	writes: Write[];
+	did: string;
+};
+
+type CapturedCalls = {
+	calls: Call[];
+};
+
+type ThreadTriple = { uri: string; cid: string; tid: string };
+
+type PostMetaResponse = {
+	post_id: number;
+	meta: Record< string, unknown >;
+};
+
+const nonceHeaders = async ( page: Page ) => ( {
+	'Content-Type': 'application/json',
+	'X-WP-Nonce': await page.evaluate(
+		() => ( window as any ).wpApiSettings.nonce
+	),
+} );
+
+/**
+ * Exercise the long-form `teaser-thread` strategy end-to-end.
+ *
+ * Setup pins `activitypub_object_type` to `wordpress-post-format` (the
+ * Object_Type bridge's pass-through branch) and
+ * `atmosphere_long_form_composition` to `teaser-thread`. With a titled
+ * post that has a curated excerpt of ≥ 10 chars plus a body of ≥ 10
+ * chars, `Transformer\Post::compute_default_teaser_thread()` returns
+ * `[ excerpt-hook, body-chunk, cta ]` — three entries, no redundancy
+ * collapse (the collapse requires no excerpt). The Publisher then
+ * issues:
+ *
+ *   1. root + doc atomically (2 writes in one applyWrites call)
+ *   2. reply 1 = body-chunk (1 write, reply.root + reply.parent → root)
+ *   3. reply 2 = CTA       (1 write, reply.root → root, reply.parent → reply 1)
+ *
+ * Sizing the post is deliberate: a body whose plain-text length is in
+ * `[10, 280]` chars and a separate excerpt keeps `compute_default_teaser_thread`
+ * in the 3-entry branch. The redundancy collapse would only trigger
+ * with NO excerpt and a body ≤ 280 chars, so the explicit excerpt
+ * here also defends against future tweaks to the body-as-hook path.
+ */
+test.describe( 'long-form teaser-thread path', () => {
+	test.afterAll( async ( { browser }, testInfo ) => {
+		const baseURL = testInfo.project.use.baseURL;
+		if ( ! baseURL ) {
+			throw new Error(
+				'baseURL must be configured in playwright.config.ts'
+			);
+		}
+		await resetBlueskyState( browser, baseURL );
+	} );
+
+	test( 'teaser-thread: three applyWrites calls with chained reply refs', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/post-new.php' );
+
+		await page.waitForFunction(
+			() => !! ( window as any ).wpApiSettings?.nonce
+		);
+
+		// Flip activitypub_object_type to pass-through mode (so the
+		// Object_Type bridge defers to Atmosphere's own short-form
+		// detection — a titled post is long-form) and pin the long-
+		// form composition to 'teaser-thread' so this spec is robust
+		// even if FOSSE's default ever changes.
+		const flipResult = await page.evaluate( async () => {
+			const headers = {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+			};
+			const otype = await fetch( '/wp-json/fosse-e2e/v1/object-type', {
+				method: 'POST',
+				headers,
+				body: JSON.stringify( {
+					value: 'wordpress-post-format',
+				} ),
+			} );
+			const strategy = await fetch(
+				'/wp-json/fosse-e2e/v1/long-form-strategy',
+				{
+					method: 'POST',
+					headers,
+					body: JSON.stringify( { value: 'teaser-thread' } ),
+				}
+			);
+			return {
+				otypeStatus: otype.status,
+				otypeText: await otype.text(),
+				strategyStatus: strategy.status,
+				strategyText: await strategy.text(),
+			};
+		} );
+		expect(
+			flipResult.otypeStatus,
+			`object-type returned: ${ flipResult.otypeText.slice( 0, 300 ) }`
+		).toBe( 200 );
+		expect(
+			flipResult.strategyStatus,
+			`long-form-strategy returned: ${ flipResult.strategyText.slice(
+				0,
+				300
+			) }`
+		).toBe( 200 );
+
+		// Connect Bluesky and reset the capture so only this test's
+		// publish populates it.
+		await setBlueskyState( page, { connected: true } );
+		await page.evaluate( async () => {
+			await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
+				method: 'DELETE',
+				headers: {
+					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+				},
+			} );
+		} );
+
+		const postTitle = 'Long-form post composed as a teaser thread';
+		// Curated excerpt drives the hook (≥ 10 chars triggers the
+		// excerpt branch of compute_default_teaser_thread).
+		const postExcerpt =
+			'A curated excerpt that becomes the teaser-thread hook so callers can preview the prose before the body chunk arrives.';
+		// Body is short enough to fit cleanly in a single chunk reply
+		// (well under 280 chars). With an excerpt-as-hook,
+		// chunk_source == the whole body; ≥ 10 chars keeps us in the
+		// 3-entry [ hook, body_chunk, cta ] branch.
+		const postBody =
+			'The body of the post continues where the excerpt leaves off. A short paragraph of prose is enough to land in the body-chunk reply of the teaser thread.';
+
+		const created = await page.evaluate(
+			async ( { title, content, excerpt } ) => {
+				const res = await fetch( '/wp-json/wp/v2/posts', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+					},
+					body: JSON.stringify( {
+						title,
+						content,
+						excerpt,
+						status: 'publish',
+					} ),
+				} );
+				return { status: res.status, text: await res.text() };
+			},
+			{ title: postTitle, content: postBody, excerpt: postExcerpt }
+		);
+
+		expect(
+			created.status,
+			`POST /posts returned: ${ created.text.slice( 0, 300 ) }`
+		).toBe( 201 );
+		const postId = ( JSON.parse( created.text ) as { id: number } ).id;
+		expect( postId ).toBeGreaterThan( 0 );
+
+		const headers = await nonceHeaders( page );
+
+		// Poll for all three applyWrites calls to be recorded. The
+		// capture mu-plugin runs Atmosphere's scheduled publish
+		// inline on transition_post_status, so all three batches
+		// should be on disk by the time POST /posts returns; the poll
+		// guards against option-write flush latency.
+		let captured: CapturedCalls | null = null;
+		await expect
+			.poll(
+				async () => {
+					const r = await page.request.get(
+						'/wp-json/fosse-e2e/v1/apply-writes',
+						{ headers }
+					);
+					if ( ! r.ok() ) {
+						return 0;
+					}
+					captured = ( await r.json() ) as CapturedCalls;
+					return captured.calls.length;
+				},
+				{ timeout: 5_000, intervals: [ 100, 250, 500 ] }
+			)
+			.toBe( 3 );
+
+		const calls = captured!.calls;
+
+		// Call 1: root post + doc atomically.
+		const rootCall = calls[ 0 ];
+		expect( rootCall.writes ).toHaveLength( 2 );
+		const rootBskyWrite = rootCall.writes.find(
+			( w ) => w.collection === 'app.bsky.feed.post'
+		);
+		const rootDocWrite = rootCall.writes.find(
+			( w ) => w.collection === 'site.standard.document'
+		);
+		expect(
+			rootBskyWrite,
+			'root applyWrites batch includes the post'
+		).toBeTruthy();
+		expect(
+			rootDocWrite,
+			'root applyWrites batch includes the document'
+		).toBeTruthy();
+
+		const rootRecord = rootBskyWrite!.value as BskyRecord;
+		expect( rootRecord.$type ).toBe( 'app.bsky.feed.post' );
+		expect( rootRecord.reply, 'root has no reply ref' ).toBeUndefined();
+		// The hook should be derived from the excerpt; we don't
+		// assert the exact text (sanitize_text + truncate_to_budget
+		// transformations are upstream's contract) — just that the
+		// excerpt prose made it through.
+		expect( rootRecord.text ).toContain( 'curated excerpt' );
+
+		// Synthetic URI/CID the capture helper handed back to
+		// Publisher; the post's _atmosphere_bsky_uri meta should
+		// mirror it.
+		const synthRootUri = `at://${ rootCall.did }/app.bsky.feed.post/${
+			rootBskyWrite!.rkey
+		}`;
+
+		// Call 2: body-chunk reply, chained to the root.
+		const chunkCall = calls[ 1 ];
+		expect( chunkCall.writes ).toHaveLength( 1 );
+		const chunkWrite = chunkCall.writes[ 0 ];
+		expect( chunkWrite.collection ).toBe( 'app.bsky.feed.post' );
+		const chunkRecord = chunkWrite.value as BskyRecord;
+		expect( chunkRecord.reply, 'body-chunk has reply refs' ).toBeDefined();
+		expect( chunkRecord.reply!.root.uri ).toBe( synthRootUri );
+		expect( chunkRecord.reply!.parent.uri ).toBe( synthRootUri );
+
+		// Call 3: CTA reply, chained root→root, parent→body-chunk.
+		const ctaCall = calls[ 2 ];
+		expect( ctaCall.writes ).toHaveLength( 1 );
+		const ctaWrite = ctaCall.writes[ 0 ];
+		expect( ctaWrite.collection ).toBe( 'app.bsky.feed.post' );
+		const ctaRecord = ctaWrite.value as BskyRecord;
+		expect( ctaRecord.reply, 'CTA has reply refs' ).toBeDefined();
+		expect( ctaRecord.reply!.root.uri ).toBe( synthRootUri );
+		expect( ctaRecord.reply!.parent.uri ).toBe(
+			`at://${ ctaCall.did }/app.bsky.feed.post/${ chunkWrite.rkey }`
+		);
+		// CTA text carries the localized "Continue reading: <permalink>"
+		// form. The exact prefix is i18n-sensitive; assert on the
+		// permalink substring instead.
+		expect( ctaRecord.text ).toMatch( /https?:\/\// );
+		// CTA carries the terminal link-card embed.
+		expect( ctaRecord.embed ).toBeDefined();
+		expect( ctaRecord.embed!.$type ).toBe( 'app.bsky.embed.external' );
+
+		// Post-meta side effects: META_THREAD_RECORDS mirrors the
+		// three published thread entries in order, and META_URI
+		// points at the root.
+		const metaRes = await page.request.get(
+			`/wp-json/fosse-e2e/v1/post-meta?post_id=${ postId }&keys=_atmosphere_bsky_thread_records,_atmosphere_bsky_uri`,
+			{ headers }
+		);
+		expect( metaRes.ok() ).toBe( true );
+		const metaJson = ( await metaRes.json() ) as PostMetaResponse;
+		const threadRecords = metaJson.meta
+			._atmosphere_bsky_thread_records as ThreadTriple[];
+		expect( Array.isArray( threadRecords ) ).toBe( true );
+		expect( threadRecords ).toHaveLength( 3 );
+		expect( threadRecords[ 0 ].uri ).toBe( synthRootUri );
+		expect( threadRecords[ 0 ].tid ).toBe( rootBskyWrite!.rkey );
+		expect( threadRecords[ 1 ].tid ).toBe( chunkWrite.rkey );
+		expect( threadRecords[ 2 ].tid ).toBe( ctaWrite.rkey );
+		for ( const triple of threadRecords ) {
+			expect( triple.cid ).toMatch( /^bafyrei/ );
+		}
+
+		expect( metaJson.meta._atmosphere_bsky_uri ).toBe( synthRootUri );
+	} );
+} );

--- a/tests/e2e/mu-plugins/fosse-bsky-capture.php
+++ b/tests/e2e/mu-plugins/fosse-bsky-capture.php
@@ -1,79 +1,158 @@
 <?php
 /**
  * Plugin Name: FOSSE e2e Atmosphere Capture
- * Description: Test-only helper. Hooks transition_post_status BEFORE
- *   Atmosphere's publisher and dumps both transformed records (the
- *   app.bsky.feed.post and the site.standard.document that
- *   Publisher::publish would write in an atomic applyWrites call) to
- *   uploads/fosse-bsky-capture.json so Playwright can assert their
- *   shape without standing up a real PDS or OAuth connection. Also
- *   exposes a REST helper so specs can flip the activitypub_object_type
- *   option between tests without re-booting Playground. Copied into
- *   wp-content/mu-plugins/ by blueprint.json.
+ * Description: Test-only helper. Short-circuits Atmosphere's
+ *   `atmosphere_pre_apply_writes` filter so every batch of writes the
+ *   Publisher emits is recorded to a WordPress option (instead of
+ *   being sent to a real PDS) while still committing the publisher's
+ *   own post-meta side effects (META_THREAD_RECORDS, META_URI, etc.).
+ *   The filter returns a synthesized `applyWrites` success response
+ *   with one deterministic uri/cid per write so Publisher's sequential
+ *   thread path can chain reply refs across calls. Specs read the
+ *   recorded batches via `GET /wp-json/fosse-e2e/v1/apply-writes`,
+ *   reset state between tests via `DELETE` on the same route, and
+ *   inspect committed post-meta via `GET /wp-json/fosse-e2e/v1/post-meta`
+ *   (since `_atmosphere_*` keys aren't `show_in_rest`).
+ *
+ *   Atmosphere's publish flow normally queues `atmosphere_publish_post`
+ *   on the cron, which Playground would only drain on a subsequent
+ *   HTTP request. To keep specs deterministic without polling cron,
+ *   we hook `transition_post_status` at priority 11 (right after
+ *   Atmosphere's own scheduler at priority 10), clear the freshly-
+ *   queued event, and invoke the async hook synchronously so the
+ *   apply_writes filter fires before the REST POST returns.
+ *
+ *   Also exposes seed endpoints so specs can flip the canonical
+ *   object-type option, pin the long-form composition strategy, and
+ *   toggle the Atmosphere connection without re-booting Playground.
+ *   Copied into wp-content/mu-plugins/ by blueprint.json.
  *
  * @package Automattic\Fosse\Tests\E2E
  */
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Option name where each captured `applyWrites` batch is appended.
+ *
+ * Stored shape: `[ { writes: array, did: string }, ... ]` — one entry
+ * per `apply_writes` call, in invocation order. A 3-entry teaser-thread
+ * produces 3 entries (root+doc, then each reply as its own batch).
+ */
+const FOSSE_E2E_APPLY_WRITES_OPTION = 'fosse_e2e_apply_writes_calls';
+
+/*
+ * Capture every applyWrites batch the Publisher emits and short-circuit
+ * the PDS round-trip with a deterministic success response.
+ *
+ * Synthesized `uri` mirrors the real PDS shape so Publisher's reply-ref
+ * chaining works end-to-end without a real network: each create yields
+ * `at://<did>/<collection>/<rkey>` derived from the write itself. `cid`
+ * uses a deterministic `bafyrei…`-prefixed hash so META_THREAD_RECORDS
+ * gets populated with realistic-looking values (and so specs can
+ * compare CIDs across writes).
+ *
+ * Filter runs at priority 10 (default). API::apply_writes validates
+ * the return shape (`[ 'results' => [ { uri, cid }, ... ] ]` with one
+ * entry per write), so failures here surface as Publisher WP_Errors
+ * and specs see the publish path break cleanly rather than time out.
+ */
+add_filter(
+	'atmosphere_pre_apply_writes',
+	static function ( $short_circuit, array $writes ) {
+		// Defensive: respect an upstream short-circuit if anything
+		// else is already in the chain (other mu-plugins, dev shims).
+		if ( null !== $short_circuit ) {
+			return $short_circuit;
+		}
+
+		$did = \function_exists( 'Atmosphere\\get_did' ) ? \Atmosphere\get_did() : '';
+
+		$existing = \get_option( FOSSE_E2E_APPLY_WRITES_OPTION, array() );
+		if ( ! \is_array( $existing ) ) {
+			$existing = array();
+		}
+
+		$existing[] = array(
+			'writes' => $writes,
+			'did'    => $did,
+		);
+		\update_option( FOSSE_E2E_APPLY_WRITES_OPTION, $existing, false );
+
+		$results = array();
+		foreach ( $writes as $write ) {
+			$type       = (string) ( $write['$type'] ?? '' );
+			$collection = (string) ( $write['collection'] ?? '' );
+			$rkey       = (string) ( $write['rkey'] ?? '' );
+
+			if ( 'com.atproto.repo.applyWrites#delete' === $type ) {
+				// Deletes have no uri/cid response per the lexicon.
+				$results[] = array();
+				continue;
+			}
+
+			$results[] = array(
+				'uri' => \sprintf( 'at://%s/%s/%s', $did, $collection, $rkey ),
+				'cid' => 'bafyrei' . \substr( \hash( 'sha256', $collection . '/' . $rkey ), 0, 32 ),
+			);
+		}
+
+		return array( 'results' => $results );
+	},
+	10,
+	2
+);
+
+/*
+ * Drain the freshly-scheduled `atmosphere_publish_post` (or
+ * `_update_post`, `_delete_post`) cron event inline so specs don't
+ * need to wait on Playground's cron loop.
+ *
+ * Atmosphere's `on_status_change` callback at priority 10 calls
+ * `wp_schedule_single_event` for the relevant async hook. We run at
+ * priority 11, clear the just-scheduled event so it can't double-fire
+ * later, and dispatch the action synchronously. With the apply_writes
+ * filter already in place, this means by the time `POST /wp/v2/posts`
+ * returns, the capture option is fully populated and any post-meta
+ * side effects (META_THREAD_RECORDS, META_URI, etc.) are committed.
+ */
 add_action(
 	'transition_post_status',
 	static function ( string $new_status, string $old_status, \WP_Post $post ): void {
-		if ( 'publish' !== $new_status || 'publish' === $old_status ) {
-			return;
-		}
+		unset( $new_status, $old_status );
 
 		if ( ! \in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
 			return;
 		}
 
-		if ( ! \class_exists( '\Atmosphere\Transformer\Post' )
-			|| ! \class_exists( '\Atmosphere\Transformer\Document' )
-		) {
+		if ( ! \class_exists( '\\Atmosphere\\Publisher' ) ) {
 			return;
 		}
 
-		$upload = \wp_upload_dir();
-		if ( ! empty( $upload['error'] ) ) {
-			\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				'[fosse-bsky-capture] wp_upload_dir() error: ' . $upload['error']
-			);
-			return;
-		}
-
-		$bsky = ( new \Atmosphere\Transformer\Post( $post ) )->transform();
-		$doc  = ( new \Atmosphere\Transformer\Document( $post ) )->transform();
-
-		$path    = \trailingslashit( $upload['basedir'] ) . 'fosse-bsky-capture.json';
-		$written = \file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			$path,
-			\wp_json_encode(
-				array(
-					'post_id'     => $post->ID,
-					'bsky_record' => $bsky,
-					'doc_record'  => $doc,
-				)
-			)
+		$hooks = array(
+			'atmosphere_publish_post',
+			'atmosphere_update_post',
+			'atmosphere_delete_post',
 		);
-		if ( false === $written ) {
-			\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				'[fosse-bsky-capture] file_put_contents failed writing to ' . $path
-			);
+
+		foreach ( $hooks as $hook ) {
+			$scheduled = \wp_next_scheduled( $hook, array( $post->ID ) );
+			if ( false === $scheduled ) {
+				continue;
+			}
+
+			\wp_clear_scheduled_hook( $hook, array( $post->ID ) );
+			\do_action( $hook, $post->ID );
 		}
 	},
-	5,
+	11,
 	3
 );
 
 /*
- * Test-only REST endpoint so specs can set/clear the canonical
- * `activitypub_object_type` option between tests without re-booting
- * Playground. The Object_Type bridge reads this option directly post-
- * canonicalization (`sdd/canonical-upstream-options/`); writing the
- * legacy `fosse_object_type` instead would no-op against the bridge.
- * manage_options gate keeps this inaccessible to unauthenticated
- * requests; Playground's `login: true` blueprint step admin-session
- * satisfies it.
+ * Test-only REST endpoints registered on `rest_api_init`. Behind
+ * `manage_options` so they are inaccessible to unauthenticated
+ * requests; Playground's `login: true` blueprint step satisfies that.
  */
 add_action(
 	'rest_api_init',
@@ -120,6 +199,56 @@ add_action(
 			)
 		);
 
+		/*
+		 * Pin Atmosphere's long-form composition strategy
+		 * (`atmosphere_long_form_composition`) between tests. FOSSE's
+		 * canonical-options migrator seeds this to `'teaser-thread'`
+		 * for fresh installs; specs that want to assert the
+		 * `'link-card'` or `'truncate-link'` branches need to flip it
+		 * explicitly so test ordering can't bleed state.
+		 */
+		\register_rest_route(
+			'fosse-e2e/v1',
+			'/long-form-strategy',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => static function (): bool {
+					return \current_user_can( 'manage_options' );
+				},
+				'args'                => array(
+					'value' => array(
+						'type'     => 'string',
+						'required' => false,
+					),
+				),
+				'callback'            => static function ( $request ) {
+					try {
+						$value = $request->get_param( 'value' );
+						if ( null === $value || '' === $value ) {
+							\delete_option( 'atmosphere_long_form_composition' );
+						} else {
+							\update_option( 'atmosphere_long_form_composition', $value );
+						}
+						return \rest_ensure_response(
+							array(
+								'ok'      => true,
+								'current' => \get_option( 'atmosphere_long_form_composition', null ),
+							)
+						);
+					} catch ( \Throwable $e ) {
+						\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+							'[fosse-e2e/long-form-strategy] ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine()
+						);
+						return new \WP_Error(
+							'fosse_e2e_error',
+							$e->getMessage(),
+							array( 'status' => 500 )
+						);
+					}
+				},
+			)
+		);
+
 		\register_rest_route(
 			'fosse-e2e/v1',
 			'/bluesky-state',
@@ -152,7 +281,7 @@ add_action(
 				),
 				'callback'            => static function ( $request ) {
 					try {
-						$connected = (bool) $request->get_param( 'connected' );
+						$connected    = (bool) $request->get_param( 'connected' );
 						$auto_publish = $request->get_param( 'auto_publish' );
 
 						if ( $connected ) {
@@ -167,6 +296,13 @@ add_action(
 							);
 						} else {
 							\delete_option( 'atmosphere_connection' );
+							// Atmosphere's get_identity() lazy-migrates from
+							// atmosphere_connection into atmosphere_identity
+							// on first read after a connect, and the cached
+							// identity outlives the connection. A spec that
+							// disconnects without clearing identity would
+							// see a poisoned reconnect path on its next seed.
+							\delete_option( 'atmosphere_identity' );
 						}
 
 						if ( null !== $auto_publish ) {
@@ -175,10 +311,10 @@ add_action(
 
 						return \rest_ensure_response(
 							array(
-								'ok'             => true,
-								'connected'      => $connected,
-								'connection'     => \get_option( 'atmosphere_connection', array() ),
-								'auto_publish'   => \get_option( 'atmosphere_auto_publish', '1' ),
+								'ok'           => true,
+								'connected'    => $connected,
+								'connection'   => \get_option( 'atmosphere_connection', array() ),
+								'auto_publish' => \get_option( 'atmosphere_auto_publish', '1' ),
 							)
 						);
 					} catch ( \Throwable $e ) {
@@ -191,6 +327,87 @@ add_action(
 							array( 'status' => 500 )
 						);
 					}
+				},
+			)
+		);
+
+		/*
+		 * Read and reset the captured applyWrites batches.
+		 *
+		 * `GET` returns `{ calls: [ { writes, did }, ... ] }` in
+		 * invocation order. `DELETE` clears the option so specs can
+		 * isolate one publish flow per test.
+		 */
+		\register_rest_route(
+			'fosse-e2e/v1',
+			'/apply-writes',
+			array(
+				array(
+					'methods'             => 'GET',
+					'permission_callback' => static function (): bool {
+						return \current_user_can( 'manage_options' );
+					},
+					'callback'            => static function () {
+						$calls = \get_option( FOSSE_E2E_APPLY_WRITES_OPTION, array() );
+						if ( ! \is_array( $calls ) ) {
+							$calls = array();
+						}
+						return \rest_ensure_response( array( 'calls' => $calls ) );
+					},
+				),
+				array(
+					'methods'             => 'DELETE',
+					'permission_callback' => static function (): bool {
+						return \current_user_can( 'manage_options' );
+					},
+					'callback'            => static function () {
+						\delete_option( FOSSE_E2E_APPLY_WRITES_OPTION );
+						return \rest_ensure_response( array( 'ok' => true ) );
+					},
+				),
+			)
+		);
+
+		/*
+		 * Read selected post-meta keys for a given post. Needed
+		 * because the publisher writes to `_atmosphere_*` keys
+		 * (META_URI, META_THREAD_RECORDS, etc.) that aren't
+		 * registered with `show_in_rest`, so the standard
+		 * /wp/v2/posts/<id> response omits them.
+		 */
+		\register_rest_route(
+			'fosse-e2e/v1',
+			'/post-meta',
+			array(
+				'methods'             => 'GET',
+				'permission_callback' => static function (): bool {
+					return \current_user_can( 'manage_options' );
+				},
+				'args'                => array(
+					'post_id' => array(
+						'type'     => 'integer',
+						'required' => true,
+					),
+					'keys'    => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+				'callback'            => static function ( $request ) {
+					$post_id = (int) $request->get_param( 'post_id' );
+					$keys    = \array_filter( \array_map( 'trim', \explode( ',', (string) $request->get_param( 'keys' ) ) ) );
+
+					$out = array();
+					foreach ( $keys as $key ) {
+						$out[ $key ] = \get_post_meta( $post_id, $key, true );
+					}
+
+					return \rest_ensure_response(
+						array(
+							'post_id' => $post_id,
+							'meta'    => $out,
+						)
+					);
 				},
 			)
 		);

--- a/tests/e2e/short-form-facets.spec.ts
+++ b/tests/e2e/short-form-facets.spec.ts
@@ -122,7 +122,10 @@ test.describe( 'short-form facet capture', () => {
 		// Publisher emits and runs the publish inline on
 		// transition_post_status, so the capture option is populated
 		// by the time POST /posts returns. Poll briefly in case the
-		// option write hasn't flushed yet.
+		// option write hasn't flushed yet. Short-form publishes through
+		// `publish_single`, which emits exactly one batch — asserting
+		// the count is `1` (not `>= 1`) catches future regressions
+		// where the Publisher accidentally fans out to extra batches.
 		const headers = await nonceHeaders( page );
 		let captured: CapturedCalls | null = null;
 		await expect
@@ -140,7 +143,7 @@ test.describe( 'short-form facet capture', () => {
 				},
 				{ timeout: 5_000, intervals: [ 100, 250, 500 ] }
 			)
-			.toBeGreaterThanOrEqual( 1 );
+			.toBe( 1 );
 
 		// Short-form path: one applyWrites call, two writes
 		// (app.bsky.feed.post + site.standard.document atomically).

--- a/tests/e2e/short-form-facets.spec.ts
+++ b/tests/e2e/short-form-facets.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+import { resetBlueskyState, setBlueskyState } from './test-helpers';
 
 type BskyRecord = {
 	$type?: string;
@@ -18,118 +19,179 @@ type DocRecord = {
 	[ key: string ]: unknown;
 };
 
-type Capture = {
-	post_id: number;
-	bsky_record: BskyRecord;
-	doc_record: DocRecord;
+type Write = {
+	$type: string;
+	collection: string;
+	rkey: string;
+	value: Record< string, unknown >;
 };
 
-test( 'short-form post: tag/mention/link facets captured, no embed, plus document record', async ( {
-	page,
-} ) => {
-	await page.goto( '/wp-admin/post-new.php' );
+type Call = {
+	writes: Write[];
+	did: string;
+};
 
-	// wpApiSettings is localized on editor-ish admin pages where api-fetch is
-	// enqueued; we need its nonce to POST to /wp/v2/posts.
-	await page.waitForFunction(
-		() => !! ( window as any ).wpApiSettings?.nonce
-	);
+type CapturedCalls = {
+	calls: Call[];
+};
 
-	// Set activitypub_object_type=note explicitly so this spec is robust
-	// to run order — long-form-link-card.spec.ts flips the canonical
-	// option to 'wordpress-post-format'; without this reset, order-
-	// dependence would break one of the two tests.
-	const flipResult = await page.evaluate( async () => {
-		const res = await fetch( '/wp-json/fosse-e2e/v1/object-type', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
-			},
-			body: JSON.stringify( { value: 'note' } ),
-		} );
-		return { status: res.status, text: await res.text() };
+const nonceHeaders = async ( page: Page ) => ( {
+	'Content-Type': 'application/json',
+	'X-WP-Nonce': await page.evaluate(
+		() => ( window as any ).wpApiSettings.nonce
+	),
+} );
+
+test.describe( 'short-form facet capture', () => {
+	test.afterAll( async ( { browser }, testInfo ) => {
+		const baseURL = testInfo.project.use.baseURL;
+		if ( ! baseURL ) {
+			throw new Error(
+				'baseURL must be configured in playwright.config.ts'
+			);
+		}
+		await resetBlueskyState( browser, baseURL );
 	} );
-	expect(
-		flipResult.status,
-		`fosse-e2e/v1/object-type returned: ${ flipResult.text.slice(
-			0,
-			300
-		) }`
-	).toBe( 200 );
 
-	const body = 'hello #world @alice.test https://example.com';
+	test( 'short-form post: tag/mention/link facets captured, no embed, plus document record', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/post-new.php' );
 
-	const created = await page.evaluate( async ( content ) => {
-		const res = await fetch( '/wp-json/wp/v2/posts', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
-			},
-			body: JSON.stringify( {
-				title: '',
-				content,
-				status: 'publish',
-			} ),
+		// wpApiSettings is localized on editor-ish admin pages where api-fetch
+		// is enqueued; we need its nonce to POST to /wp/v2/posts.
+		await page.waitForFunction(
+			() => !! ( window as any ).wpApiSettings?.nonce
+		);
+
+		// Set activitypub_object_type=note explicitly so this spec is robust
+		// to run order — long-form-link-card.spec.ts flips the canonical
+		// option to 'wordpress-post-format'; without this reset, order-
+		// dependence would break one of the two tests.
+		const flipResult = await page.evaluate( async () => {
+			const res = await fetch( '/wp-json/fosse-e2e/v1/object-type', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+				},
+				body: JSON.stringify( { value: 'note' } ),
+			} );
+			return { status: res.status, text: await res.text() };
 		} );
-		const text = await res.text();
-		return { status: res.status, text };
-	}, body );
+		expect(
+			flipResult.status,
+			`fosse-e2e/v1/object-type returned: ${ flipResult.text.slice(
+				0,
+				300
+			) }`
+		).toBe( 200 );
 
-	expect(
-		created.status,
-		`POST /posts returned: ${ created.text.slice( 0, 300 ) }`
-	).toBe( 201 );
-	const postId = ( JSON.parse( created.text ) as { id: number } ).id;
+		// Connect Bluesky and reset the capture so only this test's
+		// publish populates it.
+		await setBlueskyState( page, { connected: true } );
+		await page.evaluate( async () => {
+			await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
+				method: 'DELETE',
+				headers: {
+					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+				},
+			} );
+		} );
 
-	// The mu-plugin writes uploads/fosse-bsky-capture.json synchronously on the
-	// transition_post_status publish transition — so by the time /posts returns
-	// 201, the capture should be on disk. Poll briefly for filesystem flush.
-	const captureUrl = '/wp-content/uploads/fosse-bsky-capture.json';
-	let captured: Capture | null = null;
-	await expect
-		.poll(
-			async () => {
-				const r = await page.request.get( captureUrl );
-				if ( ! r.ok() ) {
-					return false;
-				}
-				captured = ( await r.json() ) as Capture;
-				return captured.post_id === postId;
-			},
-			{ timeout: 5_000, intervals: [ 100, 250, 500 ] }
-		)
-		.toBe( true );
+		const body = 'hello #world @alice.test https://example.com';
 
-	// app.bsky.feed.post record: short-form composition + facet parity.
-	const bsky = captured!.bsky_record;
+		const created = await page.evaluate( async ( content ) => {
+			const res = await fetch( '/wp-json/wp/v2/posts', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+				},
+				body: JSON.stringify( {
+					title: '',
+					content,
+					status: 'publish',
+				} ),
+			} );
+			const text = await res.text();
+			return { status: res.status, text };
+		}, body );
 
-	expect( bsky.text ).toBe( body );
-	expect( bsky.embed ).toBeUndefined();
-	expect( bsky.facets ).toBeDefined();
-	expect( bsky.facets! ).toHaveLength( 3 );
+		expect(
+			created.status,
+			`POST /posts returned: ${ created.text.slice( 0, 300 ) }`
+		).toBe( 201 );
+		const postId = ( JSON.parse( created.text ) as { id: number } ).id;
+		expect( postId ).toBeGreaterThan( 0 );
 
-	const facetOfType = ( type: string ) =>
-		bsky.facets!.find( ( f ) => f.features[ 0 ]?.$type === type );
+		// The capture mu-plugin records every applyWrites batch the
+		// Publisher emits and runs the publish inline on
+		// transition_post_status, so the capture option is populated
+		// by the time POST /posts returns. Poll briefly in case the
+		// option write hasn't flushed yet.
+		const headers = await nonceHeaders( page );
+		let captured: CapturedCalls | null = null;
+		await expect
+			.poll(
+				async () => {
+					const r = await page.request.get(
+						'/wp-json/fosse-e2e/v1/apply-writes',
+						{ headers }
+					);
+					if ( ! r.ok() ) {
+						return 0;
+					}
+					captured = ( await r.json() ) as CapturedCalls;
+					return captured.calls.length;
+				},
+				{ timeout: 5_000, intervals: [ 100, 250, 500 ] }
+			)
+			.toBeGreaterThanOrEqual( 1 );
 
-	const tag = facetOfType( 'app.bsky.richtext.facet#tag' );
-	expect( tag, 'tag facet present' ).toBeTruthy();
-	expect( tag!.features[ 0 ].tag ).toBe( 'world' );
+		// Short-form path: one applyWrites call, two writes
+		// (app.bsky.feed.post + site.standard.document atomically).
+		const writes = captured!.calls[ 0 ].writes;
+		const bskyWrite = writes.find(
+			( w ) => w.collection === 'app.bsky.feed.post'
+		);
+		expect( bskyWrite, 'app.bsky.feed.post write present' ).toBeTruthy();
+		const docWrite = writes.find(
+			( w ) => w.collection === 'site.standard.document'
+		);
+		expect(
+			docWrite,
+			'site.standard.document write present (DOTCOM-16809 guard)'
+		).toBeTruthy();
 
-	const mention = facetOfType( 'app.bsky.richtext.facet#mention' );
-	expect( mention, 'mention facet present' ).toBeTruthy();
-	expect( mention!.features[ 0 ].did as string ).toMatch( /^did:/ );
+		const bsky = bskyWrite!.value as BskyRecord;
 
-	const link = facetOfType( 'app.bsky.richtext.facet#link' );
-	expect( link, 'link facet present' ).toBeTruthy();
-	expect( link!.features[ 0 ].uri ).toBe( 'https://example.com' );
+		expect( bsky.text ).toBe( body );
+		expect( bsky.embed ).toBeUndefined();
+		expect( bsky.facets ).toBeDefined();
+		expect( bsky.facets! ).toHaveLength( 3 );
 
-	// site.standard.document record: must still be written on the short-form
-	// path (DOTCOM-16809). Publisher::publish atomically writes both records;
-	// this guards against a future regression if the document path ever grows
-	// a post-format sensitivity.
-	const doc = captured!.doc_record;
-	expect( doc.$type ).toBe( 'site.standard.document' );
-	expect( doc.publishedAt as string ).toMatch( /^\d{4}-\d{2}-\d{2}T/ );
+		const facetOfType = ( type: string ) =>
+			bsky.facets!.find( ( f ) => f.features[ 0 ]?.$type === type );
+
+		const tag = facetOfType( 'app.bsky.richtext.facet#tag' );
+		expect( tag, 'tag facet present' ).toBeTruthy();
+		expect( tag!.features[ 0 ].tag ).toBe( 'world' );
+
+		const mention = facetOfType( 'app.bsky.richtext.facet#mention' );
+		expect( mention, 'mention facet present' ).toBeTruthy();
+		expect( mention!.features[ 0 ].did as string ).toMatch( /^did:/ );
+
+		const link = facetOfType( 'app.bsky.richtext.facet#link' );
+		expect( link, 'link facet present' ).toBeTruthy();
+		expect( link!.features[ 0 ].uri ).toBe( 'https://example.com' );
+
+		// site.standard.document record: must still be written on the
+		// short-form path (DOTCOM-16809). Publisher::publish atomically
+		// writes both records; this guards against a future regression
+		// if the document path ever grows a post-format sensitivity.
+		const doc = docWrite!.value as DocRecord;
+		expect( doc.$type ).toBe( 'site.standard.document' );
+		expect( doc.publishedAt as string ).toMatch( /^\d{4}-\d{2}-\d{2}T/ );
+	} );
 } );

--- a/tests/e2e/short-form-facets.spec.ts
+++ b/tests/e2e/short-form-facets.spec.ts
@@ -88,16 +88,21 @@ test.describe( 'short-form facet capture', () => {
 		).toBe( 200 );
 
 		// Connect Bluesky and reset the capture so only this test's
-		// publish populates it.
+		// publish populates it. Assert the DELETE succeeded — a silent
+		// failure would let prior runs' stale calls leak into the
+		// later "captured.calls" assertions and make this spec
+		// order-dependent.
 		await setBlueskyState( page, { connected: true } );
-		await page.evaluate( async () => {
-			await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
+		const resetStatus = await page.evaluate( async () => {
+			const res = await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
 				method: 'DELETE',
 				headers: {
 					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
 				},
 			} );
+			return res.status;
 		} );
+		expect( resetStatus, 'apply-writes DELETE succeeded' ).toBe( 200 );
 
 		const body = 'hello #world @alice.test https://example.com';
 

--- a/tests/e2e/short-form-facets.spec.ts
+++ b/tests/e2e/short-form-facets.spec.ts
@@ -1,5 +1,10 @@
-import { test, expect, type Page } from '@playwright/test';
-import { resetBlueskyState, setBlueskyState } from './test-helpers';
+import { test, expect } from '@playwright/test';
+import {
+	nonceHeaders,
+	resetApplyWritesCapture,
+	resetBlueskyState,
+	setBlueskyState,
+} from './test-helpers';
 
 type BskyRecord = {
 	$type?: string;
@@ -34,13 +39,6 @@ type Call = {
 type CapturedCalls = {
 	calls: Call[];
 };
-
-const nonceHeaders = async ( page: Page ) => ( {
-	'Content-Type': 'application/json',
-	'X-WP-Nonce': await page.evaluate(
-		() => ( window as any ).wpApiSettings.nonce
-	),
-} );
 
 test.describe( 'short-form facet capture', () => {
 	test.afterAll( async ( { browser }, testInfo ) => {
@@ -88,21 +86,11 @@ test.describe( 'short-form facet capture', () => {
 		).toBe( 200 );
 
 		// Connect Bluesky and reset the capture so only this test's
-		// publish populates it. Assert the DELETE succeeded — a silent
-		// failure would let prior runs' stale calls leak into the
-		// later "captured.calls" assertions and make this spec
-		// order-dependent.
+		// publish populates it. The helper asserts the DELETE succeeded
+		// so a silent failure can't let prior runs' stale calls leak
+		// into the later "captured.calls" assertions.
 		await setBlueskyState( page, { connected: true } );
-		const resetStatus = await page.evaluate( async () => {
-			const res = await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
-				method: 'DELETE',
-				headers: {
-					'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
-				},
-			} );
-			return res.status;
-		} );
-		expect( resetStatus, 'apply-writes DELETE succeeded' ).toBe( 200 );
+		await resetApplyWritesCapture( page );
 
 		const body = 'hello #world @alice.test https://example.com';
 

--- a/tests/e2e/test-helpers.ts
+++ b/tests/e2e/test-helpers.ts
@@ -130,6 +130,59 @@ export const resetBlueskyState = async (
 };
 
 /**
+ * Build the JSON + nonce headers required to POST to authenticated WP REST
+ * endpoints from a Playwright `page.request` call.
+ *
+ * Reads `wpApiSettings.nonce` from the current page's window object, so the
+ * caller must already be on a wp-admin screen that localizes wpApiSettings
+ * (e.g. `post-new.php`). Shared across the Bluesky e2e specs that issue
+ * authenticated REST calls outside of `page.evaluate()`.
+ *
+ * @param {Page} page Playwright page; must be on a wp-admin screen so
+ *                    `wpApiSettings.nonce` is available.
+ * @return {Promise<Record<string, string>>} Headers object suitable for
+ *                                           `page.request.get/post/delete`.
+ */
+export const nonceHeaders = async (
+	page: Page
+): Promise< Record< string, string > > => ( {
+	'Content-Type': 'application/json',
+	'X-WP-Nonce': await page.evaluate(
+		() => ( window as any ).wpApiSettings.nonce
+	),
+} );
+
+/**
+ * Reset the captured `applyWrites` batches recorded by the e2e mu-plugin
+ * (`tests/e2e/mu-plugins/fosse-bsky-capture.php`).
+ *
+ * Issues a DELETE to `/wp-json/fosse-e2e/v1/apply-writes` from inside the
+ * page's browser context so the request carries the wp-admin session
+ * cookie, then asserts the response status so a silent failure can't let
+ * stale batches from a prior test leak into the current spec's
+ * assertions. Specs that publish a post and then assert on captured
+ * applyWrites batches should call this immediately before publish.
+ *
+ * @param {Page} page Playwright page; must be on a wp-admin screen so
+ *                    `wpApiSettings.nonce` is available.
+ * @return {Promise<void>} Resolves once the reset returns 200.
+ */
+export const resetApplyWritesCapture = async (
+	page: Page
+): Promise< void > => {
+	const resetStatus = await page.evaluate( async () => {
+		const res = await fetch( '/wp-json/fosse-e2e/v1/apply-writes', {
+			method: 'DELETE',
+			headers: {
+				'X-WP-Nonce': ( window as any ).wpApiSettings.nonce,
+			},
+		} );
+		return res.status;
+	} );
+	expect( resetStatus, 'apply-writes DELETE succeeded' ).toBe( 200 );
+};
+
+/**
  * Reset the FOSSE onboarding wizard back to the destinations step when it is
  * currently in the completed state.
  *


### PR DESCRIPTION
## Summary

Rewrites the e2e Bluesky capture mu-plugin to hook Atmosphere's `atmosphere_pre_apply_writes` filter instead of shadowing the publisher through `transition_post_status` + manual transformer calls. The new seam records every applyWrites batch the Publisher emits, returns a synthesized success response so the publisher's reply-ref chaining works without a real PDS, and commits the publisher's own post-meta side effects (`META_THREAD_RECORDS`, `META_URI`, etc.) along the way. Adds a new Playwright spec covering the previously-untested teaser-thread strategy end-to-end, including chained reply refs across three sequential applyWrites calls.

## What this PR ships

### Capture mu-plugin (`tests/e2e/mu-plugins/fosse-bsky-capture.php`)

- Hooks `atmosphere_pre_apply_writes` at priority 10. Each batch is appended to a new `fosse_e2e_apply_writes_calls` option in the shape `[ { writes, did }, ... ]`, one entry per `apply_writes` invocation. The filter returns a synthesized `[ 'results' => [ { uri, cid }, ... ] ]` response where `uri` is `at://<did>/<collection>/<rkey>` and `cid` is a deterministic `bafyrei…`-prefixed hash, so the publisher's sequential thread path can chain `reply.root` / `reply.parent` refs across calls.
- Drains the freshly-scheduled `atmosphere_publish_post` (and `_update_post`, `_delete_post`) cron event inline on `transition_post_status` priority 11, so specs do not have to wait on Playground's cron loop.
- Disconnect now also clears `atmosphere_identity` to avoid the lazy-migration cache poisoning reconnect-path tests.

### New REST endpoints

- `GET` / `DELETE /wp-json/fosse-e2e/v1/apply-writes` — read and reset the captured batches.
- `GET /wp-json/fosse-e2e/v1/post-meta?post_id=N&keys=...` — read `_atmosphere_*` post-meta keys that aren't `show_in_rest` (so specs can assert META_THREAD_RECORDS / META_URI without registering them upstream).
- `POST /wp-json/fosse-e2e/v1/long-form-strategy` — pin `atmosphere_long_form_composition` between tests, since FOSSE's canonical-options migrator seeds `teaser-thread` as the default and specs need to assert each branch deterministically.
- Existing `/object-type` and `/bluesky-state` endpoints kept as-is (with the identity-cleanup tweak above).

### Existing-spec updates

- `tests/e2e/short-form-facets.spec.ts` — migrates to the new capture shape. Connects Bluesky via `setBlueskyState`, resets `apply-writes` before publish, asserts the single applyWrites batch contains one `app.bsky.feed.post` (with tag/mention/link facets, no embed) plus one `site.standard.document`.
- `tests/e2e/long-form-link-card.spec.ts` — same migration. Pins `atmosphere_long_form_composition=link-card` so the pass-through bridge assertion stays focused on Object_Type behavior even after the FOSSE default changed to `teaser-thread`.

### New `tests/e2e/long-form-teaser-thread.spec.ts`

- Pins `activitypub_object_type=wordpress-post-format` (pass-through) and `atmosphere_long_form_composition=teaser-thread`.
- Publishes a titled post with a curated excerpt (10+ chars → drives the excerpt-as-hook branch of `compute_default_teaser_thread`) and a body that lands in the 3-entry `[ hook, body_chunk, cta ]` shape.
- Asserts exactly **three** applyWrites calls:
  1. Root + doc atomically (2 writes in one batch).
  2. Body-chunk reply (1 write, `reply.root` = `reply.parent` = root URI).
  3. CTA reply (1 write, `reply.root` = root URI, `reply.parent` = body-chunk URI), with the terminal `app.bsky.embed.external` card attached.
- Asserts `_atmosphere_bsky_thread_records` post-meta carries the three ordered triples and `_atmosphere_bsky_uri` mirrors the synthesized root URI.

## Test plan

- [ ] `composer run-script lint-php` — clean.
- [ ] `pnpm run format:check` — clean.
- [ ] `pnpm run lint` — clean.
- [ ] `pnpm exec playwright test short-form-facets long-form-link-card long-form-teaser-thread` — all three pass locally against Playground.
- [ ] CI e2e job (`e2e.yml`) passes.

## Related

- Fixes DOTCOM-16889.
- Unblocks future teaser-thread iteration (filter shape, CTA wording, mid-thread failure rollback assertions).