### PR TITLE
chore: bump version to 0.1.3-alpha

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -3,7 +3,7 @@
  * Plugin Name: FOSSE
  * Plugin URI:  https://github.com/Automattic/fosse
  * Description: Social Web
- * Version:     0.1.2
+ * Version:     0.1.3-alpha
  * Requires at least: 6.9
  * Tested up to: 7.0
  * Requires PHP: 8.2
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  * `ACTIVITYPUB_PLUGIN_VERSION` / `ATMOSPHERE_VERSION` pattern of the
  * bundled backends. Keep in sync with the `Version:` header above.
  */
-define( 'FOSSE_VERSION', '0.1.2' );
+define( 'FOSSE_VERSION', '0.1.3-alpha' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload_packages.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload_packages.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fosse",
-	"version": "0.1.2",
+	"version": "0.1.3-alpha",
 	"description": "Social Web for WordPress.",
 	"private": true,
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Post-release development bump following the 0.1.2 release.

Moves trunk to `0.1.3-alpha` so ongoing work is clearly marked as pre-release, mirroring the `0.1.1` → `0.1.2-alpha` bump after the 0.1.1 release.

- `fosse.php` — `Version:` header + `FOSSE_VERSION` constant
- `package.json` — `version` field

No functional changes.