### PR TITLE
fix: keep the AP Blurhash test stub out of autoloader classmaps

### DIFF
--- a/tests/php/fixtures/class-activitypub-blurhash-stub.php
+++ b/tests/php/fixtures/class-activitypub-blurhash-stub.php
@@ -8,47 +8,62 @@
  * bundled ActivityPub carries the real class, the stub silently steps
  * aside and the same tests exercise the genuine implementation.
  *
+ * The class is declared in the test namespace and aliased to
+ * `\Activitypub\Blurhash` at require time, NOT declared in the
+ * `Activitypub` namespace directly. The jetpack-autoloader manifest
+ * generator merges the root package's `autoload-dev` even on
+ * `--no-dev` installs (AutoloadGenerator::parseAutoloadsType), and
+ * `--optimize-autoloader` scans `tests/php/` into the production
+ * classmap. A literal `Activitypub\Blurhash` declaration here ends up
+ * shadowing bundled AP's real class at runtime — AP hooks
+ * `Blurhash::init`, the stub has no `init()`, and activation fatals
+ * (this took down the Playground e2e suite). `class_alias()` is
+ * runtime-only and invisible to classmap scanners, so the alias can
+ * never leak into an autoloader manifest.
+ *
  * @package Automattic\Fosse
  */
 
-namespace Activitypub;
+namespace Automattic\Fosse\Tests\Fixtures;
 
-if ( ! class_exists( __NAMESPACE__ . '\Blurhash' ) ) {
+/**
+ * Minimal mirror of AP's Blurhash storage surface.
+ */
+class Activitypub_Blurhash_Stub {
+
 	/**
-	 * Minimal mirror of AP's Blurhash storage surface.
+	 * AP's attachment postmeta key — matches the real class.
+	 *
+	 * @var string
 	 */
-	class Blurhash {
+	public const META_KEY = '_activitypub_blurhash';
 
-		/**
-		 * AP's attachment postmeta key — matches the real class.
-		 *
-		 * @var string
-		 */
-		public const META_KEY = '_activitypub_blurhash';
-
-		/**
-		 * Read a stored blurhash, or null when absent.
-		 *
-		 * @param int $attachment_id Attachment post ID.
-		 * @return string|null
-		 */
-		public static function get( int $attachment_id ): ?string {
-			$value = \get_post_meta( $attachment_id, self::META_KEY, true );
-			if ( ! \is_string( $value ) || '' === $value ) {
-				return null;
-			}
-			return $value;
+	/**
+	 * Read a stored blurhash, or null when absent.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return string|null
+	 */
+	public static function get( int $attachment_id ): ?string {
+		$value = \get_post_meta( $attachment_id, self::META_KEY, true );
+		if ( ! \is_string( $value ) || '' === $value ) {
+			return null;
 		}
-
-		/**
-		 * Persist a blurhash on the attachment.
-		 *
-		 * @param int    $attachment_id Attachment post ID.
-		 * @param string $hash          Encoded blurhash string.
-		 * @return void
-		 */
-		public static function set( int $attachment_id, string $hash ): void {
-			\update_post_meta( $attachment_id, self::META_KEY, $hash );
-		}
+		return $value;
 	}
+
+	/**
+	 * Persist a blurhash on the attachment.
+	 *
+	 * @param int    $attachment_id Attachment post ID.
+	 * @param string $hash          Encoded blurhash string.
+	 * @return void
+	 */
+	public static function set( int $attachment_id, string $hash ): void {
+		\update_post_meta( $attachment_id, self::META_KEY, $hash );
+	}
+}
+
+if ( ! \class_exists( '\Activitypub\Blurhash' ) ) {
+	\class_alias( Activitypub_Blurhash_Stub::class, '\Activitypub\Blurhash' );
 }


### PR DESCRIPTION
## Summary
- Trunk's Playground e2e suite has been red since #206 landed: activation fatals with `class Activitypub\Blurhash does not have a method "init"`, the server dies, and all 28 specs cascade-fail with `ERR_CONNECTION_REFUSED`.
- Root cause: the PHPUnit stub fixture declares `Activitypub\Blurhash` directly, and jetpack-autoloader's generator merges the root package's `autoload-dev` even on `--no-dev` installs (`AutoloadGenerator::parseAutoloadsType`). The e2e workflow's `composer install --no-dev --optimize-autoloader` scans `tests/php/` into the production classmap, where the stub entry shadows bundled AP's real `Blurhash` class. AP hooks `Blurhash::init`, the stub has no `init()`, activation dies. The fixture's `class_exists` guard can't help — it runs *inside* the autoload call for that very class.
- Side effect fixed too: the shadow made `Blurhash_Handoff::should_defer()` report `true` even where the loaded AP has no native encoder, silently disabling FOSSE's own blurhash pipeline.
- Fix: declare the stub as `Automattic\Fosse\Tests\Fixtures\Activitypub_Blurhash_Stub` and `class_alias()` it to `\Activitypub\Blurhash` at require time. `class_alias` is runtime-only and invisible to classmap scanners, so no manifest can ever map the AP class name to the fixture.
- Release zips were never affected: `build-zip` stages via `git archive`, which export-ignores `tests/`.

## Test plan
- [x] Reproduced CI's exact failure locally: clean trunk worktree + `composer install --no-dev --optimize-autoloader` + Playground boot → fatals at the `activatePlugin` blueprint step with the same exit code 255 / wp-die page as CI
- [x] With this fix applied to the same worktree: `jetpack_autoload_classmap.php` carries no `Activitypub\Blurhash` entry and Playground boots clean
- [x] `composer test` green (806 tests, 1849 assertions) — `BlurhashHandoffTest` passes against the aliased stub
- [x] `composer lint-php` clean
- [ ] Playwright (Playground) check on this PR goes green (the real proof — this PR's CI run includes the fix)

Refs: #206

Note: `exclude-from-classmap` does **not** fix this — the jetpack generator's psr-4→classmap scan ignores it for the root package's dev dirs. The generator merging `autoload-dev` on `--no-dev` installs looks like an upstream jetpack-autoloader bug worth filing separately.