### PR TITLE
Defer to ActivityPub's native blurhash encoder when present

### DIFF
--- a/fosse.php
+++ b/fosse.php
@@ -278,10 +278,25 @@ add_action(
  *
  * Same degradation posture as the projectors above — if FOSSE's
  * autoload is missing entirely, both classes silently skip.
+ *
+ * Deferral: newer ActivityPub ships this exact implementation natively
+ * (FOSSE's encoder upstreamed — same hooks, same injected `blurhash`
+ * member, its own `_activitypub_blurhash` meta key). Running both would
+ * double the cron encode work and meta rows for identical output, so
+ * when AP's class is present FOSSE registers only the hand-off bridge,
+ * which lazily copies FOSSE-era hashes into AP's store the first time
+ * each attachment federates ({@see Automattic\Fosse\Blurhash_Handoff}).
+ * Backfills then belong to AP's own `wp activitypub blurhash` command.
  */
 add_action(
 	'init',
 	static function () {
+		if ( class_exists( \Automattic\Fosse\Blurhash_Handoff::class )
+			&& \Automattic\Fosse\Blurhash_Handoff::should_defer() ) {
+			\Automattic\Fosse\Blurhash_Handoff::register();
+			return;
+		}
+
 		if ( ! class_exists( \Automattic\Fosse\Blurhash::class ) ) {
 			return;
 		}

--- a/src/class-blurhash-handoff.php
+++ b/src/class-blurhash-handoff.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Hand-off bridge from FOSSE's blurhash store to ActivityPub's native one.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse;
+
+/**
+ * Lazily migrates FOSSE-era blurhashes to ActivityPub's native encoder.
+ *
+ * ActivityPub upstreamed FOSSE's blurhash implementation (same hooks,
+ * same injected `blurhash` member) under its own postmeta key
+ * (`_activitypub_blurhash`). When that native encoder is present FOSSE
+ * stops registering its own pipeline ({@see Blurhash}) — but images
+ * encoded before the switch hold their hash under FOSSE's
+ * `_fosse_blurhash` key, which AP's injector can't see. Rather than a
+ * bulk meta migration (heavy on large libraries) or letting AP
+ * re-encode everything (wasted CPU for identical output), this bridge
+ * copies the existing hash across the first time each attachment
+ * federates:
+ *
+ * - AP's injector runs at priority 10 and wins whenever it already has
+ *   a hash; the bridge at priority 20 only acts when the outbound
+ *   attachment left AP's injector empty-handed.
+ * - On a hit, the FOSSE-era hash is written to AP's key (so AP's own
+ *   `get()` finds it on every subsequent render and this bridge
+ *   becomes a no-op for that attachment) and injected into the
+ *   in-flight payload so the current delivery keeps its placeholder.
+ *
+ * FOSSE's `_fosse_blurhash` rows are left in place — they're tiny,
+ * deleting them per-render would add a write to a hot path, and a
+ * future cleanup can drop them wholesale once the fleet has converged.
+ */
+class Blurhash_Handoff {
+
+	/**
+	 * Whether FOSSE should defer to ActivityPub's native blurhash encoder.
+	 *
+	 * True when the loaded ActivityPub (bundled or standalone) ships its
+	 * own `Blurhash` class — the upstreamed copy of FOSSE's encoder.
+	 * Checked at `init`, well after the plugin load that registers AP's
+	 * autoloader, so the class probe is reliable.
+	 *
+	 * @return bool
+	 */
+	public static function should_defer(): bool {
+		return \class_exists( '\Activitypub\Blurhash' );
+	}
+
+	/**
+	 * Hook the hand-off bridge.
+	 *
+	 * Priority 20 is load-bearing: AP's native injector registers at the
+	 * default 10, and the bridge must only fill gaps it leaves.
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		\add_filter( 'activitypub_attachment', array( self::class, 'backfill_native_blurhash' ), 20, 2 );
+	}
+
+	/**
+	 * Copy a FOSSE-era blurhash into AP's store when AP has none.
+	 *
+	 * @param mixed $attachment    The attachment array as built by bundled AP.
+	 * @param mixed $attachment_id The attachment post ID (loosely typed upstream).
+	 * @return mixed
+	 */
+	public static function backfill_native_blurhash( $attachment, $attachment_id ) {
+		if ( ! \is_array( $attachment ) ) {
+			return $attachment;
+		}
+		if ( 'Image' !== ( $attachment['type'] ?? '' ) ) {
+			return $attachment;
+		}
+		if ( ! empty( $attachment['blurhash'] ) ) {
+			// AP's native injector (or another subscriber) already
+			// provided one — nothing to hand off.
+			return $attachment;
+		}
+		if ( ! self::should_defer() ) {
+			// Defensive: the bridge is only registered when AP's class
+			// exists, but a mid-request unload is cheap to guard.
+			return $attachment;
+		}
+
+		// FOSSE's get() validates the stored value against the base83
+		// shape, so a poisoned row reads as absent here too.
+		$hash = Blurhash::get( (int) $attachment_id );
+		if ( null === $hash ) {
+			return $attachment;
+		}
+
+		\Activitypub\Blurhash::set( (int) $attachment_id, $hash );
+		$attachment['blurhash'] = $hash;
+
+		return $attachment;
+	}
+}

--- a/tests/php/BlurhashHandoffTest.php
+++ b/tests/php/BlurhashHandoffTest.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Tests for Blurhash_Handoff.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Automattic\Fosse\Tests;
+
+use Automattic\Fosse\Blurhash;
+use Automattic\Fosse\Blurhash_Handoff;
+use PHPUnit\Framework\Attributes\Before;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '/fixtures/class-activitypub-blurhash-stub.php';
+
+/**
+ * Verifies the lazy FOSSE-to-AP blurhash hand-off bridge.
+ */
+class BlurhashHandoffTest extends BaseTestCase {
+
+	/**
+	 * A valid blurhash used across cases.
+	 *
+	 * @var string
+	 */
+	private const HASH = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
+
+	/**
+	 * Reset filter state and register the bridge fresh for each test.
+	 *
+	 * The boot-time `init` closure may have hooked FOSSE's own injector
+	 * (when the bundled AP predates the native class); drop everything
+	 * on the filter so each test exercises exactly the bridge plus
+	 * whatever it registers itself.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function set_up_state(): void {
+		remove_all_filters( 'activitypub_attachment' );
+		Blurhash_Handoff::register();
+	}
+
+	/**
+	 * Create a bare attachment post.
+	 *
+	 * @return int Attachment ID.
+	 */
+	private function make_attachment(): int {
+		return (int) wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Hand-off fixture',
+			)
+		);
+	}
+
+	/**
+	 * Run the filter the way bundled AP does.
+	 *
+	 * @param array<string, mixed> $attachment Outbound attachment array.
+	 * @param int                  $id         Attachment ID.
+	 * @return mixed Filtered attachment.
+	 */
+	private function apply( array $attachment, int $id ) {
+		return apply_filters( 'activitypub_attachment', $attachment, $id );
+	}
+
+	/**
+	 * Deferral reflects the presence of AP's native class — true here
+	 * because the suite loads the stub (or the real class once the
+	 * bundled AP carries it).
+	 */
+	public function test_should_defer_when_ap_class_exists(): void {
+		$this->assertTrue( Blurhash_Handoff::should_defer() );
+	}
+
+	/**
+	 * A FOSSE-era hash is copied into AP's store and injected into the
+	 * in-flight payload when AP's injector left the attachment bare.
+	 */
+	public function test_copies_fosse_hash_to_ap_store_and_injects(): void {
+		$id = $this->make_attachment();
+		update_post_meta( $id, Blurhash::META_KEY, self::HASH );
+
+		$result = $this->apply(
+			array(
+				'type' => 'Image',
+				'url'  => 'https://example.com/a.jpg',
+			),
+			$id
+		);
+
+		$this->assertSame( self::HASH, $result['blurhash'] );
+		$this->assertSame( self::HASH, \Activitypub\Blurhash::get( $id ) );
+	}
+
+	/**
+	 * Once the hash lives in AP's store, AP's own injector provides it
+	 * and the bridge must not touch the payload again — pinned by
+	 * pre-filling the `blurhash` member the way AP's injector would.
+	 */
+	public function test_respects_blurhash_already_provided(): void {
+		$id = $this->make_attachment();
+		update_post_meta( $id, Blurhash::META_KEY, self::HASH );
+
+		$result = $this->apply(
+			array(
+				'type'     => 'Image',
+				'blurhash' => 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+			),
+			$id
+		);
+
+		// The pre-existing value wins and AP's store is left alone.
+		$this->assertSame( 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH', $result['blurhash'] );
+		$this->assertNull( \Activitypub\Blurhash::get( $id ) );
+	}
+
+	/**
+	 * No FOSSE-era hash means no injection and no AP meta write.
+	 */
+	public function test_no_fosse_hash_is_a_noop(): void {
+		$id = $this->make_attachment();
+
+		$result = $this->apply( array( 'type' => 'Image' ), $id );
+
+		$this->assertArrayNotHasKey( 'blurhash', $result );
+		$this->assertNull( \Activitypub\Blurhash::get( $id ) );
+	}
+
+	/**
+	 * Malformed stored values read as absent through FOSSE's validating
+	 * get(), so poison never crosses into AP's store.
+	 */
+	public function test_malformed_fosse_hash_is_not_handed_off(): void {
+		$id = $this->make_attachment();
+		update_post_meta( $id, Blurhash::META_KEY, "LEHV6nWB\x00<script>" );
+
+		$result = $this->apply( array( 'type' => 'Image' ), $id );
+
+		$this->assertArrayNotHasKey( 'blurhash', $result );
+		$this->assertNull( \Activitypub\Blurhash::get( $id ) );
+	}
+
+	/**
+	 * Non-Image attachments and non-array payloads pass through verbatim.
+	 */
+	public function test_ignores_non_image_and_non_array_payloads(): void {
+		$id = $this->make_attachment();
+		update_post_meta( $id, Blurhash::META_KEY, self::HASH );
+
+		$document = array( 'type' => 'Document' );
+		$this->assertSame( $document, $this->apply( $document, $id ) );
+		$this->assertSame( 'scalar', apply_filters( 'activitypub_attachment', 'scalar', $id ) );
+		$this->assertNull( \Activitypub\Blurhash::get( $id ) );
+	}
+
+	/**
+	 * The FOSSE meta row is intentionally preserved after a hand-off —
+	 * cleanup is a future bulk concern, not a hot-path write.
+	 */
+	public function test_fosse_meta_survives_handoff(): void {
+		$id = $this->make_attachment();
+		update_post_meta( $id, Blurhash::META_KEY, self::HASH );
+
+		$this->apply( array( 'type' => 'Image' ), $id );
+
+		$this->assertSame( self::HASH, get_post_meta( $id, Blurhash::META_KEY, true ) );
+	}
+}

--- a/tests/php/fixtures/class-activitypub-blurhash-stub.php
+++ b/tests/php/fixtures/class-activitypub-blurhash-stub.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Test stub for ActivityPub's native Blurhash class.
+ *
+ * Newer ActivityPub ships `\Activitypub\Blurhash` (FOSSE's encoder
+ * upstreamed). The bundled copy in this checkout may predate it, so the
+ * hand-off tests load this minimal stand-in — guarded so that once the
+ * bundled ActivityPub carries the real class, the stub silently steps
+ * aside and the same tests exercise the genuine implementation.
+ *
+ * @package Automattic\Fosse
+ */
+
+namespace Activitypub;
+
+if ( ! class_exists( __NAMESPACE__ . '\Blurhash' ) ) {
+	/**
+	 * Minimal mirror of AP's Blurhash storage surface.
+	 */
+	class Blurhash {
+
+		/**
+		 * AP's attachment postmeta key — matches the real class.
+		 *
+		 * @var string
+		 */
+		public const META_KEY = '_activitypub_blurhash';
+
+		/**
+		 * Read a stored blurhash, or null when absent.
+		 *
+		 * @param int $attachment_id Attachment post ID.
+		 * @return string|null
+		 */
+		public static function get( int $attachment_id ): ?string {
+			$value = \get_post_meta( $attachment_id, self::META_KEY, true );
+			if ( ! \is_string( $value ) || '' === $value ) {
+				return null;
+			}
+			return $value;
+		}
+
+		/**
+		 * Persist a blurhash on the attachment.
+		 *
+		 * @param int    $attachment_id Attachment post ID.
+		 * @param string $hash          Encoded blurhash string.
+		 * @return void
+		 */
+		public static function set( int $attachment_id, string $hash ): void {
+			\update_post_meta( $attachment_id, self::META_KEY, $hash );
+		}
+	}
+}


### PR DESCRIPTION
## What

Newer ActivityPub ships FOSSE's blurhash implementation natively (upstreamed nearly verbatim — same `wp_generate_attachment_metadata` scheduling, cron encode, and `activitypub_attachment` injection, under its own `_activitypub_blurhash` meta key). Once the bundled AP is refreshed (see [PR 205](https://github.com/Automattic/fosse/pull/205)), running FOSSE's pipeline alongside it would double the cron encode work and meta rows per image for identical output.

This PR makes FOSSE defer:

- The `init` registration in `fosse.php` now checks for `\Activitypub\Blurhash`. When present, FOSSE skips its own encoder **and** the `wp fosse blurhash` CLI (backfills belong to AP's native `wp activitypub blurhash` command), and registers `Blurhash_Handoff` instead.
- `Blurhash_Handoff` (new) hooks `activitypub_attachment` at priority 20 — after AP's native injector at 10 — and only acts when the outbound attachment has no `blurhash`. On a hit it copies the validated FOSSE-era hash into AP's store (so AP's own `get()` finds it on every subsequent render and the bridge becomes a per-attachment no-op) and injects it into the in-flight payload.

## Why lazy hand-off instead of bulk migration or re-encode

- Bulk meta copy is heavy on large libraries and pointless for images that never federate again.
- Letting AP re-encode wastes CPU producing byte-identical hashes and drops placeholders from outbound payloads until its backfill runs.
- The lazy bridge preserves placeholder continuity at the cost of one idempotent meta write per previously-encoded attachment, then converges to AP-only storage. `_fosse_blurhash` rows are deliberately left in place — dropping them is a future bulk cleanup, not a hot-path write.

## Behavior on current trunk

No-op: the bundled AP (8.3.0) predates the native class, so FOSSE's encoder keeps running exactly as today. The deferral activates automatically when PR 205 (or any AP carrying the class) lands — either merge order works.

## Sequencing with the upstream hardening

The four hardenings FOSSE's encoder carried over the original upstream (decode-bomb pre-decode gate, alpha flattening, +60s cron deferral, three-state skip/failure routing) were ported to wordpress-activitypub in [upstream PR 3386](https://github.com/Automattic/wordpress-activitypub/pull/3386), now landed on AP `trunk` (merge `d482b49`). PR 205's bundled refresh pulls them into FOSSE — so the native `\Activitypub\Blurhash` this PR defers to ships with the same robustness as FOSSE's own copy. FOSSE's class is gated rather than deleted to keep coverage for sites running the standalone-AP path on an older release; deletion can follow once the floor catches up.

This also makes [PR 198](https://github.com/Automattic/fosse/pull/198) (FOSSE-side blurhash hardenings) effectively redundant once PR 205 and this PR both land: the FOSSE encoder it hardens is exactly what this PR gates off, and upstream PR 3386 ports the same four fixes to the encoder that takes over. PR 198 stays useful only as belt-and-braces for the older-AP fallback window.

## Testing

- 7 new tests in `BlurhashHandoffTest` cover the copy/inject path, AP-already-provided short-circuit, absent/malformed FOSSE meta, non-Image payloads, and FOSSE-meta preservation. A guarded `\Activitypub\Blurhash` stub fixture stands in until the bundled AP ships the real class, at which point the same tests exercise the genuine implementation.
- `composer run-script lint-php` clean; `composer run-script test-php` green (806 tests, 1849 assertions).
