### PR TITLE
chore: exclude docs/ and CONTRIBUTING.md from the plugin zip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,7 @@
 /CONTRIBUTING.md       export-ignore
 /bin                   export-ignore
 /bin/**                export-ignore
+/docs                  export-ignore
 /docs/**               export-ignore
 /eslint.config.mjs     export-ignore
 /jest.config.js        export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,7 +21,6 @@
 /CONTRIBUTING.md       export-ignore
 /bin                   export-ignore
 /bin/**                export-ignore
-/docs                  export-ignore
 /docs/**               export-ignore
 /eslint.config.mjs     export-ignore
 /jest.config.js        export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,8 +18,11 @@
 /.prettierignore       export-ignore
 /AGENTS.md             export-ignore
 /CLAUDE.md             export-ignore
+/CONTRIBUTING.md       export-ignore
 /bin                   export-ignore
 /bin/**                export-ignore
+/docs                  export-ignore
+/docs/**               export-ignore
 /eslint.config.mjs     export-ignore
 /jest.config.js        export-ignore
 /package.json          export-ignore

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It bundles [wordpress-activitypub](https://github.com/Automattic/wordpress-activ
 
 Repository: <https://github.com/Automattic/fosse>
 
-![FOSSE setup wizard in WordPress admin](docs/assets/fosse-wizard.png)
+![FOSSE setup wizard in WordPress admin](https://raw.githubusercontent.com/Automattic/fosse/trunk/docs/assets/fosse-wizard.png)
 
 ## Requirements
 
@@ -31,7 +31,7 @@ After activation, go to **FOSSE** in wp-admin:
 -   **Status** shows the available providers and connection health.
 -   The first-run wizard walks through the basic ActivityPub and Bluesky setup.
 
-See the [FOSSE Publishing FAQ](./docs/fosse-publishing-faq.md) for how fediverse publishing works, how it differs from Bluesky, and how to edit the site fediverse profile.
+See the [FOSSE Publishing FAQ](https://github.com/Automattic/fosse/blob/trunk/docs/fosse-publishing-faq.md) for how fediverse publishing works, how it differs from Bluesky, and how to edit the site fediverse profile.
 
 ## Local Setup
 
@@ -68,4 +68,4 @@ pnpm run lint
 
 -   `src/` contains FOSSE's glue code and admin UI.
 -   `bundled/` contains vendored upstream plugin builds; do not edit it directly.
--   See [CONTRIBUTING.md](./CONTRIBUTING.md) and [AGENTS.md](./AGENTS.md) for workflow, coding standards, CI details, and upstream contribution policy.
+-   See [CONTRIBUTING.md](https://github.com/Automattic/fosse/blob/trunk/CONTRIBUTING.md) and [AGENTS.md](https://github.com/Automattic/fosse/blob/trunk/AGENTS.md) for workflow, coding standards, CI details, and upstream contribution policy.


### PR DESCRIPTION
## Summary
- Mark `docs/` and `CONTRIBUTING.md` as `export-ignore` so they no longer ship in `build/fosse.zip`
- Same leak mechanism as the `audits/` incident (#191): anything tracked and not listed in `.gitattributes` ships by default via `git archive`
- `README.md` deliberately left shipping

## Test plan
- [x] `git check-attr export-ignore` reports `set` for `CONTRIBUTING.md`, `docs/fosse-publishing-faq.md`, `docs/assets/fosse-wizard.png`
- [x] `git archive HEAD | tar -t` no longer lists `docs/` or `CONTRIBUTING.md` (only `README.md` remains from the root markdown set)

Refs: #191