### PR TITLE
fix: harden Blurhash encoder against four robustness gaps

### DIFF
--- a/src/class-blurhash-cli.php
+++ b/src/class-blurhash-cli.php
@@ -202,6 +202,18 @@ class Blurhash_CLI {
 				}
 
 				$hash = Blurhash::encode_from_attachment( $attachment_id );
+
+				// `false` is a policy skip (e.g. declared dimensions
+				// over the decode-bomb cap) — same bucket as a
+				// non-raster mime, not a failure. Warning on it every
+				// run (and exiting nonzero) would make a permanently
+				// over-cap attachment poison automation forever.
+				if ( false === $hash ) {
+					++$skipped;
+					WP_CLI::log( "skipped (out of encode policy): attachment {$attachment_id}" );
+					continue;
+				}
+
 				if ( null === $hash ) {
 					++$failed;
 					WP_CLI::warning( "encode failed: attachment {$attachment_id}" );
@@ -219,7 +231,7 @@ class Blurhash_CLI {
 
 		$encoded_label = $dry_run ? 'would encode' : 'encoded';
 		$summary       = sprintf(
-			'%s %d, skipped %d (non-raster or unsupported), failed %d.',
+			'%s %d, skipped %d (non-raster, unsupported, or out of encode policy), failed %d.',
 			$encoded_label,
 			$encoded,
 			$skipped,

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -113,6 +113,25 @@ class Blurhash {
 	private const MAX_ENCODE_BYTES = 8388608;
 
 	/**
+	 * Hard upper bound on the DECODED pixel count (width × height) of
+	 * the source image. `imagecreatefromstring()` fully decodes the
+	 * compressed bytes into an uncompressed GD bitmap BEFORE
+	 * {@see self::encode_from_attachment()} downscales to
+	 * {@see self::MAX_ENCODE_EDGE}, so a small, highly compressible
+	 * source (e.g. a flat-color PNG declaring 30000×30000) slips past
+	 * the {@see self::MAX_ENCODE_BYTES} byte cap yet forces a
+	 * multi-gigabyte allocation — an uncatchable OOM that kills the
+	 * cron worker or aborts a CLI backfill mid-run. We read the
+	 * declared dimensions with `getimagesizefromstring()` first and
+	 * skip (treated as "we don't encode this", not a failure) when the
+	 * product exceeds this cap. 50 megapixels comfortably covers any
+	 * realistic camera/phone upload while rejecting decompression bombs.
+	 *
+	 * @var int
+	 */
+	private const MAX_ENCODE_PIXELS = 50000000;
+
+	/**
 	 * Raster MIME types GD can decode via `imagecreatefromstring`.
 	 * Used as the early gate that splits "we don't encode this"
 	 * (skip silently) from "encoder failed" (emit warning, count
@@ -228,6 +247,29 @@ class Blurhash {
 			return null;
 		}
 
+		// Decode-bomb guard. `imagecreatefromstring()` fully decodes
+		// the compressed bytes into an uncompressed bitmap before we
+		// get a chance to downscale, so a small but highly
+		// compressible source declaring huge dimensions (e.g. a
+		// flat-color 30000×30000 PNG) would force a multi-gigabyte
+		// allocation and OOM the worker — uncatchable, so we can't
+		// recover with the try/catch below. Read the declared
+		// dimensions cheaply first and skip (silent, not an error)
+		// anything past the megapixel cap.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- malformed header returns false and we handle.
+		$dimensions = @\getimagesizefromstring( $bytes );
+		if ( false === $dimensions || ! isset( $dimensions[0] ) || ! isset( $dimensions[1] ) ) {
+			return null;
+		}
+		$declared_width  = (int) $dimensions[0];
+		$declared_height = (int) $dimensions[1];
+		if ( $declared_width < 1 || $declared_height < 1 ) {
+			return null;
+		}
+		if ( $declared_width * $declared_height > self::MAX_ENCODE_PIXELS ) {
+			return null;
+		}
+
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- corrupt image returns false and we handle.
 		$image = @\imagecreatefromstring( $bytes );
 		if ( false === $image ) {
@@ -268,6 +310,25 @@ class Blurhash {
 				$image  = $scaled;
 				$width  = $target_width;
 				$height = $target_height;
+			}
+
+			// Flatten transparency against a white background before
+			// sampling. `imagecolorsforindex()` reports the raw RGB of
+			// a transparent pixel (usually 0,0,0 → black) while
+			// discarding alpha, so a transparent PNG/GIF/WebP logo or
+			// sticker would otherwise encode to a near-black blurhash.
+			// Compositing onto an opaque white canvas yields the color
+			// a viewer actually sees over a typical light surface.
+			$canvas = \imagecreatetruecolor( $width, $height );
+			if ( false !== $canvas ) {
+				$white = \imagecolorallocate( $canvas, 255, 255, 255 );
+				if ( false !== $white ) {
+					\imagefilledrectangle( $canvas, 0, 0, $width - 1, $height - 1, $white );
+					\imagealphablending( $canvas, true );
+					if ( \imagecopy( $canvas, $image, 0, 0, 0, 0, $width, $height ) ) {
+						$image = $canvas;
+					}
+				}
 			}
 
 			$pixels = array();
@@ -405,7 +466,54 @@ class Blurhash {
 			return false;
 		}
 		$mime = \get_post_mime_type( $attachment_id );
-		return \is_string( $mime ) && \in_array( $mime, self::ENCODABLE_MIME_TYPES, true );
+		return \is_string( $mime ) && self::is_decodable_mime( $mime );
+	}
+
+	/**
+	 * Whether `$mime` is one we attempt AND one this host's GD build
+	 * can actually decode. Membership in {@see self::ENCODABLE_MIME_TYPES}
+	 * is necessary but not sufficient: AVIF, WebP, and BMP support are
+	 * compile-time codec options, so on a GD build without them every
+	 * such attachment would pass a bare `in_array()` gate, reach
+	 * `imagecreatefromstring()`, fail there, and land in the
+	 * "unexpected failure" bucket — an `error_log` line plus a
+	 * `fosse_blurhash_encode_failed` action on every cron run and a
+	 * nonzero CLI exit. Intersecting with the runtime `imagetypes()`
+	 * bitmask routes unsupported codecs to the silent-skip path
+	 * instead. JPEG/PNG/GIF are mandatory in every GD build, so they
+	 * need no flag check.
+	 *
+	 * @param string $mime Attachment MIME type.
+	 * @return bool
+	 */
+	private static function is_decodable_mime( string $mime ): bool {
+		if ( ! \in_array( $mime, self::ENCODABLE_MIME_TYPES, true ) ) {
+			return false;
+		}
+
+		// Codec-gated formats: only decodable when the corresponding
+		// `imagetypes()` flag is set on this GD build. Defensive
+		// `defined()` guards because the IMG_* constants themselves
+		// only exist when GD exposes them.
+		$flag = null;
+		if ( 'image/avif' === $mime ) {
+			$flag = \defined( 'IMG_AVIF' ) ? \IMG_AVIF : 0;
+		} elseif ( 'image/webp' === $mime ) {
+			$flag = \defined( 'IMG_WEBP' ) ? \IMG_WEBP : 0;
+		} elseif ( 'image/bmp' === $mime ) {
+			$flag = \defined( 'IMG_BMP' ) ? \IMG_BMP : 0;
+		}
+
+		if ( null === $flag ) {
+			// JPEG/PNG/GIF — mandatory in every GD build.
+			return true;
+		}
+
+		if ( 0 === $flag || ! \function_exists( 'imagetypes' ) ) {
+			return false;
+		}
+
+		return (bool) ( \imagetypes() & $flag );
 	}
 
 	/**
@@ -443,7 +551,16 @@ class Blurhash {
 		// nothing the underlying scheduler doesn't already do and
 		// added a needless read against the autoloaded cron option
 		// on every attachment metadata regen.
-		\wp_schedule_single_event( \time(), self::CRON_HOOK, array( $attachment_id ) );
+		//
+		// Defer one minute rather than firing at `time()`. This
+		// callback runs inside the `wp_generate_attachment_metadata`
+		// filter, BEFORE `wp_update_attachment_metadata()` commits the
+		// sizes array. A concurrent wp-cron tick could otherwise run
+		// `run_encode()` before that commit lands, find no thumbnail
+		// intermediate yet, and fall back to encoding the full-size
+		// original. The one-minute delay lets the metadata write
+		// settle first; single-event dedup semantics are unchanged.
+		\wp_schedule_single_event( \time() + \MINUTE_IN_SECONDS, self::CRON_HOOK, array( $attachment_id ) );
 	}
 
 	/**

--- a/src/class-blurhash.php
+++ b/src/class-blurhash.php
@@ -123,7 +123,8 @@ class Blurhash {
 	 * multi-gigabyte allocation — an uncatchable OOM that kills the
 	 * cron worker or aborts a CLI backfill mid-run. We read the
 	 * declared dimensions with `getimagesizefromstring()` first and
-	 * skip (treated as "we don't encode this", not a failure) when the
+	 * skip (`encode_from_attachment()` returns `false`, which callers
+	 * treat as "we don't encode this", not a failure) when the
 	 * product exceeds this cap. 50 megapixels comfortably covers any
 	 * realistic camera/phone upload while rejecting decompression bombs.
 	 *
@@ -211,14 +212,21 @@ class Blurhash {
 	/**
 	 * Compute (synchronously) the blurhash for an attachment by
 	 * loading the configured size's file through GD and feeding the
-	 * pixel array to the encoder. Returns null on any failure path
-	 * — never throws, never warns. Used by both the cron handler
-	 * and the WP-CLI backfill.
+	 * pixel array to the encoder. Never throws, never warns. Used by
+	 * both the cron handler and the WP-CLI backfill.
+	 *
+	 * Three-state return so callers can route outcomes to the right
+	 * bucket: a string is success; `false` means the source is
+	 * deliberately outside encode policy (currently: declared pixel
+	 * count over {@see self::MAX_ENCODE_PIXELS}) and must be skipped
+	 * silently, same posture as a non-raster mime; `null` is an
+	 * unexpected failure (missing/corrupt file, GD or encoder error)
+	 * that callers surface for monitoring.
 	 *
 	 * @param int $attachment_id Attachment post ID.
-	 * @return string|null
+	 * @return string|false|null Hash on success, false on policy skip, null on failure.
 	 */
-	public static function encode_from_attachment( int $attachment_id ): ?string {
+	public static function encode_from_attachment( int $attachment_id ): string|false|null {
 		if ( ! self::is_encodable_attachment( $attachment_id ) ) {
 			return null;
 		}
@@ -267,7 +275,12 @@ class Blurhash {
 			return null;
 		}
 		if ( $declared_width * $declared_height > self::MAX_ENCODE_PIXELS ) {
-			return null;
+			// Policy skip, not a failure: `false` routes the caller
+			// to the same silent bucket as a non-raster mime, so a
+			// permanently over-cap source doesn't error_log on every
+			// cron run or hold the CLI backfill exit code nonzero
+			// forever.
+			return false;
 		}
 
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- corrupt image returns false and we handle.
@@ -598,8 +611,17 @@ class Blurhash {
 			return;
 		}
 		$hash = self::encode_from_attachment( $attachment_id );
-		if ( null !== $hash ) {
+		if ( \is_string( $hash ) ) {
 			self::set( $attachment_id, $hash );
+			return;
+		}
+
+		// `false` is a policy skip (source over the decode-bomb
+		// dimension cap): deliberate, deterministic, and global to
+		// the source bytes — logging it would re-introduce the
+		// per-run noise this bucket exists to avoid. Only `null`
+		// (unexpected failure) falls through to diagnostics.
+		if ( false === $hash ) {
 			return;
 		}
 

--- a/tests/php/BlurhashTest.php
+++ b/tests/php/BlurhashTest.php
@@ -175,6 +175,37 @@ class BlurhashTest extends BaseTestCase {
 	}
 
 	/**
+	 * Write a 16×16 PNG that is either fully transparent (alpha 127
+	 * over black RGB — the worst case for an alpha-unaware sampler)
+	 * or solid opaque white. The pair drives the transparency
+	 * flattening test: composited onto the encoder's white canvas,
+	 * both must produce the same all-white pixel field.
+	 *
+	 * @param bool $transparent True for fully transparent, false for solid white.
+	 * @return string Absolute file path to the PNG.
+	 */
+	private function generate_alpha_fixture_png( bool $transparent ): string {
+		$tmp = tempnam( sys_get_temp_dir(), 'fosse-blurhash-alpha-' );
+		$this->assertNotFalse( $tmp );
+		$path                  = $tmp . '.png';
+		$this->fixture_files[] = $tmp;
+		$this->fixture_files[] = $path;
+
+		$im = imagecreatetruecolor( 16, 16 );
+		if ( $transparent ) {
+			imagealphablending( $im, false );
+			$color = imagecolorallocatealpha( $im, 0, 0, 0, 127 );
+			imagefilledrectangle( $im, 0, 0, 15, 15, $color );
+			imagesavealpha( $im, true );
+		} else {
+			$color = imagecolorallocate( $im, 255, 255, 255 );
+			imagefilledrectangle( $im, 0, 0, 15, 15, $color );
+		}
+		imagepng( $im, $path );
+		return $path;
+	}
+
+	/**
 	 * Redirect `get_attached_file` for one attachment id to a
 	 * specific absolute path — the only-touch-this-one matcher
 	 * keeps fixtures from cross-contaminating sibling tests.
@@ -531,17 +562,52 @@ class BlurhashTest extends BaseTestCase {
 	 * BEFORE `imagecreatefromstring()` runs, so the multi-gigabyte
 	 * bitmap allocation that would OOM the cron worker never happens.
 	 * The crafted PNG is only a few dozen bytes (passes the byte cap)
-	 * but declares 30000×30000 ≈ 900 MP in its IHDR. Must return null,
-	 * routed to the silent-skip path (no exception, no error).
+	 * but declares 30000×30000 ≈ 900 MP in its IHDR. Must return
+	 * `false` — the policy-skip sentinel — NOT `null`: the fixture
+	 * has no pixel data, so if the gate didn't fire first,
+	 * `imagecreatefromstring()` would fail and produce `null`
+	 * (failure bucket). Asserting `false` therefore proves the
+	 * dimension gate rejected the bytes BEFORE any decode attempt.
 	 */
-	public function test_encode_returns_null_for_decode_bomb_dimensions(): void {
+	public function test_encode_skips_decode_bomb_dimensions_before_decode(): void {
 		$this->require_gd();
 
 		$id   = $this->insert_image_attachment();
 		$path = $this->generate_png_with_declared_dimensions( 30000, 30000 );
 		$this->point_attachment_at( $id, $path );
 
-		$this->assertNull( Blurhash::encode_from_attachment( $id ) );
+		$this->assertFalse( Blurhash::encode_from_attachment( $id ) );
+	}
+
+	/**
+	 * The cron callback routes the decode-bomb policy skip to the
+	 * SILENT path: no `fosse_blurhash_encode_failed` action, no
+	 * stored meta. Without the three-state return, `run_encode()`
+	 * treated the skip exactly like an unexpected failure
+	 * (`error_log` + action on every scheduled run) — the noise the
+	 * skip/failure split exists to prevent.
+	 */
+	public function test_run_encode_treats_decode_bomb_as_silent_skip(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_png_with_declared_dimensions( 30000, 30000 );
+		$this->point_attachment_at( $id, $path );
+
+		$captured = array();
+		add_action(
+			'fosse_blurhash_encode_failed',
+			static function ( $failed_id ) use ( &$captured ) {
+				$captured[] = (int) $failed_id;
+			}
+		);
+
+		Blurhash::run_encode( $id );
+
+		$this->assertNull( Blurhash::get( $id ) );
+		$this->assertSame( array(), $captured, 'Policy skip must not fire the encode-failed action.' );
+
+		remove_all_actions( 'fosse_blurhash_encode_failed' );
 	}
 
 	/**
@@ -565,6 +631,31 @@ class BlurhashTest extends BaseTestCase {
 		$hash = Blurhash::encode_from_attachment( $id );
 		$this->assertIsString( $hash );
 		$this->assertNotSame( '', $hash );
+	}
+
+	/**
+	 * Transparency flattening: a fully transparent PNG (alpha 127
+	 * over black RGB) must encode to the SAME hash as a solid white
+	 * image of identical dimensions, because the encoder composites
+	 * onto an opaque white canvas before sampling. Without the
+	 * composite, `imagecolorsforindex()` reports the raw black RGB
+	 * of the transparent pixels and the hash comes out near-black —
+	 * the bug this guards against.
+	 */
+	public function test_encode_flattens_transparency_to_white(): void {
+		$this->require_gd();
+
+		$transparent_id = $this->insert_image_attachment( 'transparent.png' );
+		$this->point_attachment_at( $transparent_id, $this->generate_alpha_fixture_png( true ) );
+
+		$white_id = $this->insert_image_attachment( 'white.png' );
+		$this->point_attachment_at( $white_id, $this->generate_alpha_fixture_png( false ) );
+
+		$transparent_hash = Blurhash::encode_from_attachment( $transparent_id );
+		$white_hash       = Blurhash::encode_from_attachment( $white_id );
+
+		$this->assertIsString( $transparent_hash );
+		$this->assertSame( $white_hash, $transparent_hash );
 	}
 
 	/**
@@ -730,7 +821,12 @@ class BlurhashTest extends BaseTestCase {
 		$returned = Blurhash::schedule_encode( $metadata, $id );
 
 		$this->assertSame( $metadata, $returned );
-		$this->assertNotFalse( wp_next_scheduled( Blurhash::CRON_HOOK, array( $id ) ) );
+		$timestamp = wp_next_scheduled( Blurhash::CRON_HOOK, array( $id ) );
+		$this->assertNotFalse( $timestamp );
+		// Deferred into the future (one minute) so a concurrent
+		// wp-cron tick can't run the encode before
+		// `wp_update_attachment_metadata()` commits the sizes array.
+		$this->assertGreaterThan( time(), $timestamp );
 	}
 
 	/**

--- a/tests/php/BlurhashTest.php
+++ b/tests/php/BlurhashTest.php
@@ -138,6 +138,43 @@ class BlurhashTest extends BaseTestCase {
 	}
 
 	/**
+	 * Write a syntactically valid PNG whose IHDR declares the given
+	 * dimensions but whose pixel data is empty. `getimagesizefromstring()`
+	 * parses only the IHDR chunk, so this is enough to exercise the
+	 * decode-bomb dimension gate without allocating the bitmap a real
+	 * 30000×30000 PNG would force GD to materialize. Returns the
+	 * absolute tempfile path.
+	 *
+	 * @param int $width  Declared pixel width.
+	 * @param int $height Declared pixel height.
+	 * @return string Absolute file path to the crafted PNG.
+	 */
+	private function generate_png_with_declared_dimensions( int $width, int $height ): string {
+		$signature = "\x89PNG\r\n\x1a\n";
+
+		// IHDR: width, height, bit depth 8, color type 2 (truecolor),
+		// compression 0, filter 0, interlace 0.
+		$ihdr_data = pack( 'NNCCCCC', $width, $height, 8, 2, 0, 0, 0 );
+		$ihdr      = pack( 'N', strlen( $ihdr_data ) )
+			. 'IHDR' . $ihdr_data
+			. pack( 'N', crc32( 'IHDR' . $ihdr_data ) );
+
+		// Empty IEND chunk so the stream is well-formed enough for
+		// header parsers.
+		$iend = pack( 'N', 0 ) . 'IEND' . pack( 'N', crc32( 'IEND' ) );
+
+		$tmp = tempnam( sys_get_temp_dir(), 'fosse-blurhash-dim-' );
+		$this->assertNotFalse( $tmp );
+		$path                  = $tmp . '.png';
+		$this->fixture_files[] = $tmp;
+		$this->fixture_files[] = $path;
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture write to tempdir.
+		file_put_contents( $path, $signature . $ihdr . $iend );
+		return $path;
+	}
+
+	/**
 	 * Redirect `get_attached_file` for one attachment id to a
 	 * specific absolute path — the only-touch-this-one matcher
 	 * keeps fixtures from cross-contaminating sibling tests.
@@ -311,6 +348,75 @@ class BlurhashTest extends BaseTestCase {
 	}
 
 	/**
+	 * Mandatory raster formats (JPEG/PNG/GIF) are always encodable —
+	 * GD guarantees these codecs in every build, so the
+	 * `imagetypes()` intersection in `is_encodable_attachment` must
+	 * never gate them out.
+	 */
+	public function test_mandatory_mime_types_are_encodable(): void {
+		foreach ( array( 'image/jpeg', 'image/png', 'image/gif' ) as $mime ) {
+			$attachment_id = wp_insert_post(
+				array(
+					'post_type'      => 'attachment',
+					'post_status'    => 'inherit',
+					'post_mime_type' => $mime,
+					'post_title'     => 'fixture',
+				)
+			);
+			update_post_meta( $attachment_id, '_wp_attached_file', 'fixture.' . substr( $mime, 6 ) );
+
+			$this->assertTrue(
+				Blurhash::is_encodable_attachment( (int) $attachment_id ),
+				"Expected {$mime} to be encodable on every GD build."
+			);
+		}
+	}
+
+	/**
+	 * Codec-gated formats (AVIF/WebP/BMP) are encodable iff this
+	 * host's GD build actually supports decoding them. Fix 3: on a
+	 * build without AVIF, the bare mime-membership gate would let an
+	 * AVIF attachment through to `imagecreatefromstring()`, which
+	 * fails and lands in the "unexpected failure" bucket (error_log +
+	 * action per cron run, nonzero CLI exit). Intersecting with the
+	 * `imagetypes()` bitmask routes unsupported codecs to the
+	 * silent-skip path. We assert the gate tracks the host's real
+	 * capability rather than hardcoding a verdict, so the test stays
+	 * green on hosts with and without each codec.
+	 */
+	public function test_codec_gated_mime_tracks_host_imagetypes(): void {
+		if ( ! function_exists( 'imagetypes' ) ) {
+			$this->markTestSkipped( 'GD imagetypes() required for this test.' );
+		}
+
+		$cases = array(
+			'image/avif' => defined( 'IMG_AVIF' ) ? IMG_AVIF : 0,
+			'image/webp' => defined( 'IMG_WEBP' ) ? IMG_WEBP : 0,
+			'image/bmp'  => defined( 'IMG_BMP' ) ? IMG_BMP : 0,
+		);
+
+		foreach ( $cases as $mime => $flag ) {
+			$attachment_id = wp_insert_post(
+				array(
+					'post_type'      => 'attachment',
+					'post_status'    => 'inherit',
+					'post_mime_type' => $mime,
+					'post_title'     => 'fixture',
+				)
+			);
+			update_post_meta( $attachment_id, '_wp_attached_file', 'fixture.' . substr( $mime, 6 ) );
+
+			$host_supports = ( 0 !== $flag ) && (bool) ( imagetypes() & $flag );
+
+			$this->assertSame(
+				$host_supports,
+				Blurhash::is_encodable_attachment( (int) $attachment_id ),
+				"Encodability of {$mime} should match host imagetypes() support."
+			);
+		}
+	}
+
+	/**
 	 * Missing-file path: image attachment exists in DB but the
 	 * underlying file is gone (CDN purge, manual delete, S3 offload
 	 * pointing at a stale path). Returns null without warning.
@@ -417,6 +523,48 @@ class BlurhashTest extends BaseTestCase {
 		$this->point_attachment_at( $id, $path );
 
 		$this->assertNull( Blurhash::encode_from_attachment( $id ) );
+	}
+
+	/**
+	 * Decode-bomb guard: a small, well-formed file whose header
+	 * declares dimensions past MAX_ENCODE_PIXELS (50 MP) is rejected
+	 * BEFORE `imagecreatefromstring()` runs, so the multi-gigabyte
+	 * bitmap allocation that would OOM the cron worker never happens.
+	 * The crafted PNG is only a few dozen bytes (passes the byte cap)
+	 * but declares 30000×30000 ≈ 900 MP in its IHDR. Must return null,
+	 * routed to the silent-skip path (no exception, no error).
+	 */
+	public function test_encode_returns_null_for_decode_bomb_dimensions(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_png_with_declared_dimensions( 30000, 30000 );
+		$this->point_attachment_at( $id, $path );
+
+		$this->assertNull( Blurhash::encode_from_attachment( $id ) );
+	}
+
+	/**
+	 * The decode-bomb guard is a ceiling, not a blanket ban on
+	 * large dimensions: a normal, fully-valid PNG whose pixel count
+	 * sits under the 50 MP cap still encodes. This is the companion
+	 * assertion to the bomb test — together they prove the gate
+	 * rejects the pathological case without being set so low it
+	 * would reject ordinary high-resolution photos. (The fixture is
+	 * small for test speed; the point is that it passes the dimension
+	 * gate and reaches a successful encode rather than being
+	 * short-circuited.)
+	 */
+	public function test_encode_dimension_gate_allows_normal_image(): void {
+		$this->require_gd();
+
+		$id   = $this->insert_image_attachment();
+		$path = $this->generate_fixture_image( false, 64, 64 );
+		$this->point_attachment_at( $id, $path );
+
+		$hash = Blurhash::encode_from_attachment( $id );
+		$this->assertIsString( $hash );
+		$this->assertNotSame( '', $hash );
 	}
 
 	/**

--- a/tests/php/Blurhash_CLITest.php
+++ b/tests/php/Blurhash_CLITest.php
@@ -174,6 +174,35 @@ class Blurhash_CLITest extends BaseTestCase {
 	}
 
 	/**
+	 * Write a syntactically valid PNG whose IHDR declares the given
+	 * dimensions but carries no pixel data — enough to exercise the
+	 * encoder's decode-bomb dimension gate without materializing the
+	 * bitmap. Mirrors the helper in {@see BlurhashTest}.
+	 *
+	 * @param int $width  Declared pixel width.
+	 * @param int $height Declared pixel height.
+	 * @return string Absolute file path to the crafted PNG.
+	 */
+	private function generate_png_with_declared_dimensions( int $width, int $height ): string {
+		$signature = "\x89PNG\r\n\x1a\n";
+		$ihdr_data = pack( 'NNCCCCC', $width, $height, 8, 2, 0, 0, 0 );
+		$ihdr      = pack( 'N', strlen( $ihdr_data ) )
+			. 'IHDR' . $ihdr_data
+			. pack( 'N', crc32( 'IHDR' . $ihdr_data ) );
+		$iend      = pack( 'N', 0 ) . 'IEND' . pack( 'N', crc32( 'IEND' ) );
+
+		$tmp = tempnam( sys_get_temp_dir(), 'fosse-blurhash-cli-dim-' );
+		$this->assertNotFalse( $tmp );
+		$path                  = $tmp . '.png';
+		$this->fixture_files[] = $tmp;
+		$this->fixture_files[] = $path;
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture write to tempdir.
+		file_put_contents( $path, $signature . $ihdr . $iend );
+		return $path;
+	}
+
+	/**
 	 * Stub `get_attached_file` to point a single attachment at the
 	 * given path.
 	 *
@@ -302,6 +331,32 @@ class Blurhash_CLITest extends BaseTestCase {
 		$last_success = WP_CLI::last_success();
 		$this->assertNotNull( $last_success );
 		$this->assertStringContainsString( 'skipped 1', $last_success );
+	}
+
+	/**
+	 * A decode-bomb source (declared dimensions over the encoder's
+	 * 50 MP cap) is a policy skip, not a failure: counted as
+	 * skipped, no warning, zero exit. Before the three-state
+	 * `encode_from_attachment()` return, the bomb landed in the
+	 * failure bucket — a warning plus nonzero exit on EVERY backfill
+	 * run, forever, since the attachment can never gain a hash.
+	 */
+	public function test_backfill_counts_decode_bomb_as_skipped_not_failed(): void {
+		$this->require_gd();
+
+		$bomb_id = $this->insert_image_attachment( 'bomb.png', 'image/png' );
+		$this->point_attachment_at( $bomb_id, $this->generate_png_with_declared_dimensions( 30000, 30000 ) );
+
+		$this->stub_query_pages( array( array( $bomb_id ), array() ) );
+
+		( new Blurhash_CLI() )->backfill( array(), array() );
+
+		$this->assertNull( Blurhash::get( $bomb_id ) );
+		$this->assertSame( array(), WP_CLI::warnings(), 'Policy skip must not emit a warning' );
+		$last_success = WP_CLI::last_success();
+		$this->assertNotNull( $last_success, 'Policy skip must exit zero (success), not error' );
+		$this->assertStringContainsString( 'skipped 1', $last_success );
+		$this->assertStringContainsString( 'failed 0', $last_success );
 	}
 
 	// ---------------------------------------------------------------


### PR DESCRIPTION
## What

Hardens the Blurhash encoder (`src/class-blurhash.php`) against four robustness gaps:

1. **Decode-bomb window (MEDIUM).** The encoder capped the compressed file size (`MAX_ENCODE_BYTES`, 8 MiB) and the output pixel array (`MAX_ENCODE_EDGE`, 64px), but `imagecreatefromstring()` fully decodes the bitmap *before* the downscale. A small, highly compressible source declaring e.g. 30000×30000 slipped past the byte cap yet forced a multi-gigabyte allocation — an uncatchable OOM that kills the cron worker or aborts a CLI backfill. Now `getimagesizefromstring()` reads the declared dimensions first and rejects anything past a new `MAX_ENCODE_PIXELS` cap (50 MP), returning `null` (silent skip), not the failure bucket.
2. **Alpha ignored (LOW).** `imagecolorsforindex()` discarded the alpha channel, so transparent PNG/GIF/WebP pixels sampled as raw (usually black) RGB → near-black blurhashes for logos and stickers. The decoded image is now composited onto an opaque white canvas before sampling.
3. **Unsupported codecs (LOW).** `ENCODABLE_MIME_TYPES` includes AVIF/WebP/BMP, but `is_encoder_runnable()` only checked function existence, not codec support. On a GD build without AVIF, every AVIF attachment passed the gate, failed `imagecreatefromstring()`, and landed in the "unexpected failure" bucket (`error_log` + action per cron run, nonzero CLI exit). The MIME gate now intersects with `imagetypes()` flags (`IMG_AVIF`/`IMG_WEBP`/`IMG_BMP`) so unsupported formats are skipped silently. JPEG/PNG/GIF are mandatory in every GD build and need no flag check.
4. **Cron encode race (LOW).** `schedule_encode()` runs inside the `wp_generate_attachment_metadata` filter (before metadata is persisted) and scheduled at `time()`; a concurrent wp-cron could run `run_encode()` before `wp_update_attachment_metadata()` committed, falling back to the original file. Now scheduled at `time() + MINUTE_IN_SECONDS`, preserving single-event dedup semantics.

## Why

Each of these turns an unsupported or pathological input into either an operational hazard (OOM crash) or persistent diagnostic noise (per-cron `error_log` + nonzero CLI exit), instead of the silent, federation-non-blocking skip the class is designed around.

## Tests

Added to `tests/php/BlurhashTest.php`:
- Decode-bomb dimension cap: a crafted few-byte PNG whose IHDR declares 30000×30000 is rejected before decode (returns `null`), plus a companion test that a normal under-cap image still encodes.
- `imagetypes()` intersection: mandatory formats (JPEG/PNG/GIF) are always encodable; codec-gated formats (AVIF/WebP/BMP) track the host's real `imagetypes()` support.

All 803 tests pass; lint clean.