### PR TITLE
Resync bundled backends and release 0.1.2

### DIFF
--- a/bundled/activitypub/assets/js/activitypub-admin.js
+++ b/bundled/activitypub/assets/js/activitypub-admin.js
@@ -17,4 +17,33 @@ jQuery( function( $ ) {
 			$( '.activate-now' ).removeClass( 'thickbox open-plugin-details-modal' );
 		}, 1200 );
 	} );
+
+	/*
+	 * Lazy-load embedded iframes (e.g. the Fediverse intro video) only once their
+	 * container becomes visible. Help tab panels are rendered hidden, and players
+	 * like PeerTube abort with an "invalid width" error when initialized inside a
+	 * zero-width container. Deferring the src until the panel is shown avoids that.
+	 */
+	var lazyIframes = document.querySelectorAll( 'iframe[data-src]' );
+
+	if ( lazyIframes.length && 'IntersectionObserver' in window ) {
+		var iframeObserver = new IntersectionObserver( function( entries, observer ) {
+			entries.forEach( function( entry ) {
+				if ( entry.isIntersecting ) {
+					// Set once, then stop observing so it never reloads.
+					entry.target.src = entry.target.dataset.src;
+					observer.unobserve( entry.target );
+				}
+			} );
+		} );
+
+		lazyIframes.forEach( function( iframe ) {
+			iframeObserver.observe( iframe );
+		} );
+	} else {
+		// IntersectionObserver unsupported: load immediately as a fallback.
+		lazyIframes.forEach( function( iframe ) {
+			iframe.src = iframe.dataset.src;
+		} );
+	}
 } );

--- a/bundled/activitypub/includes/activity/class-activity.php
+++ b/bundled/activitypub/includes/activity/class-activity.php
@@ -38,9 +38,10 @@ class Activity extends Base_Object {
 	const JSON_LD_CONTEXT = array(
 		'https://www.w3.org/ns/activitystreams',
 		array(
-			'toot'         => 'http://joinmastodon.org/ns#',
-			'QuoteRequest' => 'toot:QuoteRequest',
-			'blurhash'     => 'toot:blurhash',
+			'toot'           => 'http://joinmastodon.org/ns#',
+			'QuoteRequest'   => 'toot:QuoteRequest',
+			'blurhash'       => 'toot:blurhash',
+			'FeatureRequest' => 'https://w3id.org/fep/7aa9#FeatureRequest',
 		),
 	);
 
@@ -71,6 +72,7 @@ class Activity extends Base_Object {
 		'Move',
 		'Offer',
 		'QuoteRequest', // @see https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md
+		'FeatureRequest', // @see https://w3id.org/fep/7aa9 (FEP-7aa9 draft)
 		'Read',
 		'Reject',
 		'Remove',

--- a/bundled/activitypub/includes/activity/class-actor.php
+++ b/bundled/activitypub/includes/activity/class-actor.php
@@ -74,6 +74,7 @@ class Actor extends Base_Object {
 			'toot'                      => 'http://joinmastodon.org/ns#',
 			'lemmy'                     => 'https://join-lemmy.org/ns#',
 			'litepub'                   => 'http://litepub.social/ns#',
+			'gts'                       => 'https://gotosocial.org/ns#',
 			'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
 			'PropertyValue'             => 'schema:PropertyValue',
 			'value'                     => 'schema:value',
@@ -106,6 +107,18 @@ class Actor extends Base_Object {
 				'@id'        => 'https://w3id.org/fep/844e/implements',
 				'@type'      => '@id',
 				'@container' => '@list',
+			),
+			'interactionPolicy'         => array(
+				'@id'   => 'gts:interactionPolicy',
+				'@type' => '@id',
+			),
+			'canFeature'                => array(
+				'@id'   => 'https://w3id.org/fep/7aa9#canFeature',
+				'@type' => '@id',
+			),
+			'automaticApproval'         => array(
+				'@id'   => 'gts:automaticApproval',
+				'@type' => '@id',
 			),
 			'postingRestrictedToMods'   => 'lemmy:postingRestrictedToMods',
 			'discoverable'              => 'toot:discoverable',
@@ -369,4 +382,43 @@ class Actor extends Base_Object {
 	 * @var boolean|null
 	 */
 	protected $invisible = null;
+
+	/**
+	 * Get the actor-level interaction policy.
+	 *
+	 * Overrides the magic property accessor on Base_Object so that we always
+	 * compute the policy from the current site setting rather than returning a
+	 * cached property value. Currently only emits `canFeature` (FEP-7aa9).
+	 * Driven by the site option `activitypub_default_feature_policy` and
+	 * defaults to denying all featured-collection requests, in line with
+	 * FEP-7aa9's "absence of policy = no consent" rule.
+	 *
+	 * @see https://w3id.org/fep/7aa9
+	 *
+	 * @since unreleased
+	 *
+	 * @return array
+	 */
+	public function get_interaction_policy() {
+		return array_merge( (array) parent::get_interaction_policy(), array( 'canFeature' => $this->build_can_feature_policy() ) );
+	}
+
+	/**
+	 * Build the `canFeature` policy array from the site option.
+	 *
+	 * @return array
+	 */
+	protected function build_can_feature_policy() {
+		$policy = \get_option( 'activitypub_default_feature_policy', ACTIVITYPUB_INTERACTION_POLICY_ME );
+
+		switch ( $policy ) {
+			case ACTIVITYPUB_INTERACTION_POLICY_ANYONE:
+				return array( 'automaticApproval' => array( 'https://www.w3.org/ns/activitystreams#Public' ) );
+			case ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS:
+				return array( 'automaticApproval' => array( $this->get_followers() ) );
+			case ACTIVITYPUB_INTERACTION_POLICY_ME:
+			default:
+				return array( 'automaticApproval' => array( $this->get_id() ) );
+		}
+	}
 }

--- a/bundled/activitypub/includes/activity/extended-object/class-feature-authorization.php
+++ b/bundled/activitypub/includes/activity/extended-object/class-feature-authorization.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Feature_Authorization is an implementation of the FeatureAuthorization activity type,
+ * as defined in FEP-7aa9 (https://w3id.org/fep/7aa9).
+ *
+ * This class represents a FeatureAuthorization activity for ActivityPub implementations.
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Activity\Extended_Object;
+
+use Activitypub\Activity\Base_Object;
+
+/**
+ * Class representing a FeatureAuthorization activity.
+ *
+ * @see https://w3id.org/fep/7aa9
+ *
+ * @since unreleased
+ *
+ * @method Base_Object|string|array|null get_interacting_object() Gets the interacting object property of the object.
+ * @method Base_Object|string|array|null get_interaction_target() Gets the interaction target property of the object.
+ *
+ * @method Feature_Authorization set_interacting_object( string|array|Base_Object|null $data ) Sets the interacting object property of the object.
+ * @method Feature_Authorization set_interaction_target( string|array|Base_Object|null $data ) Sets the interaction target property of the object.
+ */
+class Feature_Authorization extends Base_Object {
+	/**
+	 * The JSON-LD context for the object.
+	 *
+	 * Intentionally minimal: stamps are always served standalone at their own
+	 * URL, so we ship only the vocabulary the stamp document itself uses.
+	 * Mirrors the Quote_Authorization (FEP-044f) approach.
+	 *
+	 * @var array
+	 */
+	const JSON_LD_CONTEXT = array(
+		'https://www.w3.org/ns/activitystreams',
+		array(
+			'FeatureAuthorization' => 'https://w3id.org/fep/7aa9#FeatureAuthorization',
+			'gts'                  => 'https://gotosocial.org/ns#',
+			'interactingObject'    => array(
+				'@id'   => 'gts:interactingObject',
+				'@type' => '@id',
+			),
+			'interactionTarget'    => array(
+				'@id'   => 'gts:interactionTarget',
+				'@type' => '@id',
+			),
+		),
+	);
+
+	/**
+	 * The type of the object.
+	 *
+	 * @var string
+	 */
+	protected $type = 'FeatureAuthorization';
+
+	/**
+	 * The object that is being interacted with.
+	 *
+	 * @var Base_Object|string|array|null
+	 */
+	protected $interacting_object;
+
+	/**
+	 * The target of the interaction.
+	 *
+	 * @var Base_Object|string|array|null
+	 */
+	protected $interaction_target;
+}

--- a/bundled/activitypub/includes/class-blocks.php
+++ b/bundled/activitypub/includes/class-blocks.php
@@ -674,6 +674,21 @@ class Blocks {
 			return null;
 		}
 
+		/*
+		 * In feed contexts (RSS, Atom, and anything else WordPress treats as a feed) the styled
+		 * embed card depends on plugin CSS that isn't loaded, so it degrades to an unreadable
+		 * wall of text. Substitute the same simplified mention link the federation path uses,
+		 * and if the remote lookup fails fall through to the plain `<a class="u-in-reply-to">`
+		 * link below so the feed item still surfaces *some* indication that it's a reply.
+		 */
+		if ( \is_feed() ) {
+			$mention = self::generate_reply_link( '', array( 'attrs' => $attrs ) );
+			if ( ! empty( $mention ) ) {
+				return $mention;
+			}
+			$attrs['embedPost'] = false;
+		}
+
 		$show_embed = isset( $attrs['embedPost'] ) && $attrs['embedPost'];
 
 		$wrapper_attrs = get_block_wrapper_attributes(

--- a/bundled/activitypub/includes/class-handler.php
+++ b/bundled/activitypub/includes/class-handler.php
@@ -28,6 +28,7 @@ class Handler {
 		Handler\Collection_Sync::init();
 		Handler\Create::init();
 		Handler\Delete::init();
+		Handler\Feature_Request::init();
 		Handler\Follow::init();
 		Handler\Like::init();
 		Handler\Move::init();

--- a/bundled/activitypub/includes/class-mailer.php
+++ b/bundled/activitypub/includes/class-mailer.php
@@ -120,7 +120,19 @@ class Mailer {
 		/* translators: 1: Website name, 2: Website IP address, 3: Website hostname. */
 		$notify_message .= \sprintf( \esc_html__( 'From: %1$s (IP address: %2$s, %3$s)', 'activitypub' ), \esc_html( $comment->comment_author ), \esc_html( $comment->comment_author_IP ), \esc_html( $comment_author_domain ) ) . "\r\n";
 		/* translators: Reaction author URL. */
-		$notify_message .= \sprintf( \esc_html__( 'URL: %s', 'activitypub' ), \esc_url( $comment->comment_author_url ) ) . "\r\n\r\n";
+		$notify_message .= \sprintf( \esc_html__( 'URL: %s', 'activitypub' ), \esc_url( $comment->comment_author_url ) ) . "\r\n";
+
+		// For quotes, link to the quoting post itself so the author can review and respond.
+		if ( 'quote' === $comment->comment_type ) {
+			$quote_url = Comment::get_source_url( $comment->comment_ID );
+
+			if ( $quote_url ) {
+				/* translators: Quoting post URL. */
+				$notify_message .= \sprintf( \esc_html__( 'Quoting post: %s', 'activitypub' ), \esc_url( $quote_url ) ) . "\r\n";
+			}
+		}
+
+		$notify_message .= "\r\n";
 		/* translators: Comment type label */
 		$notify_message .= \sprintf( \esc_html__( 'You can see all %s on this post here:', 'activitypub' ), \esc_html( $comment_type['label'] ) ) . "\r\n";
 		$notify_message .= \get_permalink( $comment->comment_post_ID ) . '#' . \esc_attr( $comment_type['type'] ) . "\r\n\r\n";

--- a/bundled/activitypub/includes/class-options.php
+++ b/bundled/activitypub/includes/class-options.php
@@ -203,6 +203,24 @@ class Options {
 
 		\register_setting(
 			'activitypub',
+			'activitypub_default_feature_policy',
+			array(
+				'type'              => 'string',
+				'description'       => 'Default policy for who can include this site\'s actors in featured collections (FEP-7aa9).',
+				'default'           => ACTIVITYPUB_INTERACTION_POLICY_ME,
+				'sanitize_callback' => static function ( $value ) {
+					$allowed = array(
+						ACTIVITYPUB_INTERACTION_POLICY_ANYONE,
+						ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS,
+						ACTIVITYPUB_INTERACTION_POLICY_ME,
+					);
+					return \in_array( $value, $allowed, true ) ? $value : ACTIVITYPUB_INTERACTION_POLICY_ME;
+				},
+			)
+		);
+
+		\register_setting(
+			'activitypub',
 			'activitypub_relays',
 			array(
 				'type'              => 'array',

--- a/bundled/activitypub/includes/class-query.php
+++ b/bundled/activitypub/includes/class-query.php
@@ -7,6 +7,7 @@
 
 namespace Activitypub;
 
+use Activitypub\Activity\Extended_Object\Feature_Authorization;
 use Activitypub\Activity\Extended_Object\Quote_Authorization;
 use Activitypub\Collection\Actors;
 use Activitypub\Collection\Outbox;
@@ -139,8 +140,14 @@ class Query {
 	private function prepare_activitypub_data() {
 		$queried_object = $this->get_queried_object();
 
-		if ( $queried_object instanceof \WP_Post && \get_query_var( 'stamp' ) ) {
-			return $this->maybe_get_stamp();
+		if ( \get_query_var( 'stamp' ) ) {
+			if ( $queried_object instanceof \WP_Post ) {
+				return $this->maybe_get_stamp();
+			}
+
+			if ( $queried_object instanceof \WP_User || \get_query_var( 'actor' ) ) {
+				return $this->maybe_get_actor_stamp();
+			}
 		}
 
 		// Check for Outbox Activity.
@@ -430,6 +437,65 @@ class Query {
 
 		$this->activitypub_object    = $activitypub_object;
 		$this->activitypub_object_id = $activitypub_object->get_id();
+
+		return true;
+	}
+
+	/**
+	 * Maybe get a FeatureAuthorization object from an actor-scoped stamp.
+	 *
+	 * Resolves URLs of the form `?actor=USER_ID&stamp=UMETA_ID` against the
+	 * `_activitypub_featured_by` user meta. The umeta_id doubles as the stamp
+	 * identifier; ownership is enforced by checking the row's user_id matches
+	 * the queried actor.
+	 *
+	 * @return bool True if a FeatureAuthorization was prepared, false otherwise.
+	 */
+	private function maybe_get_actor_stamp() {
+		$stamp_id = (int) \get_query_var( 'stamp' );
+		$actor_id = (int) \get_query_var( 'actor' );
+
+		if ( ! $stamp_id ) {
+			return false;
+		}
+
+		if ( ! $actor_id ) {
+			$queried = $this->get_queried_object();
+			if ( $queried instanceof \WP_User ) {
+				$actor_id = (int) $queried->ID;
+			}
+		}
+
+		if ( ! $actor_id ) {
+			return false;
+		}
+
+		$meta = \get_metadata_by_mid( 'user', $stamp_id );
+		if ( ! $meta || '_activitypub_featured_by' !== $meta->meta_key || (int) $meta->user_id !== $actor_id ) {
+			return false;
+		}
+
+		$actor = Actors::get_by_id( $actor_id );
+		if ( \is_wp_error( $actor ) ) {
+			return false;
+		}
+
+		$stamp_url = \add_query_arg(
+			array(
+				'actor' => $actor_id,
+				'stamp' => $meta->umeta_id,
+			),
+			\home_url( '/' )
+		);
+
+		$authorization = new Feature_Authorization();
+		$authorization->set_id( $stamp_url );
+		$authorization->set_attributed_to( $actor->get_id() );
+		$authorization->set_interacting_object( $meta->meta_value );
+		$authorization->set_interaction_target( $actor->get_id() );
+
+		$this->activitypub_object    = $authorization;
+		$this->activitypub_object_id = $authorization->get_id();
 
 		return true;
 	}

--- a/bundled/activitypub/includes/class-router.php
+++ b/bundled/activitypub/includes/class-router.php
@@ -290,8 +290,16 @@ class Router {
 			exit;
 		}
 
-		$actor = \get_query_var( 'actor', null );
-		if ( $actor ) {
+		/*
+		 * Skip the actor branch when this looks like an actor-scoped FEP-7aa9
+		 * stamp URL: numeric `actor` paired with a `stamp`. Those resolve to a
+		 * FeatureAuthorization via Activitypub\Query, not via the username
+		 * lookup which would 404 the numeric ID. Non-numeric actors fall
+		 * through to the regular Mastodon-style profile lookup.
+		 */
+		$actor        = \get_query_var( 'actor', null );
+		$is_stamp_url = $actor && \get_query_var( 'stamp' ) && \ctype_digit( (string) $actor );
+		if ( $actor && ! $is_stamp_url ) {
 			$actor = Actors::get_by_username( $actor );
 			if ( ! $actor || \is_wp_error( $actor ) ) {
 				$wp_query->set_404();

--- a/bundled/activitypub/includes/handler/class-feature-request.php
+++ b/bundled/activitypub/includes/handler/class-feature-request.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Handler for FeatureRequest activities (FEP-7aa9).
+ *
+ * @package Activitypub
+ */
+
+namespace Activitypub\Handler;
+
+use Activitypub\Activity\Activity;
+use Activitypub\Collection\Actors;
+use Activitypub\Collection\Followers;
+use Activitypub\Collection\Remote_Actors;
+
+use function Activitypub\add_to_outbox;
+use function Activitypub\object_to_uri;
+use function Activitypub\user_can_activitypub;
+
+/**
+ * Handler for FeatureRequest activities.
+ *
+ * @see https://w3id.org/fep/7aa9
+ */
+class Feature_Request {
+	/**
+	 * Initialize the class, registering WordPress hooks.
+	 */
+	public static function init() {
+		\add_action( 'activitypub_inbox_feature_request', array( self::class, 'handle_feature_request' ), 10, 2 );
+		\add_action( 'activitypub_rest_inbox_disallowed', array( self::class, 'handle_blocked_request' ), 10, 3 );
+
+		\add_filter( 'activitypub_validate_object', array( self::class, 'validate_object' ), 10, 3 );
+	}
+
+	/**
+	 * Handle FeatureRequest activities.
+	 *
+	 * @param array     $activity The activity object.
+	 * @param int|int[] $user_ids The user ID(s) targeted by the inbox dispatch.
+	 */
+	public static function handle_feature_request( $activity, $user_ids ) {
+		$state      = true;
+		$object_uri = object_to_uri( $activity['object'] );
+		$target     = Actors::get_by_resource( $object_uri );
+
+		if ( \is_wp_error( $target ) ) {
+			$user_id = \is_array( $user_ids ) ? \reset( $user_ids ) : $user_ids;
+			self::queue_reject( $activity, $user_id );
+			return;
+		}
+
+		$user_id = $target->get__id();
+
+		$policy = \get_option( 'activitypub_default_feature_policy', ACTIVITYPUB_INTERACTION_POLICY_ME );
+
+		switch ( $policy ) {
+			case ACTIVITYPUB_INTERACTION_POLICY_ANYONE:
+				self::queue_accept( $activity, $user_id );
+				break;
+
+			case ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS:
+				$follower = Remote_Actors::get_by_uri( object_to_uri( $activity['actor'] ) );
+				if ( ! \is_wp_error( $follower ) && Followers::follows( $follower->ID, $user_id ) ) {
+					self::queue_accept( $activity, $user_id );
+				} else {
+					self::queue_reject( $activity, $user_id );
+					$state = false;
+				}
+				break;
+
+			case ACTIVITYPUB_INTERACTION_POLICY_ME:
+			default:
+				self::queue_reject( $activity, $user_id );
+				$state = false;
+				break;
+		}
+
+		/**
+		 * Fires after an ActivityPub FeatureRequest activity has been handled.
+		 *
+		 * @param array  $activity The ActivityPub activity data.
+		 * @param int[]  $user_ids The local user IDs.
+		 * @param bool   $state    True on accept, false otherwise.
+		 * @param string $policy   The active site policy.
+		 */
+		\do_action( 'activitypub_handled_feature_request', $activity, (array) $user_ids, $state, $policy );
+	}
+
+	/**
+	 * ActivityPub inbox disallowed activity.
+	 *
+	 * @param array          $activity The activity array.
+	 * @param int|int[]|null $user_ids The user ID(s).
+	 * @param string         $type     The activity type.
+	 */
+	public static function handle_blocked_request( $activity, $user_ids, $type ) {
+		if ( ! \in_array( \strtolower( $type ), array( 'featurerequest', 'feature_request' ), true ) ) {
+			return;
+		}
+
+		$user_id = \is_array( $user_ids ) ? \reset( $user_ids ) : $user_ids;
+		self::queue_reject( $activity, $user_id );
+	}
+
+	/**
+	 * Send an Accept activity in response to the FeatureRequest, issuing a stamp.
+	 *
+	 * Idempotent: a second call with the same instrument for the same user reuses
+	 * the existing umeta row instead of minting a duplicate stamp.
+	 *
+	 * @param array $activity_object The activity object.
+	 * @param int   $user_id         The local user ID being featured.
+	 */
+	public static function queue_accept( $activity_object, $user_id ) {
+		if ( ! user_can_activitypub( $user_id ) ) {
+			$user_id = Actors::BLOG_USER_ID;
+		}
+
+		$actor = Actors::get_by_id( $user_id );
+		if ( \is_wp_error( $actor ) ) {
+			return;
+		}
+
+		$activity_object['instrument'] = object_to_uri( $activity_object['instrument'] );
+
+		// Idempotent stamp creation.
+		$existing = \get_user_meta( $user_id, '_activitypub_featured_by', false );
+		if ( \in_array( $activity_object['instrument'], (array) $existing, true ) ) {
+			global $wpdb;
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$umeta_id = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT umeta_id FROM {$wpdb->usermeta} WHERE user_id = %d AND meta_key = %s AND meta_value = %s LIMIT 1",
+					$user_id,
+					'_activitypub_featured_by',
+					$activity_object['instrument']
+				)
+			);
+		} else {
+			$umeta_id = \add_user_meta( $user_id, '_activitypub_featured_by', $activity_object['instrument'] );
+		}
+
+		// Send minimal activity object back.
+		$activity_object = \array_intersect_key(
+			$activity_object,
+			array(
+				'id'         => 1,
+				'type'       => 1,
+				'actor'      => 1,
+				'object'     => 1,
+				'instrument' => 1,
+			)
+		);
+
+		$stamp_url = \add_query_arg(
+			array(
+				'actor' => $user_id,
+				'stamp' => $umeta_id,
+			),
+			\home_url( '/' )
+		);
+
+		$activity = new Activity();
+		$activity->set_type( 'Accept' );
+		$activity->set_actor( $actor->get_id() );
+		$activity->set_object( $activity_object );
+		$activity->set_result( $stamp_url );
+		$activity->add_to( object_to_uri( $activity_object['actor'] ) );
+
+		add_to_outbox( $activity, null, $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
+	}
+
+	/**
+	 * Send a Reject activity in response to the FeatureRequest.
+	 *
+	 * @param array $activity_object The activity object.
+	 * @param int   $user_id         The user ID.
+	 */
+	public static function queue_reject( $activity_object, $user_id ) {
+		if ( ! user_can_activitypub( $user_id ) ) {
+			$user_id = Actors::BLOG_USER_ID;
+		}
+
+		$actor = Actors::get_by_id( $user_id );
+		if ( \is_wp_error( $actor ) ) {
+			return;
+		}
+
+		if ( isset( $activity_object['instrument'] ) ) {
+			$activity_object['instrument'] = object_to_uri( $activity_object['instrument'] );
+		}
+
+		// Only send minimal data.
+		$activity_object = \array_intersect_key(
+			$activity_object,
+			array(
+				'id'         => 1,
+				'type'       => 1,
+				'actor'      => 1,
+				'object'     => 1,
+				'instrument' => 1,
+			)
+		);
+
+		$activity = new Activity();
+		$activity->set_type( 'Reject' );
+		$activity->set_actor( $actor->get_id() );
+		$activity->set_object( $activity_object );
+		$activity->add_to( object_to_uri( $activity_object['actor'] ) );
+
+		add_to_outbox( $activity, null, $user_id, ACTIVITYPUB_CONTENT_VISIBILITY_PRIVATE );
+	}
+
+	/**
+	 * Validate the object on incoming FeatureRequest activities.
+	 *
+	 * @param bool             $valid   The current validation state.
+	 * @param string           $param   The object parameter name.
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return bool
+	 */
+	public static function validate_object( $valid, $param, $request ) {
+		$activity = $request->get_json_params();
+
+		if ( empty( $activity['type'] ) ) {
+			return false;
+		}
+
+		if ( 'FeatureRequest' !== $activity['type'] ) {
+			return $valid;
+		}
+
+		if ( ! isset( $activity['actor'], $activity['object'], $activity['instrument'] ) ) {
+			return false;
+		}
+
+		return $valid;
+	}
+}

--- a/bundled/activitypub/includes/wp-admin/class-settings-fields.php
+++ b/bundled/activitypub/includes/wp-admin/class-settings-fields.php
@@ -122,6 +122,15 @@ class Settings_Fields {
 			array( 'label_for' => 'activitypub_default_quote_policy' )
 		);
 
+		\add_settings_field(
+			'activitypub_default_feature_policy',
+			\__( 'Default Starter Kit policy', 'activitypub' ),
+			array( self::class, 'render_default_feature_policy_field' ),
+			'activitypub_settings',
+			'activitypub_activities',
+			array( 'label_for' => 'activitypub_default_feature_policy' )
+		);
+
 		add_settings_field(
 			'activitypub_use_hashtags',
 			__( 'Hashtags', 'activitypub' ),
@@ -395,6 +404,23 @@ class Settings_Fields {
 		</select>
 		<p class="description">
 			<?php esc_html_e( 'Default setting for who can quote new posts. This can be overridden per post.', 'activitypub' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render default feature policy field.
+	 */
+	public static function render_default_feature_policy_field() {
+		$value = \get_option( 'activitypub_default_feature_policy', ACTIVITYPUB_INTERACTION_POLICY_ME );
+		?>
+		<select id="activitypub_default_feature_policy" name="activitypub_default_feature_policy" class="regular-text">
+			<option value="<?php echo \esc_attr( ACTIVITYPUB_INTERACTION_POLICY_ANYONE ); ?>" <?php \selected( $value, ACTIVITYPUB_INTERACTION_POLICY_ANYONE ); ?>><?php \esc_html_e( 'Anyone', 'activitypub' ); ?></option>
+			<option value="<?php echo \esc_attr( ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS ); ?>" <?php \selected( $value, ACTIVITYPUB_INTERACTION_POLICY_FOLLOWERS ); ?>><?php \esc_html_e( 'Followers only', 'activitypub' ); ?></option>
+			<option value="<?php echo \esc_attr( ACTIVITYPUB_INTERACTION_POLICY_ME ); ?>" <?php \selected( $value, ACTIVITYPUB_INTERACTION_POLICY_ME ); ?>><?php \esc_html_e( 'Just me', 'activitypub' ); ?></option>
+		</select>
+		<p class="description">
+			<?php \esc_html_e( 'Default setting for who can include this site\'s actors in a Starter Kit (also called a Starter Pack or Featured Collection).', 'activitypub' ); ?>
 		</p>
 		<?php
 	}

--- a/bundled/activitypub/integration/class-classic-editor.php
+++ b/bundled/activitypub/integration/class-classic-editor.php
@@ -20,7 +20,7 @@ class Classic_Editor {
 	public static function init() {
 		\add_filter( 'activitypub_attachments_media_markup', array( self::class, 'filter_attachments_media_markup' ), 10, 2 );
 		\add_filter( 'activitypub_attachment_ids', array( self::class, 'filter_attached_media_ids' ), 10, 2 );
-		\add_action( 'add_meta_boxes', array( self::class, 'add_meta_box' ) );
+		\add_action( 'add_meta_boxes', array( self::class, 'add_meta_box' ), 10, 2 );
 		\add_action( 'save_post', array( self::class, 'save_meta_data' ) );
 
 		if ( \function_exists( 'classicpress_version' ) ) {
@@ -104,11 +104,23 @@ class Classic_Editor {
 	/**
 	 * Add ActivityPub meta box to the post editor.
 	 *
-	 * @param string $post_type The post type.
+	 * @param string        $post_type The post type.
+	 * @param \WP_Post|null $post      The post being edited.
 	 */
-	public static function add_meta_box( $post_type ) {
+	public static function add_meta_box( $post_type, $post = null ) {
 		// Only add for post types that support ActivityPub.
 		if ( ! \post_type_supports( $post_type, 'activitypub' ) ) {
+			return;
+		}
+
+		/*
+		 * The block editor ships its own ActivityPub panel, so the classic meta box must not be
+		 * added there. With the Classic Editor plugin in switchable mode a post can still open in
+		 * the block editor, where both would otherwise render and the meta box's save_post handler
+		 * would overwrite the panel's value. The function_exists() check keeps ClassicPress and
+		 * other block-less setups (where use_block_editor_for_post() is absent) safe.
+		 */
+		if ( $post instanceof \WP_Post && \function_exists( 'use_block_editor_for_post' ) && \use_block_editor_for_post( $post ) ) {
 			return;
 		}
 

--- a/bundled/activitypub/integration/class-nodeinfo.php
+++ b/bundled/activitypub/integration/class-nodeinfo.php
@@ -26,7 +26,7 @@ class Nodeinfo {
 		\add_filter( 'nodeinfo_data', array( self::class, 'add_nodeinfo_data' ), 10, 2 );
 		\add_filter( 'nodeinfo2_data', array( self::class, 'add_nodeinfo2_data' ) );
 
-		\add_filter( 'wellknown_nodeinfo_data', array( self::class, 'add_wellknown_nodeinfo_data' ) );
+		\add_filter( 'nodeinfo_discovery', array( self::class, 'add_wellknown_nodeinfo_data' ) );
 	}
 
 	/**

--- a/bundled/activitypub/templates/help-tab/getting-started.php
+++ b/bundled/activitypub/templates/help-tab/getting-started.php
@@ -11,7 +11,7 @@
 <p><?php esc_html_e( 'The Fediverse is a collection of social networks that talk to each other, similar to how email works between different providers. It allows people on different platforms to follow and interact with each other, regardless of which service they use.', 'activitypub' ); ?></p>
 <p><?php esc_html_e( 'Unlike traditional social media where everyone must use the same service (like Twitter or Facebook), the Fediverse lets you choose where your content lives while still reaching people across many different platforms.', 'activitypub' ); ?></p>
 <p style="position: relative; padding-top: 56.25%;">
-	<iframe title="<?php echo esc_attr__( 'What is the Fediverse?', 'activitypub' ); ?>" width="100%" height="100%" src="https://framatube.org/videos/embed/9dRFC6Ya11NCVeYKn8ZhiD?subtitle=<?php echo esc_attr( substr( get_locale(), 0, 2 ) ); ?>" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups allow-forms" style="position: absolute; inset: 0;"></iframe>
+	<iframe title="<?php echo esc_attr__( 'What is the Fediverse?', 'activitypub' ); ?>" width="100%" height="100%" data-src="https://framatube.org/videos/embed/9dRFC6Ya11NCVeYKn8ZhiD?subtitle=<?php echo esc_attr( substr( get_locale(), 0, 2 ) ); ?>" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups allow-forms" style="position: absolute; inset: 0;"></iframe>
 </p>
 
 <h2><?php esc_html_e( 'How WordPress fits into the Fediverse', 'activitypub' ); ?></h2>

--- a/bundled/atmosphere/atmosphere.php
+++ b/bundled/atmosphere/atmosphere.php
@@ -3,7 +3,7 @@
  * Plugin Name: ATmosphere
  * Plugin URI: https://github.com/pfefferle/atmosphere
  * Description: Publish WordPress posts to AT Protocol (Bluesky + standard.site) via native OAuth.
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL-2.0-or-later
@@ -19,7 +19,7 @@ namespace Atmosphere;
 
 \defined( 'ABSPATH' ) || exit;
 
-\define( 'ATMOSPHERE_VERSION', '1.0.0' );
+\define( 'ATMOSPHERE_VERSION', '1.1.1' );
 \define( 'ATMOSPHERE_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'ATMOSPHERE_PLUGIN_URL', \plugin_dir_url( __FILE__ ) );
 \define( 'ATMOSPHERE_PLUGIN_FILE', __FILE__ );

--- a/bundled/atmosphere/includes/class-api.php
+++ b/bundled/atmosphere/includes/class-api.php
@@ -24,13 +24,16 @@ class API {
 	/**
 	 * Send a DPoP-authenticated request to the connected PDS.
 	 *
-	 * @param string      $method   HTTP method.
-	 * @param string      $endpoint XRPC path, e.g. /xrpc/com.atproto.repo.createRecord.
-	 * @param array       $args     wp_safe_remote_request() arguments.
-	 * @param string|null $nonce    Explicit DPoP nonce (used on retry).
+	 * @param string      $method       HTTP method.
+	 * @param string      $endpoint     XRPC path, e.g. /xrpc/com.atproto.repo.createRecord.
+	 * @param array       $args         wp_safe_remote_request() arguments.
+	 * @param string|null $nonce        Explicit DPoP nonce (used on retry).
+	 * @param bool        $auth_retried Internal marker: set on the recursive call after a
+	 *                                  proactive refresh so a still-failing token does not
+	 *                                  loop.
 	 * @return array|\WP_Error Decoded JSON body or error.
 	 */
-	public static function request( string $method, string $endpoint, array $args = array(), ?string $nonce = null ): array|\WP_Error {
+	public static function request( string $method, string $endpoint, array $args = array(), ?string $nonce = null, bool $auth_retried = false ): array|\WP_Error {
 		$original_args = $args;
 
 		$access_token = Client::access_token();
@@ -39,6 +42,23 @@ class API {
 		}
 
 		$conn = \get_option( 'atmosphere_connection', array() );
+
+		/*
+		 * Snapshot the access-token ciphertext we are about to use,
+		 * BEFORE the HTTP round-trip. If the request comes back 401
+		 * and a concurrent worker rotated the token while our HTTP
+		 * call was in-flight, the rotated ciphertext will already be
+		 * in `atmosphere_connection` by the time we read it again
+		 * inside the 401 branch — and a snapshot taken there would
+		 * equal the rotated value, defeating
+		 * `Client::wait_for_token_refresh($snapshot)`'s "wait until
+		 * the ciphertext differs from snapshot" semantics. Capturing
+		 * here pins the comparison value to the token that ACTUALLY
+		 * went on the wire, so any rotation that happened during the
+		 * round-trip (or that lands during the wait) trips the
+		 * differs-from-snapshot check correctly.
+		 */
+		$access_token_snapshot = (string) ( $conn['access_token'] ?? '' );
 
 		$dpop_jwk_json = Encryption::decrypt( $conn['dpop_jwk'] ?? '' );
 		if ( false === $dpop_jwk_json ) {
@@ -97,7 +117,81 @@ class API {
 			&& \in_array( $status, array( 400, 401 ), true )
 			&& ( $body['error'] ?? '' ) === 'use_dpop_nonce'
 		) {
-			return self::request( $method, $endpoint, $original_args, $response_nonce );
+			return self::request( $method, $endpoint, $original_args, $response_nonce, $auth_retried );
+		}
+
+		/*
+		 * Retry once after a proactive token refresh when the PDS rejects
+		 * the access token as expired or invalid. The previous behaviour
+		 * surfaced these as a hard `atmosphere_pds` error even though a
+		 * refresh-then-retry would have recovered the request — the most
+		 * common reason for hitting this branch is an access token that
+		 * `Client::access_token()` considered fresh (because `expires_at`
+		 * was still in the future) but the auth server has revoked or
+		 * rotated under us.
+		 *
+		 * Only recurse if the refresh either succeeded or is racing
+		 * another worker (`atmosphere_refresh_locked`, in which case the
+		 * recursive `Client::access_token()` will wait for that worker to
+		 * land a new token). On any other refresh error — missing refresh
+		 * token, decrypt failure, transient network blip — surface that
+		 * error instead of retrying with the same stale access token; the
+		 * second PDS call would just hit the same 401 and mask the more
+		 * actionable upstream cause.
+		 */
+		if ( ! $auth_retried
+			&& 401 === $status
+			&& \in_array(
+				$body['error'] ?? '',
+				array( 'InvalidToken', 'ExpiredToken', 'AuthenticationRequired' ),
+				true
+			)
+		) {
+			/*
+			 * `$access_token_snapshot` was captured at the top of this
+			 * function, BEFORE the HTTP request — see the comment
+			 * there for why post-request snapshotting would race
+			 * a concurrent rotation. The retry must run against a
+			 * rotated token, and the ciphertext-comparison is the
+			 * only signal that reliably distinguishes "we still hold
+			 * the version that just got rejected" from "someone
+			 * already rotated":
+			 *
+			 *   - `Client::refresh()` short-circuits with `true` when
+			 *     another worker holds the lock AND the local
+			 *     `expires_at` is still in the future. Without the
+			 *     ciphertext check we would retry immediately with
+			 *     the same stale token.
+			 *   - `Client::refresh()` returns `atmosphere_refresh_locked`
+			 *     because another worker is mid-flight. The wait must
+			 *     block until that worker writes a fresh token, not
+			 *     just until the existing `expires_at` re-clears the
+			 *     5-minute window.
+			 */
+			$refresh = Client::refresh();
+			if ( \is_wp_error( $refresh ) && 'atmosphere_refresh_locked' !== $refresh->get_error_code() ) {
+				return $refresh;
+			}
+
+			/*
+			 * Whether `refresh()` returned `true` (we acquired the
+			 * lock and rotated, or another worker just finished
+			 * rotating), short-circuited to `true` on a locally-fresh
+			 * `expires_at`, or returned `atmosphere_refresh_locked`,
+			 * the same wait covers all three: it blocks until the
+			 * stored access-token ciphertext differs from the
+			 * snapshot above (or until `needs_reauth` flips, or
+			 * until the lock TTL elapses). On the
+			 * we-rotated-ourselves path this returns almost
+			 * immediately on the first poll; on the concurrent-worker
+			 * path it waits for their write to land.
+			 */
+			$waited = Client::wait_for_token_refresh( $access_token_snapshot );
+			if ( \is_wp_error( $waited ) ) {
+				return $waited;
+			}
+
+			return self::request( $method, $endpoint, $original_args, null, true );
 		}
 
 		if ( $status >= 400 ) {

--- a/bundled/atmosphere/includes/class-atmosphere.php
+++ b/bundled/atmosphere/includes/class-atmosphere.php
@@ -173,8 +173,21 @@ class Atmosphere {
 		// Token refresh cron.
 		\add_action( 'atmosphere_refresh_token', array( $this, 'cron_refresh_token' ) );
 
+		/*
+		 * Migrate sites that scheduled this event on a previous version
+		 * (twicedaily) to the hourly cadence. Bluesky access tokens live
+		 * 60 minutes and the auth server's DPoP nonces only 3 minutes,
+		 * so a 12-hour interval left the refresh worker far too sparse
+		 * to recover from a single failed run before the session aged
+		 * past the refresh-token replay window.
+		 */
+		$schedule = \wp_get_schedule( 'atmosphere_refresh_token' );
+		if ( false !== $schedule && 'hourly' !== $schedule ) {
+			\wp_clear_scheduled_hook( 'atmosphere_refresh_token' );
+		}
+
 		if ( ! \wp_next_scheduled( 'atmosphere_refresh_token' ) && is_connected() ) {
-			\wp_schedule_event( \time(), 'twicedaily', 'atmosphere_refresh_token' );
+			\wp_schedule_event( \time(), 'hourly', 'atmosphere_refresh_token' );
 		}
 
 		/*
@@ -212,6 +225,16 @@ class Atmosphere {
 	 * verification link survives a temporary OAuth refresh failure —
 	 * the document AT-URI is computed from the DID, which is stable
 	 * across session expiry and `needs_reauth` states.
+	 *
+	 * Also gated on `META_URI` so the link is emitted only for posts
+	 * the Publisher actually wrote to the PDS. Without this check, a
+	 * disconnected site (identity preserved, no live session) would
+	 * advertise document AT-URIs for every published WP post and lazy-
+	 * mint META_TID rows for posts that have no corresponding record
+	 * on the PDS — federation/discovery consumers would 404 each one.
+	 * Posts published before a disconnect already carry META_URI and
+	 * remain correctly advertised; new posts created during a disconnect
+	 * stay silent until reconnect + publish lands a real record.
 	 */
 	public function output_document_link(): void {
 		if ( ! has_identity() || ! \is_singular() ) {
@@ -225,6 +248,11 @@ class Atmosphere {
 		}
 
 		if ( ! is_post_publishable( $post ) ) {
+			return;
+		}
+
+		$bsky_uri = \get_post_meta( $post->ID, Post::META_URI, true );
+		if ( empty( $bsky_uri ) ) {
 			return;
 		}
 
@@ -316,20 +344,28 @@ class Atmosphere {
 	}
 
 	/**
+	 * Regex patterns of the well-known rewrite rules this plugin owns.
+	 *
+	 * Maps each pattern to its `index.php` query target. Kept as a single
+	 * source of truth so {@see register_wellknown_rewrite()} and
+	 * {@see maybe_flush_wellknown_rewrites()} stay in lockstep — if a
+	 * future rule is added or renamed, both surfaces pick it up without
+	 * a separate edit, and the persisted-rules check still detects drift.
+	 *
+	 * @var array<string, string>
+	 */
+	private const WELLKNOWN_REWRITE_PATTERNS = array(
+		'^\.well-known/atproto-did$'                 => 'index.php?atmosphere_wellknown=atproto-did',
+		'^\.well-known/site\.standard\.publication$' => 'index.php?atmosphere_wellknown=publication',
+	);
+
+	/**
 	 * Register rewrite rules for well-known endpoints.
 	 */
 	public function register_wellknown_rewrite(): void {
-		\add_rewrite_rule(
-			'^\.well-known/atproto-did$',
-			'index.php?atmosphere_wellknown=atproto-did',
-			'top'
-		);
-
-		\add_rewrite_rule(
-			'^\.well-known/site\.standard\.publication$',
-			'index.php?atmosphere_wellknown=publication',
-			'top'
-		);
+		foreach ( self::WELLKNOWN_REWRITE_PATTERNS as $pattern => $target ) {
+			\add_rewrite_rule( $pattern, $target, 'top' );
+		}
 
 		\add_filter(
 			'query_vars',
@@ -338,6 +374,87 @@ class Atmosphere {
 				return $vars;
 			}
 		);
+	}
+
+	/**
+	 * Ensure the well-known rewrite rules are present in the persisted
+	 * `rewrite_rules` option, and flush them in if not.
+	 *
+	 * The activation hook flushes once, but the rule set can drift away
+	 * from the persisted array later for several real install paths:
+	 *
+	 * - Programmatic loads (FOSSE bundle, `require_once`, mu-plugin,
+	 *   etc.) never fire `register_activation_hook`, so the initial
+	 *   flush never runs.
+	 * - Some plugins or hosts wipe `wp_options.rewrite_rules` outside
+	 *   of activation. WP then rebuilds the array from whatever rules
+	 *   happen to be registered at that moment, which may or may not
+	 *   include ours.
+	 * - Another plugin that flushes earlier on `init` than our rule
+	 *   registration produces a persisted array missing our patterns.
+	 *
+	 * In all three cases the runtime registration in
+	 * {@see register_wellknown_rewrite()} keeps happening on every
+	 * request but is functionally inert, because WP routes from the
+	 * persisted array, not the in-memory one. The user-facing symptom
+	 * is "External handle did not resolve to DID" when the PDS fetches
+	 * `/.well-known/atproto-did` and WP serves the normal 404 template
+	 * instead of our handler.
+	 *
+	 * Called surgically from the moments that matter so this is not
+	 * paid on every request:
+	 *
+	 * - After a successful OAuth handshake persists an identity —
+	 *   {@see \Atmosphere\OAuth\Client::handle_callback()}.
+	 * - When an administrator loads the Atmosphere settings page —
+	 *   {@see \Atmosphere\WP_Admin\Admin::add_menu()}.
+	 * - Before the `updateHandle` XRPC call, which triggers the PDS to
+	 *   fetch the well-known endpoint immediately —
+	 *   {@see \Atmosphere\Handle::set_handle()}.
+	 *
+	 * Uses a soft flush (no `.htaccess` rewrite): WordPress's default
+	 * rewrite fallback already routes unmatched URLs to `index.php`, so
+	 * refreshing the persisted `rewrite_rules` option is enough to make
+	 * our rules take effect without touching the webserver config.
+	 */
+	public static function maybe_flush_wellknown_rewrites(): void {
+		global $wp_rewrite;
+
+		/*
+		 * Plain permalinks (the WordPress default `?p=N` scheme) keep
+		 * `rewrite_rules` empty and route every request through the query
+		 * string. Our `^\.well-known/...$` patterns can never appear in
+		 * the persisted array on such a site, and the endpoints cannot
+		 * resolve via rewrite there regardless. Bail before the
+		 * missing-pattern check so we do not read an always-empty array
+		 * as "patterns missing" and burn an `update_option` write on
+		 * every call.
+		 *
+		 * Read the state from `$wp_rewrite` rather than the
+		 * `permalink_structure` option: `flush_rewrite_rules()` rebuilds
+		 * from `$wp_rewrite`'s in-memory structure, so gating on the same
+		 * source keeps the guard and the flush in agreement even if
+		 * something wrote the option directly after `WP_Rewrite::init()`
+		 * ran this request.
+		 */
+		if ( ! $wp_rewrite instanceof \WP_Rewrite || ! $wp_rewrite->using_permalinks() ) {
+			return;
+		}
+
+		$rules = \get_option( 'rewrite_rules' );
+
+		if ( \is_array( $rules ) ) {
+			foreach ( self::WELLKNOWN_REWRITE_PATTERNS as $pattern => $target ) {
+				if ( ! isset( $rules[ $pattern ] ) || $rules[ $pattern ] !== $target ) {
+					\flush_rewrite_rules( false );
+					return;
+				}
+			}
+
+			return;
+		}
+
+		\flush_rewrite_rules( false );
 	}
 
 	/**
@@ -1049,9 +1166,23 @@ class Atmosphere {
 
 	/**
 	 * Cron: proactively refresh the access token.
+	 *
+	 * Skips when the stored access token still has more than ten
+	 * minutes of life on it — the hourly cadence catches up before
+	 * any genuine expiry, and an unconditional refresh on every tick
+	 * burns a refresh-token rotation that does not need to happen.
+	 * Each rotation is also another chance for the dead-holder
+	 * scenario (worker dies mid-flight after the auth server has
+	 * already rotated) to bite, so refreshing less aggressively is
+	 * strictly more reliable on a healthy session.
 	 */
 	public function cron_refresh_token(): void {
 		if ( ! is_connected() ) {
+			return;
+		}
+
+		$conn = \get_option( 'atmosphere_connection', array() );
+		if ( ! empty( $conn['expires_at'] ) && $conn['expires_at'] > \time() + 600 ) {
 			return;
 		}
 

--- a/bundled/atmosphere/includes/class-cid.php
+++ b/bundled/atmosphere/includes/class-cid.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * AT Protocol CID computation.
+ *
+ * Implements the minimum DAG-CBOR encoder + CIDv1 builder needed to
+ * pre-compute the CID of a record we are about to write, so a
+ * strongRef pointing at that record can ride along in the same
+ * atomic `applyWrites` batch. Without this, AT Protocol's chicken-
+ * and-egg constraint — strongRefs need the target's CID, which only
+ * exists after the write returns — forces a follow-up
+ * `applyWrites#update`. The follow-up does land at the PDS but
+ * Bluesky's AppView indexes posts at initial create only, ignoring
+ * later updates for `source` / `associatedProfiles` enrichment, so
+ * the visible UI never picks up the added refs (verified on
+ * `atmosphere-blog.bsky.social` 3mn7u77lp4dns — PDS holds both refs,
+ * AppView serves the initial one-ref version indefinitely).
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * CID generator + DAG-CBOR encoder targeted at the AT Protocol
+ * record subset Atmosphere produces.
+ *
+ * Scope:
+ *   - Encodes the types Atmosphere records actually use: null,
+ *     booleans, integers, UTF-8 strings, arrays, maps, and cid-link
+ *     tags via the `{ "$link": "bafy..." }` JSON convention.
+ *   - Treats maps with exactly one string key `$link` as cid-link
+ *     references (CBOR tag 42), matching the canonical atproto data
+ *     model JSON form. Other map shapes encode as plain CBOR maps.
+ *   - Sorts map keys length-first then bytewise per DAG-CBOR.
+ *   - Uses shortest integer encoding (DAG-CBOR requires it).
+ *   - Throws on NaN / Infinity floats — disallowed by DAG-CBOR.
+ *
+ * Out of scope: indefinite-length encoding (DAG-CBOR forbids it),
+ * float16 / float32, arbitrary tags beyond 42, big-int beyond
+ * PHP_INT_MAX (Atmosphere records do not produce those).
+ */
+class CID {
+
+	/**
+	 * Compute the CIDv1 base32 string of a record using AT Protocol's
+	 * encoding (DAG-CBOR + SHA-256 + dag-cbor codec).
+	 *
+	 * The returned value matches what the PDS round-trips back in
+	 * `applyWrites` / `getRecord` responses, byte-for-byte. Round-trip
+	 * stability is the contract: if a third party encodes the same
+	 * record and computes its CID independently, they must get the
+	 * same string.
+	 *
+	 * Returns a `WP_Error` if the encoder hits a record shape it cannot
+	 * handle (an unsupported value type, NaN / Infinity float, a
+	 * malformed `$link` cid-link, etc.). Callers in the publish path
+	 * treat that as "skip the optional strongRef" rather than aborting
+	 * the publish — the record still ships, just without the
+	 * `associatedRefs` entry that depended on the failed CID.
+	 *
+	 * @param array $record Record value (typically a transformer's
+	 *                      `transform()` output).
+	 * @return string|\WP_Error CID string with multibase prefix `b`, or
+	 *                          an error from the encoder.
+	 */
+	public static function from_record( array $record ): string|\WP_Error {
+		$bytes = self::encode( $record );
+		if ( \is_wp_error( $bytes ) ) {
+			return $bytes;
+		}
+
+		$digest = \hash( 'sha256', $bytes, true );
+
+		/*
+		 * Build the CIDv1 byte string:
+		 *   0x01 — CIDv1 version
+		 *   0x71 — multicodec for dag-cbor
+		 *   0x12 — multihash code for sha2-256
+		 *   0x20 — multihash digest length (32 bytes)
+		 *   $digest — the 32-byte SHA-256 hash
+		 *
+		 * Multibase-prefixed with `b` to flag base32 lowercase (RFC 4648,
+		 * no padding) per the atproto data model spec.
+		 */
+		$cid_bytes = "\x01\x71\x12\x20" . $digest;
+
+		return 'b' . self::base32_lower_encode( $cid_bytes );
+	}
+
+	/**
+	 * Decode a CID string (e.g. `bafyrei...`) back to its raw bytes.
+	 *
+	 * Used inside this class to reconstruct the byte form when
+	 * encoding cid-link tags, and exposed for callers that need to
+	 * verify a CID independently of the multibase form.
+	 *
+	 * @param string $cid_string CID string (must start with `b` multibase prefix).
+	 * @return string|\WP_Error Raw CIDv1 bytes, or `atmosphere_cid_invalid_*`
+	 *                          when the prefix is missing or the base32 body
+	 *                          contains characters outside the alphabet.
+	 */
+	public static function decode_string( string $cid_string ): string|\WP_Error {
+		if ( '' === $cid_string || 'b' !== $cid_string[0] ) {
+			return new \WP_Error(
+				'atmosphere_cid_invalid_multibase',
+				\sprintf(
+					/* translators: %s: the raw CID string the caller passed in. */
+					\__( 'CID must use the base32 multibase prefix "b": %s', 'atmosphere' ),
+					$cid_string
+				)
+			);
+		}
+
+		$decoded = self::base32_lower_decode( \substr( $cid_string, 1 ) );
+		if ( false === $decoded ) {
+			return new \WP_Error(
+				'atmosphere_cid_invalid_base32',
+				\__( 'CID body contains characters outside the base32 alphabet.', 'atmosphere' )
+			);
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * Encode an arbitrary PHP value as DAG-CBOR bytes.
+	 *
+	 * Dispatches by PHP type. The only non-obvious mapping is the
+	 * `{ "$link": "bafy..." }` shape — a one-key associative array
+	 * whose key is exactly `$link` and value is a string is encoded
+	 * as a CBOR tag-42 CID rather than a plain map, matching the
+	 * canonical JSON form for cid-link types in the atproto data
+	 * model. Callers that legitimately want a literal `$link` map
+	 * key with multiple sibling keys are unaffected (the detector
+	 * requires exactly one key).
+	 *
+	 * @param mixed $value PHP value.
+	 * @return string|\WP_Error DAG-CBOR encoded bytes, or an
+	 *                          `atmosphere_cid_*` error for an
+	 *                          unsupported value type / shape.
+	 */
+	public static function encode( $value ): string|\WP_Error {
+		if ( null === $value ) {
+			return "\xf6";
+		}
+
+		if ( true === $value ) {
+			return "\xf5";
+		}
+
+		if ( false === $value ) {
+			return "\xf4";
+		}
+
+		if ( \is_int( $value ) ) {
+			return self::encode_int( $value );
+		}
+
+		if ( \is_string( $value ) ) {
+			return self::encode_text_string( $value );
+		}
+
+		if ( \is_array( $value ) ) {
+			/*
+			 * `{ "$link": "bafy..." }` is the atproto JSON form for a
+			 * cid-link. Detect that exact shape — exactly one key
+			 * named `$link`, value is a string — and emit CBOR tag 42
+			 * instead of a plain map. Anything else (two keys, a
+			 * different key name, a non-string value) falls through
+			 * to the normal map/array encoding.
+			 */
+			if ( 1 === \count( $value ) && isset( $value['$link'] ) && \is_string( $value['$link'] ) ) {
+				return self::encode_cid_link( $value['$link'] );
+			}
+
+			if ( \array_is_list( $value ) ) {
+				return self::encode_array( $value );
+			}
+
+			return self::encode_map( $value );
+		}
+
+		if ( \is_float( $value ) ) {
+			return self::encode_float( $value );
+		}
+
+		return new \WP_Error(
+			'atmosphere_cid_unsupported_type',
+			\sprintf(
+				/* translators: %s: PHP type name (e.g. "object", "resource"). */
+				\__( 'DAG-CBOR encoder cannot handle value of type %s.', 'atmosphere' ),
+				\gettype( $value )
+			)
+		);
+	}
+
+	/**
+	 * Encode a CBOR major-type byte plus the smallest integer
+	 * argument encoding that fits the value.
+	 *
+	 * DAG-CBOR requires the shortest possible encoding for every
+	 * integer; this helper centralises that choice across all type
+	 * tags (positive ints, negative ints, byte strings, text strings,
+	 * arrays, maps). On a 64-bit PHP build the `>= 2^32` branch
+	 * handles values up to PHP_INT_MAX via `pack('J', ...)`.
+	 *
+	 * @param int $major_type CBOR major type (0..7).
+	 * @param int $argument   Length / value to encode (must be non-negative).
+	 * @return string CBOR header bytes.
+	 */
+	private static function encode_argument( int $major_type, int $argument ): string {
+		$prefix = $major_type << 5;
+
+		if ( $argument < 24 ) {
+			return \chr( $prefix | $argument );
+		}
+
+		if ( $argument < 256 ) {
+			return \chr( $prefix | 0x18 ) . \chr( $argument );
+		}
+
+		if ( $argument < 65536 ) {
+			return \chr( $prefix | 0x19 ) . \pack( 'n', $argument );
+		}
+
+		if ( $argument < 4294967296 ) {
+			return \chr( $prefix | 0x1a ) . \pack( 'N', $argument );
+		}
+
+		return \chr( $prefix | 0x1b ) . \pack( 'J', $argument );
+	}
+
+	/**
+	 * Encode an integer.
+	 *
+	 * Positive ints use major type 0. Negative ints use major type 1
+	 * with argument `-1 - value`, the standard CBOR convention for
+	 * representing arbitrary negative values without a sign bit.
+	 *
+	 * @param int $value Integer to encode.
+	 * @return string CBOR bytes.
+	 */
+	private static function encode_int( int $value ): string {
+		if ( $value >= 0 ) {
+			return self::encode_argument( 0, $value );
+		}
+
+		return self::encode_argument( 1, -1 - $value );
+	}
+
+	/**
+	 * Encode a UTF-8 text string (major type 3).
+	 *
+	 * @param string $value Text bytes.
+	 * @return string CBOR bytes.
+	 */
+	private static function encode_text_string( string $value ): string {
+		return self::encode_argument( 3, \strlen( $value ) ) . $value;
+	}
+
+	/**
+	 * Encode a byte string (major type 2).
+	 *
+	 * @param string $value Raw bytes.
+	 * @return string CBOR bytes.
+	 */
+	private static function encode_byte_string( string $value ): string {
+		return self::encode_argument( 2, \strlen( $value ) ) . $value;
+	}
+
+	/**
+	 * Encode a list-shaped array (major type 4).
+	 *
+	 * Propagates the first `WP_Error` from a nested `encode()` call so
+	 * an unsupported value buried deep inside a record short-circuits
+	 * the whole encode without producing partial bytes.
+	 *
+	 * @param array $value List to encode.
+	 * @return string|\WP_Error CBOR bytes or the propagated error.
+	 */
+	private static function encode_array( array $value ): string|\WP_Error {
+		$bytes = self::encode_argument( 4, \count( $value ) );
+
+		foreach ( $value as $item ) {
+			$encoded = self::encode( $item );
+			if ( \is_wp_error( $encoded ) ) {
+				return $encoded;
+			}
+			$bytes .= $encoded;
+		}
+
+		return $bytes;
+	}
+
+	/**
+	 * Encode a map / associative array (major type 5).
+	 *
+	 * DAG-CBOR requires keys to be sorted length-first (shorter byte
+	 * length comes first), then bytewise for ties. This is a strict
+	 * canonical-encoding requirement — round-trip equality with the
+	 * PDS depends on it.
+	 *
+	 * @param array $value Map to encode.
+	 * @return string|\WP_Error CBOR bytes or the propagated error from
+	 *                          a nested `encode()` call.
+	 */
+	private static function encode_map( array $value ): string|\WP_Error {
+		$keys = \array_map( 'strval', \array_keys( $value ) );
+
+		\usort(
+			$keys,
+			static function ( string $a, string $b ): int {
+				$len_diff = \strlen( $a ) - \strlen( $b );
+				if ( 0 !== $len_diff ) {
+					return $len_diff;
+				}
+				return \strcmp( $a, $b );
+			}
+		);
+
+		$bytes = self::encode_argument( 5, \count( $keys ) );
+		foreach ( $keys as $key ) {
+			$bytes  .= self::encode_text_string( $key );
+			$encoded = self::encode( $value[ $key ] );
+			if ( \is_wp_error( $encoded ) ) {
+				return $encoded;
+			}
+			$bytes .= $encoded;
+		}
+
+		return $bytes;
+	}
+
+	/**
+	 * Encode a float as IEEE 754 double-precision (major type 7,
+	 * additional info 27 / 0xfb).
+	 *
+	 * DAG-CBOR forbids NaN, +Inf, and -Inf, and forbids the smaller
+	 * float16 / float32 representations.
+	 *
+	 * @param float $value Float to encode.
+	 * @return string|\WP_Error CBOR bytes, or
+	 *                          `atmosphere_cid_invalid_float` for NaN /
+	 *                          ±Infinity.
+	 */
+	private static function encode_float( float $value ): string|\WP_Error {
+		if ( \is_nan( $value ) || \is_infinite( $value ) ) {
+			return new \WP_Error(
+				'atmosphere_cid_invalid_float',
+				\__( 'DAG-CBOR does not permit NaN or Infinity.', 'atmosphere' )
+			);
+		}
+
+		// 'E' = IEEE 754 double precision, big-endian (PHP 7.0.15+ / 7.1.1+).
+		return "\xfb" . \pack( 'E', $value );
+	}
+
+	/**
+	 * Encode a CID-link as CBOR tag 42 containing a byte string of
+	 * `0x00 || cid_v1_bytes`.
+	 *
+	 * The leading `0x00` is the multibase identity prefix that
+	 * DAG-CBOR's cid-link spec requires; without it the encoding
+	 * would not round-trip through atproto's own decoders.
+	 *
+	 * @param string $cid_string CID string (with multibase prefix `b`).
+	 * @return string|\WP_Error CBOR bytes, or the propagated decode error.
+	 */
+	private static function encode_cid_link( string $cid_string ): string|\WP_Error {
+		$cid_bytes = self::decode_string( $cid_string );
+
+		if ( \is_wp_error( $cid_bytes ) ) {
+			return $cid_bytes;
+		}
+
+		// 0xd8 0x2a = CBOR tag 42 with a 1-byte argument.
+		return "\xd8\x2a" . self::encode_byte_string( "\x00" . $cid_bytes );
+	}
+
+
+	/**
+	 * Base32 RFC 4648 lowercase encode (no padding).
+	 *
+	 * @param string $bytes Raw bytes.
+	 * @return string Base32 string.
+	 */
+	private static function base32_lower_encode( string $bytes ): string {
+		$alphabet = 'abcdefghijklmnopqrstuvwxyz234567';
+		$result   = '';
+		$buffer   = 0;
+		$bits     = 0;
+		$length   = \strlen( $bytes );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$buffer = ( $buffer << 8 ) | \ord( $bytes[ $i ] );
+			$bits  += 8;
+			while ( $bits >= 5 ) {
+				$bits   -= 5;
+				$result .= $alphabet[ ( $buffer >> $bits ) & 31 ];
+			}
+		}
+
+		if ( $bits > 0 ) {
+			$result .= $alphabet[ ( $buffer << ( 5 - $bits ) ) & 31 ];
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Base32 RFC 4648 lowercase decode (no padding).
+	 *
+	 * Mirrors the `string|false` shape of the OAuth crypto / encoder
+	 * helpers ({@see \Atmosphere\OAuth\DPoP::base64url_decode()},
+	 * {@see \Atmosphere\OAuth\Encryption::decrypt()}) so callers
+	 * branch on `false === $decoded` rather than on a thrown
+	 * exception.
+	 *
+	 * @param string $value Base32 string.
+	 * @return string|false Raw bytes, or false on a character outside
+	 *                      the base32 alphabet.
+	 */
+	private static function base32_lower_decode( string $value ): string|false {
+		static $lookup = null;
+		if ( null === $lookup ) {
+			$lookup = \array_flip( \str_split( 'abcdefghijklmnopqrstuvwxyz234567' ) );
+		}
+
+		$buffer = 0;
+		$bits   = 0;
+		$result = '';
+		$length = \strlen( $value );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $value[ $i ];
+			if ( ! isset( $lookup[ $char ] ) ) {
+				return false;
+			}
+			$buffer = ( $buffer << 5 ) | $lookup[ $char ];
+			$bits  += 5;
+			if ( $bits >= 8 ) {
+				$bits   -= 8;
+				$result .= \chr( ( $buffer >> $bits ) & 0xff );
+			}
+		}
+
+		return $result;
+	}
+}

--- a/bundled/atmosphere/includes/class-handle.php
+++ b/bundled/atmosphere/includes/class-handle.php
@@ -45,13 +45,6 @@ class Handle {
 	public const NOTICE_SETTING = 'atmosphere';
 
 	/**
-	 * Option storing the previous handle so disconnect can revert.
-	 *
-	 * @var string
-	 */
-	public const OPTION_PREVIOUS_HANDLE = 'atmosphere_previous_handle';
-
-	/**
 	 * Whether the entire feature is enabled.
 	 *
 	 * @return bool
@@ -61,7 +54,7 @@ class Handle {
 		 * Filter whether the domain-handle feature is enabled.
 		 *
 		 * Filter to false to fully disable: the Settings panel suppresses
-		 * the confirm button, and disconnect does not attempt to revert.
+		 * the confirm button.
 		 *
 		 * @param bool $enabled Default true.
 		 */
@@ -136,9 +129,9 @@ class Handle {
 	 * `updateHandle` against the user's connected account without an
 	 * explicit cap-bearing context.
 	 *
-	 * On success: snapshots the current handle (so disconnect can revert),
-	 * invokes `com.atproto.identity.updateHandle` via Atmosphere's DPoP
-	 * client, and posts a settings notice describing the outcome.
+	 * On success: invokes `com.atproto.identity.updateHandle` via
+	 * Atmosphere's DPoP client and posts a settings notice describing
+	 * the outcome.
 	 *
 	 * @return true|\WP_Error|null Null when the feature is disabled, the
 	 *                              install is ineligible, the current user
@@ -179,15 +172,15 @@ class Handle {
 			return null;
 		}
 
-		if ( '' !== $current ) {
-			/*
-			 * Snapshot the current handle BEFORE the XRPC call. If the call
-			 * succeeds, the snapshot is what we revert to on disconnect. If it
-			 * fails, the PDS handle is unchanged, so the snapshot still equals
-			 * the user's actual handle and a later revert call is a safe no-op.
-			 */
-			\update_option( self::OPTION_PREVIOUS_HANDLE, $current, false );
-		}
+		/*
+		 * Self-heal the well-known rewrite before the XRPC call: the PDS
+		 * fetches `/.well-known/atproto-did` within milliseconds of
+		 * `updateHandle`, so the persisted rule must be in place by then.
+		 * This is the exact failure surface from issue 90. See
+		 * {@see Atmosphere::maybe_flush_wellknown_rewrites()} for why the
+		 * activation-time flush alone is not enough.
+		 */
+		Atmosphere::maybe_flush_wellknown_rewrites();
 
 		$result = self::call_update_handle( $target );
 
@@ -213,65 +206,6 @@ class Handle {
 				$target
 			),
 			'success'
-		);
-
-		return true;
-	}
-
-	/**
-	 * Attempt to revert to the previously snapshotted handle.
-	 *
-	 * No-op when the feature is disabled or there is nothing to revert.
-	 * Caller (the disconnect flow) MUST invoke this BEFORE
-	 * `\Atmosphere\OAuth\Client::disconnect()` so the access token is still
-	 * valid for the call.
-	 *
-	 * @return true|\WP_Error|null Null when no revert was attempted.
-	 */
-	public static function maybe_revert_on_disconnect(): true|\WP_Error|null {
-		if ( ! self::is_enabled() ) {
-			return null;
-		}
-
-		$previous = (string) \get_option( self::OPTION_PREVIOUS_HANDLE, '' );
-		if ( '' === $previous ) {
-			return null;
-		}
-
-		$result = self::call_update_handle( $previous );
-
-		if ( \is_wp_error( $result ) ) {
-			self::add_settings_notice(
-				\sprintf(
-					/* translators: 1: previous handle to restore; 2: error message from the PDS. */
-					\__( 'Could not restore your previous Bluesky handle (%1$s): %2$s', 'atmosphere' ),
-					$previous,
-					$result->get_error_message()
-				),
-				'warning'
-			);
-			return $result;
-		}
-
-		\delete_option( self::OPTION_PREVIOUS_HANDLE );
-
-		/*
-		 * Mirror the restored handle into atmosphere_connection. On the
-		 * standard disconnect path Client::disconnect() drops the option
-		 * moments later, so this write is wasted there — but keeping it
-		 * decouples Handle from disconnect ordering, so any future caller
-		 * (e.g. a manual revert action that does not also disconnect) gets
-		 * a consistent local snapshot.
-		 */
-		self::sync_connection_handle( $previous );
-
-		self::add_settings_notice(
-			\sprintf(
-				/* translators: %s: the handle that was restored (e.g. alice.bsky.social). */
-				\__( 'Restored your previous Bluesky handle: %s.', 'atmosphere' ),
-				$previous
-			),
-			'info'
 		);
 
 		return true;

--- a/bundled/atmosphere/includes/class-publisher.php
+++ b/bundled/atmosphere/includes/class-publisher.php
@@ -108,21 +108,85 @@ class Publisher {
 		$bsky_transformer = new Post( $post );
 		$doc_transformer  = new Document( $post );
 
+		/*
+		 * Pre-compute the document's CID locally and inject the
+		 * resulting strongRef into the post transformer BEFORE the
+		 * post record is built. The document and post are written
+		 * atomically in a single applyWrites batch, so without
+		 * client-side CID computation the post's
+		 * `embed.external.associatedRefs` cannot carry the document
+		 * ref at initial-create time — and Bluesky's AppView only
+		 * resolves `source` / `associatedProfiles` / document
+		 * `readingTime` enrichment from the initial-create payload
+		 * (subsequent `applyWrites#update` to add the ref doesn't
+		 * trigger re-indexing).
+		 *
+		 * The transform result is captured into `$doc_record` once
+		 * and threaded through to `publish_single()` /
+		 * `publish_thread()` so the document is transformed exactly
+		 * once per publish. Without that reuse, the CID computed here
+		 * and the record actually written by the publish call would
+		 * diverge whenever `atmosphere_transform_document` is
+		 * non-deterministic (timestamps, UUIDs, retried blob uploads),
+		 * and the document strongRef in `associatedRefs` would point
+		 * at a CID that no record at that URI matches.
+		 *
+		 * Short-form posts use `app.bsky.embed.images` rather than
+		 * `app.bsky.embed.external`, so the document strongRef has no
+		 * place to land. Skip the precompute on that path — the
+		 * downstream call falls back to a single transform itself
+		 * when `$doc_record` is null.
+		 */
+		$doc_record = null;
+		if ( ! $bsky_transformer->is_short_form_post() ) {
+			$doc_record = $doc_transformer->transform();
+			$doc_cid    = CID::from_record( $doc_record );
+
+			if ( ! \is_wp_error( $doc_cid ) ) {
+				$bsky_transformer->set_document_strong_ref(
+					array(
+						'uri' => build_at_uri( get_did(), 'site.standard.document', $doc_transformer->get_rkey() ),
+						'cid' => $doc_cid,
+					)
+				);
+			} else {
+				/*
+				 * Encoder hit a record shape it could not handle.
+				 * Surfacing the post error here would abort an
+				 * otherwise-fine publish; instead, log a breadcrumb
+				 * and let the publish proceed with publication-ref-only
+				 * (or no associatedRefs at all). The post still
+				 * reaches Bluesky — just without the AppView's rich
+				 * `source` / `associatedProfiles` enrichment for this
+				 * one record.
+				 */
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				\error_log(
+					\sprintf(
+						'[atmosphere] post %d: document CID precompute failed (%s) — publishing without document associatedRef',
+						$post->ID,
+						$doc_cid->get_error_code()
+					)
+				);
+			}
+		}
+
 		if ( $bsky_transformer->is_short_form_post() ) {
 			// Short-form path: single record via today's transform().
 			$result = self::publish_single(
 				$post,
 				$bsky_transformer->transform(),
 				$bsky_transformer,
-				$doc_transformer
+				$doc_transformer,
+				$doc_record
 			);
 		} else {
 			$records = $bsky_transformer->build_long_form_records();
 
 			if ( 1 === \count( $records ) ) {
-				$result = self::publish_single( $post, $records[0], $bsky_transformer, $doc_transformer );
+				$result = self::publish_single( $post, $records[0], $bsky_transformer, $doc_transformer, $doc_record );
 			} else {
-				$result = self::publish_thread( $post, $records, $bsky_transformer, $doc_transformer );
+				$result = self::publish_thread( $post, $records, $bsky_transformer, $doc_transformer, $doc_record );
 			}
 		}
 
@@ -217,20 +281,39 @@ class Publisher {
 	 * here when a record arrives without `createdAt` (for example, if a
 	 * filter stripped it).
 	 *
-	 * @param \WP_Post $post             WordPress post.
-	 * @param array    $bsky_record      Pre-composed bsky post record.
-	 * @param Post     $bsky_transformer Bsky transformer instance.
-	 * @param Document $doc_transformer  Document transformer instance.
+	 * @param \WP_Post   $post             WordPress post.
+	 * @param array      $bsky_record      Pre-composed bsky post record.
+	 * @param Post       $bsky_transformer Bsky transformer instance.
+	 * @param Document   $doc_transformer  Document transformer instance.
+	 * @param array|null $doc_record       Pre-computed document record from
+	 *                                     `publish_post()`. Reused as the write
+	 *                                     payload so the document is transformed
+	 *                                     exactly once per publish — same array
+	 *                                     the long-form CID precompute was
+	 *                                     derived from, guaranteeing the
+	 *                                     embedded document strongRef points at
+	 *                                     a CID that actually matches the
+	 *                                     record being written even when
+	 *                                     `atmosphere_transform_document` is
+	 *                                     non-deterministic. Null on the
+	 *                                     short-form path (no associatedRefs,
+	 *                                     no precompute) — falls back to a
+	 *                                     single transform here.
 	 * @return array|\WP_Error
 	 */
 	private static function publish_single(
 		\WP_Post $post,
 		array $bsky_record,
 		Post $bsky_transformer,
-		Document $doc_transformer
+		Document $doc_transformer,
+		?array $doc_record = null
 	): array|\WP_Error {
 		if ( empty( $bsky_record['createdAt'] ) ) {
 			$bsky_record['createdAt'] = to_iso8601( $post->post_date_gmt );
+		}
+
+		if ( null === $doc_record ) {
+			$doc_record = $doc_transformer->transform();
 		}
 
 		$writes = array(
@@ -244,7 +327,7 @@ class Publisher {
 				'$type'      => 'com.atproto.repo.applyWrites#create',
 				'collection' => 'site.standard.document',
 				'rkey'       => $doc_transformer->get_rkey(),
-				'value'      => $doc_transformer->transform(),
+				'value'      => $doc_record,
 			),
 		);
 
@@ -289,23 +372,34 @@ class Publisher {
 	 * WP_Error is returned. If rollback also fails, the return wraps
 	 * both errors and includes the partial thread state.
 	 *
-	 * @param \WP_Post $post             WordPress post.
-	 * @param array[]  $records          Records from build_long_form_records().
-	 * @param Post     $bsky_transformer Bsky transformer instance.
-	 * @param Document $doc_transformer  Document transformer instance.
+	 * @param \WP_Post   $post             WordPress post.
+	 * @param array[]    $records          Records from build_long_form_records().
+	 * @param Post       $bsky_transformer Bsky transformer instance.
+	 * @param Document   $doc_transformer  Document transformer instance.
+	 * @param array|null $doc_record       Pre-computed document record from
+	 *                                     `publish_post()`. See
+	 *                                     {@see self::publish_single()} for
+	 *                                     why the document must be
+	 *                                     transformed exactly once per
+	 *                                     publish.
 	 * @return array|\WP_Error
 	 */
 	private static function publish_thread(
 		\WP_Post $post,
 		array $records,
 		Post $bsky_transformer,
-		Document $doc_transformer
+		Document $doc_transformer,
+		?array $doc_record = null
 	): array|\WP_Error {
 		$root_record = $records[0];
 		if ( empty( $root_record['createdAt'] ) ) {
 			$root_record['createdAt'] = to_iso8601( $post->post_date_gmt );
 		}
 		$root_rkey = $bsky_transformer->get_rkey();
+
+		if ( null === $doc_record ) {
+			$doc_record = $doc_transformer->transform();
+		}
 
 		$root_result = API::apply_writes(
 			array(
@@ -319,7 +413,7 @@ class Publisher {
 					'$type'      => 'com.atproto.repo.applyWrites#create',
 					'collection' => 'site.standard.document',
 					'rkey'       => $doc_transformer->get_rkey(),
-					'value'      => $doc_transformer->transform(),
+					'value'      => $doc_record,
 				),
 			)
 		);
@@ -1346,7 +1440,7 @@ class Publisher {
 		 * reconnects, so the record always lands at the same address
 		 * for the active owner.
 		 */
-		return API::post(
+		$result = API::post(
 			'/xrpc/com.atproto.repo.putRecord',
 			array(
 				'repo'       => $did,
@@ -1355,6 +1449,19 @@ class Publisher {
 				'record'     => $pub->transform(),
 			)
 		);
+
+		/*
+		 * Capture the publication's CID from the PDS response so post
+		 * publishes can build the publication strongRef without an
+		 * extra `getRecord` round-trip. Overwritten on every
+		 * successful sync because the CID changes whenever the
+		 * publication's content changes.
+		 */
+		if ( ! \is_wp_error( $result ) && ! empty( $result['cid'] ) ) {
+			\update_option( Publication::OPTION_CID, (string) $result['cid'], false );
+		}
+
+		return $result;
 	}
 
 	/**

--- a/bundled/atmosphere/includes/class-reaction-sync.php
+++ b/bundled/atmosphere/includes/class-reaction-sync.php
@@ -10,6 +10,7 @@ namespace Atmosphere;
 
 \defined( 'ABSPATH' ) || exit;
 
+use Atmosphere\OAuth\Client;
 use Atmosphere\Transformer\Post as BskyPost;
 
 /**
@@ -155,6 +156,26 @@ class Reaction_Sync {
 	 */
 	public static function sync(): void {
 		if ( ! is_connected() ) {
+			return;
+		}
+
+		/*
+		 * Probe the access token once before walking the four streams.
+		 * Without this, a refresh that's locked or has just flipped
+		 * `needs_reauth` would be hit independently by each
+		 * {@see self::paginate()} call below — surfacing the same
+		 * incident four times in the error log and re-triggering the
+		 * refresh path on a session we already know is broken.
+		 */
+		$token = Client::access_token();
+		if ( \is_wp_error( $token ) ) {
+			\error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				\sprintf(
+					'[atmosphere] reaction sync aborted: %s — %s',
+					$token->get_error_code(),
+					$token->get_error_message()
+				)
+			);
 			return;
 		}
 
@@ -376,7 +397,6 @@ class Reaction_Sync {
 		}
 
 		$parent_uri = $record['reply']['parent']['uri'] ?? '';
-		$root_uri   = $record['reply']['root']['uri'] ?? '';
 
 		if ( empty( $parent_uri ) ) {
 			return false;
@@ -399,11 +419,27 @@ class Reaction_Sync {
 			}
 		}
 
-		if ( ! $post_id ) {
-			// Deep thread rooted at one of our posts.
-			$post_id = self::find_post_by_bsky_uri( $root_uri );
-		}
-
+		/*
+		 * Drop replies whose parent we can't resolve. A parent that
+		 * doesn't match a local WP post or a previously-synced WP
+		 * comment is either:
+		 *
+		 *   - Orphaned: the parent was deleted on Bluesky (e.g. blocked
+		 *     user, account deletion) or removed from our moderation
+		 *     queue. Falling back to the root post would re-attach
+		 *     every subsequent re-walk as a top-level orphan, looping
+		 *     the moderation queue indefinitely until the watermark
+		 *     advances past it.
+		 *
+		 *   - Out-of-order: a deep reply seen before its parent in the
+		 *     same `listNotifications`/`listRecords` page. Dropping
+		 *     here is recoverable: the parent gets synced in the same
+		 *     run, the child re-enters via the WATERMARK_GRACE window
+		 *     on the next run, and parent resolution succeeds.
+		 *
+		 * Direct replies (parent_uri is one of our WP posts) and
+		 * resolved nested replies are unaffected.
+		 */
 		if ( ! $post_id ) {
 			return false;
 		}
@@ -543,6 +579,10 @@ class Reaction_Sync {
 		$timestamp = \strtotime( $record['createdAt'] ?? '' );
 		$gm_date   = \gmdate( 'Y-m-d H:i:s', false === $timestamp ? 0 : $timestamp );
 
+		if ( '' === $content ) {
+			$content = self::default_reaction_excerpt( $comment_type );
+		}
+
 		$comment_data = array(
 			'comment_post_ID'      => $post_id,
 			'comment_parent'       => $comment_parent,
@@ -633,6 +673,30 @@ class Reaction_Sync {
 		\do_action( 'atmosphere_reaction_synced', $comment_id, $notification, $post_id, $comment_type );
 
 		return $comment_id;
+	}
+
+	/**
+	 * Default comment body for content-less reactions (likes and reposts).
+	 *
+	 * Mirrors the wording the wordpress-activitypub plugin uses for its
+	 * own like/repost rows, so themes that render activity feeds get a
+	 * consistent reading experience across protocols. The leading
+	 * ellipsis is intentional: most themes render the author name
+	 * immediately before the comment body, so the result reads as
+	 * "Jane Doe … liked this!".
+	 *
+	 * @param string $comment_type One of 'like', 'repost'.
+	 * @return string Translated excerpt, or empty string for unknown types.
+	 */
+	private static function default_reaction_excerpt( string $comment_type ): string {
+		switch ( $comment_type ) {
+			case 'like':
+				return \__( '… liked this!', 'atmosphere' );
+			case 'repost':
+				return \__( '… reposted this!', 'atmosphere' );
+			default:
+				return '';
+		}
 	}
 
 	/**

--- a/bundled/atmosphere/includes/functions.php
+++ b/bundled/atmosphere/includes/functions.php
@@ -46,14 +46,20 @@ function build_at_uri( string $did, string $collection, string $rkey ): string {
 }
 
 /**
- * Strip HTML, decode entities, normalise whitespace.
+ * Decode entities, strip HTML, normalise whitespace.
  *
  * @param string $text Raw text.
  * @return string Clean text.
  */
 function sanitize_text( string $text ): string {
-	$text = \wp_strip_all_tags( $text );
+	// Decode BEFORE stripping. WordPress stores many strings HTML-entity
+	// encoded (esc_html at save time), so an entity-encoded tag such as
+	// `&lt;script&gt;` arrives with no literal angle brackets. Stripping
+	// first would leave it untouched and the later decode would turn it
+	// into live `<script>` markup in the record. Decoding first turns it
+	// into a real tag that wp_strip_all_tags then removes.
 	$text = \html_entity_decode( $text, ENT_QUOTES, 'UTF-8' );
+	$text = \wp_strip_all_tags( $text );
 	// `/u` matches Unicode whitespace too — without it NBSP (U+00A0),
 	// ideographic space (U+3000), and similar survive both this collapse
 	// and the trim() below, masquerading as real prose downstream.
@@ -101,10 +107,19 @@ function to_iso8601( string $datetime ): string {
 /**
  * Get the stored connection (OAuth credentials + ephemeral state).
  *
+ * Normalizes non-array values to an empty array so a corrupted
+ * `atmosphere_connection` option (e.g. an admin overwrote it with a
+ * scalar via wp-cli or a misbehaving import plugin) cannot raise a
+ * TypeError at every caller's `: array` return-type check. The
+ * `admin_notices` hook in particular composes this with other
+ * checks during page render — a TypeError there whitescreens the
+ * admin until the row is repaired.
+ *
  * @return array
  */
 function get_connection(): array {
-	return \get_option( 'atmosphere_connection', array() );
+	$conn = \get_option( 'atmosphere_connection', array() );
+	return \is_array( $conn ) ? $conn : array();
 }
 
 /**

--- a/bundled/atmosphere/includes/oauth/class-client.php
+++ b/bundled/atmosphere/includes/oauth/class-client.php
@@ -12,6 +12,7 @@ namespace Atmosphere\OAuth;
 
 \defined( 'ABSPATH' ) || exit;
 
+use Atmosphere\Atmosphere;
 use function Atmosphere\clear_scheduled_hooks;
 use function Atmosphere\get_connection;
 
@@ -49,6 +50,19 @@ class Client {
 	 * @var string
 	 */
 	public const REFRESH_LOCK_OPTION = '_atmosphere_refresh_lock';
+
+	/**
+	 * `wp_options` row name flagging an explicit operator-initiated disconnect.
+	 *
+	 * Set on {@see self::disconnect()} so the admin reauth notice can tell
+	 * "user clicked Disconnect" apart from "refresh token failed". Cleared
+	 * on the next successful authorization. Public so `uninstall.php` and
+	 * the test suite can refer to the same key without drifting from the
+	 * canonical value used here.
+	 *
+	 * @var string
+	 */
+	public const DISCONNECTED_OPTION = 'atmosphere_disconnected';
 
 	/**
 	 * Get the client_id URL (= client metadata endpoint).
@@ -525,6 +539,30 @@ class Client {
 		);
 
 		/*
+		 * Clear any prior explicit-disconnect marker BEFORE persisting
+		 * the new connection. Doing so afterward exposes a cross-tab
+		 * race: a stale Disconnect link fired from another admin tab
+		 * during the OAuth callback would land between the
+		 * `update_option('atmosphere_connection', ...)` and the
+		 * `delete_option(DISCONNECTED_OPTION)`, stamping a fresh marker
+		 * (Client::disconnect() also runs `delete_option`) — the
+		 * callback would then clear the new marker on its way out.
+		 * Final state: identity preserved, connection gone, marker
+		 * gone — the reauth notice would fall through to "session
+		 * expired" copy when the user actually triggered a deliberate
+		 * disconnect from another tab.
+		 *
+		 * Clearing first means: any concurrent disconnect that lands
+		 * between this delete and the persist below leaves the marker
+		 * set AND the connection gone, which the notice gate correctly
+		 * renders as "disconnected." The disconnect's own marker write
+		 * is the authoritative signal of operator intent. Safe to call
+		 * when nothing was set — `delete_option` is a no-op for missing
+		 * rows.
+		 */
+		\delete_option( self::DISCONNECTED_OPTION );
+
+		/*
 		 * Encrypted token blobs do not need to ride along in every
 		 * request's `alloptions` payload; they're only read on the
 		 * paths that actually talk to the PDS. WP 6.6+ honours the
@@ -533,6 +571,17 @@ class Client {
 		 */
 		\update_option( 'atmosphere_connection', $connection, false );
 
+		/*
+		 * Connecting is the moment our well-known endpoints become
+		 * meaningful — the PDS starts fetching `/.well-known/atproto-did`
+		 * to verify a domain handle, and resolvers hit
+		 * `/.well-known/site.standard.publication`. Make sure the
+		 * persisted rewrite rules serve them on the very next request.
+		 * See {@see Atmosphere::maybe_flush_wellknown_rewrites()} for the
+		 * install paths that need this beyond activation.
+		 */
+		Atmosphere::maybe_flush_wellknown_rewrites();
+
 		return true;
 	}
 
@@ -540,24 +589,29 @@ class Client {
 	 * Maximum lifetime (seconds) of the refresh lock before it is
 	 * presumed stale and reclaimed.
 	 *
-	 * `refresh_locked()` can issue up to two HTTP POSTs sequentially when
-	 * the auth server requires a `use_dpop_nonce` retry — each with a
-	 * 15-second `wp_safe_remote_post` timeout, plus encryption /
-	 * option I/O overhead. A TTL shorter than that worst case would
-	 * let a second worker reclaim a lock the first worker is still
-	 * legitimately holding, which reintroduces the concurrent-refresh
-	 * race the lock exists to close. 90 seconds covers 2 × 15s
-	 * timeouts plus ample margin.
+	 * `refresh_locked()` can issue up to two sequential HTTP POSTs on
+	 * the `use_dpop_nonce` retry path, each with a 15s
+	 * `wp_safe_remote_post` timeout. The first call typically returns
+	 * the nonce error in well under a second (the auth server rejects
+	 * before any real work) — but on a degraded auth server that
+	 * actually hangs on every call, both legs can run the full 15s
+	 * timeout, yielding a worst-case ~30s + encryption + option I/O
+	 * overhead. 45 seconds covers that pathological case plus a small
+	 * margin so a slow-but-legitimate refresh isn't stomped by a
+	 * second worker's CAS-steal. Going lower than the actual worst
+	 * case reintroduces the concurrent-refresh race the lock exists
+	 * to close; going much higher keeps a crashed worker's lock alive
+	 * for proportionally longer before any successor can take over.
 	 *
 	 * @var int
 	 */
-	private const REFRESH_LOCK_TTL = 90;
+	private const REFRESH_LOCK_TTL = 45;
 
 	/**
 	 * Refresh the access token.
 	 *
 	 * Gated by a cross-process coordination lock so a publish event
-	 * firing inline through `access_token()`, the twice-daily refresh
+	 * firing inline through `access_token()`, the hourly refresh
 	 * cron, an admin click, or any combination of those cannot both
 	 * POST the same refresh token to the auth server. The auth server
 	 * consumes the refresh token on first success and the loser would
@@ -962,7 +1016,7 @@ class Client {
 	 * holder to write a fresh access token (or to flip
 	 * `needs_reauth` on a permanent failure).
 	 *
-	 * The deadline matches `REFRESH_LOCK_TTL` (90s) rather than a
+	 * The deadline matches `REFRESH_LOCK_TTL` (45s) rather than a
 	 * conservative few-seconds wait. The previous 5-second budget
 	 * was shorter than the realistic worst case — two sequential
 	 * `wp_safe_remote_post` calls at 15-second timeouts on the
@@ -981,9 +1035,26 @@ class Client {
 	 * comment cron event does not get silently dropped when it
 	 * arrives mid-refresh.
 	 *
+	 * `$current_access_token_ciphertext` lets callers in the API
+	 * 401-recovery path require the access-token ciphertext to
+	 * *differ* from a known-stale snapshot before declaring the
+	 * wait done. The default behaviour (empty string) trusts the
+	 * `expires_at` window alone — fine for the `access_token()`
+	 * caller, which only waits when `expires_at` was within 5
+	 * minutes of now. For a 401 from the PDS, `expires_at` may
+	 * still be in the future (the auth server invalidated the jti
+	 * without the local clock catching up), so the ciphertext
+	 * snapshot is the only reliable "token has actually rotated"
+	 * signal.
+	 *
+	 * @param string $current_access_token_ciphertext Snapshot of
+	 *               `atmosphere_connection['access_token']` taken
+	 *               BEFORE the failed request whose retry is
+	 *               waiting on a fresh token. Empty string disables
+	 *               the ciphertext-change requirement.
 	 * @return true|\WP_Error
 	 */
-	private static function wait_for_token_refresh(): true|\WP_Error {
+	public static function wait_for_token_refresh( string $current_access_token_ciphertext = '' ): true|\WP_Error {
 		$deadline = \microtime( true ) + (float) self::REFRESH_LOCK_TTL;
 
 		while ( \microtime( true ) < $deadline ) {
@@ -1002,6 +1073,8 @@ class Client {
 			if ( ! empty( $conn['access_token'] )
 				&& ! empty( $conn['expires_at'] )
 				&& $conn['expires_at'] > \time() + 300
+				&& ( '' === $current_access_token_ciphertext
+					|| ( $conn['access_token'] ?? '' ) !== $current_access_token_ciphertext )
 			) {
 				return true;
 			}
@@ -1138,6 +1211,29 @@ class Client {
 				(string) $conn['auth_server'],
 			);
 		}
+
+		/*
+		 * Mark the disconnect as operator-initiated BEFORE wiping the
+		 * connection row so the admin reauth notice's copy swap is
+		 * race-free. With the marker set first, any concurrent admin
+		 * request that loads `Admin::maybe_render_reauth_notice()` while
+		 * this method is in-flight sees either: (a) a live connection
+		 * (needs_reauth false, notice silent), or (b) a missing
+		 * connection AND a set marker (the "disconnected" copy renders).
+		 * Reversing the order would expose a narrow window where the
+		 * connection is gone but the marker is not yet present — the
+		 * gate would fall through to the misleading "session has
+		 * expired" wording the marker exists to suppress. Set with
+		 * `autoload = false` because the value is only consulted by the
+		 * admin notice (single per-request read after a needs_reauth
+		 * gate), so paying for it on every page-load is wasteful.
+		 *
+		 * Stamped with `\time()` so a future caller could expire stale
+		 * markers (e.g. after N days); the notice gate itself only
+		 * reads truthiness. Cleared on the next successful
+		 * authorization (see `handle_callback()`).
+		 */
+		\update_option( self::DISCONNECTED_OPTION, \time(), false );
 
 		\delete_option( 'atmosphere_connection' );
 		\delete_option( self::REFRESH_LOCK_OPTION );

--- a/bundled/atmosphere/includes/oauth/class-encryption.php
+++ b/bundled/atmosphere/includes/oauth/class-encryption.php
@@ -18,13 +18,28 @@ namespace Atmosphere\OAuth;
 class Encryption {
 
 	/**
-	 * Derive a 32-byte key from WordPress auth constants.
+	 * Derive a 32-byte key from the site's auth salt.
+	 *
+	 * Prefers `AUTH_KEY . AUTH_SALT` so previously encrypted tokens still
+	 * decrypt; falls back to `wp_salt( 'auth' )` on sites that don't
+	 * define those constants.
 	 *
 	 * @return string
 	 */
 	private static function key(): string {
+		if (
+			\defined( 'AUTH_KEY' )
+			&& \defined( 'AUTH_SALT' )
+			&& '' !== AUTH_KEY
+			&& '' !== AUTH_SALT
+		) {
+			$material = AUTH_KEY . AUTH_SALT;
+		} else {
+			$material = \wp_salt( 'auth' );
+		}
+
 		return \sodium_crypto_generichash(
-			AUTH_KEY . AUTH_SALT,
+			$material,
 			'',
 			SODIUM_CRYPTO_SECRETBOX_KEYBYTES
 		);

--- a/bundled/atmosphere/includes/oauth/class-nonce-storage.php
+++ b/bundled/atmosphere/includes/oauth/class-nonce-storage.php
@@ -30,9 +30,14 @@ class Nonce_Storage {
 	/**
 	 * Time-to-live in seconds.
 	 *
+	 * Must stay shorter than the auth server's own DPoP nonce lifetime
+	 * (atproto-oauth-provider uses 180s) so we expire stored nonces
+	 * before the server starts rejecting them as stale and forcing an
+	 * extra `use_dpop_nonce` round-trip on every DPoP-bound request.
+	 *
 	 * @var int
 	 */
-	private const TTL = 300;
+	private const TTL = 150;
 
 	/**
 	 * Retrieve a stored nonce for a URL.

--- a/bundled/atmosphere/includes/transformer/class-post.php
+++ b/bundled/atmosphere/includes/transformer/class-post.php
@@ -121,6 +121,56 @@ class Post extends Base {
 	public const META_DOC_REF_PENDING = '_atmosphere_doc_ref_pending';
 
 	/**
+	 * Document strongRef the Publisher pre-computed for the initial
+	 * atomic `applyWrites#create`.
+	 *
+	 * AT Protocol's chicken-and-egg: a strongRef needs the target's
+	 * CID, and the document's CID only exists after a write. The
+	 * Publisher closes the gap by computing the document's CID
+	 * locally via the DAG-CBOR encoder ({@see \Atmosphere\CID}) and
+	 * pushing the resulting `{uri, cid}` here before any
+	 * `transform()` / `build_long_form_records()` call. The embed
+	 * builder picks the ref up and includes it in the post's
+	 * `embed.external.associatedRefs` array on the very first
+	 * applyWrites — which is what Bluesky's AppView indexes
+	 * (subsequent `applyWrites#update` follow-ups are ignored for
+	 * `source` / `associatedProfiles` enrichment).
+	 *
+	 * Null on a fresh transformer; reset whenever a fresh Post object
+	 * is constructed. Subsequent publishes of the same post
+	 * (`update_post()` flow) do not inject — by then
+	 * `Document::META_URI` / `Document::META_CID` are populated and
+	 * {@see self::build_embed()} reads the ref from meta instead.
+	 *
+	 * @var array{$type: string, uri: string, cid: string}|null
+	 */
+	private ?array $document_strong_ref = null;
+
+	/**
+	 * Inject the document strongRef the embed builder should advertise
+	 * in `associatedRefs` on the initial publish.
+	 *
+	 * See {@see self::$document_strong_ref} for the why. Passing an
+	 * empty array or a malformed shape (missing `uri` / `cid`) clears
+	 * the injection and the embed builder falls back to reading from
+	 * `Document::META_*`.
+	 *
+	 * @param array $ref StrongRef to advertise (keys: optional `$type`, required `uri` and `cid`).
+	 */
+	public function set_document_strong_ref( array $ref ): void {
+		if ( empty( $ref['uri'] ) || empty( $ref['cid'] ) ) {
+			$this->document_strong_ref = null;
+			return;
+		}
+
+		$this->document_strong_ref = array(
+			'$type' => 'com.atproto.repo.strongRef',
+			'uri'   => (string) $ref['uri'],
+			'cid'   => (string) $ref['cid'],
+		);
+	}
+
+	/**
 	 * Transform the post.
 	 *
 	 * @return array app.bsky.feed.post record.
@@ -156,9 +206,17 @@ class Post extends Base {
 		$text  = $redacted ? '' : ( $is_short ? $this->build_short_form_text() : '' );
 		$embed = null;
 
-		if ( ! $redacted && '' === $text ) {
-			$text  = $this->build_text();
-			$embed = $this->build_embed();
+		if ( ! $redacted ) {
+			if ( $is_short ) {
+				$embed = $this->build_images_embed();
+				if ( '' === $text && null === $embed ) {
+					$text  = $this->build_text();
+					$embed = $this->build_embed();
+				}
+			} else {
+				$text  = $this->build_text();
+				$embed = $this->build_embed();
+			}
 		}
 
 		if ( ! $redacted ) {
@@ -326,6 +384,167 @@ class Post extends Base {
 	}
 
 	/**
+	 * Build an `app.bsky.embed.images` record from the post's images.
+	 *
+	 * Source priority:
+	 *   1. `core/image` blocks parsed from `post_content` (deduped,
+	 *      document order, capped at 4).
+	 *   2. Featured image (`get_post_thumbnail_id`) when no in-body
+	 *      images are found.
+	 *
+	 * Returns null when neither source yields an image, when every
+	 * attempted blob upload fails, or for redacted posts. Partial upload
+	 * failures are silently skipped; the record ships with whatever
+	 * uploaded successfully. Used by the
+	 * short-form `transform()` path so aside/status/quote posts that
+	 * contain images actually ship them to Bluesky instead of silently
+	 * dropping them with the post content's HTML.
+	 *
+	 * @return array|null app.bsky.embed.images record or null.
+	 */
+	private function build_images_embed(): ?array {
+		if ( $this->is_redacted() ) {
+			return null;
+		}
+
+		$attachment_ids = $this->collect_image_attachment_ids();
+
+		if ( empty( $attachment_ids ) ) {
+			$thumb_id = \get_post_thumbnail_id( $this->object );
+			if ( $thumb_id ) {
+				$attachment_ids[] = (int) $thumb_id;
+			}
+		}
+
+		if ( empty( $attachment_ids ) ) {
+			return null;
+		}
+
+		// AT Protocol `app.bsky.embed.images` caps at 4 images.
+		$attachment_ids = \array_slice( $attachment_ids, 0, 4 );
+
+		$images = array();
+		foreach ( $attachment_ids as $attachment_id ) {
+			$blob = self::upload_image_blob( $attachment_id );
+			if ( ! $blob ) {
+				continue;
+			}
+
+			$image = array(
+				'image' => $blob,
+				'alt'   => $this->image_alt_text( $attachment_id ),
+			);
+
+			$aspect_ratio = self::get_attachment_aspect_ratio( $attachment_id );
+			if ( null !== $aspect_ratio ) {
+				$image['aspectRatio'] = $aspect_ratio;
+			}
+
+			$images[] = $image;
+		}
+
+		if ( empty( $images ) ) {
+			return null;
+		}
+
+		return array(
+			'$type'  => 'app.bsky.embed.images',
+			'images' => $images,
+		);
+	}
+
+	/**
+	 * Collect attachment IDs from `core/image` blocks in post_content.
+	 *
+	 * Walks the block tree recursively (into `innerBlocks`) so an image
+	 * nested in a group, column, or cover block is still picked up.
+	 * Order is document order; duplicates are removed; non-positive IDs
+	 * are skipped. Only `core/image` blocks are inspected — `core/cover`
+	 * background images and `core/media-text` images are intentionally
+	 * out of scope; consumers needing those can wire them in via the
+	 * `atmosphere_post_embed` filter.
+	 *
+	 * The walker stops collecting once 32 IDs have been gathered — well
+	 * above the 4-image AT Protocol cap, but enough headroom that dedupe
+	 * still preserves document order on realistic posts. Bounds the
+	 * memory profile so an attacker-controlled `post_content` packed with
+	 * thousands of `core/image` blocks can't grow the working array
+	 * past a constant ceiling.
+	 *
+	 * Recursion is also depth-capped at 16 levels. The 32-ID breadth cap
+	 * only protects against wide trees: a deeply-nested input with no
+	 * images (e.g. 500 nested `core/group` wrappers) would never
+	 * accumulate IDs and never trip the breadth guard, but each level
+	 * still costs a PHP frame on the C stack. 16 leaves ample headroom
+	 * over realistic theme/block nesting (cover → group → columns →
+	 * column → group → image is six) while keeping the worst-case stack
+	 * use bounded against an adversarial `post_content`.
+	 *
+	 * @return int[]
+	 */
+	private function collect_image_attachment_ids(): array {
+		$content = (string) $this->object->post_content;
+
+		if ( '' === $content || ! \has_blocks( $content ) ) {
+			return array();
+		}
+
+		$blocks = \parse_blocks( $content );
+		$ids    = array();
+
+		// Generous ceiling: well above the 4-image cap, enough that
+		// dedupe still preserves document order on realistic posts,
+		// small enough to bound attacker-controlled memory growth.
+		$max_ids   = 32;
+		$max_depth = 16;
+
+		$walker = static function ( array $blocks, int $depth ) use ( &$walker, &$ids, $max_ids, $max_depth ): void {
+			if ( $depth > $max_depth ) {
+				return;
+			}
+
+			foreach ( $blocks as $block ) {
+				if ( \count( $ids ) >= $max_ids ) {
+					return;
+				}
+
+				if ( ( $block['blockName'] ?? '' ) === 'core/image'
+					&& isset( $block['attrs']['id'] )
+					&& (int) $block['attrs']['id'] > 0
+				) {
+					$ids[] = (int) $block['attrs']['id'];
+				}
+
+				if ( ! empty( $block['innerBlocks'] ) && \is_array( $block['innerBlocks'] ) ) {
+					$walker( $block['innerBlocks'], $depth + 1 );
+				}
+			}
+		};
+
+		$walker( $blocks, 0 );
+
+		return \array_values( \array_unique( $ids ) );
+	}
+
+	/**
+	 * Resolve the alt text for an attachment.
+	 *
+	 * Uses the WordPress canonical attachment alt meta key
+	 * (`_wp_attachment_image_alt`). Returns an empty string when the meta
+	 * is missing or non-string — AT Protocol's `app.bsky.embed.images`
+	 * requires the `alt` field to be present, and an empty string is a
+	 * valid value.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return string
+	 */
+	private function image_alt_text( int $attachment_id ): string {
+		$alt = \get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+
+		return \is_string( $alt ) ? truncate_text( sanitize_text( $alt ), 1000 ) : '';
+	}
+
+	/**
 	 * Build an app.bsky.embed.external card.
 	 *
 	 * @return array|null
@@ -351,6 +570,59 @@ class Post extends Base {
 			if ( $blob ) {
 				$external['thumb'] = $blob;
 			}
+		}
+
+		/*
+		 * Build the `associatedRefs` array. Order: publication first,
+		 * document second — matches what Bluesky's manual-share UI
+		 * emits and keeps the test fixtures stable. Lexicon does not
+		 * mandate ordering, but pinning a deterministic order avoids
+		 * spurious CID drift on no-op republishes.
+		 *
+		 * Publication ref comes from a stored site-wide option, set
+		 * by `Publisher::sync_publication()` once the publication
+		 * record has been written.
+		 *
+		 * Document ref has two sources:
+		 *   - On the *initial* publish, the Publisher precomputes the
+		 *     document's CID locally via DAG-CBOR and injects via
+		 *     `set_document_strong_ref()`. Without this, the document
+		 *     ref could only be added after the atomic write returned
+		 *     — and Bluesky's AppView ignores subsequent
+		 *     `applyWrites#update` for the purposes of indexing
+		 *     `source` / `associatedProfiles` enrichment.
+		 *   - On an *update* publish, the injection is absent but
+		 *     `Document::META_*` are already populated by the
+		 *     previous publish's `store_document_meta()`, so reading
+		 *     from meta produces an equivalent ref.
+		 *
+		 * The injection wins if both sources are present — it
+		 * reflects what the Publisher is *about* to write, the meta
+		 * reflects the previous write.
+		 */
+		$associated_refs = array();
+
+		$publication_ref = Publication::get_strong_ref();
+		if ( null !== $publication_ref ) {
+			$associated_refs[] = $publication_ref;
+		}
+
+		if ( null !== $this->document_strong_ref ) {
+			$associated_refs[] = $this->document_strong_ref;
+		} else {
+			$doc_uri = (string) \get_post_meta( $this->object->ID, Document::META_URI, true );
+			$doc_cid = (string) \get_post_meta( $this->object->ID, Document::META_CID, true );
+			if ( '' !== $doc_uri && '' !== $doc_cid ) {
+				$associated_refs[] = array(
+					'$type' => 'com.atproto.repo.strongRef',
+					'uri'   => $doc_uri,
+					'cid'   => $doc_cid,
+				);
+			}
+		}
+
+		if ( ! empty( $associated_refs ) ) {
+			$external['associatedRefs'] = $associated_refs;
 		}
 
 		return array(
@@ -500,7 +772,9 @@ class Post extends Base {
 	 * applyWrites batch from a malformed embed.
 	 *
 	 * @param array|null $embed    Default embed for this strategy
-	 *                             (null for short-form, an
+	 *                             (an `app.bsky.embed.images` record for
+	 *                             short-form posts with images, null for
+	 *                             short-form posts without images, an
 	 *                             `app.bsky.embed.external` card for the
 	 *                             link-card and teaser-thread strategies).
 	 * @param string     $strategy Composition strategy: 'short-form',
@@ -511,15 +785,16 @@ class Post extends Base {
 		/**
 		 * Filters the embed attached to a Bluesky post record.
 		 *
-		 * Fires for every composition strategy, including short-form
-		 * (where the default is `null` — short-form posts ship without
-		 * an embed unless something opts in). Consumers can:
+		 * Fires for every composition strategy. The default for short-form
+		 * posts is an `app.bsky.embed.images` record when the post has
+		 * images (in-body `core/image` blocks, or the featured image as a
+		 * fallback), and `null` otherwise. Consumers can:
 		 *
 		 *   - Replace the default external link card with a richer
 		 *     embed type (`app.bsky.embed.images`, `app.bsky.embed.video`,
 		 *     `app.bsky.embed.record`).
 		 *   - Attach an embed to a short-form post that would otherwise
-		 *     ship plain.
+		 *     ship plain (e.g. an image-free aside).
 		 *   - Suppress the default embed by returning null.
 		 *
 		 * Valid returns are `null` or an array with a non-empty string
@@ -540,9 +815,12 @@ class Post extends Base {
 		 * post object to embed filters would leak the protected payload.
 		 *
 		 * @param array|null $embed    Default embed for this strategy
-		 *                             (null for short-form, an
-		 *                             `app.bsky.embed.external` card
-		 *                             otherwise).
+		 *                             (an `app.bsky.embed.images` record
+		 *                             for short-form posts with images,
+		 *                             null for short-form posts without
+		 *                             images, an `app.bsky.embed.external`
+		 *                             card for the link-card and
+		 *                             teaser-thread strategies).
 		 * @param \WP_Post   $post     The post being transformed.
 		 * @param string     $strategy Composition strategy: 'short-form',
 		 *                             'link-card', or 'teaser-thread'.

--- a/bundled/atmosphere/includes/transformer/class-publication.php
+++ b/bundled/atmosphere/includes/transformer/class-publication.php
@@ -12,7 +12,9 @@ namespace Atmosphere\Transformer;
 
 \defined( 'ABSPATH' ) || exit;
 
+use function Atmosphere\build_at_uri;
 use function Atmosphere\get_did;
+use function Atmosphere\sanitize_text;
 
 /**
  * Standard.site publication transformer.
@@ -27,25 +29,46 @@ class Publication extends Base {
 	public const OPTION_TID = 'atmosphere_publication_tid';
 
 	/**
+	 * Option key for the publication CID captured at the last successful
+	 * `sync_publication()` write.
+	 *
+	 * Stored so {@see self::get_strong_ref()} can build a strongRef
+	 * without a `getRecord` round-trip. The CID rotates whenever the
+	 * publication's content changes (site title, theme color, etc.)
+	 * and is re-captured on every successful putRecord. Both the TID
+	 * and CID survive disconnect for the same reason — they're the
+	 * stable site-level identifiers — and are only cleared on
+	 * uninstall.
+	 *
+	 * @var string
+	 */
+	public const OPTION_CID = 'atmosphere_publication_cid';
+
+	/**
 	 * Transform site settings into a publication record.
 	 *
 	 * @return array site.standard.publication record.
 	 */
 	public function transform(): array {
+		// WordPress stores the site name and tagline HTML-entity encoded
+		// (esc_html at save time). sanitize_text() strips tags, decodes
+		// those entities, and collapses whitespace, so the record carries
+		// clean plain text rather than codes like `&#039;`.
 		$record = array(
 			'$type'       => 'site.standard.publication',
 			'url'         => \home_url( '/' ),
-			'name'        => \get_bloginfo( 'name' ),
-			'displayName' => \get_bloginfo( 'name' ),
-			'description' => \get_bloginfo( 'description' ),
+			'name'        => sanitize_text( \get_bloginfo( 'name' ) ),
+			'description' => sanitize_text( \get_bloginfo( 'description' ) ),
 		);
 
-		// Site icon as avatar.
+		// Site icon. The site.standard.publication lexicon expects a square
+		// `icon` blob (at least 256x256). The Site Icon control crops to a
+		// square and recommends 512px, which clears that guideline.
 		$icon_id = \get_option( 'site_icon' );
 		if ( $icon_id ) {
 			$blob = Post::upload_thumbnail( (int) $icon_id );
 			if ( $blob ) {
-				$record['avatar'] = $blob;
+				$record['icon'] = $blob;
 			}
 		}
 
@@ -96,6 +119,42 @@ class Publication extends Base {
 		}
 
 		return $rkey;
+	}
+
+	/**
+	 * Build a {@link https://atproto.com/specs/lexicon com.atproto.repo.strongRef}
+	 * pointing at the connected site's publication record, or null
+	 * when the strongRef cannot be safely constructed.
+	 *
+	 * Both the TID and the CID are required: the URI half is derivable
+	 * from the connected DID + the stored TID, but the strongRef shape
+	 * also needs the content-hash from {@see self::OPTION_CID}, which
+	 * is only populated after a successful `sync_publication()` write.
+	 * A fresh-connect install that has not yet synced returns null
+	 * here and callers omit `associatedRefs` rather than ship a
+	 * malformed strongRef.
+	 *
+	 * @return array{$type: string, uri: string, cid: string}|null
+	 */
+	public static function get_strong_ref(): ?array {
+		$tid = (string) \get_option( self::OPTION_TID, '' );
+		$cid = (string) \get_option( self::OPTION_CID, '' );
+
+		if ( '' === $tid || '' === $cid ) {
+			return null;
+		}
+
+		$did = get_did();
+
+		if ( '' === $did ) {
+			return null;
+		}
+
+		return array(
+			'$type' => 'com.atproto.repo.strongRef',
+			'uri'   => build_at_uri( $did, 'site.standard.publication', $tid ),
+			'cid'   => $cid,
+		);
 	}
 
 	/**

--- a/bundled/atmosphere/includes/wp-admin/class-admin.php
+++ b/bundled/atmosphere/includes/wp-admin/class-admin.php
@@ -19,6 +19,7 @@ use function Atmosphere\get_supported_post_types;
 use function Atmosphere\has_identity;
 use function Atmosphere\is_connected;
 use function Atmosphere\needs_reauth;
+use function Atmosphere\sanitize_text;
 
 /**
  * Admin class.
@@ -52,13 +53,27 @@ class Admin {
 	 * Register the settings page under Settings.
 	 */
 	public static function add_menu(): void {
-		\add_options_page(
+		$hook = \add_options_page(
 			\__( 'ATmosphere', 'atmosphere' ),
 			\__( 'ATmosphere', 'atmosphere' ),
 			'manage_options',
 			'atmosphere',
 			array( self::class, 'render_page' )
 		);
+
+		if ( ! $hook ) {
+			return;
+		}
+
+		/*
+		 * Self-heal the well-known rewrite rules whenever an
+		 * administrator loads our settings page — the surface where this
+		 * bug surfaces, and so the right place to silently fix it.
+		 * Hooked on `load-{suffix}` so it runs before the page renders
+		 * and only on our page, not on every admin request. See
+		 * {@see Atmosphere::maybe_flush_wellknown_rewrites()} for detail.
+		 */
+		\add_action( "load-{$hook}", array( Atmosphere::class, 'maybe_flush_wellknown_rewrites' ) );
 	}
 
 	/**
@@ -193,12 +208,17 @@ class Admin {
 		/*
 		 * Register the domain-handle confirm row only when the offer is
 		 * meaningful (root install, feature enabled, current handle differs
-		 * from the site host). Skipping registration is the cleanest way to
-		 * suppress the row entirely without rendering an empty <tr>.
+		 * from the site host, AND a live OAuth session exists). Skipping
+		 * registration is the cleanest way to suppress the row entirely
+		 * without rendering an empty <tr>. The `is_connected()` check
+		 * matters specifically while identity is preserved across a
+		 * disconnect — without it, the row would render after Disconnect
+		 * and a click would dead-end at `Handle::set_handle()`'s "Connect
+		 * to Bluesky before setting your domain handle." gate.
 		 */
 		if ( Handle::should_offer(
 			array(
-				'connected' => true,
+				'connected' => is_connected(),
 				'handle'    => get_connection()['handle'] ?? '',
 			)
 		) ) {
@@ -750,24 +770,6 @@ class Admin {
 
 		\check_admin_referer( 'atmosphere_disconnect', 'atmosphere_nonce' );
 
-		/*
-		 * Best-effort handle revert BEFORE the disconnect drops the OAuth
-		 * token: if the site previously set the handle to its domain, restore
-		 * the snapshotted previous handle while the access token is still
-		 * valid. The call posts a notice on the way out; disconnect proceeds
-		 * regardless of result so a token-revoked or network-failed revert
-		 * can't trap the user in a connected state.
-		 */
-		Handle::maybe_revert_on_disconnect();
-
-		/*
-		 * Clear the snapshot regardless of revert outcome so it cannot be
-		 * revived by a future reconnect to a different account. Once the
-		 * OAuth token is gone there is no way to retry a failed revert
-		 * anyway, so the snapshot is dead weight after this point.
-		 */
-		\delete_option( Handle::OPTION_PREVIOUS_HANDLE );
-
 		Client::disconnect();
 
 		\add_settings_error(
@@ -822,6 +824,10 @@ class Admin {
 	 * user reconnects — without a visible nudge, an expired refresh
 	 * token can sit unnoticed for days. The notice is dismissible per
 	 * page-load only so the user is reminded again on their next visit.
+	 *
+	 * Swaps copy when the disconnect was operator-initiated (the user
+	 * clicked Disconnect) so the message does not falsely claim "your
+	 * session has expired" for a state the user just chose.
 	 */
 	public static function maybe_render_reauth_notice(): void {
 		if ( ! \current_user_can( 'manage_options' ) ) {
@@ -834,19 +840,41 @@ class Admin {
 
 		$settings_url = \admin_url( 'options-general.php?page=atmosphere' );
 
+		/*
+		 * Treat the explicit-disconnect marker as authoritative only
+		 * when the connection row is genuinely empty. `Client::disconnect()`
+		 * deletes `atmosphere_connection` before any other admin request
+		 * can land, so a missing connection alongside the marker is a
+		 * true operator-initiated disconnect. After a refresh failure,
+		 * the connection row stays put (with `needs_reauth = true` and
+		 * an emptied access_token) — if a stale marker from an earlier
+		 * disconnect survived (e.g. `handle_callback()`'s `delete_option`
+		 * silently failed at a cache layer), the connection's presence
+		 * outs the marker as stale and the gate falls through to the
+		 * "session expired" copy, which is the accurate framing for the
+		 * actual failure mode.
+		 */
+		$disconnected = \get_option( Client::DISCONNECTED_OPTION, false ) && empty( get_connection() );
+
+		if ( $disconnected ) {
+			$heading = \__( 'ATmosphere: disconnected', 'atmosphere' );
+			/* translators: %s: URL to the ATmosphere settings page. */
+			$message = \__( 'ATmosphere is disconnected from AT Protocol. New posts and comments will not publish until you <a href="%s">reconnect on the settings page</a>. Your publishing preferences and verification headers stay in place in the meantime.', 'atmosphere' );
+		} else {
+			$heading = \__( 'ATmosphere: reconnection required', 'atmosphere' );
+			/* translators: %s: URL to the ATmosphere settings page. */
+			$message = \__( 'Your AT Protocol session has expired. New posts and comments will not publish until you <a href="%s">reconnect on the settings page</a>. Your publishing preferences and verification headers stay in place in the meantime.', 'atmosphere' );
+		}
+
 		?>
 		<div class="notice notice-warning is-dismissible">
 			<p>
-				<strong><?php \esc_html_e( 'ATmosphere: reconnection required', 'atmosphere' ); ?></strong>
+				<strong><?php echo \esc_html( $heading ); ?></strong>
 			</p>
 			<p>
 				<?php
 				echo \wp_kses(
-					\sprintf(
-						/* translators: %s: URL to the ATmosphere settings page. */
-						\__( 'Your AT Protocol session has expired. New posts and comments will not publish until you <a href="%s">reconnect on the settings page</a>. Your publishing preferences and verification headers stay in place in the meantime.', 'atmosphere' ),
-						\esc_url( $settings_url )
-					),
+					\sprintf( $message, \esc_url( $settings_url ) ),
 					array( 'a' => array( 'href' => array() ) )
 				);
 				?>
@@ -880,7 +908,7 @@ class Admin {
 	public static function serve_client_metadata(): \WP_REST_Response {
 		$metadata = array(
 			'client_id'                  => Client::client_id(),
-			'client_name'                => \get_bloginfo( 'name' ) . ' (ATmosphere)',
+			'client_name'                => sanitize_text( \get_bloginfo( 'name' ) ) . ' (ATmosphere)',
 			'client_uri'                 => \home_url( '/' ),
 			'redirect_uris'              => array( Client::redirect_uri() ),
 			'grant_types'                => array( 'authorization_code', 'refresh_token' ),

--- a/bundled/atmosphere/readme.txt
+++ b/bundled/atmosphere/readme.txt
@@ -1,10 +1,10 @@
 === ATmosphere ===
-Contributors: automattic, pfefferle, kraftbj, ryancowles
+Contributors: automattic, pfefferle, kraftbj, jeherve, ryanc413
 Tags: at-protocol, bluesky, fediverse, atproto, crossposting
 Requires at least: 6.2
 Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPL-2.0-or-later
 License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
 
@@ -91,6 +91,23 @@ Not at this time. ATmosphere is designed for a single WordPress site. On a Netwo
 
 == Changelog ==
 
+### 1.1.1 - 2026-06-01
+#### Added
+- Posts shared to Bluesky now link back to both the site's publication record and the per-post document record, so Bluesky shows your site source, profile, and richer document metadata alongside the link preview.
+
+#### Changed
+- Likes and reposts synced from Bluesky now include a readable comment body ("… liked this!" / "… reposted this!") so they display sensibly in themes that render activity-feed comments.
+
+#### Fixed
+- Aside, status, and other short-form posts now include their images when published to Bluesky.
+- Fix a fatal error when saving the Bluesky handle on sites without auth keys defined in wp-config.php.
+- Fix unexpected disconnections by refreshing the AT Protocol session more reliably.
+- Preserve your AT Protocol identity when disconnecting so a custom domain handle (`example.com` instead of `alice.bsky.social`) can be used to reconnect later. Disconnect no longer wipes the verification endpoint that the handle resolver depends on, no longer auto-reverts the Bluesky handle back to its pre-domain value, and shows a clearer "disconnected" notice instead of a "session expired" warning.
+- Refresh admin assets after updating, so the latest styles and scripts load correctly.
+- Site names and descriptions containing characters like apostrophes or ampersands now publish correctly instead of showing raw HTML codes.
+- Stop reinjecting replies into the moderation queue when the parent Bluesky message has been deleted or blocked.
+- Your site icon now appears on your standard.site publication.
+
 ### 1.1.0 - 2026-05-21
 #### Added
 - Add `atmosphere_post_embed` filter so downstream code can swap the default external link card for a richer embed (`app.bsky.embed.images`, `app.bsky.embed.video`, …) or attach an embed to a short-form post that would otherwise ship with none. The filter accepts `null` (suppress) or an array with a non-empty string `$type` key; non-array, empty-array, or missing-`$type` returns are rejected with `_doing_it_wrong` and the pre-filter value is restored. `Post::upload_thumbnail()` becomes a backward-compatible alias for the new generic `Post::upload_image_blob()`; a new `Post::get_attachment_aspect_ratio()` helper exposes the pixel dimensions consumers need for `embed.images`.
@@ -154,6 +171,7 @@ Not at this time. ATmosphere is designed for a single WordPress site. On a Netwo
 - Remove a comment reply from Bluesky if the comment was deleted or unapproved while it was being published, instead of leaving an orphan reply behind.
 - Short posts under the long-form teaser-thread strategy no longer ship a redundant "continue reading" reply when the entire body already fits in a single Bluesky post. The link-back is preserved as a card on the same post.
 
+[1.1.1]: https://github.com/Automattic/wordpress-atmosphere/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/Automattic/wordpress-atmosphere/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/Automattic/wordpress-atmosphere/releases
 

--- a/bundled/atmosphere/uninstall.php
+++ b/bundled/atmosphere/uninstall.php
@@ -26,8 +26,14 @@ $atmosphere_options = array(
 	'atmosphere_connection',
 	'atmosphere_identity',
 	'atmosphere_publication_tid',
+	'atmosphere_publication_cid',
 	'atmosphere_publication_uri',
 	'atmosphere_auto_publish',
+	// Legacy: written by set_handle() in 1.0.x and 1.1.0 as a revert
+	// snapshot for disconnect. The revert path was removed; the option
+	// no longer has a producer or consumer. Kept in the uninstall sweep
+	// so installs upgraded from those versions do not leave an orphan
+	// row behind.
 	'atmosphere_previous_handle',
 	'atmosphere_long_form_composition',
 	'atmosphere_support_post_types',
@@ -40,6 +46,9 @@ $atmosphere_options = array(
 	// Hardcoded here because `uninstall.php` runs before the plugin
 	// bootstrap is loaded, so the constant isn't available.
 	'_atmosphere_refresh_lock',
+	// Canonical value: `\Atmosphere\OAuth\Client::DISCONNECTED_OPTION`.
+	// Hardcoded for the same reason as `_atmosphere_refresh_lock`.
+	'atmosphere_disconnected',
 );
 
 foreach ( $atmosphere_options as $atmosphere_option ) {

--- a/bundled/atmosphere/vendor/composer/installed.php
+++ b/bundled/atmosphere/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'automattic/atmosphere',
         'pretty_version' => 'dev-trunk',
         'version' => 'dev-trunk',
-        'reference' => 'c03581874229f5a20f22489653fc4bb974078e20',
+        'reference' => 'aae00b363cc8038eaeee05436322e74710e805c8',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'automattic/atmosphere' => array(
             'pretty_version' => 'dev-trunk',
             'version' => 'dev-trunk',
-            'reference' => 'c03581874229f5a20f22489653fc4bb974078e20',
+            'reference' => 'aae00b363cc8038eaeee05436322e74710e805c8',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/fosse.php
+++ b/fosse.php
@@ -3,7 +3,7 @@
  * Plugin Name: FOSSE
  * Plugin URI:  https://github.com/Automattic/fosse
  * Description: Social Web
- * Version:     0.1.2-alpha
+ * Version:     0.1.2
  * Requires at least: 6.9
  * Tested up to: 7.0
  * Requires PHP: 8.2
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  * `ACTIVITYPUB_PLUGIN_VERSION` / `ATMOSPHERE_VERSION` pattern of the
  * bundled backends. Keep in sync with the `Version:` header above.
  */
-define( 'FOSSE_VERSION', '0.1.2-alpha' );
+define( 'FOSSE_VERSION', '0.1.2' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload_packages.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload_packages.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fosse",
-	"version": "0.1.2-alpha",
+	"version": "0.1.2",
 	"description": "Social Web for WordPress.",
 	"private": true,
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Summary

Refreshes the bundled federation backends to their latest upstream trunk and cuts the **0.1.2** stable release.

### Bundled backend updates

- **ActivityPub** re-vendored from `origin/trunk` (8.3.0 line). Keeps the merged blurhash support and the SWICG ActivityPub API Basic Profile OAuth scope work, and picks up merged trunk improvements plus two new handlers (`class-feature-request.php`, `class-feature-authorization.php`).
- **Atmosphere** bumped 1.1.0 → **1.1.1**, including the well-known rewrite flush fix (domain-handle verification reliability) and client-side CID computation (`class-cid.php`).
- Atmosphere production `vendor/` rebuilt via `composer update --no-dev --optimize-autoloader` (autoload scaffolding only — no runtime deps), with the stale gitignored `composer.lock`/`vendor/` scrubbed first per the documented sync caveat.

### Release

- Version bumped `0.1.2-alpha` → `0.1.2` in `fosse.php` (header + `FOSSE_VERSION`) and `package.json`.

## Notes

- `bundled/` is vendored upstream code, excluded from PHPCS/PHPUnit/ESLint/Prettier/Jest. No FOSSE source changed apart from the version strings — all bundled-version references in FOSSE are dynamic runtime constants, so no compat guards needed updating.

## Test plan

- `composer run-script lint-php` — clean (72/72)
- `pnpm run format:check` — clean
- `pnpm run lint` — clean
- `composer run-script test-php` — 799 tests, 1836 assertions, OK