### PR TITLE
fix: style --ap-address and --handle identity-token modifiers (issue 163 Part B)

### DIFF
--- a/src/Admin/assets/css/admin.css
+++ b/src/Admin/assets/css/admin.css
@@ -836,6 +836,12 @@
 	-webkit-box-decoration-break: clone;
 }
 
+.fosse-token--ap-address,
+.fosse-admin-token--ap-address,
+.fosse-status-card__token--ap-address,
+.fosse-token--handle,
+.fosse-admin-token--handle,
+.fosse-status-card__token--handle,
 .fosse-token--host,
 .fosse-admin-token--host {
 	font-weight: 500;

--- a/tests/php/Admin/Admin_CSS_Test.php
+++ b/tests/php/Admin/Admin_CSS_Test.php
@@ -74,8 +74,14 @@ class Admin_CSS_Test extends BaseTestCase {
 	 */
 	public static function provide_identity_token_modifier_selectors(): array {
 		return array(
-			'completion host token' => array( '.fosse-token--host' ),
-			'admin host token'      => array( '.fosse-admin-token--host' ),
+			'completion host token'        => array( '.fosse-token--host' ),
+			'admin host token'             => array( '.fosse-admin-token--host' ),
+			'completion handle token'      => array( '.fosse-token--handle' ),
+			'admin handle token'           => array( '.fosse-admin-token--handle' ),
+			'status card handle token'     => array( '.fosse-status-card__token--handle' ),
+			'completion ap-address token'  => array( '.fosse-token--ap-address' ),
+			'admin ap-address token'       => array( '.fosse-admin-token--ap-address' ),
+			'status card ap-address token' => array( '.fosse-status-card__token--ap-address' ),
 		);
 	}
 }


### PR DESCRIPTION
## Summary

Resolves Part B of issue 163 — the leftover unstyled identity-token modifier classes called out by the PR 161 maintainability review.

Part A of the issue (handle-shape defense moved into `Bluesky_Provider::get_status()`, plus its unit test) is already on trunk and not part of this PR.

## What this PR ships

### CSS: style the `--ap-address` and `--handle` modifiers

`src/Admin/assets/css/admin.css` had a font-weight: 500 rule for `.fosse-token--host` / `.fosse-admin-token--host`. The matching modifiers for `--ap-address` and `--handle` were being emitted by every call site (`class-ap-provider.php`, `class-bluesky-provider.php`, `class-onboarding-wizard.php`) and pinned by regex assertions in `Onboarding_WizardTest.php`, but no stylesheet rule honored them. They were load-bearing for tests yet invisible to users — the worst of both worlds.

Extended the existing selector list to include all six emitted variants:

```css
.fosse-token--ap-address,
.fosse-admin-token--ap-address,
.fosse-status-card__token--ap-address,
.fosse-token--handle,
.fosse-admin-token--handle,
.fosse-status-card__token--handle,
.fosse-token--host,
.fosse-admin-token--host {
    font-weight: 500;
}
```

The `fosse-status-card__token--*` variants are included because grep against the source tree confirmed `class-ap-provider.php` and `class-bluesky-provider.php` both emit them on real render paths. No status-card variant of `--host` is emitted anywhere, so it's deliberately absent from the rule.

### Test: extend the data-provider contract guard

`tests/php/Admin/Admin_CSS_Test.php` has `test_identity_token_modifiers_have_css_rules`, a data-provider-driven test built precisely to catch the "class emitted in PHP but missing from admin.css" gap this PR is fixing. The provider only listed `--host`. Extended it to include all six newly-styled selectors so future accidental deletion of any of them fails a test instead of slipping through silently. PHPUnit confirms: 9 tests, 18 assertions, all green.

## What this PR does not do

The code-review pass caught one additional concern that's intentionally out of scope:

- **`--did` and `--url` modifier classes are also unstyled.** They're emitted at four call sites in `class-bluesky-provider.php` (lines 429, 437, 801, 811) but have no CSS rule of their own. The issue body claimed they were already styled — that's stale info from before the CSS file was restructured. Adjacent to the now-styled `--handle` siblings in the same Bluesky status-card surface, the unstyled `--did` / `--url` will read as visually quieter, which may or may not be the right call (DIDs and URLs are opaque references, not identity strings — the typographic distinction is arguably correct). Worth a separate decision in its own follow-up, not silently in this one.

## Test plan

- [x] `vendor/bin/phpunit --filter Admin_CSS_Test` — 9 tests, 18 assertions
- [x] `vendor/bin/phpunit --filter Bluesky_ProviderTest` — 131 tests, 345 assertions
- [x] `vendor/bin/phpunit --filter Onboarding_WizardTest` — 106 tests, 414 assertions
- [x] `tools/vendor/bin/phpcs tests/php/Admin/Admin_CSS_Test.php` — clean
- [x] `pnpm exec prettier --check src/Admin/assets/css/admin.css` — clean
- [ ] Visual check in wp-admin — confirm `@user.bsky.social` handles and `@user@example.com` AP addresses render with the same bold treatment as host tokens

## Review

Ran `/ce-code-review` (multi-agent) and `/codex challenge` (adversarial). Round 1 surfaced one cross-reviewer finding (the `Admin_CSS_Test` data provider gap, called out independently by correctness, testing, and maintainability) — addressed in this same PR. Codex challenge round returned no production failures. Single-reviewer `--did`/`--url` concern carried forward as a known follow-up above.

Fixes #163
